### PR TITLE
Fix search icon overlap: global CSS padding was overriding Tailwind pl-9

### DIFF
--- a/src/app/browse-operators/page.tsx
+++ b/src/app/browse-operators/page.tsx
@@ -703,7 +703,7 @@ export default function BrowseOperatorsPage() {
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 placeholder="Search operators by name, city, state..."
-                className="w-full rounded-xl border border-gray-200 bg-white py-3 pl-9 pr-10 text-sm shadow-sm placeholder:text-gray-400 focus:border-green-primary focus:ring-2 focus:ring-green-primary/20"
+                className="w-full rounded-xl border border-gray-200 bg-white py-3 !pl-9 pr-10 text-sm shadow-sm placeholder:text-gray-400 focus:border-green-primary focus:ring-2 focus:ring-green-primary/20"
               />
               {search && (
                 <button

--- a/src/app/browse-requests/page.tsx
+++ b/src/app/browse-requests/page.tsx
@@ -428,7 +428,7 @@ export default function BrowseRequestsPage() {
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 placeholder="Search by city, state, or location type..."
-                className="w-full rounded-xl border border-gray-200 bg-white py-3 pl-9 pr-10 text-sm shadow-sm placeholder:text-gray-400 focus:border-green-primary focus:ring-2 focus:ring-green-primary/20"
+                className="w-full rounded-xl border border-gray-200 bg-white py-3 !pl-9 pr-10 text-sm shadow-sm placeholder:text-gray-400 focus:border-green-primary focus:ring-2 focus:ring-green-primary/20"
               />
               {search && (
                 <button

--- a/src/app/routes-for-sale/page.tsx
+++ b/src/app/routes-for-sale/page.tsx
@@ -230,7 +230,7 @@ export default function RoutesForSalePage() {
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 placeholder="Search by city, state, or title..."
-                className="w-full rounded-xl border border-gray-200 bg-white py-3 pl-9 pr-10 text-sm shadow-sm placeholder:text-gray-400 focus:border-green-primary focus:ring-2 focus:ring-green-primary/20"
+                className="w-full rounded-xl border border-gray-200 bg-white py-3 !pl-9 pr-10 text-sm shadow-sm placeholder:text-gray-400 focus:border-green-primary focus:ring-2 focus:ring-green-primary/20"
               />
               {search && (
                 <button


### PR DESCRIPTION
The global `padding: 0.625rem 0.875rem` on input[type="text"] in globals.css was overriding the Tailwind padding-left class. Added !important via Tailwind's `!pl-9` to ensure the search inputs have enough left padding to clear the magnifying glass icon.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2