### PR TITLE
Set metadataBase to vendingconnector.com for canonical/OG URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 
 # App
-NEXT_PUBLIC_SITE_URL=http://localhost:3000
+NEXT_PUBLIC_SITE_URL=https://vendingconnector.com
 
 # Apify
 APIFY_API_TOKEN=your-apify-api-token

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,9 @@ import Navbar from "./components/Navbar";
 import Footer from "./components/Footer";
 
 export const metadata: Metadata = {
+  metadataBase: new URL(
+    process.env.NEXT_PUBLIC_SITE_URL || "https://vendingconnector.com"
+  ),
   title: "VendHub — Vending Machine Marketplace",
   description:
     "Connect locations that need vending machines with operators ready to serve. The smarter way to place vending machines.",


### PR DESCRIPTION
- Add metadataBase in root layout so Next.js resolves all metadata URLs (canonical, Open Graph, etc.) against vendingconnector.com instead of the Vercel deployment URL
- Update .env.example to show production domain as the expected value

Note: NEXT_PUBLIC_SITE_URL must also be set to
https://vendingconnector.com in the Vercel environment variables.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2