### PR TITLE
Add "Routes for Sale" to header navigation

### DIFF
--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -9,6 +9,7 @@ import type { Profile } from "@/lib/types";
 
 const navLinks = [
   { label: "Browse Requests", href: "/browse-requests" },
+  { label: "Routes for Sale", href: "/routes-for-sale" },
   { label: "Browse Operators", href: "/browse-operators" },
   { label: "How It Works", href: "/how-it-works" },
 ];


### PR DESCRIPTION
Adds Routes for Sale as a top-level nav link in the header, positioned next to Browse Requests for easy access.

https://claude.ai/code/session_01LYhDu2dDFB227i3Le5AZxK