### PR TITLE
Fix form submission crash: field name mismatch and unsafe error rende…

### DIFF
--- a/src/app/listings/new/page.tsx
+++ b/src/app/listings/new/page.tsx
@@ -94,8 +94,12 @@ export default function NewListingPage() {
       });
 
       if (!res.ok) {
-        const data = await res.json();
-        setSubmitError(typeof data.error === "string" ? data.error : "Something went wrong.");
+        try {
+          const data = await res.json();
+          setSubmitError(typeof data.error === "string" ? data.error : "Something went wrong.");
+        } catch {
+          setSubmitError("Something went wrong.");
+        }
         return;
       }
 


### PR DESCRIPTION
…ring

Root cause: The post-request form sent field names that didn't match the API's Zod schema (machine_types vs machine_types_wanted, daily_foot_traffic vs estimated_daily_traffic, etc). The title field was entirely missing. Zod returned field errors as an object, which was set as submitError and rendered via <span>{submitError}</span> — React crashed trying to render a plain object, triggering the error boundary "Something went wrong" page.

Fixes:
- Map all form display values to API enum values (location types, machine types, urgency, contact preference)
- Auto-generate title from location type + location name
- Parse Zod error objects safely, extracting first readable message
- Fix urgency values (2_weeks -> within_2_weeks, 1_month -> within_1_month)
- Fix contact_preference (platform -> platform_message)
- Safe error handling in listings/new page too

https://claude.ai/code/session_01LYhDu2dDFB227i3Le5AZxK