### PR TITLE
Fix navbar to show logged-in state using session, not just profile

### DIFF
--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -44,6 +44,10 @@ export async function GET(req: NextRequest) {
       full_name: fullName,
       role: meta.role || "requestor",
       avatar_url: meta.avatar_url || meta.picture || null,
+      country: "US",
+      verified: false,
+      rating: 0,
+      review_count: 0,
     };
 
     const { data: created, error: insertError } = await supabaseAdmin


### PR DESCRIPTION
The navbar relied entirely on the profile API succeeding to show the logged-in UI. Now uses the Supabase session directly as the primary auth indicator, with profile data as optional enrichment. Also adds missing required fields (country, verified, rating, review_count) to the auto-create profile to prevent DB insert failures.

https://claude.ai/code/session_01LYhDu2dDFB227i3Le5AZxK