### PR TITLE
Redirect users to /browse-requests after login

### DIFF
--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -43,7 +43,7 @@ export default function AuthCallbackPage() {
 
             // Redirect to the stored path (e.g. user tried to visit
             // /browse-requests before logging in) or fall back to /dashboard.
-            const redirectTo = consumeRedirectAfterLogin() || "/dashboard";
+            const redirectTo = consumeRedirectAfterLogin() || "/browse-requests";
             window.location.href = redirectTo;
           }
         }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -154,7 +154,7 @@ export default function HomePage() {
     const supabase = createBrowserClient();
     supabase.auth.getSession().then(({ data: { session } }) => {
       if (session) {
-        router.replace("/dashboard");
+        router.replace("/browse-requests");
       } else {
         setAuthChecked(true);
       }


### PR DESCRIPTION
- Auth callback now defaults to /browse-requests instead of /dashboard
- Homepage auth redirect also sends to /browse-requests

https://claude.ai/code/session_01LYhDu2dDFB227i3Le5AZxK