### PR TITLE
Fix admin panel: use API check instead of hardcoded email, fix middle…

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -30,5 +30,5 @@ export async function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/dashboard/:path*", "/messages/:path*", "/post-request/:path*", "/listings/new/:path*", "/admin/:path*"],
+  matcher: ["/dashboard/:path*", "/messages/:path*", "/post-request/:path*", "/listings/new/:path*", "/admin", "/admin/:path*"],
 };


### PR DESCRIPTION
…ware matcher

The navbar admin link was checking profile.email from the profiles table, which may not contain the email field. Now uses /api/admin/check endpoint. Also fixes middleware matcher to cover /admin route (not just /admin/*).

https://claude.ai/code/session_01LYhDu2dDFB227i3Le5AZxK