### PR TITLE
Fix search icon overlapping placeholder text on Routes for Sale page

### DIFF
--- a/src/app/routes-for-sale/page.tsx
+++ b/src/app/routes-for-sale/page.tsx
@@ -224,13 +224,13 @@ export default function RoutesForSalePage() {
           {/* Search */}
           <div className="mx-auto mt-8 max-w-2xl">
             <div className="relative">
-              <Search className="pointer-events-none absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-gray-400" />
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
               <input
                 type="text"
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 placeholder="Search by city, state, or title..."
-                className="w-full rounded-xl border border-gray-200 bg-white py-3 pl-12 pr-10 text-sm shadow-sm placeholder:text-gray-400 focus:border-green-primary focus:ring-2 focus:ring-green-primary/20"
+                className="w-full rounded-xl border border-gray-200 bg-white py-3 pl-9 pr-10 text-sm shadow-sm placeholder:text-gray-400 focus:border-green-primary focus:ring-2 focus:ring-green-primary/20"
               />
               {search && (
                 <button


### PR DESCRIPTION
Reduced icon size from h-5/w-5 to h-4/w-4 and adjusted positioning (left-3 instead of left-4) with matching input padding (pl-9 instead of pl-12) so the magnifying glass no longer covers the text.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2