### PR TITLE
Add full admin CRUD panel, user profile editing, and admin API endpoints

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,38 +1,47 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import {
   Shield,
   Building2,
   MapPin,
   Route,
+  Users,
   Plus,
   Loader2,
   CheckCircle2,
   AlertTriangle,
   ChevronDown,
+  Pencil,
+  Trash2,
+  Search,
+  X,
+  BadgeCheck,
+  Eye,
 } from "lucide-react";
 import { createBrowserClient } from "@/lib/supabase";
-import { MACHINE_TYPES, LOCATION_TYPES, URGENCY_OPTIONS, US_STATES } from "@/lib/types";
+import {
+  MACHINE_TYPES,
+  LOCATION_TYPES,
+  URGENCY_OPTIONS,
+  US_STATES,
+} from "@/lib/types";
+import type { Profile, VendingRequest, OperatorListing } from "@/lib/types";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
 /* ------------------------------------------------------------------ */
 
-type Tab = "operators" | "locations" | "routes";
+type Tab = "users" | "operators" | "locations" | "routes";
 
 /* ------------------------------------------------------------------ */
-/*  Multi-select toggle helper                                         */
+/*  Shared helpers                                                     */
 /* ------------------------------------------------------------------ */
 
 function toggle(arr: string[], val: string) {
   return arr.includes(val) ? arr.filter((v) => v !== val) : [...arr, val];
 }
-
-/* ------------------------------------------------------------------ */
-/*  Toast                                                              */
-/* ------------------------------------------------------------------ */
 
 function Toast({
   message,
@@ -43,23 +52,19 @@ function Toast({
 }) {
   return (
     <div
-      className={`toast ${type === "success" ? "toast-success" : "toast-error"}`}
+      className={`fixed bottom-6 right-6 z-50 flex items-center gap-2 rounded-xl px-5 py-3 text-sm font-medium shadow-lg ${
+        type === "success" ? "bg-green-600 text-white" : "bg-red-600 text-white"
+      }`}
     >
-      <div className="flex items-center gap-2">
-        {type === "success" ? (
-          <CheckCircle2 className="h-4 w-4" />
-        ) : (
-          <AlertTriangle className="h-4 w-4" />
-        )}
-        {message}
-      </div>
+      {type === "success" ? (
+        <CheckCircle2 className="h-4 w-4" />
+      ) : (
+        <AlertTriangle className="h-4 w-4" />
+      )}
+      {message}
     </div>
   );
 }
-
-/* ------------------------------------------------------------------ */
-/*  Chip selector                                                      */
-/* ------------------------------------------------------------------ */
 
 function ChipSelect({
   label,
@@ -97,10 +102,6 @@ function ChipSelect({
   );
 }
 
-/* ------------------------------------------------------------------ */
-/*  State selector                                                     */
-/* ------------------------------------------------------------------ */
-
 function StateSelect({
   label,
   selected,
@@ -135,8 +136,946 @@ function StateSelect({
   );
 }
 
+function ConfirmModal({
+  title,
+  message,
+  onConfirm,
+  onCancel,
+  loading,
+}: {
+  title: string;
+  message: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  loading: boolean;
+}) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+      <div className="mx-4 w-full max-w-md rounded-2xl bg-white p-6 shadow-2xl">
+        <h3 className="text-lg font-semibold text-black-primary">{title}</h3>
+        <p className="mt-2 text-sm text-black-primary/60">{message}</p>
+        <div className="mt-6 flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={loading}
+            className="rounded-xl border border-gray-200 px-4 py-2 text-sm font-medium text-black-primary transition-colors hover:bg-gray-50 cursor-pointer"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={loading}
+            className="inline-flex items-center gap-2 rounded-xl bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 disabled:opacity-50 cursor-pointer"
+          >
+            {loading && <Loader2 className="h-4 w-4 animate-spin" />}
+            Delete
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 /* ------------------------------------------------------------------ */
-/*  Operator Listing Form                                              */
+/*  Users Management                                                   */
+/* ------------------------------------------------------------------ */
+
+function UsersManager({ token }: { token: string }) {
+  const [users, setUsers] = useState<Profile[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+  const [roleFilter, setRoleFilter] = useState("");
+  const [editingUser, setEditingUser] = useState<Profile | null>(null);
+  const [editForm, setEditForm] = useState({ role: "", verified: false, full_name: "", email: "" });
+  const [saving, setSaving] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<Profile | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const [total, setTotal] = useState(0);
+
+  const fetchUsers = useCallback(async () => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams();
+      if (search) params.set("search", search);
+      if (roleFilter) params.set("role", roleFilter);
+      params.set("limit", "100");
+      const res = await fetch(`/api/admin/users?${params}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = await res.json();
+      setUsers(data.users || []);
+      setTotal(data.total || 0);
+    } catch {
+      /* noop */
+    } finally {
+      setLoading(false);
+    }
+  }, [token, search, roleFilter]);
+
+  useEffect(() => {
+    fetchUsers();
+  }, [fetchUsers]);
+
+  function openEdit(user: Profile) {
+    setEditingUser(user);
+    setEditForm({
+      role: user.role,
+      verified: user.verified,
+      full_name: user.full_name,
+      email: user.email,
+    });
+  }
+
+  async function handleSaveUser() {
+    if (!editingUser) return;
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/admin/users/${editingUser.id}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(editForm),
+      });
+      if (res.ok) {
+        setEditingUser(null);
+        fetchUsers();
+      }
+    } catch {
+      /* noop */
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDeleteUser() {
+    if (!deleteTarget) return;
+    setDeleting(true);
+    try {
+      await fetch(`/api/admin/users/${deleteTarget.id}`, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      setDeleteTarget(null);
+      fetchUsers();
+    } catch {
+      /* noop */
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  const roleBadge = (role: string) => {
+    const colors: Record<string, string> = {
+      operator: "bg-blue-50 text-blue-700 ring-blue-200",
+      location_manager: "bg-purple-50 text-purple-700 ring-purple-200",
+      requestor: "bg-gray-100 text-gray-700 ring-gray-200",
+    };
+    const labels: Record<string, string> = {
+      operator: "Operator",
+      location_manager: "Location Mgr",
+      requestor: "Requestor",
+    };
+    return (
+      <span
+        className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${
+          colors[role] || colors.requestor
+        }`}
+      >
+        {labels[role] || role}
+      </span>
+    );
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Search & Filter */}
+      <div className="flex flex-col gap-3 sm:flex-row">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-black-primary/30" />
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search by name or email..."
+            className="w-full rounded-xl border border-gray-200 py-2.5 pl-10 pr-4 text-sm focus:border-green-primary focus:outline-none focus:ring-1 focus:ring-green-primary"
+          />
+        </div>
+        <select
+          value={roleFilter}
+          onChange={(e) => setRoleFilter(e.target.value)}
+          className="rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:border-green-primary focus:outline-none focus:ring-1 focus:ring-green-primary"
+        >
+          <option value="">All Roles</option>
+          <option value="operator">Operators</option>
+          <option value="location_manager">Location Managers</option>
+          <option value="requestor">Requestors</option>
+        </select>
+      </div>
+
+      <p className="text-xs text-black-primary/40">{total} user{total !== 1 ? "s" : ""} total</p>
+
+      {/* Users Table */}
+      {loading ? (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="h-6 w-6 animate-spin text-green-primary" />
+        </div>
+      ) : users.length === 0 ? (
+        <p className="py-8 text-center text-sm text-black-primary/40">No users found</p>
+      ) : (
+        <div className="overflow-x-auto rounded-xl border border-gray-100">
+          <table className="w-full text-left text-sm">
+            <thead className="border-b border-gray-100 bg-gray-50/50">
+              <tr>
+                <th className="px-4 py-3 font-medium text-black-primary/60">Name</th>
+                <th className="px-4 py-3 font-medium text-black-primary/60">Email</th>
+                <th className="px-4 py-3 font-medium text-black-primary/60">Role</th>
+                <th className="px-4 py-3 font-medium text-black-primary/60">Verified</th>
+                <th className="px-4 py-3 font-medium text-black-primary/60">Joined</th>
+                <th className="px-4 py-3 font-medium text-black-primary/60">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-50">
+              {users.map((user) => (
+                <tr key={user.id} className="hover:bg-gray-50/50">
+                  <td className="px-4 py-3 font-medium text-black-primary">
+                    {user.full_name}
+                  </td>
+                  <td className="px-4 py-3 text-black-primary/60">{user.email}</td>
+                  <td className="px-4 py-3">{roleBadge(user.role)}</td>
+                  <td className="px-4 py-3">
+                    {user.verified ? (
+                      <BadgeCheck className="h-5 w-5 text-green-500" />
+                    ) : (
+                      <span className="text-xs text-black-primary/30">No</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-black-primary/40 text-xs">
+                    {new Date(user.created_at).toLocaleDateString()}
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-1">
+                      <button
+                        type="button"
+                        onClick={() => openEdit(user)}
+                        className="rounded-lg p-1.5 text-black-primary/40 transition-colors hover:bg-blue-50 hover:text-blue-600 cursor-pointer"
+                        title="Edit"
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setDeleteTarget(user)}
+                        className="rounded-lg p-1.5 text-black-primary/40 transition-colors hover:bg-red-50 hover:text-red-600 cursor-pointer"
+                        title="Delete"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Edit Modal */}
+      {editingUser && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+          <div className="mx-4 w-full max-w-lg rounded-2xl bg-white p-6 shadow-2xl">
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-lg font-semibold text-black-primary">Edit User</h3>
+              <button
+                type="button"
+                onClick={() => setEditingUser(null)}
+                className="rounded-lg p-1 text-black-primary/40 hover:bg-gray-100 cursor-pointer"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+            <div className="space-y-4">
+              <div>
+                <label className="mb-1 block text-sm font-medium text-black-primary">Name</label>
+                <input
+                  type="text"
+                  value={editForm.full_name}
+                  onChange={(e) => setEditForm((f) => ({ ...f, full_name: e.target.value }))}
+                  className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:border-green-primary focus:outline-none focus:ring-1 focus:ring-green-primary"
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-sm font-medium text-black-primary">Email</label>
+                <input
+                  type="email"
+                  value={editForm.email}
+                  onChange={(e) => setEditForm((f) => ({ ...f, email: e.target.value }))}
+                  className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:border-green-primary focus:outline-none focus:ring-1 focus:ring-green-primary"
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-sm font-medium text-black-primary">Role</label>
+                <select
+                  value={editForm.role}
+                  onChange={(e) => setEditForm((f) => ({ ...f, role: e.target.value }))}
+                  className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:border-green-primary focus:outline-none focus:ring-1 focus:ring-green-primary"
+                >
+                  <option value="operator">Operator</option>
+                  <option value="location_manager">Location Manager</option>
+                  <option value="requestor">Requestor</option>
+                </select>
+              </div>
+              <div className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  id="edit_verified"
+                  checked={editForm.verified}
+                  onChange={(e) => setEditForm((f) => ({ ...f, verified: e.target.checked }))}
+                  className="h-4 w-4 rounded border-gray-300"
+                />
+                <label htmlFor="edit_verified" className="text-sm text-black-primary">
+                  Verified
+                </label>
+              </div>
+            </div>
+            <div className="mt-6 flex justify-end gap-3">
+              <button
+                type="button"
+                onClick={() => setEditingUser(null)}
+                className="rounded-xl border border-gray-200 px-4 py-2 text-sm font-medium text-black-primary hover:bg-gray-50 cursor-pointer"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleSaveUser}
+                disabled={saving}
+                className="inline-flex items-center gap-2 rounded-xl bg-green-primary px-4 py-2 text-sm font-medium text-white hover:bg-green-hover disabled:opacity-50 cursor-pointer"
+              >
+                {saving && <Loader2 className="h-4 w-4 animate-spin" />}
+                Save
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Delete Confirm */}
+      {deleteTarget && (
+        <ConfirmModal
+          title="Delete User"
+          message={`Are you sure you want to delete "${deleteTarget.full_name}" (${deleteTarget.email})? This will remove their account and all associated data.`}
+          onConfirm={handleDeleteUser}
+          onCancel={() => setDeleteTarget(null)}
+          loading={deleting}
+        />
+      )}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Listings Management                                                */
+/* ------------------------------------------------------------------ */
+
+type ListingWithProfile = Omit<OperatorListing, "profiles"> & {
+  profiles?: { id: string; full_name: string; email: string };
+};
+
+function ListingsManager({
+  token,
+  onSuccess,
+}: {
+  token: string;
+  onSuccess: (msg: string) => void;
+}) {
+  const [view, setView] = useState<"list" | "add">("list");
+  const [listings, setListings] = useState<ListingWithProfile[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [editingListing, setEditingListing] = useState<ListingWithProfile | null>(null);
+  const [editForm, setEditForm] = useState({ title: "", status: "", featured: false });
+  const [saving, setSaving] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<ListingWithProfile | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  const fetchListings = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/admin/operators", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = await res.json();
+      setListings(data.listings || []);
+    } catch {
+      /* noop */
+    } finally {
+      setLoading(false);
+    }
+  }, [token]);
+
+  useEffect(() => {
+    fetchListings();
+  }, [fetchListings]);
+
+  function openEdit(listing: ListingWithProfile) {
+    setEditingListing(listing);
+    setEditForm({
+      title: listing.title,
+      status: listing.status,
+      featured: listing.featured,
+    });
+  }
+
+  async function handleSave() {
+    if (!editingListing) return;
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/admin/listings/${editingListing.id}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(editForm),
+      });
+      if (res.ok) {
+        setEditingListing(null);
+        fetchListings();
+        onSuccess("Listing updated!");
+      }
+    } catch {
+      /* noop */
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!deleteTarget) return;
+    setDeleting(true);
+    try {
+      await fetch(`/api/admin/listings/${deleteTarget.id}`, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      setDeleteTarget(null);
+      fetchListings();
+      onSuccess("Listing deleted!");
+    } catch {
+      /* noop */
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  const statusBadge = (status: string) => {
+    const colors: Record<string, string> = {
+      available: "bg-green-50 text-green-700 ring-green-200",
+      limited: "bg-amber-50 text-amber-700 ring-amber-200",
+      full: "bg-red-50 text-red-700 ring-red-200",
+    };
+    return (
+      <span
+        className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${
+          colors[status] || "bg-gray-100 text-gray-700 ring-gray-200"
+        }`}
+      >
+        {status}
+      </span>
+    );
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Toggle between list and add */}
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-black-primary">
+          {view === "list" ? "All Operator Listings" : "Add Operator Listing"}
+        </h2>
+        <button
+          type="button"
+          onClick={() => setView(view === "list" ? "add" : "list")}
+          className="inline-flex items-center gap-1.5 rounded-xl border border-gray-200 px-4 py-2 text-sm font-medium text-black-primary transition-colors hover:bg-gray-50 cursor-pointer"
+        >
+          {view === "list" ? (
+            <>
+              <Plus className="h-4 w-4" />
+              Add New
+            </>
+          ) : (
+            <>
+              <Eye className="h-4 w-4" />
+              View All
+            </>
+          )}
+        </button>
+      </div>
+
+      {view === "add" ? (
+        <OperatorForm
+          token={token}
+          onSuccess={(msg) => {
+            onSuccess(msg);
+            setView("list");
+            fetchListings();
+          }}
+        />
+      ) : loading ? (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="h-6 w-6 animate-spin text-green-primary" />
+        </div>
+      ) : listings.length === 0 ? (
+        <p className="py-8 text-center text-sm text-black-primary/40">No listings yet</p>
+      ) : (
+        <div className="overflow-x-auto rounded-xl border border-gray-100">
+          <table className="w-full text-left text-sm">
+            <thead className="border-b border-gray-100 bg-gray-50/50">
+              <tr>
+                <th className="px-4 py-3 font-medium text-black-primary/60">Title</th>
+                <th className="px-4 py-3 font-medium text-black-primary/60">Operator</th>
+                <th className="px-4 py-3 font-medium text-black-primary/60">Machines</th>
+                <th className="px-4 py-3 font-medium text-black-primary/60">Status</th>
+                <th className="px-4 py-3 font-medium text-black-primary/60">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-50">
+              {listings.map((listing) => (
+                <tr key={listing.id} className="hover:bg-gray-50/50">
+                  <td className="px-4 py-3 font-medium text-black-primary max-w-[200px] truncate">
+                    {listing.title}
+                    {listing.featured && (
+                      <span className="ml-1.5 inline-flex items-center rounded-full bg-amber-50 px-1.5 py-0.5 text-[10px] font-medium text-amber-700 ring-1 ring-inset ring-amber-200">
+                        Featured
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-black-primary/60 text-xs">
+                    {listing.profiles?.full_name || "Unknown"}
+                  </td>
+                  <td className="px-4 py-3 text-black-primary/60">
+                    {listing.machine_count_available}
+                  </td>
+                  <td className="px-4 py-3">{statusBadge(listing.status)}</td>
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-1">
+                      <button
+                        type="button"
+                        onClick={() => openEdit(listing)}
+                        className="rounded-lg p-1.5 text-black-primary/40 transition-colors hover:bg-blue-50 hover:text-blue-600 cursor-pointer"
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setDeleteTarget(listing)}
+                        className="rounded-lg p-1.5 text-black-primary/40 transition-colors hover:bg-red-50 hover:text-red-600 cursor-pointer"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Edit Modal */}
+      {editingListing && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+          <div className="mx-4 w-full max-w-lg rounded-2xl bg-white p-6 shadow-2xl">
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-lg font-semibold text-black-primary">Edit Listing</h3>
+              <button
+                type="button"
+                onClick={() => setEditingListing(null)}
+                className="rounded-lg p-1 text-black-primary/40 hover:bg-gray-100 cursor-pointer"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+            <div className="space-y-4">
+              <div>
+                <label className="mb-1 block text-sm font-medium text-black-primary">Title</label>
+                <input
+                  type="text"
+                  value={editForm.title}
+                  onChange={(e) => setEditForm((f) => ({ ...f, title: e.target.value }))}
+                  className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:border-green-primary focus:outline-none focus:ring-1 focus:ring-green-primary"
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-sm font-medium text-black-primary">Status</label>
+                <select
+                  value={editForm.status}
+                  onChange={(e) => setEditForm((f) => ({ ...f, status: e.target.value }))}
+                  className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:border-green-primary focus:outline-none focus:ring-1 focus:ring-green-primary"
+                >
+                  <option value="available">Available</option>
+                  <option value="limited">Limited</option>
+                  <option value="full">Full</option>
+                </select>
+              </div>
+              <div className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  id="edit_featured"
+                  checked={editForm.featured}
+                  onChange={(e) => setEditForm((f) => ({ ...f, featured: e.target.checked }))}
+                  className="h-4 w-4 rounded border-gray-300"
+                />
+                <label htmlFor="edit_featured" className="text-sm text-black-primary">
+                  Featured listing
+                </label>
+              </div>
+            </div>
+            <div className="mt-6 flex justify-end gap-3">
+              <button
+                type="button"
+                onClick={() => setEditingListing(null)}
+                className="rounded-xl border border-gray-200 px-4 py-2 text-sm font-medium text-black-primary hover:bg-gray-50 cursor-pointer"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleSave}
+                disabled={saving}
+                className="inline-flex items-center gap-2 rounded-xl bg-green-primary px-4 py-2 text-sm font-medium text-white hover:bg-green-hover disabled:opacity-50 cursor-pointer"
+              >
+                {saving && <Loader2 className="h-4 w-4 animate-spin" />}
+                Save
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {deleteTarget && (
+        <ConfirmModal
+          title="Delete Listing"
+          message={`Are you sure you want to delete "${deleteTarget.title}"?`}
+          onConfirm={handleDelete}
+          onCancel={() => setDeleteTarget(null)}
+          loading={deleting}
+        />
+      )}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Requests Management                                                */
+/* ------------------------------------------------------------------ */
+
+type RequestWithProfile = Omit<VendingRequest, "profiles"> & {
+  profiles?: { id: string; full_name: string; email: string };
+};
+
+function RequestsManager({
+  token,
+  onSuccess,
+}: {
+  token: string;
+  onSuccess: (msg: string) => void;
+}) {
+  const [view, setView] = useState<"list" | "add">("list");
+  const [requests, setRequests] = useState<RequestWithProfile[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [editingRequest, setEditingRequest] = useState<RequestWithProfile | null>(null);
+  const [editForm, setEditForm] = useState({ title: "", status: "", urgency: "", is_public: true });
+  const [saving, setSaving] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<RequestWithProfile | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  const fetchRequests = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/admin/requests", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = await res.json();
+      setRequests(data.requests || []);
+    } catch {
+      /* noop */
+    } finally {
+      setLoading(false);
+    }
+  }, [token]);
+
+  useEffect(() => {
+    fetchRequests();
+  }, [fetchRequests]);
+
+  function openEdit(request: RequestWithProfile) {
+    setEditingRequest(request);
+    setEditForm({
+      title: request.title,
+      status: request.status,
+      urgency: request.urgency,
+      is_public: request.is_public,
+    });
+  }
+
+  async function handleSave() {
+    if (!editingRequest) return;
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/admin/requests/${editingRequest.id}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(editForm),
+      });
+      if (res.ok) {
+        setEditingRequest(null);
+        fetchRequests();
+        onSuccess("Request updated!");
+      }
+    } catch {
+      /* noop */
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!deleteTarget) return;
+    setDeleting(true);
+    try {
+      await fetch(`/api/admin/requests/${deleteTarget.id}`, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      setDeleteTarget(null);
+      fetchRequests();
+      onSuccess("Request deleted!");
+    } catch {
+      /* noop */
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  const statusBadge = (status: string) => {
+    const colors: Record<string, string> = {
+      open: "bg-green-50 text-green-700 ring-green-200",
+      matched: "bg-blue-50 text-blue-700 ring-blue-200",
+      closed: "bg-gray-100 text-gray-500 ring-gray-200",
+    };
+    return (
+      <span
+        className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${
+          colors[status] || "bg-gray-100 text-gray-700 ring-gray-200"
+        }`}
+      >
+        {status}
+      </span>
+    );
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-black-primary">
+          {view === "list" ? "All Vending Requests" : "Add Location Request"}
+        </h2>
+        <button
+          type="button"
+          onClick={() => setView(view === "list" ? "add" : "list")}
+          className="inline-flex items-center gap-1.5 rounded-xl border border-gray-200 px-4 py-2 text-sm font-medium text-black-primary transition-colors hover:bg-gray-50 cursor-pointer"
+        >
+          {view === "list" ? (
+            <>
+              <Plus className="h-4 w-4" />
+              Add New
+            </>
+          ) : (
+            <>
+              <Eye className="h-4 w-4" />
+              View All
+            </>
+          )}
+        </button>
+      </div>
+
+      {view === "add" ? (
+        <LocationForm
+          token={token}
+          onSuccess={(msg) => {
+            onSuccess(msg);
+            setView("list");
+            fetchRequests();
+          }}
+        />
+      ) : loading ? (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="h-6 w-6 animate-spin text-green-primary" />
+        </div>
+      ) : requests.length === 0 ? (
+        <p className="py-8 text-center text-sm text-black-primary/40">No requests yet</p>
+      ) : (
+        <div className="overflow-x-auto rounded-xl border border-gray-100">
+          <table className="w-full text-left text-sm">
+            <thead className="border-b border-gray-100 bg-gray-50/50">
+              <tr>
+                <th className="px-4 py-3 font-medium text-black-primary/60">Title</th>
+                <th className="px-4 py-3 font-medium text-black-primary/60">Location</th>
+                <th className="px-4 py-3 font-medium text-black-primary/60">Posted By</th>
+                <th className="px-4 py-3 font-medium text-black-primary/60">Status</th>
+                <th className="px-4 py-3 font-medium text-black-primary/60">Urgency</th>
+                <th className="px-4 py-3 font-medium text-black-primary/60">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-50">
+              {requests.map((request) => (
+                <tr key={request.id} className="hover:bg-gray-50/50">
+                  <td className="px-4 py-3 font-medium text-black-primary max-w-[200px] truncate">
+                    {request.title}
+                  </td>
+                  <td className="px-4 py-3 text-black-primary/60 text-xs">
+                    {request.city}, {request.state}
+                  </td>
+                  <td className="px-4 py-3 text-black-primary/60 text-xs">
+                    {request.profiles?.full_name || "Unknown"}
+                  </td>
+                  <td className="px-4 py-3">{statusBadge(request.status)}</td>
+                  <td className="px-4 py-3">
+                    <span className="text-xs text-black-primary/60">
+                      {URGENCY_OPTIONS.find((u) => u.value === request.urgency)?.label || request.urgency}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-1">
+                      <button
+                        type="button"
+                        onClick={() => openEdit(request)}
+                        className="rounded-lg p-1.5 text-black-primary/40 transition-colors hover:bg-blue-50 hover:text-blue-600 cursor-pointer"
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setDeleteTarget(request)}
+                        className="rounded-lg p-1.5 text-black-primary/40 transition-colors hover:bg-red-50 hover:text-red-600 cursor-pointer"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Edit Modal */}
+      {editingRequest && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+          <div className="mx-4 w-full max-w-lg rounded-2xl bg-white p-6 shadow-2xl">
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-lg font-semibold text-black-primary">Edit Request</h3>
+              <button
+                type="button"
+                onClick={() => setEditingRequest(null)}
+                className="rounded-lg p-1 text-black-primary/40 hover:bg-gray-100 cursor-pointer"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+            <div className="space-y-4">
+              <div>
+                <label className="mb-1 block text-sm font-medium text-black-primary">Title</label>
+                <input
+                  type="text"
+                  value={editForm.title}
+                  onChange={(e) => setEditForm((f) => ({ ...f, title: e.target.value }))}
+                  className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:border-green-primary focus:outline-none focus:ring-1 focus:ring-green-primary"
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-sm font-medium text-black-primary">Status</label>
+                <select
+                  value={editForm.status}
+                  onChange={(e) => setEditForm((f) => ({ ...f, status: e.target.value }))}
+                  className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:border-green-primary focus:outline-none focus:ring-1 focus:ring-green-primary"
+                >
+                  <option value="open">Open</option>
+                  <option value="matched">Matched</option>
+                  <option value="closed">Closed</option>
+                </select>
+              </div>
+              <div>
+                <label className="mb-1 block text-sm font-medium text-black-primary">Urgency</label>
+                <select
+                  value={editForm.urgency}
+                  onChange={(e) => setEditForm((f) => ({ ...f, urgency: e.target.value }))}
+                  className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:border-green-primary focus:outline-none focus:ring-1 focus:ring-green-primary"
+                >
+                  {URGENCY_OPTIONS.map((u) => (
+                    <option key={u.value} value={u.value}>
+                      {u.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  id="edit_public"
+                  checked={editForm.is_public}
+                  onChange={(e) => setEditForm((f) => ({ ...f, is_public: e.target.checked }))}
+                  className="h-4 w-4 rounded border-gray-300"
+                />
+                <label htmlFor="edit_public" className="text-sm text-black-primary">
+                  Publicly visible
+                </label>
+              </div>
+            </div>
+            <div className="mt-6 flex justify-end gap-3">
+              <button
+                type="button"
+                onClick={() => setEditingRequest(null)}
+                className="rounded-xl border border-gray-200 px-4 py-2 text-sm font-medium text-black-primary hover:bg-gray-50 cursor-pointer"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleSave}
+                disabled={saving}
+                className="inline-flex items-center gap-2 rounded-xl bg-green-primary px-4 py-2 text-sm font-medium text-white hover:bg-green-hover disabled:opacity-50 cursor-pointer"
+              >
+                {saving && <Loader2 className="h-4 w-4 animate-spin" />}
+                Save
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {deleteTarget && (
+        <ConfirmModal
+          title="Delete Request"
+          message={`Are you sure you want to delete "${deleteTarget.title}"?`}
+          onConfirm={handleDelete}
+          onCancel={() => setDeleteTarget(null)}
+          loading={deleting}
+        />
+      )}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Operator Listing Form (kept from original)                         */
 /* ------------------------------------------------------------------ */
 
 function OperatorForm({
@@ -177,11 +1116,7 @@ function OperatorForm({
 
       const data = await res.json();
       if (!res.ok) {
-        setError(
-          typeof data.error === "string"
-            ? data.error
-            : JSON.stringify(data.error)
-        );
+        setError(typeof data.error === "string" ? data.error : JSON.stringify(data.error));
         return;
       }
 
@@ -211,11 +1146,8 @@ function OperatorForm({
           {error}
         </div>
       )}
-
       <div>
-        <label className="mb-1.5 block text-sm font-medium text-black-primary">
-          Listing Title *
-        </label>
+        <label className="mb-1.5 block text-sm font-medium text-black-primary">Listing Title *</label>
         <input
           type="text"
           value={form.title}
@@ -224,99 +1156,66 @@ function OperatorForm({
           required
         />
       </div>
-
       <div>
-        <label className="mb-1.5 block text-sm font-medium text-black-primary">
-          Description
-        </label>
+        <label className="mb-1.5 block text-sm font-medium text-black-primary">Description</label>
         <textarea
           rows={3}
           value={form.description}
-          onChange={(e) =>
-            setForm((f) => ({ ...f, description: e.target.value }))
-          }
+          onChange={(e) => setForm((f) => ({ ...f, description: e.target.value }))}
           placeholder="Describe the operator's services..."
         />
       </div>
-
       <ChipSelect
         label="Machine Types *"
         options={MACHINE_TYPES}
         selected={form.machine_types}
         onChange={(val) => setForm((f) => ({ ...f, machine_types: val }))}
       />
-
       <div className="grid grid-cols-2 gap-4">
         <div>
-          <label className="mb-1.5 block text-sm font-medium text-black-primary">
-            Machines Available
-          </label>
+          <label className="mb-1.5 block text-sm font-medium text-black-primary">Machines Available</label>
           <input
             type="number"
             min={1}
             max={1000}
             value={form.machine_count_available}
-            onChange={(e) =>
-              setForm((f) => ({
-                ...f,
-                machine_count_available: parseInt(e.target.value) || 1,
-              }))
-            }
+            onChange={(e) => setForm((f) => ({ ...f, machine_count_available: parseInt(e.target.value) || 1 }))}
           />
         </div>
         <div>
-          <label className="mb-1.5 block text-sm font-medium text-black-primary">
-            Service Radius (mi)
-          </label>
+          <label className="mb-1.5 block text-sm font-medium text-black-primary">Service Radius (mi)</label>
           <input
             type="number"
             min={1}
             max={500}
             value={form.service_radius_miles}
-            onChange={(e) =>
-              setForm((f) => ({
-                ...f,
-                service_radius_miles: parseInt(e.target.value) || 50,
-              }))
-            }
+            onChange={(e) => setForm((f) => ({ ...f, service_radius_miles: parseInt(e.target.value) || 50 }))}
           />
         </div>
       </div>
-
       <StateSelect
         label="States Served *"
         selected={form.states_served}
         onChange={(val) => setForm((f) => ({ ...f, states_served: val }))}
       />
-
       <div className="flex items-center gap-2">
         <input
           type="checkbox"
           id="accepts_commission"
           checked={form.accepts_commission}
-          onChange={(e) =>
-            setForm((f) => ({ ...f, accepts_commission: e.target.checked }))
-          }
+          onChange={(e) => setForm((f) => ({ ...f, accepts_commission: e.target.checked }))}
           className="h-4 w-4 rounded border-gray-300"
         />
-        <label
-          htmlFor="accepts_commission"
-          className="text-sm text-black-primary"
-        >
+        <label htmlFor="accepts_commission" className="text-sm text-black-primary">
           Accepts commission-based arrangements
         </label>
       </div>
-
       <button
         type="submit"
         disabled={saving}
         className="inline-flex items-center gap-2 rounded-xl bg-green-primary px-6 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-green-hover disabled:opacity-50 cursor-pointer"
       >
-        {saving ? (
-          <Loader2 className="h-4 w-4 animate-spin" />
-        ) : (
-          <Plus className="h-4 w-4" />
-        )}
+        {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
         Add Operator Listing
       </button>
     </form>
@@ -324,7 +1223,7 @@ function OperatorForm({
 }
 
 /* ------------------------------------------------------------------ */
-/*  Location Request Form                                              */
+/*  Location Request Form (kept from original)                         */
 /* ------------------------------------------------------------------ */
 
 function LocationForm({
@@ -380,11 +1279,7 @@ function LocationForm({
 
       const data = await res.json();
       if (!res.ok) {
-        setError(
-          typeof data.error === "string"
-            ? data.error
-            : JSON.stringify(data.error)
-        );
+        setError(typeof data.error === "string" ? data.error : JSON.stringify(data.error));
         return;
       }
 
@@ -420,11 +1315,8 @@ function LocationForm({
           {error}
         </div>
       )}
-
       <div>
-        <label className="mb-1.5 block text-sm font-medium text-black-primary">
-          Request Title *
-        </label>
+        <label className="mb-1.5 block text-sm font-medium text-black-primary">Request Title *</label>
         <input
           type="text"
           value={form.title}
@@ -433,40 +1325,27 @@ function LocationForm({
           required
         />
       </div>
-
       <div>
-        <label className="mb-1.5 block text-sm font-medium text-black-primary">
-          Location Name *
-        </label>
+        <label className="mb-1.5 block text-sm font-medium text-black-primary">Location Name *</label>
         <input
           type="text"
           value={form.location_name}
-          onChange={(e) =>
-            setForm((f) => ({ ...f, location_name: e.target.value }))
-          }
+          onChange={(e) => setForm((f) => ({ ...f, location_name: e.target.value }))}
           placeholder="e.g. Apex Office Park Building A"
           required
         />
       </div>
-
       <div>
-        <label className="mb-1.5 block text-sm font-medium text-black-primary">
-          Description
-        </label>
+        <label className="mb-1.5 block text-sm font-medium text-black-primary">Description</label>
         <textarea
           rows={3}
           value={form.description}
-          onChange={(e) =>
-            setForm((f) => ({ ...f, description: e.target.value }))
-          }
+          onChange={(e) => setForm((f) => ({ ...f, description: e.target.value }))}
           placeholder="Describe the location and what you're looking for..."
         />
       </div>
-
       <div>
-        <label className="mb-1.5 block text-sm font-medium text-black-primary">
-          Address
-        </label>
+        <label className="mb-1.5 block text-sm font-medium text-black-primary">Address</label>
         <input
           type="text"
           value={form.address}
@@ -474,12 +1353,9 @@ function LocationForm({
           placeholder="123 Main St"
         />
       </div>
-
       <div className="grid grid-cols-3 gap-4">
         <div>
-          <label className="mb-1.5 block text-sm font-medium text-black-primary">
-            City *
-          </label>
+          <label className="mb-1.5 block text-sm font-medium text-black-primary">City *</label>
           <input
             type="text"
             value={form.city}
@@ -488,9 +1364,7 @@ function LocationForm({
           />
         </div>
         <div>
-          <label className="mb-1.5 block text-sm font-medium text-black-primary">
-            State *
-          </label>
+          <label className="mb-1.5 block text-sm font-medium text-black-primary">State *</label>
           <select
             value={form.state}
             onChange={(e) => setForm((f) => ({ ...f, state: e.target.value }))}
@@ -498,16 +1372,12 @@ function LocationForm({
           >
             <option value="">Select</option>
             {US_STATES.map((st) => (
-              <option key={st} value={st}>
-                {st}
-              </option>
+              <option key={st} value={st}>{st}</option>
             ))}
           </select>
         </div>
         <div>
-          <label className="mb-1.5 block text-sm font-medium text-black-primary">
-            ZIP
-          </label>
+          <label className="mb-1.5 block text-sm font-medium text-black-primary">ZIP</label>
           <input
             type="text"
             value={form.zip}
@@ -516,99 +1386,64 @@ function LocationForm({
           />
         </div>
       </div>
-
       <div>
-        <label className="mb-1.5 block text-sm font-medium text-black-primary">
-          Location Type *
-        </label>
+        <label className="mb-1.5 block text-sm font-medium text-black-primary">Location Type *</label>
         <select
           value={form.location_type}
-          onChange={(e) =>
-            setForm((f) => ({ ...f, location_type: e.target.value }))
-          }
+          onChange={(e) => setForm((f) => ({ ...f, location_type: e.target.value }))}
         >
           {LOCATION_TYPES.map((lt) => (
-            <option key={lt.value} value={lt.value}>
-              {lt.label}
-            </option>
+            <option key={lt.value} value={lt.value}>{lt.label}</option>
           ))}
         </select>
       </div>
-
       <ChipSelect
         label="Machine Types Wanted *"
         options={MACHINE_TYPES}
         selected={form.machine_types_wanted}
-        onChange={(val) =>
-          setForm((f) => ({ ...f, machine_types_wanted: val }))
-        }
+        onChange={(val) => setForm((f) => ({ ...f, machine_types_wanted: val }))}
       />
-
       <div className="grid grid-cols-2 gap-4">
         <div>
-          <label className="mb-1.5 block text-sm font-medium text-black-primary">
-            Est. Daily Traffic
-          </label>
+          <label className="mb-1.5 block text-sm font-medium text-black-primary">Est. Daily Traffic</label>
           <input
             type="number"
             min={0}
             max={100000}
             value={form.estimated_daily_traffic}
-            onChange={(e) =>
-              setForm((f) => ({
-                ...f,
-                estimated_daily_traffic: parseInt(e.target.value) || 0,
-              }))
-            }
+            onChange={(e) => setForm((f) => ({ ...f, estimated_daily_traffic: parseInt(e.target.value) || 0 }))}
           />
         </div>
         <div>
-          <label className="mb-1.5 block text-sm font-medium text-black-primary">
-            Urgency
-          </label>
+          <label className="mb-1.5 block text-sm font-medium text-black-primary">Urgency</label>
           <select
             value={form.urgency}
-            onChange={(e) =>
-              setForm((f) => ({ ...f, urgency: e.target.value }))
-            }
+            onChange={(e) => setForm((f) => ({ ...f, urgency: e.target.value }))}
           >
             {URGENCY_OPTIONS.map((u) => (
-              <option key={u.value} value={u.value}>
-                {u.label}
-              </option>
+              <option key={u.value} value={u.value}>{u.label}</option>
             ))}
           </select>
         </div>
       </div>
-
       <div className="flex items-center gap-2">
         <input
           type="checkbox"
           id="commission_offered"
           checked={form.commission_offered}
-          onChange={(e) =>
-            setForm((f) => ({ ...f, commission_offered: e.target.checked }))
-          }
+          onChange={(e) => setForm((f) => ({ ...f, commission_offered: e.target.checked }))}
           className="h-4 w-4 rounded border-gray-300"
         />
-        <label
-          htmlFor="commission_offered"
-          className="text-sm text-black-primary"
-        >
+        <label htmlFor="commission_offered" className="text-sm text-black-primary">
           Commission offered to operator
         </label>
       </div>
-
       <button
         type="submit"
         disabled={saving}
         className="inline-flex items-center gap-2 rounded-xl bg-green-primary px-6 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-green-hover disabled:opacity-50 cursor-pointer"
       >
-        {saving ? (
-          <Loader2 className="h-4 w-4 animate-spin" />
-        ) : (
-          <Plus className="h-4 w-4" />
-        )}
+        {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
         Add Location Request
       </button>
     </form>
@@ -616,7 +1451,7 @@ function LocationForm({
 }
 
 /* ------------------------------------------------------------------ */
-/*  Route For Sale Form                                                */
+/*  Route For Sale Form (kept from original)                           */
 /* ------------------------------------------------------------------ */
 
 function RouteForm({
@@ -671,11 +1506,7 @@ function RouteForm({
 
       const data = await res.json();
       if (!res.ok) {
-        setError(
-          typeof data.error === "string"
-            ? data.error
-            : JSON.stringify(data.error)
-        );
+        setError(typeof data.error === "string" ? data.error : JSON.stringify(data.error));
         return;
       }
 
@@ -711,11 +1542,8 @@ function RouteForm({
           {error}
         </div>
       )}
-
       <div>
-        <label className="mb-1.5 block text-sm font-medium text-black-primary">
-          Route Title *
-        </label>
+        <label className="mb-1.5 block text-sm font-medium text-black-primary">Route Title *</label>
         <input
           type="text"
           value={form.title}
@@ -724,26 +1552,18 @@ function RouteForm({
           required
         />
       </div>
-
       <div>
-        <label className="mb-1.5 block text-sm font-medium text-black-primary">
-          Description
-        </label>
+        <label className="mb-1.5 block text-sm font-medium text-black-primary">Description</label>
         <textarea
           rows={4}
           value={form.description}
-          onChange={(e) =>
-            setForm((f) => ({ ...f, description: e.target.value }))
-          }
+          onChange={(e) => setForm((f) => ({ ...f, description: e.target.value }))}
           placeholder="Describe the route, locations, revenue history, reason for selling..."
         />
       </div>
-
       <div className="grid grid-cols-2 gap-4">
         <div>
-          <label className="mb-1.5 block text-sm font-medium text-black-primary">
-            City *
-          </label>
+          <label className="mb-1.5 block text-sm font-medium text-black-primary">City *</label>
           <input
             type="text"
             value={form.city}
@@ -752,9 +1572,7 @@ function RouteForm({
           />
         </div>
         <div>
-          <label className="mb-1.5 block text-sm font-medium text-black-primary">
-            State *
-          </label>
+          <label className="mb-1.5 block text-sm font-medium text-black-primary">State *</label>
           <select
             value={form.state}
             onChange={(e) => setForm((f) => ({ ...f, state: e.target.value }))}
@@ -762,116 +1580,73 @@ function RouteForm({
           >
             <option value="">Select</option>
             {US_STATES.map((st) => (
-              <option key={st} value={st}>
-                {st}
-              </option>
+              <option key={st} value={st}>{st}</option>
             ))}
           </select>
         </div>
       </div>
-
       <div className="grid grid-cols-2 gap-4">
         <div>
-          <label className="mb-1.5 block text-sm font-medium text-black-primary">
-            Number of Machines *
-          </label>
+          <label className="mb-1.5 block text-sm font-medium text-black-primary">Number of Machines *</label>
           <input
             type="number"
             min={1}
             value={form.num_machines}
-            onChange={(e) =>
-              setForm((f) => ({
-                ...f,
-                num_machines: parseInt(e.target.value) || 1,
-              }))
-            }
+            onChange={(e) => setForm((f) => ({ ...f, num_machines: parseInt(e.target.value) || 1 }))}
           />
         </div>
         <div>
-          <label className="mb-1.5 block text-sm font-medium text-black-primary">
-            Number of Locations *
-          </label>
+          <label className="mb-1.5 block text-sm font-medium text-black-primary">Number of Locations *</label>
           <input
             type="number"
             min={1}
             value={form.num_locations}
-            onChange={(e) =>
-              setForm((f) => ({
-                ...f,
-                num_locations: parseInt(e.target.value) || 1,
-              }))
-            }
+            onChange={(e) => setForm((f) => ({ ...f, num_locations: parseInt(e.target.value) || 1 }))}
           />
         </div>
       </div>
-
       <div className="grid grid-cols-2 gap-4">
         <div>
-          <label className="mb-1.5 block text-sm font-medium text-black-primary">
-            Monthly Revenue ($)
-          </label>
+          <label className="mb-1.5 block text-sm font-medium text-black-primary">Monthly Revenue ($)</label>
           <input
             type="number"
             min={0}
             value={form.monthly_revenue}
-            onChange={(e) =>
-              setForm((f) => ({
-                ...f,
-                monthly_revenue: parseFloat(e.target.value) || 0,
-              }))
-            }
+            onChange={(e) => setForm((f) => ({ ...f, monthly_revenue: parseFloat(e.target.value) || 0 }))}
           />
         </div>
         <div>
-          <label className="mb-1.5 block text-sm font-medium text-black-primary">
-            Asking Price ($)
-          </label>
+          <label className="mb-1.5 block text-sm font-medium text-black-primary">Asking Price ($)</label>
           <input
             type="number"
             min={0}
             value={form.asking_price}
-            onChange={(e) =>
-              setForm((f) => ({
-                ...f,
-                asking_price: parseFloat(e.target.value) || 0,
-              }))
-            }
+            onChange={(e) => setForm((f) => ({ ...f, asking_price: parseFloat(e.target.value) || 0 }))}
           />
         </div>
       </div>
-
       <ChipSelect
         label="Machine Types *"
         options={MACHINE_TYPES}
         selected={form.machine_types}
         onChange={(val) => setForm((f) => ({ ...f, machine_types: val }))}
       />
-
       <ChipSelect
         label="Location Types"
         options={LOCATION_TYPES}
         selected={form.location_types}
         onChange={(val) => setForm((f) => ({ ...f, location_types: val }))}
       />
-
       <div className="flex flex-wrap gap-6">
         <div className="flex items-center gap-2">
           <input
             type="checkbox"
             id="includes_equipment"
             checked={form.includes_equipment}
-            onChange={(e) =>
-              setForm((f) => ({
-                ...f,
-                includes_equipment: e.target.checked,
-              }))
-            }
+            onChange={(e) => setForm((f) => ({ ...f, includes_equipment: e.target.checked }))}
             className="h-4 w-4 rounded border-gray-300"
           />
-          <label
-            htmlFor="includes_equipment"
-            className="text-sm text-black-primary"
-          >
+          <label htmlFor="includes_equipment" className="text-sm text-black-primary">
             Includes equipment
           </label>
         </div>
@@ -880,62 +1655,40 @@ function RouteForm({
             type="checkbox"
             id="includes_contracts"
             checked={form.includes_contracts}
-            onChange={(e) =>
-              setForm((f) => ({
-                ...f,
-                includes_contracts: e.target.checked,
-              }))
-            }
+            onChange={(e) => setForm((f) => ({ ...f, includes_contracts: e.target.checked }))}
             className="h-4 w-4 rounded border-gray-300"
           />
-          <label
-            htmlFor="includes_contracts"
-            className="text-sm text-black-primary"
-          >
+          <label htmlFor="includes_contracts" className="text-sm text-black-primary">
             Includes location contracts
           </label>
         </div>
       </div>
-
       <div className="grid grid-cols-2 gap-4">
         <div>
-          <label className="mb-1.5 block text-sm font-medium text-black-primary">
-            Contact Email
-          </label>
+          <label className="mb-1.5 block text-sm font-medium text-black-primary">Contact Email</label>
           <input
             type="email"
             value={form.contact_email}
-            onChange={(e) =>
-              setForm((f) => ({ ...f, contact_email: e.target.value }))
-            }
+            onChange={(e) => setForm((f) => ({ ...f, contact_email: e.target.value }))}
             placeholder="seller@example.com"
           />
         </div>
         <div>
-          <label className="mb-1.5 block text-sm font-medium text-black-primary">
-            Contact Phone
-          </label>
+          <label className="mb-1.5 block text-sm font-medium text-black-primary">Contact Phone</label>
           <input
             type="tel"
             value={form.contact_phone}
-            onChange={(e) =>
-              setForm((f) => ({ ...f, contact_phone: e.target.value }))
-            }
+            onChange={(e) => setForm((f) => ({ ...f, contact_phone: e.target.value }))}
             placeholder="(555) 123-4567"
           />
         </div>
       </div>
-
       <button
         type="submit"
         disabled={saving}
         className="inline-flex items-center gap-2 rounded-xl bg-green-primary px-6 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-green-hover disabled:opacity-50 cursor-pointer"
       >
-        {saving ? (
-          <Loader2 className="h-4 w-4 animate-spin" />
-        ) : (
-          <Plus className="h-4 w-4" />
-        )}
+        {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
         Add Route Listing
       </button>
     </form>
@@ -951,7 +1704,7 @@ export default function AdminPage() {
   const [loading, setLoading] = useState(true);
   const [isAdmin, setIsAdmin] = useState(false);
   const [token, setToken] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = useState<Tab>("operators");
+  const [activeTab, setActiveTab] = useState<Tab>("users");
   const [toast, setToast] = useState<{
     message: string;
     type: "success" | "error";
@@ -1005,6 +1758,7 @@ export default function AdminPage() {
   if (!isAdmin || !token) return null;
 
   const tabs: { key: Tab; label: string; icon: typeof Building2 }[] = [
+    { key: "users", label: "Users", icon: Users },
     { key: "operators", label: "Operator Listings", icon: Building2 },
     { key: "locations", label: "Location Requests", icon: MapPin },
     { key: "routes", label: "Routes For Sale", icon: Route },
@@ -1014,7 +1768,7 @@ export default function AdminPage() {
     <div className="min-h-[calc(100vh-160px)] bg-light">
       {/* Header */}
       <div className="border-b border-gray-100 bg-white">
-        <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
           <div className="flex items-center gap-3">
             <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-green-50">
               <Shield className="h-6 w-6 text-green-primary" />
@@ -1024,14 +1778,14 @@ export default function AdminPage() {
                 Admin Panel
               </h1>
               <p className="text-sm text-black-primary/50">
-                Add listings, locations, and routes to the platform
+                Manage users, listings, requests, and routes
               </p>
             </div>
           </div>
         </div>
       </div>
 
-      <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
         {/* Tabs */}
         <div className="mb-8 flex gap-1 rounded-xl border border-gray-200 bg-white p-1 shadow-sm">
           {tabs.map((tab) => {
@@ -1054,22 +1808,22 @@ export default function AdminPage() {
           })}
         </div>
 
-        {/* Form Container */}
+        {/* Content */}
         <div className="rounded-2xl border border-gray-100 bg-white p-6 shadow-sm sm:p-8">
-          <h2 className="mb-6 text-lg font-semibold text-black-primary">
-            {activeTab === "operators" && "Add Operator Listing"}
-            {activeTab === "locations" && "Add Location Request"}
-            {activeTab === "routes" && "Add Route For Sale"}
-          </h2>
-
+          {activeTab === "users" && <UsersManager token={token} />}
           {activeTab === "operators" && (
-            <OperatorForm token={token} onSuccess={handleSuccess} />
+            <ListingsManager token={token} onSuccess={handleSuccess} />
           )}
           {activeTab === "locations" && (
-            <LocationForm token={token} onSuccess={handleSuccess} />
+            <RequestsManager token={token} onSuccess={handleSuccess} />
           )}
           {activeTab === "routes" && (
-            <RouteForm token={token} onSuccess={handleSuccess} />
+            <>
+              <h2 className="mb-6 text-lg font-semibold text-black-primary">
+                Add Route For Sale
+              </h2>
+              <RouteForm token={token} onSuccess={handleSuccess} />
+            </>
           )}
         </div>
       </div>

--- a/src/app/api/admin/listings/[id]/route.ts
+++ b/src/app/api/admin/listings/[id]/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+
+/** PATCH /api/admin/listings/[id] — admin updates an operator listing */
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { id } = await params;
+
+  try {
+    const body = await req.json();
+    const allowedFields = [
+      "title", "description", "machine_types", "service_radius_miles",
+      "cities_served", "states_served", "accepts_commission",
+      "min_daily_traffic", "machine_count_available", "status", "featured",
+    ];
+    const updates: Record<string, unknown> = {};
+    for (const field of allowedFields) {
+      if (field in body) updates[field] = body[field];
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return NextResponse.json({ error: "No valid fields to update" }, { status: 400 });
+    }
+
+    const { data, error } = await supabaseAdmin
+      .from("operator_listings")
+      .update(updates)
+      .eq("id", id)
+      .select("*, profiles!operator_id(id, full_name, email)")
+      .single();
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json(data);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Unknown error";
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}
+
+/** DELETE /api/admin/listings/[id] — admin deletes an operator listing */
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { id } = await params;
+
+  const { error } = await supabaseAdmin
+    .from("operator_listings")
+    .delete()
+    .eq("id", id);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/admin/requests/[id]/route.ts
+++ b/src/app/api/admin/requests/[id]/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+
+/** PATCH /api/admin/requests/[id] — admin updates a vending request */
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { id } = await params;
+
+  try {
+    const body = await req.json();
+    const allowedFields = [
+      "title", "description", "location_name", "address", "city", "state",
+      "zip", "location_type", "machine_types_wanted", "estimated_daily_traffic",
+      "commission_offered", "commission_notes", "urgency", "status",
+      "contact_preference", "is_public",
+    ];
+    const updates: Record<string, unknown> = {};
+    for (const field of allowedFields) {
+      if (field in body) updates[field] = body[field];
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return NextResponse.json({ error: "No valid fields to update" }, { status: 400 });
+    }
+
+    const { data, error } = await supabaseAdmin
+      .from("vending_requests")
+      .update(updates)
+      .eq("id", id)
+      .select("*, profiles!created_by(id, full_name, email)")
+      .single();
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json(data);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Unknown error";
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}
+
+/** DELETE /api/admin/requests/[id] — admin deletes a vending request */
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { id } = await params;
+
+  const { error } = await supabaseAdmin
+    .from("vending_requests")
+    .delete()
+    .eq("id", id);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+
+/** PATCH /api/admin/users/[id] — admin updates a user profile */
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { id } = await params;
+
+  try {
+    const body = await req.json();
+    const allowedFields = [
+      "full_name", "email", "role", "company_name", "phone",
+      "website", "bio", "city", "state", "zip", "country",
+      "verified", "avatar_url",
+    ];
+    const updates: Record<string, unknown> = {};
+    for (const field of allowedFields) {
+      if (field in body) updates[field] = body[field];
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return NextResponse.json({ error: "No valid fields to update" }, { status: 400 });
+    }
+
+    const { data, error } = await supabaseAdmin
+      .from("profiles")
+      .update(updates)
+      .eq("id", id)
+      .select("*")
+      .single();
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json(data);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Unknown error";
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}
+
+/** DELETE /api/admin/users/[id] — admin deletes a user */
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { id } = await params;
+
+  // Prevent admin from deleting themselves
+  if (id === adminId) {
+    return NextResponse.json({ error: "Cannot delete your own account" }, { status: 400 });
+  }
+
+  // Delete profile (cascade will handle related data via DB constraints)
+  const { error: profileError } = await supabaseAdmin
+    .from("profiles")
+    .delete()
+    .eq("id", id);
+
+  if (profileError) {
+    return NextResponse.json({ error: profileError.message }, { status: 500 });
+  }
+
+  // Also delete the auth user
+  const { error: authError } = await supabaseAdmin.auth.admin.deleteUser(id);
+  if (authError) {
+    return NextResponse.json({ error: authError.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+
+/** GET /api/admin/users — list all user profiles (admin view) */
+export async function GET(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const url = new URL(req.url);
+  const search = url.searchParams.get("search") || "";
+  const role = url.searchParams.get("role") || "";
+  const limit = Math.min(parseInt(url.searchParams.get("limit") || "50"), 200);
+  const offset = parseInt(url.searchParams.get("offset") || "0");
+
+  let query = supabaseAdmin
+    .from("profiles")
+    .select("*", { count: "exact" })
+    .order("created_at", { ascending: false })
+    .range(offset, offset + limit - 1);
+
+  if (search) {
+    query = query.or(`full_name.ilike.%${search}%,email.ilike.%${search}%`);
+  }
+
+  if (role) {
+    query = query.eq("role", role);
+  }
+
+  const { data, error, count } = await query;
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ users: data || [], total: count || 0 });
+}

--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -213,7 +213,7 @@ export default function Navbar() {
                     Dashboard
                   </Link>
                   <Link
-                    href="/dashboard"
+                    href="/dashboard/profile"
                     onClick={() => setUserMenuOpen(false)}
                     className="flex items-center gap-2 px-4 py-2.5 text-sm text-black-primary transition-colors hover:bg-gray-50"
                   >

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -21,6 +21,7 @@ import {
   Users,
   Clock,
   HandCoins,
+  Settings,
 } from "lucide-react";
 import type {
   Profile,
@@ -285,6 +286,13 @@ export default function DashboardPage() {
                   </>
                 )}
               </span>
+              <Link
+                href="/dashboard/profile"
+                className="inline-flex items-center gap-1.5 rounded-full border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-black-primary/60 transition-colors hover:border-green-200 hover:bg-green-50 hover:text-green-primary"
+              >
+                <Settings className="h-3.5 w-3.5" />
+                Edit Profile
+              </Link>
               <button
                 type="button"
                 onClick={handleSignOut}

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -1,0 +1,361 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import {
+  ArrowLeft,
+  Loader2,
+  CheckCircle2,
+  AlertTriangle,
+  User,
+  Building2,
+  MapPin,
+  Globe,
+  Phone,
+  Mail,
+} from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
+import { US_STATES } from "@/lib/types";
+import type { Profile } from "@/lib/types";
+
+export default function ProfilePage() {
+  const router = useRouter();
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [profile, setProfile] = useState<Profile | null>(null);
+  const [toast, setToast] = useState<{ message: string; type: "success" | "error" } | null>(null);
+
+  const [form, setForm] = useState({
+    full_name: "",
+    company_name: "",
+    phone: "",
+    website: "",
+    bio: "",
+    city: "",
+    state: "",
+    zip: "",
+    role: "" as string,
+  });
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+
+    async function loadProfile() {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session) {
+        router.replace("/login?redirect=/dashboard/profile");
+        return;
+      }
+
+      try {
+        const res = await fetch("/api/auth/me", {
+          headers: { Authorization: `Bearer ${session.access_token}` },
+        });
+        if (!res.ok) {
+          router.replace("/login?redirect=/dashboard/profile");
+          return;
+        }
+        const data: Profile = await res.json();
+        setProfile(data);
+        setForm({
+          full_name: data.full_name || "",
+          company_name: data.company_name || "",
+          phone: data.phone || "",
+          website: data.website || "",
+          bio: data.bio || "",
+          city: data.city || "",
+          state: data.state || "",
+          zip: data.zip || "",
+          role: data.role || "requestor",
+        });
+      } catch {
+        router.replace("/login?redirect=/dashboard/profile");
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    loadProfile();
+  }, [router]);
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    if (!profile) return;
+    setSaving(true);
+    setToast(null);
+
+    try {
+      const supabase = createBrowserClient();
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session) return;
+
+      const res = await fetch("/api/auth/me", {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${session.access_token}`,
+        },
+        body: JSON.stringify({
+          full_name: form.full_name,
+          company_name: form.company_name || null,
+          phone: form.phone || null,
+          website: form.website || null,
+          bio: form.bio || null,
+          city: form.city || null,
+          state: form.state || null,
+          zip: form.zip || null,
+          role: form.role,
+        }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        setToast({ message: data.error || "Failed to save", type: "error" });
+        return;
+      }
+
+      const updated = await res.json();
+      setProfile(updated);
+      setToast({ message: "Profile saved successfully!", type: "success" });
+      setTimeout(() => setToast(null), 3000);
+    } catch {
+      setToast({ message: "Network error. Please try again.", type: "error" });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[calc(100vh-160px)] items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-green-primary" />
+      </div>
+    );
+  }
+
+  if (!profile) return null;
+
+  return (
+    <div className="min-h-[calc(100vh-160px)] bg-light">
+      {/* Header */}
+      <div className="border-b border-gray-100 bg-white">
+        <div className="mx-auto max-w-2xl px-4 py-8 sm:px-6 lg:px-8">
+          <Link
+            href="/dashboard"
+            className="mb-4 inline-flex items-center gap-1.5 text-sm text-black-primary/50 transition-colors hover:text-green-primary"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Back to Dashboard
+          </Link>
+          <div className="flex items-center gap-3">
+            <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-green-50">
+              <User className="h-6 w-6 text-green-primary" />
+            </div>
+            <div>
+              <h1 className="text-2xl font-bold text-black-primary">
+                Edit Profile
+              </h1>
+              <p className="text-sm text-black-primary/50">
+                {profile.email}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="mx-auto max-w-2xl px-4 py-8 sm:px-6 lg:px-8">
+        <form onSubmit={handleSave} className="space-y-6">
+          {/* Personal Info */}
+          <div className="rounded-2xl border border-gray-100 bg-white p-6 shadow-sm">
+            <h2 className="mb-4 text-lg font-semibold text-black-primary">
+              Personal Information
+            </h2>
+            <div className="space-y-4">
+              <div>
+                <label className="mb-1.5 flex items-center gap-1.5 text-sm font-medium text-black-primary">
+                  <User className="h-4 w-4 text-black-primary/40" />
+                  Full Name *
+                </label>
+                <input
+                  type="text"
+                  value={form.full_name}
+                  onChange={(e) => setForm((f) => ({ ...f, full_name: e.target.value }))}
+                  required
+                  className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:border-green-primary focus:outline-none focus:ring-1 focus:ring-green-primary"
+                />
+              </div>
+
+              <div>
+                <label className="mb-1.5 flex items-center gap-1.5 text-sm font-medium text-black-primary">
+                  <Building2 className="h-4 w-4 text-black-primary/40" />
+                  Company Name
+                </label>
+                <input
+                  type="text"
+                  value={form.company_name}
+                  onChange={(e) => setForm((f) => ({ ...f, company_name: e.target.value }))}
+                  placeholder="Optional"
+                  className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:border-green-primary focus:outline-none focus:ring-1 focus:ring-green-primary"
+                />
+              </div>
+
+              <div>
+                <label className="mb-1.5 block text-sm font-medium text-black-primary">
+                  Role
+                </label>
+                <select
+                  value={form.role}
+                  onChange={(e) => setForm((f) => ({ ...f, role: e.target.value }))}
+                  className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:border-green-primary focus:outline-none focus:ring-1 focus:ring-green-primary"
+                >
+                  <option value="operator">Operator</option>
+                  <option value="location_manager">Location Manager</option>
+                  <option value="requestor">Requestor</option>
+                </select>
+              </div>
+
+              <div>
+                <label className="mb-1.5 block text-sm font-medium text-black-primary">
+                  Bio
+                </label>
+                <textarea
+                  rows={3}
+                  value={form.bio}
+                  onChange={(e) => setForm((f) => ({ ...f, bio: e.target.value }))}
+                  placeholder="Tell others about yourself or your business..."
+                  className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:border-green-primary focus:outline-none focus:ring-1 focus:ring-green-primary"
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Contact Info */}
+          <div className="rounded-2xl border border-gray-100 bg-white p-6 shadow-sm">
+            <h2 className="mb-4 text-lg font-semibold text-black-primary">
+              Contact Information
+            </h2>
+            <div className="space-y-4">
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <div>
+                  <label className="mb-1.5 flex items-center gap-1.5 text-sm font-medium text-black-primary">
+                    <Phone className="h-4 w-4 text-black-primary/40" />
+                    Phone
+                  </label>
+                  <input
+                    type="tel"
+                    value={form.phone}
+                    onChange={(e) => setForm((f) => ({ ...f, phone: e.target.value }))}
+                    placeholder="(555) 123-4567"
+                    className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:border-green-primary focus:outline-none focus:ring-1 focus:ring-green-primary"
+                  />
+                </div>
+                <div>
+                  <label className="mb-1.5 flex items-center gap-1.5 text-sm font-medium text-black-primary">
+                    <Globe className="h-4 w-4 text-black-primary/40" />
+                    Website
+                  </label>
+                  <input
+                    type="url"
+                    value={form.website}
+                    onChange={(e) => setForm((f) => ({ ...f, website: e.target.value }))}
+                    placeholder="https://example.com"
+                    className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:border-green-primary focus:outline-none focus:ring-1 focus:ring-green-primary"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Location */}
+          <div className="rounded-2xl border border-gray-100 bg-white p-6 shadow-sm">
+            <h2 className="mb-4 flex items-center gap-1.5 text-lg font-semibold text-black-primary">
+              <MapPin className="h-5 w-5 text-black-primary/40" />
+              Location
+            </h2>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+              <div>
+                <label className="mb-1.5 block text-sm font-medium text-black-primary">
+                  City
+                </label>
+                <input
+                  type="text"
+                  value={form.city}
+                  onChange={(e) => setForm((f) => ({ ...f, city: e.target.value }))}
+                  className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:border-green-primary focus:outline-none focus:ring-1 focus:ring-green-primary"
+                />
+              </div>
+              <div>
+                <label className="mb-1.5 block text-sm font-medium text-black-primary">
+                  State
+                </label>
+                <select
+                  value={form.state}
+                  onChange={(e) => setForm((f) => ({ ...f, state: e.target.value }))}
+                  className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:border-green-primary focus:outline-none focus:ring-1 focus:ring-green-primary"
+                >
+                  <option value="">Select State</option>
+                  {US_STATES.map((st) => (
+                    <option key={st} value={st}>{st}</option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="mb-1.5 block text-sm font-medium text-black-primary">
+                  ZIP Code
+                </label>
+                <input
+                  type="text"
+                  value={form.zip}
+                  onChange={(e) => setForm((f) => ({ ...f, zip: e.target.value }))}
+                  maxLength={10}
+                  className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:border-green-primary focus:outline-none focus:ring-1 focus:ring-green-primary"
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Save Button */}
+          <div className="flex items-center justify-end gap-3">
+            <Link
+              href="/dashboard"
+              className="rounded-xl border border-gray-200 bg-white px-6 py-2.5 text-sm font-medium text-black-primary transition-colors hover:bg-gray-50"
+            >
+              Cancel
+            </Link>
+            <button
+              type="submit"
+              disabled={saving}
+              className="inline-flex items-center gap-2 rounded-xl bg-green-primary px-6 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-green-hover disabled:opacity-50 cursor-pointer"
+            >
+              {saving ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <CheckCircle2 className="h-4 w-4" />
+              )}
+              Save Changes
+            </button>
+          </div>
+        </form>
+      </div>
+
+      {/* Toast */}
+      {toast && (
+        <div
+          className={`fixed bottom-6 right-6 z-50 flex items-center gap-2 rounded-xl px-5 py-3 text-sm font-medium shadow-lg ${
+            toast.type === "success"
+              ? "bg-green-600 text-white"
+              : "bg-red-600 text-white"
+          }`}
+        >
+          {toast.type === "success" ? (
+            <CheckCircle2 className="h-4 w-4" />
+          ) : (
+            <AlertTriangle className="h-4 w-4" />
+          )}
+          {toast.message}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
- Admin panel: Users tab with search/filter, edit role/verified, delete
- Admin panel: Listings tab with list view, edit status/featured, delete
- Admin panel: Requests tab with list view, edit status/urgency, delete
- All tabs include "Add New" forms (preserved from original)
- New API endpoints: /api/admin/users (GET), /api/admin/users/[id] (PATCH, DELETE)
- New API endpoints: /api/admin/listings/[id] (PATCH, DELETE)
- New API endpoints: /api/admin/requests/[id] (PATCH, DELETE)
- User profile edit page at /dashboard/profile
- Dashboard header now links to profile edit page
- Navbar Profile dropdown link fixed to point to /dashboard/profile

https://claude.ai/code/session_01LYhDu2dDFB227i3Le5AZxK