### PR TITLE
Fix 4 QA bugs: requests API 500, contact button, website link, signup…

### DIFF
--- a/src/app/api/requests/route.ts
+++ b/src/app/api/requests/route.ts
@@ -38,82 +38,88 @@ function stripRequestForOperators(request: Record<string, unknown>): Record<stri
 
 /** GET /api/requests — list vending requests with filters */
 export async function GET(req: NextRequest) {
-  const params = req.nextUrl.searchParams;
-  const search = params.get("search");
-  const locationType = params.get("location_type");
-  const state = params.get("state");
-  const urgency = params.get("urgency");
-  const commission = params.get("commission");
-  const status = params.get("status");
-  const machineTypes = params.get("machine_types");
-  const page = Math.max(0, parseInt(params.get("page") || "0"));
-  const mine = params.get("mine");
-  const saved = params.get("saved");
-  const userId = params.get("user_id");
+  try {
+    const params = req.nextUrl.searchParams;
+    const search = params.get("search");
+    const locationType = params.get("location_type");
+    const state = params.get("state");
+    const urgency = params.get("urgency");
+    const commission = params.get("commission");
+    const status = params.get("status");
+    const machineTypes = params.get("machine_types");
+    const page = Math.max(0, parseInt(params.get("page") || "0"));
+    const perPage = Math.min(100, Math.max(1, parseInt(params.get("per_page") || String(PAGE_SIZE))));
+    const mine = params.get("mine");
+    const saved = params.get("saved");
+    const userId = params.get("user_id");
 
-  // Determine if requester is an operator
-  const requesterRole = await getRequesterRole(req);
-  const isOperator = requesterRole === "operator";
+    // Determine if requester is an operator
+    const requesterRole = await getRequesterRole(req);
+    const isOperator = requesterRole === "operator";
 
-  let query = supabaseAdmin
-    .from("vending_requests")
-    .select("*, profiles!created_by(id, full_name, avatar_url, company_name, verified)", { count: "exact" });
+    let query = supabaseAdmin
+      .from("vending_requests")
+      .select("*, profiles(id, full_name, avatar_url, company_name, verified)", { count: "exact" });
 
-  // If requesting own requests, need auth context via header
-  if (mine === "true" && userId) {
-    query = query.eq("created_by", userId);
-  } else if (saved === "true" && userId) {
-    // Get saved request IDs first
-    const { data: savedData } = await supabaseAdmin
-      .from("saved_requests")
-      .select("request_id")
-      .eq("operator_id", userId);
-    const savedIds = savedData?.map((s) => s.request_id) || [];
-    if (savedIds.length === 0) {
-      return NextResponse.json({ requests: [], total: 0 });
-    }
-    query = query.in("id", savedIds);
-  } else {
-    // Public view: only show public requests
-    query = query.eq("is_public", true);
-  }
-
-  if (search) {
-    if (isOperator) {
-      // Operators can only search by state/zip
-      query = query.or(`state.ilike.%${search}%,zip.ilike.%${search}%,title.ilike.%${search}%`);
+    // If requesting own requests, need auth context via header
+    if (mine === "true" && userId) {
+      query = query.eq("created_by", userId);
+    } else if (saved === "true" && userId) {
+      // Get saved request IDs first
+      const { data: savedData } = await supabaseAdmin
+        .from("saved_requests")
+        .select("request_id")
+        .eq("operator_id", userId);
+      const savedIds = savedData?.map((s) => s.request_id) || [];
+      if (savedIds.length === 0) {
+        return NextResponse.json({ requests: [], total: 0 });
+      }
+      query = query.in("id", savedIds);
     } else {
-      query = query.or(`city.ilike.%${search}%,state.ilike.%${search}%,title.ilike.%${search}%,location_name.ilike.%${search}%`);
+      // Public view: only show public requests
+      query = query.eq("is_public", true);
     }
+
+    if (search) {
+      if (isOperator) {
+        // Operators can only search by state/zip
+        query = query.or(`state.ilike.%${search}%,zip.ilike.%${search}%,title.ilike.%${search}%`);
+      } else {
+        query = query.or(`city.ilike.%${search}%,state.ilike.%${search}%,title.ilike.%${search}%,location_name.ilike.%${search}%`);
+      }
+    }
+    if (locationType) query = query.eq("location_type", locationType);
+    if (state) query = query.eq("state", state);
+    if (urgency) query = query.eq("urgency", urgency);
+    if (commission === "true") query = query.eq("commission_offered", true);
+    if (status && status !== "all") query = query.eq("status", status);
+    if (machineTypes) {
+      const types = machineTypes.split(",");
+      query = query.overlaps("machine_types_wanted", types);
+    }
+
+    const from = page * perPage;
+    const to = from + perPage - 1;
+
+    const { data, error, count } = await query
+      .order("created_at", { ascending: false })
+      .range(from, to);
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    // Strip location data for operator accounts
+    let requests = data || [];
+    if (isOperator) {
+      requests = requests.map((r: Record<string, unknown>) => stripRequestForOperators(r));
+    }
+
+    return NextResponse.json({ requests, total: count || 0 });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Unknown error";
+    return NextResponse.json({ error: msg }, { status: 500 });
   }
-  if (locationType) query = query.eq("location_type", locationType);
-  if (state) query = query.eq("state", state);
-  if (urgency) query = query.eq("urgency", urgency);
-  if (commission === "true") query = query.eq("commission_offered", true);
-  if (status && status !== "all") query = query.eq("status", status);
-  if (machineTypes) {
-    const types = machineTypes.split(",");
-    query = query.overlaps("machine_types_wanted", types);
-  }
-
-  const from = page * PAGE_SIZE;
-  const to = from + PAGE_SIZE - 1;
-
-  const { data, error, count } = await query
-    .order("created_at", { ascending: false })
-    .range(from, to);
-
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
-  }
-
-  // Strip location data for operator accounts
-  let requests = data || [];
-  if (isOperator) {
-    requests = requests.map((r: Record<string, unknown>) => stripRequestForOperators(r));
-  }
-
-  return NextResponse.json({ requests, total: count || 0 });
 }
 
 /** POST /api/requests — create a new vending request */

--- a/src/app/browse-operators/page.tsx
+++ b/src/app/browse-operators/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import {
   Search,
   SlidersHorizontal,
@@ -373,7 +374,7 @@ function InlineStarRating({
 }
 
 /** Operator card */
-function OperatorCard({ operator, isSubscribed = false }: { operator: OperatorWithListings; isSubscribed?: boolean }) {
+function OperatorCard({ operator, isSubscribed = false, onContact }: { operator: OperatorWithListings; isSubscribed?: boolean; onContact: (operatorId: string) => void }) {
   const machineTypes = operator.aggregated_machine_types ?? [];
   const cities = operator.aggregated_cities ?? [];
   const states = operator.aggregated_states ?? [];
@@ -462,7 +463,7 @@ function OperatorCard({ operator, isSubscribed = false }: { operator: OperatorWi
           </Link>
           <button
             type="button"
-            onClick={() => alert("Sign up to connect with operators!")}
+            onClick={() => onContact(operator.id)}
             className="inline-flex items-center gap-1 rounded-lg bg-green-primary px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-green-hover"
           >
             <UserPlus className="h-3 w-3" />
@@ -479,6 +480,7 @@ function OperatorCard({ operator, isSubscribed = false }: { operator: OperatorWi
 // ---------------------------------------------------------------------------
 
 export default function BrowseOperatorsPage() {
+  const router = useRouter();
   const { subscribed: isSubscribed } = useSubscription();
 
   // Data state
@@ -655,6 +657,15 @@ export default function BrowseOperatorsPage() {
     setStateFilter("");
     setCommissionFilter(false);
     setRatingFilter("");
+  }
+
+  // ---------- Contact handler ----------
+  function handleContact(operatorId: string) {
+    if (isSubscribed) {
+      router.push(`/operators/${operatorId}`);
+    } else {
+      router.push("/login");
+    }
   }
 
   // ---------- Has more pages ----------
@@ -872,7 +883,7 @@ export default function BrowseOperatorsPage() {
           <>
             <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
               {operators.map((op) => (
-                <OperatorCard key={op.id} operator={op} isSubscribed={isSubscribed} />
+                <OperatorCard key={op.id} operator={op} isSubscribed={isSubscribed} onContact={handleContact} />
               ))}
             </div>
 

--- a/src/app/browse-requests/page.tsx
+++ b/src/app/browse-requests/page.tsx
@@ -273,8 +273,8 @@ export default function BrowseRequestsPage() {
   const [commissionFilter, setCommissionFilter] = useState(false);
   const [statusFilter, setStatusFilter] = useState<string>("all");
 
-  // Pagination
-  const [page, setPage] = useState(1);
+  // Pagination (0-indexed to match API)
+  const [page, setPage] = useState(0);
 
   // Filters panel (mobile toggle)
   const [filtersVisible, setFiltersVisible] = useState(false);
@@ -289,7 +289,7 @@ export default function BrowseRequestsPage() {
 
   // ---------- Reset page when filters change ----------
   useEffect(() => {
-    setPage(1);
+    setPage(0);
   }, [
     debouncedSearch,
     machineTypeFilters,
@@ -361,7 +361,7 @@ export default function BrowseRequestsPage() {
   );
 
   useEffect(() => {
-    fetchRequests(1);
+    fetchRequests(0);
   }, [fetchRequests]);
 
   function handleLoadMore() {

--- a/src/app/operators/[id]/page.tsx
+++ b/src/app/operators/[id]/page.tsx
@@ -477,20 +477,25 @@ export default function OperatorProfilePage() {
 
                   {/* Contact links */}
                   <div className="mt-3 flex flex-wrap items-center justify-center gap-3 sm:justify-start">
-                    {profile.website && (
-                      <a
-                        href={isSubscribed ? profile.website : "#"}
-                        target={isSubscribed ? "_blank" : undefined}
-                        rel="noopener noreferrer"
-                        className="inline-flex items-center gap-1 text-xs text-gray-500 hover:text-green-primary transition-colors"
-                        onClick={!isSubscribed ? (e) => e.preventDefault() : undefined}
-                      >
-                        <Globe className="h-3 w-3" />
-                        <BlurredText isSubscribed={isSubscribed} placeholder="website.com">
-                          Website
-                        </BlurredText>
-                      </a>
-                    )}
+                    {profile.website && (() => {
+                      const websiteUrl = profile.website.match(/^https?:\/\//)
+                        ? profile.website
+                        : `https://${profile.website}`;
+                      return (
+                        <a
+                          href={isSubscribed ? websiteUrl : "#"}
+                          target={isSubscribed ? "_blank" : undefined}
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1 text-xs text-gray-500 hover:text-green-primary transition-colors"
+                          onClick={!isSubscribed ? (e) => e.preventDefault() : undefined}
+                        >
+                          <Globe className="h-3 w-3" />
+                          <BlurredText isSubscribed={isSubscribed} placeholder="website.com">
+                            {profile.website}
+                          </BlurredText>
+                        </a>
+                      );
+                    })()}
                     {profile.phone && (
                       <span className="inline-flex items-center gap-1 text-xs text-gray-500">
                         <Phone className="h-3 w-3" />

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -36,8 +36,12 @@ export default function SignupPage() {
 
   function handleRoleSelect(selected: Role) {
     setRole(selected);
-    setStep(2);
     setError(null);
+  }
+
+  function handleContinue() {
+    if (!role) return;
+    setStep(2);
   }
 
   function handleBack() {
@@ -90,12 +94,19 @@ export default function SignupPage() {
                   key={value}
                   type="button"
                   onClick={() => handleRoleSelect(value)}
-                  className="w-full flex items-start gap-4 p-5 rounded-xl border-2 border-gray-100
-                    hover:border-green-primary hover:bg-light-warm/50 transition-all duration-200
-                    text-left cursor-pointer group"
+                  className={`w-full flex items-start gap-4 p-5 rounded-xl border-2 transition-all duration-200
+                    text-left cursor-pointer group ${
+                      role === value
+                        ? "border-green-primary bg-light-warm/50"
+                        : "border-gray-100 hover:border-green-primary hover:bg-light-warm/50"
+                    }`}
                 >
-                  <div className="flex-shrink-0 w-12 h-12 rounded-xl bg-light-warm flex items-center justify-center
-                    group-hover:bg-green-primary/10 transition-colors">
+                  <div className={`flex-shrink-0 w-12 h-12 rounded-xl flex items-center justify-center
+                    transition-colors ${
+                      role === value
+                        ? "bg-green-primary/10"
+                        : "bg-light-warm group-hover:bg-green-primary/10"
+                    }`}>
                     <Icon className="w-6 h-6 text-green-primary" />
                   </div>
                   <div>
@@ -104,6 +115,17 @@ export default function SignupPage() {
                   </div>
                 </button>
               ))}
+
+              <button
+                type="button"
+                onClick={handleContinue}
+                disabled={!role}
+                className="w-full py-3 px-4 bg-green-primary hover:bg-green-hover text-white
+                  font-semibold rounded-xl transition-colors disabled:opacity-40
+                  disabled:cursor-not-allowed mt-2 cursor-pointer"
+              >
+                Continue
+              </button>
             </div>
           )}
 


### PR DESCRIPTION
… flow

- BUG 1: Fix GET /api/requests returning HTTP 500 by removing ambiguous profiles!created_by join hint, fixing 1-indexed pagination mismatch (browse-requests sent page=1 but API expected 0-indexed), adding per_page param support, and wrapping handler in try/catch
- BUG 2: Fix Contact button on /browse-operators cards that only showed an alert. Now redirects unauthenticated users to /login and subscribed users to the operator's profile page
- BUG 3: Fix website link on /operators/[id] using href="#" by ensuring proper https:// protocol prefix and rendering the actual website URL text instead of generic "Website" label
- BUG 4: Fix signup role selection requiring double-click by separating role highlight from step advancement. Cards now show selected state visually, with an explicit Continue button to advance to Discord auth

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2