### PR TITLE
Filter out locations with literal 'Unknown' city/state values

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1020,7 +1020,11 @@ function RequestsManager({
                     {request.title}
                   </td>
                   <td className="px-4 py-3 text-black-primary/60 text-xs">
-                    {request.city}, {request.state}
+                    {request.city && request.state &&
+                      request.city.toLowerCase() !== "unknown" &&
+                      request.state.toLowerCase() !== "unknown"
+                        ? `${request.city}, ${request.state}`
+                        : "—"}
                   </td>
                   <td className="px-4 py-3 text-black-primary/60 text-xs">
                     {request.profiles?.full_name || "Unknown"}
@@ -1775,7 +1779,11 @@ function RoutesManager({
                     {route.title}
                   </td>
                   <td className="px-4 py-3 text-black-primary/60 text-xs">
-                    {route.city}, {route.state}
+                    {route.city && route.state &&
+                      route.city.toLowerCase() !== "unknown" &&
+                      route.state.toLowerCase() !== "unknown"
+                        ? `${route.city}, ${route.state}`
+                        : "—"}
                   </td>
                   <td className="px-4 py-3 text-black-primary/60 text-xs">
                     {route.profiles?.full_name || "Unknown"}

--- a/src/app/api/admin/requests/route.ts
+++ b/src/app/api/admin/requests/route.ts
@@ -14,6 +14,7 @@ export async function GET(req: NextRequest) {
     .from("vending_requests")
     .select("*, profiles!created_by(id, full_name, email)")
     .neq("city", "").neq("state", "").not("city", "is", null).not("state", "is", null)
+    .neq("city", "Unknown").neq("state", "Unknown").neq("city", "unknown").neq("state", "unknown")
     .order("created_at", { ascending: false })
     .limit(50);
 

--- a/src/app/api/admin/routes/route.ts
+++ b/src/app/api/admin/routes/route.ts
@@ -14,6 +14,7 @@ export async function GET(req: NextRequest) {
     .from("route_listings")
     .select("*, profiles!created_by(id, full_name, email)")
     .neq("city", "").neq("state", "").not("city", "is", null).not("state", "is", null)
+    .neq("city", "Unknown").neq("state", "Unknown").neq("city", "unknown").neq("state", "unknown")
     .order("created_at", { ascending: false })
     .limit(50);
 

--- a/src/app/api/matches/route.ts
+++ b/src/app/api/matches/route.ts
@@ -18,6 +18,8 @@ export async function GET(req: NextRequest) {
       .select("*, vending_requests!inner(id, title, city, state, location_type, status, machine_types_wanted)")
       .neq("vending_requests.city", "").neq("vending_requests.state", "")
       .not("vending_requests.city", "is", null).not("vending_requests.state", "is", null)
+      .neq("vending_requests.city", "Unknown").neq("vending_requests.state", "Unknown")
+      .neq("vending_requests.city", "unknown").neq("vending_requests.state", "unknown")
       .eq("operator_id", userId)
       .order("created_at", { ascending: false });
 

--- a/src/app/api/requests/[id]/route.ts
+++ b/src/app/api/requests/[id]/route.ts
@@ -33,6 +33,7 @@ export async function GET(
     .select("*, profiles!created_by(id, full_name, avatar_url, company_name, verified, city, state, rating, review_count)")
     .eq("id", id)
     .neq("city", "").neq("state", "").not("city", "is", null).not("state", "is", null)
+    .neq("city", "Unknown").neq("state", "Unknown").neq("city", "unknown").neq("state", "unknown")
     .single();
 
   if (error || !data) {

--- a/src/app/api/requests/route.ts
+++ b/src/app/api/requests/route.ts
@@ -80,8 +80,12 @@ export async function GET(req: NextRequest) {
       query = query.eq("is_public", true);
     }
 
-    // Exclude locations with missing city or state
-    query = query.neq("city", "").neq("state", "").not("city", "is", null).not("state", "is", null);
+    // Exclude locations with missing or unknown city/state
+    query = query
+      .neq("city", "").neq("state", "")
+      .not("city", "is", null).not("state", "is", null)
+      .neq("city", "Unknown").neq("state", "Unknown")
+      .neq("city", "unknown").neq("state", "unknown");
 
     if (search) {
       if (isOperator) {

--- a/src/app/api/routes/route.ts
+++ b/src/app/api/routes/route.ts
@@ -56,8 +56,12 @@ export async function GET(req: NextRequest) {
     .select("*, profiles!created_by(id, full_name, avatar_url, company_name, verified)", { count: "exact" })
     .eq("status", "active");
 
-  // Exclude locations with missing city or state
-  query = query.neq("city", "").neq("state", "").not("city", "is", null).not("state", "is", null);
+  // Exclude locations with missing or unknown city/state
+  query = query
+    .neq("city", "").neq("state", "")
+    .not("city", "is", null).not("state", "is", null)
+    .neq("city", "Unknown").neq("state", "Unknown")
+    .neq("city", "unknown").neq("state", "unknown");
 
   if (search) {
     query = query.or(`city.ilike.%${search}%,state.ilike.%${search}%,title.ilike.%${search}%`);

--- a/src/app/components/RequestCard.tsx
+++ b/src/app/components/RequestCard.tsx
@@ -50,14 +50,16 @@ export default function RequestCard({
             <h3 className="font-semibold text-black-primary text-base leading-snug truncate">
               {request.title}
             </h3>
-            <div className="flex items-center gap-1 mt-0.5 text-sm text-gray-500">
-              <MapPin className="w-3.5 h-3.5 shrink-0" />
-              <span className="truncate">
-                {request.city ? `${request.city}, ` : ""}
-                {request.zip ? `${request.zip}, ` : ""}
-                {request.state}
-              </span>
-            </div>
+            {request.city && request.state &&
+              request.city.toLowerCase() !== "unknown" &&
+              request.state.toLowerCase() !== "unknown" && (
+              <div className="flex items-center gap-1 mt-0.5 text-sm text-gray-500">
+                <MapPin className="w-3.5 h-3.5 shrink-0" />
+                <span className="truncate">
+                  {request.city}, {request.zip ? `${request.zip}, ` : ""}{request.state}
+                </span>
+              </div>
+            )}
           </div>
         </div>
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -478,12 +478,16 @@ export default function DashboardPage() {
                       <h3 className="font-semibold text-black-primary text-sm leading-snug line-clamp-2 group-hover:text-green-primary transition-colors">
                         {req.title}
                       </h3>
-                      <div className="flex items-center gap-1 mt-1 text-xs text-gray-500">
-                        <MapPin className="w-3 h-3 shrink-0" />
-                        <span className="truncate">
-                          {req.city}, {req.state}
-                        </span>
-                      </div>
+                      {req.city && req.state &&
+                        req.city.toLowerCase() !== "unknown" &&
+                        req.state.toLowerCase() !== "unknown" && (
+                        <div className="flex items-center gap-1 mt-1 text-xs text-gray-500">
+                          <MapPin className="w-3 h-3 shrink-0" />
+                          <span className="truncate">
+                            {req.city}, {req.state}
+                          </span>
+                        </div>
+                      )}
                     </div>
                   </div>
 

--- a/src/app/routes-for-sale/page.tsx
+++ b/src/app/routes-for-sale/page.tsx
@@ -63,10 +63,14 @@ function RouteCard({ route }: { route: RouteListing }) {
       </h3>
 
       {/* Location */}
-      <div className="flex items-center gap-1 mt-1.5 text-sm text-gray-500">
-        <MapPin className="w-3.5 h-3.5 shrink-0" />
-        <span>{route.city}, {route.state}</span>
-      </div>
+      {route.city && route.state &&
+        route.city.toLowerCase() !== "unknown" &&
+        route.state.toLowerCase() !== "unknown" && (
+        <div className="flex items-center gap-1 mt-1.5 text-sm text-gray-500">
+          <MapPin className="w-3.5 h-3.5 shrink-0" />
+          <span>{route.city}, {route.state}</span>
+        </div>
+      )}
 
       {/* Stats grid */}
       <div className="mt-4 grid grid-cols-2 gap-3">


### PR DESCRIPTION
- Add .neq("city","Unknown") and .neq("state","Unknown") filters to all 6 API endpoints (requests, requests/[id], routes, matches, admin/requests, admin/routes)
- Add frontend guards in RequestCard, dashboard, admin, and routes-for-sale pages to hide location display when city/state is missing or "Unknown"

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2