### PR TITLE
Add admin panel for managing operator listings, locations, and routes

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,7 +1,7 @@
 import { createMiddlewareClient } from "@/lib/supabaseMiddleware";
 import type { NextRequest } from "next/server";
 
-const PROTECTED_PATHS = ["/dashboard", "/messages", "/post-request", "/listings/new"];
+const PROTECTED_PATHS = ["/dashboard", "/messages", "/post-request", "/listings/new", "/admin"];
 
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
@@ -30,5 +30,5 @@ export async function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/dashboard/:path*", "/messages/:path*", "/post-request/:path*", "/listings/new/:path*"],
+  matcher: ["/dashboard/:path*", "/messages/:path*", "/post-request/:path*", "/listings/new/:path*", "/admin/:path*"],
 };

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,1080 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import {
+  Shield,
+  Building2,
+  MapPin,
+  Route,
+  Plus,
+  Loader2,
+  CheckCircle2,
+  AlertTriangle,
+  ChevronDown,
+} from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
+import { MACHINE_TYPES, LOCATION_TYPES, URGENCY_OPTIONS, US_STATES } from "@/lib/types";
+
+/* ------------------------------------------------------------------ */
+/*  Types                                                              */
+/* ------------------------------------------------------------------ */
+
+type Tab = "operators" | "locations" | "routes";
+
+/* ------------------------------------------------------------------ */
+/*  Multi-select toggle helper                                         */
+/* ------------------------------------------------------------------ */
+
+function toggle(arr: string[], val: string) {
+  return arr.includes(val) ? arr.filter((v) => v !== val) : [...arr, val];
+}
+
+/* ------------------------------------------------------------------ */
+/*  Toast                                                              */
+/* ------------------------------------------------------------------ */
+
+function Toast({
+  message,
+  type,
+}: {
+  message: string;
+  type: "success" | "error";
+}) {
+  return (
+    <div
+      className={`toast ${type === "success" ? "toast-success" : "toast-error"}`}
+    >
+      <div className="flex items-center gap-2">
+        {type === "success" ? (
+          <CheckCircle2 className="h-4 w-4" />
+        ) : (
+          <AlertTriangle className="h-4 w-4" />
+        )}
+        {message}
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Chip selector                                                      */
+/* ------------------------------------------------------------------ */
+
+function ChipSelect({
+  label,
+  options,
+  selected,
+  onChange,
+}: {
+  label: string;
+  options: { value: string; label: string }[];
+  selected: string[];
+  onChange: (val: string[]) => void;
+}) {
+  return (
+    <div>
+      <label className="mb-1.5 block text-sm font-medium text-black-primary">
+        {label}
+      </label>
+      <div className="flex flex-wrap gap-1.5">
+        {options.map((opt) => (
+          <button
+            key={opt.value}
+            type="button"
+            onClick={() => onChange(toggle(selected, opt.value))}
+            className={`rounded-full px-2.5 py-1 text-xs font-medium transition-colors cursor-pointer ${
+              selected.includes(opt.value)
+                ? "bg-green-primary text-white"
+                : "bg-gray-100 text-black-primary/60 hover:bg-gray-200"
+            }`}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  State selector                                                     */
+/* ------------------------------------------------------------------ */
+
+function StateSelect({
+  label,
+  selected,
+  onChange,
+}: {
+  label: string;
+  selected: string[];
+  onChange: (val: string[]) => void;
+}) {
+  return (
+    <div>
+      <label className="mb-1.5 block text-sm font-medium text-black-primary">
+        {label}
+      </label>
+      <div className="flex flex-wrap gap-1">
+        {US_STATES.map((st) => (
+          <button
+            key={st}
+            type="button"
+            onClick={() => onChange(toggle(selected, st))}
+            className={`rounded px-1.5 py-0.5 text-xs font-medium transition-colors cursor-pointer ${
+              selected.includes(st)
+                ? "bg-green-primary text-white"
+                : "bg-gray-100 text-black-primary/60 hover:bg-gray-200"
+            }`}
+          >
+            {st}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Operator Listing Form                                              */
+/* ------------------------------------------------------------------ */
+
+function OperatorForm({
+  token,
+  onSuccess,
+}: {
+  token: string;
+  onSuccess: (msg: string) => void;
+}) {
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [form, setForm] = useState({
+    title: "",
+    description: "",
+    machine_types: [] as string[],
+    service_radius_miles: 50,
+    cities_served: [] as string[],
+    states_served: [] as string[],
+    accepts_commission: true,
+    min_daily_traffic: 0,
+    machine_count_available: 1,
+  });
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+
+    try {
+      const res = await fetch("/api/admin/operators", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(form),
+      });
+
+      const data = await res.json();
+      if (!res.ok) {
+        setError(
+          typeof data.error === "string"
+            ? data.error
+            : JSON.stringify(data.error)
+        );
+        return;
+      }
+
+      onSuccess("Operator listing created!");
+      setForm({
+        title: "",
+        description: "",
+        machine_types: [],
+        service_radius_miles: 50,
+        cities_served: [],
+        states_served: [],
+        accepts_commission: true,
+        min_daily_traffic: 0,
+        machine_count_available: 1,
+      });
+    } catch {
+      setError("Network error");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-5">
+      {error && (
+        <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      <div>
+        <label className="mb-1.5 block text-sm font-medium text-black-primary">
+          Listing Title *
+        </label>
+        <input
+          type="text"
+          value={form.title}
+          onChange={(e) => setForm((f) => ({ ...f, title: e.target.value }))}
+          placeholder="e.g. Full-service vending operator in Denver metro"
+          required
+        />
+      </div>
+
+      <div>
+        <label className="mb-1.5 block text-sm font-medium text-black-primary">
+          Description
+        </label>
+        <textarea
+          rows={3}
+          value={form.description}
+          onChange={(e) =>
+            setForm((f) => ({ ...f, description: e.target.value }))
+          }
+          placeholder="Describe the operator's services..."
+        />
+      </div>
+
+      <ChipSelect
+        label="Machine Types *"
+        options={MACHINE_TYPES}
+        selected={form.machine_types}
+        onChange={(val) => setForm((f) => ({ ...f, machine_types: val }))}
+      />
+
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className="mb-1.5 block text-sm font-medium text-black-primary">
+            Machines Available
+          </label>
+          <input
+            type="number"
+            min={1}
+            max={1000}
+            value={form.machine_count_available}
+            onChange={(e) =>
+              setForm((f) => ({
+                ...f,
+                machine_count_available: parseInt(e.target.value) || 1,
+              }))
+            }
+          />
+        </div>
+        <div>
+          <label className="mb-1.5 block text-sm font-medium text-black-primary">
+            Service Radius (mi)
+          </label>
+          <input
+            type="number"
+            min={1}
+            max={500}
+            value={form.service_radius_miles}
+            onChange={(e) =>
+              setForm((f) => ({
+                ...f,
+                service_radius_miles: parseInt(e.target.value) || 50,
+              }))
+            }
+          />
+        </div>
+      </div>
+
+      <StateSelect
+        label="States Served *"
+        selected={form.states_served}
+        onChange={(val) => setForm((f) => ({ ...f, states_served: val }))}
+      />
+
+      <div className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          id="accepts_commission"
+          checked={form.accepts_commission}
+          onChange={(e) =>
+            setForm((f) => ({ ...f, accepts_commission: e.target.checked }))
+          }
+          className="h-4 w-4 rounded border-gray-300"
+        />
+        <label
+          htmlFor="accepts_commission"
+          className="text-sm text-black-primary"
+        >
+          Accepts commission-based arrangements
+        </label>
+      </div>
+
+      <button
+        type="submit"
+        disabled={saving}
+        className="inline-flex items-center gap-2 rounded-xl bg-green-primary px-6 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-green-hover disabled:opacity-50 cursor-pointer"
+      >
+        {saving ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : (
+          <Plus className="h-4 w-4" />
+        )}
+        Add Operator Listing
+      </button>
+    </form>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Location Request Form                                              */
+/* ------------------------------------------------------------------ */
+
+function LocationForm({
+  token,
+  onSuccess,
+}: {
+  token: string;
+  onSuccess: (msg: string) => void;
+}) {
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [form, setForm] = useState({
+    title: "",
+    description: "",
+    location_name: "",
+    address: "",
+    city: "",
+    state: "",
+    zip: "",
+    location_type: "office" as string,
+    machine_types_wanted: [] as string[],
+    estimated_daily_traffic: 0,
+    commission_offered: false,
+    commission_notes: "",
+    urgency: "flexible" as string,
+    contact_preference: "platform_message" as string,
+    is_public: true,
+  });
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+
+    try {
+      const payload = {
+        ...form,
+        estimated_daily_traffic: form.estimated_daily_traffic || undefined,
+        commission_notes: form.commission_notes || undefined,
+        address: form.address || undefined,
+        zip: form.zip || undefined,
+        description: form.description || undefined,
+      };
+
+      const res = await fetch("/api/admin/requests", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(payload),
+      });
+
+      const data = await res.json();
+      if (!res.ok) {
+        setError(
+          typeof data.error === "string"
+            ? data.error
+            : JSON.stringify(data.error)
+        );
+        return;
+      }
+
+      onSuccess("Location request created!");
+      setForm({
+        title: "",
+        description: "",
+        location_name: "",
+        address: "",
+        city: "",
+        state: "",
+        zip: "",
+        location_type: "office",
+        machine_types_wanted: [],
+        estimated_daily_traffic: 0,
+        commission_offered: false,
+        commission_notes: "",
+        urgency: "flexible",
+        contact_preference: "platform_message",
+        is_public: true,
+      });
+    } catch {
+      setError("Network error");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-5">
+      {error && (
+        <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      <div>
+        <label className="mb-1.5 block text-sm font-medium text-black-primary">
+          Request Title *
+        </label>
+        <input
+          type="text"
+          value={form.title}
+          onChange={(e) => setForm((f) => ({ ...f, title: e.target.value }))}
+          placeholder="e.g. Snack machine needed for office lobby"
+          required
+        />
+      </div>
+
+      <div>
+        <label className="mb-1.5 block text-sm font-medium text-black-primary">
+          Location Name *
+        </label>
+        <input
+          type="text"
+          value={form.location_name}
+          onChange={(e) =>
+            setForm((f) => ({ ...f, location_name: e.target.value }))
+          }
+          placeholder="e.g. Apex Office Park Building A"
+          required
+        />
+      </div>
+
+      <div>
+        <label className="mb-1.5 block text-sm font-medium text-black-primary">
+          Description
+        </label>
+        <textarea
+          rows={3}
+          value={form.description}
+          onChange={(e) =>
+            setForm((f) => ({ ...f, description: e.target.value }))
+          }
+          placeholder="Describe the location and what you're looking for..."
+        />
+      </div>
+
+      <div>
+        <label className="mb-1.5 block text-sm font-medium text-black-primary">
+          Address
+        </label>
+        <input
+          type="text"
+          value={form.address}
+          onChange={(e) => setForm((f) => ({ ...f, address: e.target.value }))}
+          placeholder="123 Main St"
+        />
+      </div>
+
+      <div className="grid grid-cols-3 gap-4">
+        <div>
+          <label className="mb-1.5 block text-sm font-medium text-black-primary">
+            City *
+          </label>
+          <input
+            type="text"
+            value={form.city}
+            onChange={(e) => setForm((f) => ({ ...f, city: e.target.value }))}
+            required
+          />
+        </div>
+        <div>
+          <label className="mb-1.5 block text-sm font-medium text-black-primary">
+            State *
+          </label>
+          <select
+            value={form.state}
+            onChange={(e) => setForm((f) => ({ ...f, state: e.target.value }))}
+            required
+          >
+            <option value="">Select</option>
+            {US_STATES.map((st) => (
+              <option key={st} value={st}>
+                {st}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="mb-1.5 block text-sm font-medium text-black-primary">
+            ZIP
+          </label>
+          <input
+            type="text"
+            value={form.zip}
+            onChange={(e) => setForm((f) => ({ ...f, zip: e.target.value }))}
+            maxLength={10}
+          />
+        </div>
+      </div>
+
+      <div>
+        <label className="mb-1.5 block text-sm font-medium text-black-primary">
+          Location Type *
+        </label>
+        <select
+          value={form.location_type}
+          onChange={(e) =>
+            setForm((f) => ({ ...f, location_type: e.target.value }))
+          }
+        >
+          {LOCATION_TYPES.map((lt) => (
+            <option key={lt.value} value={lt.value}>
+              {lt.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <ChipSelect
+        label="Machine Types Wanted *"
+        options={MACHINE_TYPES}
+        selected={form.machine_types_wanted}
+        onChange={(val) =>
+          setForm((f) => ({ ...f, machine_types_wanted: val }))
+        }
+      />
+
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className="mb-1.5 block text-sm font-medium text-black-primary">
+            Est. Daily Traffic
+          </label>
+          <input
+            type="number"
+            min={0}
+            max={100000}
+            value={form.estimated_daily_traffic}
+            onChange={(e) =>
+              setForm((f) => ({
+                ...f,
+                estimated_daily_traffic: parseInt(e.target.value) || 0,
+              }))
+            }
+          />
+        </div>
+        <div>
+          <label className="mb-1.5 block text-sm font-medium text-black-primary">
+            Urgency
+          </label>
+          <select
+            value={form.urgency}
+            onChange={(e) =>
+              setForm((f) => ({ ...f, urgency: e.target.value }))
+            }
+          >
+            {URGENCY_OPTIONS.map((u) => (
+              <option key={u.value} value={u.value}>
+                {u.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          id="commission_offered"
+          checked={form.commission_offered}
+          onChange={(e) =>
+            setForm((f) => ({ ...f, commission_offered: e.target.checked }))
+          }
+          className="h-4 w-4 rounded border-gray-300"
+        />
+        <label
+          htmlFor="commission_offered"
+          className="text-sm text-black-primary"
+        >
+          Commission offered to operator
+        </label>
+      </div>
+
+      <button
+        type="submit"
+        disabled={saving}
+        className="inline-flex items-center gap-2 rounded-xl bg-green-primary px-6 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-green-hover disabled:opacity-50 cursor-pointer"
+      >
+        {saving ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : (
+          <Plus className="h-4 w-4" />
+        )}
+        Add Location Request
+      </button>
+    </form>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Route For Sale Form                                                */
+/* ------------------------------------------------------------------ */
+
+function RouteForm({
+  token,
+  onSuccess,
+}: {
+  token: string;
+  onSuccess: (msg: string) => void;
+}) {
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [form, setForm] = useState({
+    title: "",
+    description: "",
+    city: "",
+    state: "",
+    num_machines: 1,
+    num_locations: 1,
+    monthly_revenue: 0,
+    asking_price: 0,
+    machine_types: [] as string[],
+    location_types: [] as string[],
+    includes_equipment: true,
+    includes_contracts: true,
+    contact_email: "",
+    contact_phone: "",
+    status: "active" as string,
+  });
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+
+    try {
+      const payload = {
+        ...form,
+        monthly_revenue: form.monthly_revenue || undefined,
+        asking_price: form.asking_price || undefined,
+        contact_email: form.contact_email || undefined,
+        contact_phone: form.contact_phone || undefined,
+      };
+
+      const res = await fetch("/api/admin/routes", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(payload),
+      });
+
+      const data = await res.json();
+      if (!res.ok) {
+        setError(
+          typeof data.error === "string"
+            ? data.error
+            : JSON.stringify(data.error)
+        );
+        return;
+      }
+
+      onSuccess("Route listing created!");
+      setForm({
+        title: "",
+        description: "",
+        city: "",
+        state: "",
+        num_machines: 1,
+        num_locations: 1,
+        monthly_revenue: 0,
+        asking_price: 0,
+        machine_types: [],
+        location_types: [],
+        includes_equipment: true,
+        includes_contracts: true,
+        contact_email: "",
+        contact_phone: "",
+        status: "active",
+      });
+    } catch {
+      setError("Network error");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-5">
+      {error && (
+        <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      <div>
+        <label className="mb-1.5 block text-sm font-medium text-black-primary">
+          Route Title *
+        </label>
+        <input
+          type="text"
+          value={form.title}
+          onChange={(e) => setForm((f) => ({ ...f, title: e.target.value }))}
+          placeholder="e.g. 15-machine Denver metro route — $8k/mo revenue"
+          required
+        />
+      </div>
+
+      <div>
+        <label className="mb-1.5 block text-sm font-medium text-black-primary">
+          Description
+        </label>
+        <textarea
+          rows={4}
+          value={form.description}
+          onChange={(e) =>
+            setForm((f) => ({ ...f, description: e.target.value }))
+          }
+          placeholder="Describe the route, locations, revenue history, reason for selling..."
+        />
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className="mb-1.5 block text-sm font-medium text-black-primary">
+            City *
+          </label>
+          <input
+            type="text"
+            value={form.city}
+            onChange={(e) => setForm((f) => ({ ...f, city: e.target.value }))}
+            required
+          />
+        </div>
+        <div>
+          <label className="mb-1.5 block text-sm font-medium text-black-primary">
+            State *
+          </label>
+          <select
+            value={form.state}
+            onChange={(e) => setForm((f) => ({ ...f, state: e.target.value }))}
+            required
+          >
+            <option value="">Select</option>
+            {US_STATES.map((st) => (
+              <option key={st} value={st}>
+                {st}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className="mb-1.5 block text-sm font-medium text-black-primary">
+            Number of Machines *
+          </label>
+          <input
+            type="number"
+            min={1}
+            value={form.num_machines}
+            onChange={(e) =>
+              setForm((f) => ({
+                ...f,
+                num_machines: parseInt(e.target.value) || 1,
+              }))
+            }
+          />
+        </div>
+        <div>
+          <label className="mb-1.5 block text-sm font-medium text-black-primary">
+            Number of Locations *
+          </label>
+          <input
+            type="number"
+            min={1}
+            value={form.num_locations}
+            onChange={(e) =>
+              setForm((f) => ({
+                ...f,
+                num_locations: parseInt(e.target.value) || 1,
+              }))
+            }
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className="mb-1.5 block text-sm font-medium text-black-primary">
+            Monthly Revenue ($)
+          </label>
+          <input
+            type="number"
+            min={0}
+            value={form.monthly_revenue}
+            onChange={(e) =>
+              setForm((f) => ({
+                ...f,
+                monthly_revenue: parseFloat(e.target.value) || 0,
+              }))
+            }
+          />
+        </div>
+        <div>
+          <label className="mb-1.5 block text-sm font-medium text-black-primary">
+            Asking Price ($)
+          </label>
+          <input
+            type="number"
+            min={0}
+            value={form.asking_price}
+            onChange={(e) =>
+              setForm((f) => ({
+                ...f,
+                asking_price: parseFloat(e.target.value) || 0,
+              }))
+            }
+          />
+        </div>
+      </div>
+
+      <ChipSelect
+        label="Machine Types *"
+        options={MACHINE_TYPES}
+        selected={form.machine_types}
+        onChange={(val) => setForm((f) => ({ ...f, machine_types: val }))}
+      />
+
+      <ChipSelect
+        label="Location Types"
+        options={LOCATION_TYPES}
+        selected={form.location_types}
+        onChange={(val) => setForm((f) => ({ ...f, location_types: val }))}
+      />
+
+      <div className="flex flex-wrap gap-6">
+        <div className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            id="includes_equipment"
+            checked={form.includes_equipment}
+            onChange={(e) =>
+              setForm((f) => ({
+                ...f,
+                includes_equipment: e.target.checked,
+              }))
+            }
+            className="h-4 w-4 rounded border-gray-300"
+          />
+          <label
+            htmlFor="includes_equipment"
+            className="text-sm text-black-primary"
+          >
+            Includes equipment
+          </label>
+        </div>
+        <div className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            id="includes_contracts"
+            checked={form.includes_contracts}
+            onChange={(e) =>
+              setForm((f) => ({
+                ...f,
+                includes_contracts: e.target.checked,
+              }))
+            }
+            className="h-4 w-4 rounded border-gray-300"
+          />
+          <label
+            htmlFor="includes_contracts"
+            className="text-sm text-black-primary"
+          >
+            Includes location contracts
+          </label>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className="mb-1.5 block text-sm font-medium text-black-primary">
+            Contact Email
+          </label>
+          <input
+            type="email"
+            value={form.contact_email}
+            onChange={(e) =>
+              setForm((f) => ({ ...f, contact_email: e.target.value }))
+            }
+            placeholder="seller@example.com"
+          />
+        </div>
+        <div>
+          <label className="mb-1.5 block text-sm font-medium text-black-primary">
+            Contact Phone
+          </label>
+          <input
+            type="tel"
+            value={form.contact_phone}
+            onChange={(e) =>
+              setForm((f) => ({ ...f, contact_phone: e.target.value }))
+            }
+            placeholder="(555) 123-4567"
+          />
+        </div>
+      </div>
+
+      <button
+        type="submit"
+        disabled={saving}
+        className="inline-flex items-center gap-2 rounded-xl bg-green-primary px-6 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-green-hover disabled:opacity-50 cursor-pointer"
+      >
+        {saving ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : (
+          <Plus className="h-4 w-4" />
+        )}
+        Add Route Listing
+      </button>
+    </form>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main Admin Page                                                    */
+/* ------------------------------------------------------------------ */
+
+export default function AdminPage() {
+  const router = useRouter();
+  const [loading, setLoading] = useState(true);
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [token, setToken] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<Tab>("operators");
+  const [toast, setToast] = useState<{
+    message: string;
+    type: "success" | "error";
+  } | null>(null);
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+
+    async function checkAdmin() {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+
+      if (!session) {
+        router.replace("/login?redirect=/admin");
+        return;
+      }
+
+      setToken(session.access_token);
+
+      const res = await fetch("/api/admin/check", {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      });
+      const data = await res.json();
+
+      if (!data.isAdmin) {
+        router.replace("/dashboard");
+        return;
+      }
+
+      setIsAdmin(true);
+      setLoading(false);
+    }
+
+    checkAdmin();
+  }, [router]);
+
+  function handleSuccess(msg: string) {
+    setToast({ message: msg, type: "success" });
+    setTimeout(() => setToast(null), 3000);
+  }
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[calc(100vh-160px)] items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-green-primary" />
+      </div>
+    );
+  }
+
+  if (!isAdmin || !token) return null;
+
+  const tabs: { key: Tab; label: string; icon: typeof Building2 }[] = [
+    { key: "operators", label: "Operator Listings", icon: Building2 },
+    { key: "locations", label: "Location Requests", icon: MapPin },
+    { key: "routes", label: "Routes For Sale", icon: Route },
+  ];
+
+  return (
+    <div className="min-h-[calc(100vh-160px)] bg-light">
+      {/* Header */}
+      <div className="border-b border-gray-100 bg-white">
+        <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+          <div className="flex items-center gap-3">
+            <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-green-50">
+              <Shield className="h-6 w-6 text-green-primary" />
+            </div>
+            <div>
+              <h1 className="text-2xl font-bold text-black-primary">
+                Admin Panel
+              </h1>
+              <p className="text-sm text-black-primary/50">
+                Add listings, locations, and routes to the platform
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+        {/* Tabs */}
+        <div className="mb-8 flex gap-1 rounded-xl border border-gray-200 bg-white p-1 shadow-sm">
+          {tabs.map((tab) => {
+            const Icon = tab.icon;
+            return (
+              <button
+                key={tab.key}
+                type="button"
+                onClick={() => setActiveTab(tab.key)}
+                className={`flex flex-1 items-center justify-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium transition-colors cursor-pointer ${
+                  activeTab === tab.key
+                    ? "bg-green-primary text-white shadow-sm"
+                    : "text-black-primary/60 hover:bg-gray-50 hover:text-black-primary"
+                }`}
+              >
+                <Icon className="h-4 w-4" />
+                <span className="hidden sm:inline">{tab.label}</span>
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Form Container */}
+        <div className="rounded-2xl border border-gray-100 bg-white p-6 shadow-sm sm:p-8">
+          <h2 className="mb-6 text-lg font-semibold text-black-primary">
+            {activeTab === "operators" && "Add Operator Listing"}
+            {activeTab === "locations" && "Add Location Request"}
+            {activeTab === "routes" && "Add Route For Sale"}
+          </h2>
+
+          {activeTab === "operators" && (
+            <OperatorForm token={token} onSuccess={handleSuccess} />
+          )}
+          {activeTab === "locations" && (
+            <LocationForm token={token} onSuccess={handleSuccess} />
+          )}
+          {activeTab === "routes" && (
+            <RouteForm token={token} onSuccess={handleSuccess} />
+          )}
+        </div>
+      </div>
+
+      {toast && <Toast message={toast.message} type={toast.type} />}
+    </div>
+  );
+}

--- a/src/app/api/admin/check/route.ts
+++ b/src/app/api/admin/check/route.ts
@@ -1,0 +1,8 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAdminUserId } from "@/lib/adminAuth";
+
+/** GET /api/admin/check — verify if current user is admin */
+export async function GET(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  return NextResponse.json({ isAdmin: !!adminId });
+}

--- a/src/app/api/admin/operators/route.ts
+++ b/src/app/api/admin/operators/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { createListingSchema } from "@/lib/schemas";
+import { getAdminUserId } from "@/lib/adminAuth";
+
+/** GET /api/admin/operators — list all operator listings (admin view) */
+export async function GET(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from("operator_listings")
+    .select("*, profiles!operator_id(id, full_name, email)")
+    .order("created_at", { ascending: false })
+    .limit(50);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ listings: data || [] });
+}
+
+/** POST /api/admin/operators — admin creates an operator listing */
+export async function POST(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  try {
+    const body = await req.json();
+    const parsed = createListingSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.flatten().fieldErrors },
+        { status: 400 }
+      );
+    }
+
+    // Admin creates on behalf — use admin's own ID as operator_id
+    const { data, error } = await supabaseAdmin
+      .from("operator_listings")
+      .insert({
+        operator_id: adminId,
+        ...parsed.data,
+      })
+      .select("id")
+      .single();
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ id: data.id }, { status: 201 });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Unknown error";
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/requests/route.ts
+++ b/src/app/api/admin/requests/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { createRequestSchema } from "@/lib/schemas";
+import { getAdminUserId } from "@/lib/adminAuth";
+
+/** GET /api/admin/requests — list all requests (admin view) */
+export async function GET(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from("vending_requests")
+    .select("*, profiles!created_by(id, full_name, email)")
+    .order("created_at", { ascending: false })
+    .limit(50);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ requests: data || [] });
+}
+
+/** POST /api/admin/requests — admin creates a location request */
+export async function POST(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  try {
+    const body = await req.json();
+    const parsed = createRequestSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.flatten().fieldErrors },
+        { status: 400 }
+      );
+    }
+
+    // Admin creates on behalf — use admin's own ID as created_by
+    const { data, error } = await supabaseAdmin
+      .from("vending_requests")
+      .insert({
+        created_by: adminId,
+        ...parsed.data,
+      })
+      .select("id")
+      .single();
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ id: data.id }, { status: 201 });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Unknown error";
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/routes/route.ts
+++ b/src/app/api/admin/routes/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { createRouteSchema } from "@/lib/schemas";
+import { getAdminUserId } from "@/lib/adminAuth";
+
+/** GET /api/admin/routes — list all route listings */
+export async function GET(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from("route_listings")
+    .select("*")
+    .order("created_at", { ascending: false })
+    .limit(50);
+
+  if (error) {
+    // Table may not exist yet — return empty
+    return NextResponse.json({ routes: [], note: error.message });
+  }
+
+  return NextResponse.json({ routes: data || [] });
+}
+
+/** POST /api/admin/routes — admin creates a route listing */
+export async function POST(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  try {
+    const body = await req.json();
+    const parsed = createRouteSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.flatten().fieldErrors },
+        { status: 400 }
+      );
+    }
+
+    const { data, error } = await supabaseAdmin
+      .from("route_listings")
+      .insert({
+        created_by: adminId,
+        ...parsed.data,
+      })
+      .select("id")
+      .single();
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ id: data.id }, { status: 201 });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Unknown error";
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/lib/adminAuth.ts
+++ b/src/lib/adminAuth.ts
@@ -1,0 +1,39 @@
+import { NextRequest } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { supabaseAdmin } from "./supabaseAdmin";
+
+const ADMIN_EMAILS = [
+  "contact@bytebitevending.com",
+];
+
+/**
+ * Check if the authenticated user is an admin.
+ * Returns the user ID if admin, null otherwise.
+ */
+export async function getAdminUserId(req: NextRequest): Promise<string | null> {
+  const authHeader = req.headers.get("authorization");
+  if (!authHeader?.startsWith("Bearer ")) return null;
+
+  const token = authHeader.replace("Bearer ", "");
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  );
+
+  const { data: { user }, error } = await supabase.auth.getUser(token);
+  if (error || !user) return null;
+
+  // Check email against admin list
+  if (user.email && ADMIN_EMAILS.includes(user.email.toLowerCase())) {
+    return user.id;
+  }
+
+  return null;
+}
+
+/**
+ * Check admin status by profile ID (for client-side usage via API).
+ */
+export async function isAdminByEmail(email: string): Promise<boolean> {
+  return ADMIN_EMAILS.includes(email.toLowerCase());
+}

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -45,6 +45,24 @@ export const createListingSchema = z.object({
   machine_count_available: z.number().int().min(1).max(1000).default(1),
 });
 
+export const createRouteSchema = z.object({
+  title: z.string().min(5, "Title must be at least 5 characters").max(200),
+  description: z.string().max(5000).optional(),
+  city: z.string().min(1, "City is required").max(100),
+  state: z.string().min(2).max(2, "Use 2-letter state code"),
+  num_machines: z.number().int().min(1).max(10000),
+  num_locations: z.number().int().min(1).max(10000),
+  monthly_revenue: z.number().min(0).max(10000000).optional(),
+  asking_price: z.number().min(0).max(100000000).optional(),
+  machine_types: z.array(z.string()).min(1, "Select at least one machine type"),
+  location_types: z.array(z.string()).default([]),
+  includes_equipment: z.boolean().default(true),
+  includes_contracts: z.boolean().default(true),
+  contact_email: z.string().email().optional().or(z.literal("")),
+  contact_phone: z.string().max(20).optional(),
+  status: z.enum(["active", "sold", "pending"]).default("active"),
+});
+
 export const sendMessageSchema = z.object({
   recipient_id: z.string().uuid(),
   match_id: z.string().uuid().optional(),
@@ -56,4 +74,5 @@ export type SignupInput = z.infer<typeof signupSchema>;
 export type LoginInput = z.infer<typeof loginSchema>;
 export type CreateRequestInput = z.infer<typeof createRequestSchema>;
 export type CreateListingInput = z.infer<typeof createListingSchema>;
+export type CreateRouteInput = z.infer<typeof createRouteSchema>;
 export type SendMessageInput = z.infer<typeof sendMessageSchema>;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -138,6 +138,30 @@ export interface Review {
   reviewer?: Profile;
 }
 
+export interface RouteListing {
+  id: string;
+  created_by: string;
+  title: string;
+  description: string | null;
+  city: string;
+  state: string;
+  num_machines: number;
+  num_locations: number;
+  monthly_revenue: number | null;
+  asking_price: number | null;
+  machine_types: MachineType[];
+  location_types: LocationType[];
+  includes_equipment: boolean;
+  includes_contracts: boolean;
+  contact_email: string | null;
+  contact_phone: string | null;
+  status: "active" | "sold" | "pending";
+  created_at: string;
+  updated_at: string;
+  // Joined
+  profiles?: Profile;
+}
+
 export interface SavedRequest {
   id: string;
   operator_id: string;


### PR DESCRIPTION
- Admin auth gated to contact@bytebitevending.com
- /admin page with 3 tabs: Operator Listings, Location Requests, Routes For Sale
- Admin API routes: POST/GET for /api/admin/operators, /api/admin/requests, /api/admin/routes
- /api/admin/check endpoint for client-side admin verification
- RouteListing type and createRouteSchema for route-for-sale data
- /admin protected by middleware (requires login)
- Non-admin users redirected to /dashboard

Note: The route_listings table must be created in Supabase before adding routes. Operator listings and location requests use existing tables.

https://claude.ai/code/session_01LYhDu2dDFB227i3Le5AZxK