### PR TITLE
Fix profile photo saving: cache-busting, path fix, storage policies

### DIFF
--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -117,7 +117,7 @@ export default function ProfilePage() {
     try {
       const supabase = createBrowserClient();
       const ext = avatarFile.name.split(".").pop() || "jpg";
-      const filePath = `avatars/${profile.id}.${ext}`;
+      const filePath = `${profile.id}.${ext}`;
 
       const { error: uploadError } = await supabase.storage
         .from("avatars")
@@ -131,7 +131,8 @@ export default function ProfilePage() {
         .from("avatars")
         .getPublicUrl(filePath);
 
-      return urlData.publicUrl;
+      // Add cache-busting param so browser doesn't serve stale image
+      return `${urlData.publicUrl}?t=${Date.now()}`;
     } catch {
       setToast({ message: "Failed to upload avatar.", type: "error" });
       return profile?.avatar_url || null;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -314,6 +314,41 @@ create trigger set_subscriptions_updated_at
   for each row execute function public.set_updated_at();
 
 -- ============================================================
+-- STORAGE: Avatars bucket
+-- ============================================================
+insert into storage.buckets (id, name, public) values ('avatars', 'avatars', true)
+  on conflict (id) do nothing;
+
+-- Anyone can view avatars (public bucket)
+create policy "Avatar images are publicly accessible"
+  on storage.objects for select using (bucket_id = 'avatars');
+
+-- Authenticated users can upload their own avatar
+create policy "Users can upload own avatar"
+  on storage.objects for insert with check (
+    bucket_id = 'avatars'
+    and auth.role() = 'authenticated'
+    and (storage.foldername(name))[1] is null
+    and starts_with(name, auth.uid()::text)
+  );
+
+-- Authenticated users can update (overwrite) their own avatar
+create policy "Users can update own avatar"
+  on storage.objects for update using (
+    bucket_id = 'avatars'
+    and auth.role() = 'authenticated'
+    and starts_with(name, auth.uid()::text)
+  );
+
+-- Authenticated users can delete their own avatar
+create policy "Users can delete own avatar"
+  on storage.objects for delete using (
+    bucket_id = 'avatars'
+    and auth.role() = 'authenticated'
+    and starts_with(name, auth.uid()::text)
+  );
+
+-- ============================================================
 -- INDEXES
 -- ============================================================
 create index idx_requests_status on public.vending_requests(status);


### PR DESCRIPTION
- Remove redundant `avatars/` prefix in upload path (was storing at avatars/avatars/{id}.ext instead of avatars/{id}.ext)
- Add cache-busting query param to avatar URL so browser doesn't serve stale cached image after re-upload
- Add Supabase storage bucket creation and RLS policies for the avatars bucket to schema.sql

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2