### PR TITLE
Add user-driven Machines for Sale marketplace

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -47,7 +47,8 @@ type Tab =
   | "agreements"
   | "sales_results"
   | "machines"
-  | "machine_orders";
+  | "machine_orders"
+  | "machine_listings";
 
 const inputClass =
   "w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:border-green-primary focus:outline-none focus:ring-1 focus:ring-green-primary";
@@ -3647,6 +3648,429 @@ function MachinesManager({
 }
 
 /* ------------------------------------------------------------------ */
+/*  Machine Listings Manager (User-submitted used machines)            */
+/* ------------------------------------------------------------------ */
+
+interface MachineListingRow {
+  id: string;
+  title: string;
+  description: string | null;
+  city: string;
+  state: string;
+  machine_make: string | null;
+  machine_model: string | null;
+  machine_year: number | null;
+  machine_type: string | null;
+  condition: string | null;
+  quantity: number;
+  asking_price: number | null;
+  includes_card_reader: boolean;
+  includes_install: boolean;
+  includes_delivery: boolean;
+  photos: string[];
+  contact_email: string | null;
+  contact_phone: string | null;
+  status: string;
+  admin_notes: string | null;
+  created_at: string;
+  profiles?: { id: string; full_name: string; email: string } | null;
+}
+
+function MachineListingsManager({
+  token,
+  onSuccess,
+}: {
+  token: string;
+  onSuccess: (msg: string) => void;
+}) {
+  const [listings, setListings] = useState<MachineListingRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [editing, setEditing] = useState<MachineListingRow | null>(null);
+  const [editForm, setEditForm] = useState({
+    title: "",
+    status: "",
+    asking_price: "",
+    admin_notes: "",
+  });
+  const [saving, setSaving] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<MachineListingRow | null>(
+    null
+  );
+  const [deleting, setDeleting] = useState(false);
+
+  const fetchListings = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/admin/machine-listings", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = await res.json();
+      setListings(data.listings || []);
+    } catch {
+      /* noop */
+    } finally {
+      setLoading(false);
+    }
+  }, [token]);
+
+  useEffect(() => {
+    fetchListings();
+  }, [fetchListings]);
+
+  function openEdit(listing: MachineListingRow) {
+    setEditing(listing);
+    setEditForm({
+      title: listing.title,
+      status: listing.status,
+      asking_price:
+        listing.asking_price != null ? String(listing.asking_price) : "",
+      admin_notes: listing.admin_notes || "",
+    });
+  }
+
+  async function handleSave() {
+    if (!editing) return;
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/admin/machine-listings/${editing.id}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          title: editForm.title,
+          status: editForm.status,
+          asking_price: editForm.asking_price
+            ? Number(editForm.asking_price)
+            : null,
+          admin_notes: editForm.admin_notes || null,
+        }),
+      });
+      if (res.ok) {
+        setEditing(null);
+        fetchListings();
+        onSuccess("Listing updated!");
+      }
+    } catch {
+      /* noop */
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleApprove(listing: MachineListingRow) {
+    try {
+      const res = await fetch(`/api/admin/machine-listings/${listing.id}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ status: "active" }),
+      });
+      if (res.ok) {
+        fetchListings();
+        onSuccess("Listing approved and now visible to buyers!");
+      }
+    } catch {
+      /* noop */
+    }
+  }
+
+  async function handleReject(listing: MachineListingRow) {
+    try {
+      const res = await fetch(`/api/admin/machine-listings/${listing.id}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ status: "rejected" }),
+      });
+      if (res.ok) {
+        fetchListings();
+        onSuccess("Listing rejected.");
+      }
+    } catch {
+      /* noop */
+    }
+  }
+
+  async function handleDelete() {
+    if (!deleteTarget) return;
+    setDeleting(true);
+    try {
+      await fetch(`/api/admin/machine-listings/${deleteTarget.id}`, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      setDeleteTarget(null);
+      fetchListings();
+      onSuccess("Listing deleted!");
+    } catch {
+      /* noop */
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  const statusBadge = (status: string) => {
+    const colors: Record<string, string> = {
+      active: "bg-green-50 text-green-700 ring-green-200",
+      pending: "bg-amber-50 text-amber-700 ring-amber-200",
+      sold: "bg-gray-100 text-gray-500 ring-gray-200",
+      rejected: "bg-red-50 text-red-700 ring-red-200",
+    };
+    return (
+      <span
+        className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${
+          colors[status] || "bg-gray-100 text-gray-700 ring-gray-200"
+        }`}
+      >
+        {status}
+      </span>
+    );
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-black-primary">
+          User-Submitted Machines
+        </h2>
+        <p className="text-xs text-black-primary/50">
+          Moderate operator-listed machines on /machines-for-sale
+        </p>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="h-6 w-6 animate-spin text-green-primary" />
+        </div>
+      ) : listings.length === 0 ? (
+        <p className="py-8 text-center text-sm text-black-primary/40">
+          No machine listings yet
+        </p>
+      ) : (
+        <div className="overflow-x-auto rounded-xl border border-gray-100">
+          <table className="w-full text-left text-sm">
+            <thead className="border-b border-gray-100 bg-gray-50/50">
+              <tr>
+                <th className="px-4 py-3 font-medium text-black-primary/60">
+                  Title
+                </th>
+                <th className="px-4 py-3 font-medium text-black-primary/60">
+                  Location
+                </th>
+                <th className="px-4 py-3 font-medium text-black-primary/60">
+                  Submitted By
+                </th>
+                <th className="px-4 py-3 font-medium text-black-primary/60">
+                  Price
+                </th>
+                <th className="px-4 py-3 font-medium text-black-primary/60">
+                  Status
+                </th>
+                <th className="px-4 py-3 font-medium text-black-primary/60">
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-50">
+              {listings.map((listing) => (
+                <tr key={listing.id} className="hover:bg-gray-50/50">
+                  <td className="px-4 py-3 font-medium text-black-primary max-w-[200px] truncate">
+                    {listing.title}
+                    {listing.machine_make || listing.machine_model ? (
+                      <div className="text-xs font-normal text-black-primary/50 truncate">
+                        {[listing.machine_make, listing.machine_model]
+                          .filter(Boolean)
+                          .join(" ")}
+                      </div>
+                    ) : null}
+                  </td>
+                  <td className="px-4 py-3 text-black-primary/60 text-xs">
+                    {listing.city && listing.state
+                      ? `${listing.city}, ${listing.state}`
+                      : "—"}
+                  </td>
+                  <td className="px-4 py-3 text-black-primary/60 text-xs">
+                    {listing.profiles?.full_name || "Unknown"}
+                  </td>
+                  <td className="px-4 py-3 text-black-primary/60 text-xs">
+                    {listing.asking_price
+                      ? `$${listing.asking_price.toLocaleString()}`
+                      : "—"}
+                  </td>
+                  <td className="px-4 py-3">{statusBadge(listing.status)}</td>
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-1">
+                      {listing.status === "pending" && (
+                        <>
+                          <button
+                            type="button"
+                            onClick={() => handleApprove(listing)}
+                            className="rounded-lg p-1.5 text-black-primary/40 transition-colors hover:bg-green-50 hover:text-green-600 cursor-pointer"
+                            title="Approve"
+                          >
+                            <CheckCircle2 className="h-4 w-4" />
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => handleReject(listing)}
+                            className="rounded-lg p-1.5 text-black-primary/40 transition-colors hover:bg-red-50 hover:text-red-600 cursor-pointer"
+                            title="Reject"
+                          >
+                            <X className="h-4 w-4" />
+                          </button>
+                        </>
+                      )}
+                      <button
+                        type="button"
+                        onClick={() => openEdit(listing)}
+                        className="rounded-lg p-1.5 text-black-primary/40 transition-colors hover:bg-blue-50 hover:text-blue-600 cursor-pointer"
+                        title="Edit"
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setDeleteTarget(listing)}
+                        className="rounded-lg p-1.5 text-black-primary/40 transition-colors hover:bg-red-50 hover:text-red-600 cursor-pointer"
+                        title="Delete"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Edit Modal */}
+      {editing && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+          <div className="mx-4 w-full max-w-lg rounded-2xl bg-white p-6 shadow-2xl">
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-lg font-semibold text-black-primary">
+                Edit Machine Listing
+              </h3>
+              <button
+                type="button"
+                onClick={() => setEditing(null)}
+                className="rounded-lg p-1 text-black-primary/40 hover:bg-gray-100 cursor-pointer"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+            <div className="space-y-4">
+              <div>
+                <label className="mb-1 block text-sm font-medium text-black-primary">
+                  Title
+                </label>
+                <input
+                  type="text"
+                  value={editForm.title}
+                  onChange={(e) =>
+                    setEditForm((f) => ({ ...f, title: e.target.value }))
+                  }
+                  className={inputClass}
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-sm font-medium text-black-primary">
+                  Status
+                </label>
+                <select
+                  value={editForm.status}
+                  onChange={(e) =>
+                    setEditForm((f) => ({ ...f, status: e.target.value }))
+                  }
+                  className={inputClass}
+                >
+                  <option value="pending">Pending</option>
+                  <option value="active">Active (Approved)</option>
+                  <option value="sold">Sold</option>
+                  <option value="rejected">Rejected</option>
+                </select>
+              </div>
+              <div>
+                <label className="mb-1 block text-sm font-medium text-black-primary">
+                  Asking Price ($)
+                </label>
+                <input
+                  type="number"
+                  min="0"
+                  step="1"
+                  value={editForm.asking_price}
+                  onChange={(e) =>
+                    setEditForm((f) => ({
+                      ...f,
+                      asking_price: e.target.value,
+                    }))
+                  }
+                  placeholder="e.g. 2500"
+                  className={inputClass}
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-sm font-medium text-black-primary">
+                  Admin Notes
+                </label>
+                <textarea
+                  rows={3}
+                  value={editForm.admin_notes}
+                  onChange={(e) =>
+                    setEditForm((f) => ({
+                      ...f,
+                      admin_notes: e.target.value,
+                    }))
+                  }
+                  placeholder="Internal notes (not visible to users)"
+                  className={inputClass}
+                />
+              </div>
+            </div>
+            <div className="mt-6 flex justify-end gap-3">
+              <button
+                type="button"
+                onClick={() => setEditing(null)}
+                className="rounded-xl border border-gray-200 px-4 py-2 text-sm font-medium text-black-primary hover:bg-gray-50 cursor-pointer"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleSave}
+                disabled={saving}
+                className="inline-flex items-center gap-2 rounded-xl bg-green-primary px-4 py-2 text-sm font-medium text-white hover:bg-green-hover disabled:opacity-50 cursor-pointer"
+              >
+                {saving && <Loader2 className="h-4 w-4 animate-spin" />}
+                Save
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {deleteTarget && (
+        <ConfirmModal
+          title="Delete Listing"
+          message={`Are you sure you want to delete "${deleteTarget.title}"?`}
+          onConfirm={handleDelete}
+          onCancel={() => setDeleteTarget(null)}
+          loading={deleting}
+        />
+      )}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
 /*  Machine Orders Manager                                             */
 /* ------------------------------------------------------------------ */
 
@@ -4088,6 +4512,7 @@ export default function AdminPage() {
     { key: "agreements", label: "Signed Agreements", icon: ScrollText },
     { key: "sales_results", label: "Sales Results", icon: TrendingUp },
     { key: "machines", label: "Machines Catalog", icon: Package },
+    { key: "machine_listings", label: "Machines For Sale", icon: Package },
     { key: "machine_orders", label: "Machine Orders", icon: ShoppingBag },
   ];
 
@@ -4165,6 +4590,9 @@ export default function AdminPage() {
           )}
           {activeTab === "machines" && (
             <MachinesManager token={token} onSuccess={handleSuccess} />
+          )}
+          {activeTab === "machine_listings" && (
+            <MachineListingsManager token={token} onSuccess={handleSuccess} />
           )}
           {activeTab === "machine_orders" && (
             <MachineOrdersManager token={token} />

--- a/src/app/api/admin/machine-listings/[id]/route.ts
+++ b/src/app/api/admin/machine-listings/[id]/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+
+/** PATCH /api/admin/machine-listings/[id] — admin updates a machine listing */
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { id } = await params;
+
+  try {
+    const body = await req.json();
+    const allowedFields = [
+      "title",
+      "description",
+      "city",
+      "state",
+      "machine_make",
+      "machine_model",
+      "machine_year",
+      "machine_type",
+      "condition",
+      "quantity",
+      "asking_price",
+      "includes_card_reader",
+      "includes_install",
+      "includes_delivery",
+      "photos",
+      "contact_email",
+      "contact_phone",
+      "status",
+      "admin_notes",
+    ];
+    const updates: Record<string, unknown> = {};
+    for (const field of allowedFields) {
+      if (field in body) updates[field] = body[field];
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return NextResponse.json(
+        { error: "No valid fields to update" },
+        { status: 400 }
+      );
+    }
+
+    const { data, error } = await supabaseAdmin
+      .from("machine_listings")
+      .update(updates)
+      .eq("id", id)
+      .select("*, profiles!created_by(id, full_name, email)")
+      .single();
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json(data);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Unknown error";
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}
+
+/** DELETE /api/admin/machine-listings/[id] — admin deletes a machine listing */
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { id } = await params;
+
+  const { error } = await supabaseAdmin
+    .from("machine_listings")
+    .delete()
+    .eq("id", id);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/admin/machine-listings/route.ts
+++ b/src/app/api/admin/machine-listings/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { createMachineListingSchema } from "@/lib/schemas";
+import { getAdminUserId } from "@/lib/adminAuth";
+
+/** GET /api/admin/machine-listings — list all machine listings */
+export async function GET(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from("machine_listings")
+    .select("*, profiles!created_by(id, full_name, email)")
+    .order("created_at", { ascending: false })
+    .limit(200);
+
+  if (error) {
+    // Table may not exist yet — return empty
+    return NextResponse.json({ listings: [], note: error.message });
+  }
+
+  return NextResponse.json({ listings: data || [] });
+}
+
+/** POST /api/admin/machine-listings — admin creates a machine listing */
+export async function POST(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  try {
+    const body = await req.json();
+    const parsed = createMachineListingSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.flatten().fieldErrors },
+        { status: 400 }
+      );
+    }
+
+    const { data, error } = await supabaseAdmin
+      .from("machine_listings")
+      .insert({
+        created_by: adminId,
+        ...parsed.data,
+      })
+      .select("id")
+      .single();
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ id: data.id }, { status: 201 });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Unknown error";
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/api/machine-listings/[id]/route.ts
+++ b/src/app/api/machine-listings/[id]/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+
+/** GET /api/machine-listings/[id] — fetch a single machine listing by ID */
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  if (!id) {
+    return NextResponse.json({ error: "Missing listing ID" }, { status: 400 });
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from("machine_listings")
+    .select("*, profiles!created_by(id, full_name, company_name, verified)")
+    .eq("id", id)
+    .single();
+
+  if (error || !data) {
+    return NextResponse.json({ error: "Listing not found" }, { status: 404 });
+  }
+
+  // Strip sensitive seller information — never expose contact_email/phone
+  // or the created_by user ID to the public
+  const {
+    contact_email: _email,
+    contact_phone: _phone,
+    created_by: _createdBy,
+    admin_notes: _notes,
+    ...publicData
+  } = data;
+  void _email;
+  void _phone;
+  void _createdBy;
+  void _notes;
+
+  return NextResponse.json(publicData);
+}

--- a/src/app/api/machine-listings/route.ts
+++ b/src/app/api/machine-listings/route.ts
@@ -1,0 +1,109 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { createMachineListingSchema } from "@/lib/schemas";
+import { getUserIdFromRequest } from "@/lib/apiAuth";
+
+const PAGE_SIZE = 12;
+
+/** POST /api/machine-listings — authenticated user creates a machine listing */
+export async function POST(req: NextRequest) {
+  const userId = await getUserIdFromRequest(req);
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const body = await req.json();
+    const parsed = createMachineListingSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.flatten().fieldErrors },
+        { status: 400 }
+      );
+    }
+
+    const { data, error } = await supabaseAdmin
+      .from("machine_listings")
+      .insert({
+        created_by: userId,
+        ...parsed.data,
+        status: "pending", // All user submissions require admin approval
+      })
+      .select("id")
+      .single();
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ id: data.id }, { status: 201 });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Unknown error";
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}
+
+/** GET /api/machine-listings — list active machine listings with filters */
+export async function GET(req: NextRequest) {
+  const params = req.nextUrl.searchParams;
+  const search = params.get("search");
+  const state = params.get("state");
+  const machineType = params.get("machine_type");
+  const condition = params.get("condition");
+  const page = Math.max(0, parseInt(params.get("page") || "0"));
+
+  let query = supabaseAdmin
+    .from("machine_listings")
+    .select("*, profiles!created_by(id, full_name, company_name, verified)", {
+      count: "exact",
+    })
+    .eq("status", "active");
+
+  // Exclude locations with missing or unknown city/state
+  query = query
+    .neq("city", "")
+    .neq("state", "")
+    .not("city", "is", null)
+    .not("state", "is", null)
+    .neq("city", "Unknown")
+    .neq("state", "Unknown")
+    .neq("city", "unknown")
+    .neq("state", "unknown");
+
+  if (search) {
+    query = query.or(
+      `city.ilike.%${search}%,state.ilike.%${search}%,title.ilike.%${search}%,machine_make.ilike.%${search}%,machine_model.ilike.%${search}%`
+    );
+  }
+  if (state) query = query.eq("state", state);
+  if (machineType) query = query.eq("machine_type", machineType);
+  if (condition) query = query.eq("condition", condition);
+
+  const from = page * PAGE_SIZE;
+  const to = from + PAGE_SIZE - 1;
+
+  const { data, error, count } = await query
+    .order("created_at", { ascending: false })
+    .range(from, to);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  // Strip sensitive contact info from list view
+  const sanitized = (data || []).map((row) => {
+    const {
+      contact_email: _e,
+      contact_phone: _p,
+      created_by: _c,
+      ...rest
+    } = row as Record<string, unknown>;
+    void _e;
+    void _p;
+    void _c;
+    return rest;
+  });
+
+  return NextResponse.json({ listings: sanitized, total: count || 0 });
+}

--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -12,6 +12,7 @@ import { TOOLTIP_COPY } from "@/lib/tooltipCopy";
 const navLinks = [
   { label: "Browse Requests", href: "/browse-requests" },
   { label: "Machines", href: "/machines" },
+  { label: "Machines for Sale", href: "/machines-for-sale" },
   { label: "Routes for Sale", href: "/routes-for-sale" },
   { label: "Browse Operators", href: "/browse-operators" },
   { label: "How It Works", href: "/how-it-works" },
@@ -21,6 +22,7 @@ const authNavLinks = [
   { label: "Browse Requests", href: "/browse-requests" },
   { label: "Your Leads", href: "/your-leads" },
   { label: "Machines", href: "/machines" },
+  { label: "Machines for Sale", href: "/machines-for-sale" },
   { label: "Routes for Sale", href: "/routes-for-sale" },
   { label: "Browse Operators", href: "/browse-operators" },
   { label: "How It Works", href: "/how-it-works" },

--- a/src/app/machines-for-sale/[id]/page.tsx
+++ b/src/app/machines-for-sale/[id]/page.tsx
@@ -1,0 +1,554 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import {
+  ArrowLeft,
+  ArrowRight,
+  MapPin,
+  DollarSign,
+  Clock,
+  Loader2,
+  AlertCircle,
+  Mail,
+  Package,
+  Check,
+} from "lucide-react";
+import type { MachineListing } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const CONDITION_LABELS: Record<string, string> = {
+  new: "New",
+  like_new: "Like New",
+  good: "Good",
+  fair: "Fair",
+  for_parts: "For Parts",
+};
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+function timeAgo(dateStr: string): string {
+  const diffMs = Date.now() - new Date(dateStr).getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  if (diffDays === 0) return "Today";
+  if (diffDays === 1) return "1 day ago";
+  if (diffDays < 30) return `${diffDays} days ago`;
+  const months = Math.floor(diffDays / 30);
+  if (months === 1) return "1 month ago";
+  return `${months} months ago`;
+}
+
+function formatCurrency(val: number | null): string {
+  if (val == null) return "Contact for price";
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(val);
+}
+
+function getStatusConfig(status: string) {
+  switch (status) {
+    case "active":
+      return { bg: "bg-green-50", text: "text-green-700", ring: "ring-green-200", label: "Available" };
+    case "sold":
+      return { bg: "bg-slate-50", text: "text-slate-600", ring: "ring-slate-200", label: "Sold" };
+    case "pending":
+      return { bg: "bg-amber-50", text: "text-amber-700", ring: "ring-amber-200", label: "Pending Review" };
+    case "rejected":
+      return { bg: "bg-red-50", text: "text-red-700", ring: "ring-red-200", label: "Rejected" };
+    default:
+      return { bg: "bg-gray-50", text: "text-gray-600", ring: "ring-gray-200", label: status };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function DetailSkeleton() {
+  return (
+    <div className="min-h-screen bg-light">
+      <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+        <div className="skeleton h-4 w-32 mb-8" />
+        <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
+          <div className="lg:col-span-2 space-y-6">
+            <div className="bg-white rounded-xl border border-gray-200 p-6">
+              <div className="skeleton h-64 w-full rounded-lg mb-6" />
+              <div className="skeleton h-6 w-3/4 mb-3" />
+              <div className="skeleton h-4 w-1/2 mb-6" />
+              <div className="grid grid-cols-2 gap-4">
+                <div className="skeleton h-16 rounded-lg" />
+                <div className="skeleton h-16 rounded-lg" />
+              </div>
+            </div>
+          </div>
+          <div className="space-y-6">
+            <div className="bg-white rounded-xl border border-gray-200 p-6">
+              <div className="skeleton h-5 w-48 mb-4" />
+              <div className="skeleton h-10 w-full rounded-lg mb-3" />
+              <div className="skeleton h-10 w-full rounded-lg" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SimilarMachineCard({ listing }: { listing: MachineListing }) {
+  return (
+    <Link
+      href={`/machines-for-sale/${listing.id}`}
+      className="block bg-white rounded-xl border border-gray-200 p-4 transition-shadow hover:shadow-lg hover:shadow-green-primary/5 group"
+    >
+      <h4 className="font-semibold text-black-primary text-sm leading-snug truncate group-hover:text-green-primary transition-colors">
+        {listing.title}
+      </h4>
+      {listing.city && listing.state && (
+        <div className="flex items-center gap-1 mt-0.5 text-xs text-gray-500">
+          <MapPin className="w-3 h-3 shrink-0" />
+          <span className="truncate">
+            {listing.city}, {listing.state}
+          </span>
+        </div>
+      )}
+      <div className="grid grid-cols-2 gap-2 mt-2">
+        <div className="rounded-md bg-green-50 px-2 py-1">
+          <p className="text-[10px] text-gray-500 font-medium">Price</p>
+          <p className="text-xs font-bold text-green-700">
+            {formatCurrency(listing.asking_price)}
+          </p>
+        </div>
+        <div className="rounded-md bg-gray-50 px-2 py-1">
+          <p className="text-[10px] text-gray-500 font-medium">Qty</p>
+          <p className="text-xs font-bold text-black-primary">
+            {listing.quantity}
+          </p>
+        </div>
+      </div>
+      <div className="flex items-center justify-end mt-3 pt-2 border-t border-gray-100">
+        <span className="inline-flex items-center gap-1 text-xs font-medium text-green-primary">
+          View
+          <ArrowRight className="h-3 w-3" />
+        </span>
+      </div>
+    </Link>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page Component
+// ---------------------------------------------------------------------------
+
+export default function MachineDetailPage() {
+  const params = useParams();
+  const id = params.id as string;
+
+  const [listing, setListing] = useState<MachineListing | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [similar, setSimilar] = useState<MachineListing[]>([]);
+  const [loadingSimilar, setLoadingSimilar] = useState(false);
+  const [activePhoto, setActivePhoto] = useState(0);
+
+  const fetchListing = useCallback(async () => {
+    if (!id) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/machine-listings/${id}`);
+      if (!res.ok) {
+        setError(
+          res.status === 404 ? "Listing not found" : "Failed to load listing"
+        );
+        return;
+      }
+      setListing(await res.json());
+    } catch {
+      setError("Failed to load listing. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    fetchListing();
+  }, [fetchListing]);
+
+  // Fetch similar listings in same state
+  useEffect(() => {
+    if (!listing) return;
+    async function fetchSimilar() {
+      setLoadingSimilar(true);
+      try {
+        const params = new URLSearchParams();
+        params.set("state", listing!.state);
+        params.set("page", "0");
+        const res = await fetch(`/api/machine-listings?${params}`);
+        if (res.ok) {
+          const data = await res.json();
+          const items: MachineListing[] = data.listings ?? [];
+          setSimilar(items.filter((r) => r.id !== listing!.id).slice(0, 3));
+        }
+      } catch {
+        // Silently fail
+      } finally {
+        setLoadingSimilar(false);
+      }
+    }
+    fetchSimilar();
+  }, [listing]);
+
+  if (loading) return <DetailSkeleton />;
+
+  if (error || !listing) {
+    return (
+      <div className="min-h-screen bg-light">
+        <div className="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
+          <div className="flex flex-col items-center justify-center text-center">
+            <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-red-50">
+              <AlertCircle className="h-7 w-7 text-red-500" />
+            </div>
+            <h2 className="text-xl font-bold text-black-primary">
+              {error || "Listing not found"}
+            </h2>
+            <p className="mt-2 text-sm text-gray-500">
+              The machine listing you are looking for may have been removed or
+              does not exist.
+            </p>
+            <Link
+              href="/machines-for-sale"
+              className="mt-6 inline-flex items-center gap-2 rounded-lg bg-green-primary px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-green-hover"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              Back to Machines for Sale
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const statusConfig = getStatusConfig(listing.status);
+  const conditionLabel = listing.condition
+    ? CONDITION_LABELS[listing.condition] ?? listing.condition
+    : null;
+  const photos = listing.photos || [];
+  const mainPhoto = photos[activePhoto] || null;
+
+  return (
+    <div className="min-h-screen bg-light">
+      <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+        {/* Back link */}
+        <Link
+          href="/machines-for-sale"
+          className="mb-6 inline-flex items-center gap-1.5 text-sm font-medium text-gray-500 transition-colors hover:text-green-primary"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to Machines for Sale
+        </Link>
+
+        <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
+          {/* Main content */}
+          <div className="lg:col-span-2 space-y-6">
+            <div className="bg-white rounded-xl border border-gray-200 p-6 sm:p-8 animate-fade-in">
+              {/* Photos */}
+              {mainPhoto ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={mainPhoto}
+                  alt={listing.title}
+                  className="mb-4 h-80 w-full rounded-lg object-cover bg-gray-100"
+                />
+              ) : (
+                <div className="mb-4 flex h-80 w-full items-center justify-center rounded-lg bg-gray-100">
+                  <Package className="h-16 w-16 text-gray-400" />
+                </div>
+              )}
+
+              {photos.length > 1 && (
+                <div className="mb-6 flex gap-2 overflow-x-auto">
+                  {photos.map((p, i) => (
+                    <button
+                      key={i}
+                      type="button"
+                      onClick={() => setActivePhoto(i)}
+                      className={`relative h-16 w-16 shrink-0 overflow-hidden rounded-lg border-2 transition-all ${
+                        i === activePhoto
+                          ? "border-green-primary"
+                          : "border-transparent opacity-60 hover:opacity-100"
+                      }`}
+                    >
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img
+                        src={p}
+                        alt={`Photo ${i + 1}`}
+                        className="h-full w-full object-cover"
+                      />
+                    </button>
+                  ))}
+                </div>
+              )}
+
+              {/* Header */}
+              <div className="flex items-start gap-4">
+                <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-amber-50 text-amber-600">
+                  <Package className="h-6 w-6" />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <h1 className="text-xl font-bold text-black-primary sm:text-2xl leading-tight">
+                    {listing.title}
+                  </h1>
+                  <div className="flex flex-wrap items-center gap-2 mt-2">
+                    <span
+                      className={`inline-flex items-center px-2.5 py-0.5 text-xs font-semibold rounded-full ring-1 ring-inset ${statusConfig.bg} ${statusConfig.text} ${statusConfig.ring}`}
+                    >
+                      {statusConfig.label}
+                    </span>
+                    {conditionLabel && (
+                      <span className="inline-flex items-center px-2.5 py-0.5 text-xs font-medium rounded-full bg-blue-50 text-blue-700 ring-1 ring-inset ring-blue-200">
+                        {conditionLabel}
+                      </span>
+                    )}
+                    {listing.machine_type && (
+                      <span className="inline-flex items-center px-2.5 py-0.5 text-xs font-medium rounded-full bg-green-50 text-green-700 ring-1 ring-inset ring-green-200">
+                        {listing.machine_type}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </div>
+
+              {/* Description */}
+              {listing.description && (
+                <div className="mt-6">
+                  <h3 className="text-sm font-semibold text-black-primary mb-2">
+                    Description
+                  </h3>
+                  <p className="text-sm text-gray-600 leading-relaxed whitespace-pre-line">
+                    {listing.description}
+                  </p>
+                </div>
+              )}
+
+              {/* Machine Details */}
+              <div className="mt-6 rounded-lg bg-light border border-green-100 p-4">
+                <h3 className="text-sm font-semibold text-black-primary mb-3 flex items-center gap-2">
+                  <Package className="h-4 w-4 text-green-primary" />
+                  Machine Details
+                </h3>
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                  {listing.city && listing.state && (
+                    <div>
+                      <p className="text-xs text-gray-500 uppercase tracking-wide font-medium">
+                        Location
+                      </p>
+                      <p className="text-sm font-medium text-black-primary mt-0.5">
+                        {listing.city}, {listing.state}
+                      </p>
+                    </div>
+                  )}
+                  {listing.machine_make && (
+                    <div>
+                      <p className="text-xs text-gray-500 uppercase tracking-wide font-medium">
+                        Make
+                      </p>
+                      <p className="text-sm font-medium text-black-primary mt-0.5">
+                        {listing.machine_make}
+                      </p>
+                    </div>
+                  )}
+                  {listing.machine_model && (
+                    <div>
+                      <p className="text-xs text-gray-500 uppercase tracking-wide font-medium">
+                        Model
+                      </p>
+                      <p className="text-sm font-medium text-black-primary mt-0.5">
+                        {listing.machine_model}
+                      </p>
+                    </div>
+                  )}
+                  {listing.machine_year && (
+                    <div>
+                      <p className="text-xs text-gray-500 uppercase tracking-wide font-medium">
+                        Year
+                      </p>
+                      <p className="text-sm font-medium text-black-primary mt-0.5">
+                        {listing.machine_year}
+                      </p>
+                    </div>
+                  )}
+                  <div>
+                    <p className="text-xs text-gray-500 uppercase tracking-wide font-medium">
+                      Quantity
+                    </p>
+                    <p className="text-sm font-medium text-black-primary mt-0.5">
+                      {listing.quantity}
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              {/* What's Included */}
+              {(listing.includes_card_reader ||
+                listing.includes_install ||
+                listing.includes_delivery) && (
+                <div className="mt-6">
+                  <h3 className="text-sm font-semibold text-black-primary mb-2">
+                    What&apos;s Included
+                  </h3>
+                  <ul className="space-y-1.5">
+                    {listing.includes_card_reader && (
+                      <li className="flex items-center gap-2 text-sm text-gray-700">
+                        <Check className="h-4 w-4 text-green-primary" />
+                        Credit card reader installed
+                      </li>
+                    )}
+                    {listing.includes_install && (
+                      <li className="flex items-center gap-2 text-sm text-gray-700">
+                        <Check className="h-4 w-4 text-green-primary" />
+                        Installation service included
+                      </li>
+                    )}
+                    {listing.includes_delivery && (
+                      <li className="flex items-center gap-2 text-sm text-gray-700">
+                        <Check className="h-4 w-4 text-green-primary" />
+                        Delivery service included
+                      </li>
+                    )}
+                  </ul>
+                </div>
+              )}
+
+              {/* Timestamps */}
+              <div className="mt-6 pt-4 border-t border-gray-100 flex flex-wrap items-center gap-x-6 gap-y-2 text-xs text-gray-400">
+                <span className="flex items-center gap-1">
+                  <Clock className="h-3 w-3" />
+                  Posted {formatDate(listing.created_at)} (
+                  {timeAgo(listing.created_at)})
+                </span>
+              </div>
+            </div>
+          </div>
+
+          {/* Sidebar */}
+          <div className="space-y-6">
+            {/* CTA Card */}
+            <div className="bg-white rounded-xl border border-gray-200 p-6 sticky top-24 animate-fade-in">
+              <h3 className="text-lg font-bold text-black-primary">
+                Interested in this machine?
+              </h3>
+              <p className="mt-1 text-sm text-gray-500">
+                Contact the admin to verify the listing and start the
+                acquisition process.
+              </p>
+
+              {listing.asking_price != null && (
+                <div className="mt-4 rounded-lg bg-green-50 border border-green-100 px-4 py-3">
+                  <div className="flex items-center gap-1.5 text-xs text-gray-500 uppercase tracking-wide font-medium">
+                    <DollarSign className="h-3 w-3" />
+                    Asking Price
+                  </div>
+                  <p className="text-2xl font-bold text-green-700">
+                    {formatCurrency(listing.asking_price)}
+                  </p>
+                </div>
+              )}
+
+              <a
+                href={`mailto:james@apexaivending.com?subject=${encodeURIComponent(
+                  `Machine Inquiry: ${listing.title}`
+                )}&body=${encodeURIComponent(
+                  `Hi,\n\nI'm interested in the machine listing "${listing.title}" in ${listing.city}, ${listing.state}.\n\nListing ID: ${listing.id}\n\nPlease share more details.\n\nThank you`
+                )}`}
+                className="mt-5 flex w-full items-center justify-center gap-2 rounded-lg bg-green-primary px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-green-hover"
+              >
+                <Mail className="h-4 w-4" />
+                Contact Admin
+              </a>
+
+              <div className="mt-5 pt-4 border-t border-gray-100 space-y-2">
+                <div className="flex items-center justify-between text-xs text-gray-500">
+                  <span>Status</span>
+                  <span
+                    className={`inline-flex items-center px-2 py-0.5 text-xs font-semibold rounded-full ring-1 ring-inset ${statusConfig.bg} ${statusConfig.text} ${statusConfig.ring}`}
+                  >
+                    {statusConfig.label}
+                  </span>
+                </div>
+                {conditionLabel && (
+                  <div className="flex items-center justify-between text-xs text-gray-500">
+                    <span>Condition</span>
+                    <span className="font-medium text-black-primary">
+                      {conditionLabel}
+                    </span>
+                  </div>
+                )}
+                <div className="flex items-center justify-between text-xs text-gray-500">
+                  <span>Quantity</span>
+                  <span className="font-medium text-black-primary">
+                    {listing.quantity}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            {/* How it works */}
+            <div className="bg-gradient-to-br from-green-50 to-light-warm rounded-xl border border-green-100 p-5">
+              <h4 className="text-sm font-semibold text-black-primary mb-2">
+                How machine sales work
+              </h4>
+              <p className="text-xs text-gray-600 leading-relaxed">
+                Browse used and refurbished vending machines from operators.
+                Contact the admin to verify condition, inspect the machine, and
+                negotiate terms through Vending Connector.
+              </p>
+              <Link
+                href="/machines-for-sale"
+                className="mt-3 inline-flex items-center gap-1 text-xs font-semibold text-green-primary hover:text-green-hover transition-colors"
+              >
+                Browse All Machines
+                <ArrowRight className="h-3 w-3" />
+              </Link>
+            </div>
+          </div>
+        </div>
+
+        {/* Similar */}
+        {(loadingSimilar || similar.length > 0) && (
+          <section className="mt-12">
+            <h2 className="text-lg font-bold text-black-primary mb-5">
+              More Machines for Sale
+            </h2>
+
+            {loadingSimilar && (
+              <div className="flex items-center gap-2 text-sm text-gray-400">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Loading similar machines...
+              </div>
+            )}
+
+            {!loadingSimilar && similar.length > 0 && (
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                {similar.map((m) => (
+                  <SimilarMachineCard key={m.id} listing={m} />
+                ))}
+              </div>
+            )}
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/machines-for-sale/page.tsx
+++ b/src/app/machines-for-sale/page.tsx
@@ -1,0 +1,446 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+import {
+  Search,
+  X,
+  Loader2,
+  SearchX,
+  MapPin,
+  Plus,
+  Package,
+} from "lucide-react";
+import type { MachineListing } from "@/lib/types";
+import { US_STATES, US_STATE_NAMES } from "@/lib/types";
+
+const MACHINE_TYPE_OPTIONS = [
+  "Snack",
+  "Beverage",
+  "Combo",
+  "Coffee",
+  "Micro Market",
+  "Cold Food",
+  "Frozen",
+  "Healthy",
+  "Specialty",
+  "Other",
+];
+
+const CONDITION_LABELS: Record<string, string> = {
+  new: "New",
+  like_new: "Like New",
+  good: "Good",
+  fair: "Fair",
+  for_parts: "For Parts",
+};
+
+function formatCurrency(val: number | null): string {
+  if (val == null) return "Contact for price";
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(val);
+}
+
+function SkeletonCard() {
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-5">
+      <div className="space-y-3">
+        <div className="skeleton h-5 w-3/4" />
+        <div className="skeleton h-4 w-1/2" />
+      </div>
+      <div className="mt-4 grid grid-cols-2 gap-3">
+        <div className="skeleton h-12 rounded-lg" />
+        <div className="skeleton h-12 rounded-lg" />
+      </div>
+      <div className="mt-3 flex gap-1.5">
+        <div className="skeleton h-5 w-16 rounded-full" />
+        <div className="skeleton h-5 w-20 rounded-full" />
+      </div>
+    </div>
+  );
+}
+
+function MachineCard({ listing }: { listing: MachineListing }) {
+  const photo = listing.photos && listing.photos.length > 0 ? listing.photos[0] : null;
+  const conditionLabel = listing.condition
+    ? CONDITION_LABELS[listing.condition] ?? listing.condition
+    : null;
+
+  return (
+    <Link
+      href={`/machines-for-sale/${listing.id}`}
+      className="block rounded-xl border border-gray-200 bg-white p-5 transition-shadow hover:shadow-lg hover:shadow-green-primary/5 group"
+    >
+      {/* Photo */}
+      {photo ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={photo}
+          alt={listing.title}
+          className="mb-4 h-40 w-full rounded-lg object-cover bg-gray-100"
+        />
+      ) : (
+        <div className="mb-4 flex h-40 w-full items-center justify-center rounded-lg bg-gray-100">
+          <Package className="h-10 w-10 text-gray-400" />
+        </div>
+      )}
+
+      {/* Title */}
+      <h3 className="font-semibold text-black-primary leading-snug group-hover:text-green-primary transition-colors line-clamp-2">
+        {listing.title}
+      </h3>
+
+      {/* Location */}
+      {listing.city && listing.state && (
+        <div className="flex items-center gap-1 mt-1.5 text-sm text-gray-500">
+          <MapPin className="w-3.5 h-3.5 shrink-0" />
+          <span>
+            {listing.city}, {listing.state}
+          </span>
+        </div>
+      )}
+
+      {/* Price + quantity */}
+      <div className="mt-4 grid grid-cols-2 gap-3">
+        <div className="rounded-lg bg-green-50 px-3 py-2">
+          <p className="text-[10px] uppercase tracking-wide text-gray-500 font-medium">
+            Asking Price
+          </p>
+          <p className="text-sm font-bold text-green-700">
+            {formatCurrency(listing.asking_price)}
+          </p>
+        </div>
+        <div className="rounded-lg bg-gray-50 px-3 py-2">
+          <p className="text-[10px] uppercase tracking-wide text-gray-500 font-medium">
+            Quantity
+          </p>
+          <p className="text-sm font-bold text-black-primary">
+            {listing.quantity}
+          </p>
+        </div>
+      </div>
+
+      {/* Tags */}
+      <div className="flex flex-wrap gap-1.5 mt-3">
+        {listing.machine_type && (
+          <span className="inline-flex items-center px-2 py-0.5 text-[10px] font-medium text-green-700 bg-green-50 rounded-full">
+            {listing.machine_type}
+          </span>
+        )}
+        {conditionLabel && (
+          <span className="inline-flex items-center px-2 py-0.5 text-[10px] font-medium text-blue-700 bg-blue-50 rounded-full">
+            {conditionLabel}
+          </span>
+        )}
+        {(listing.machine_make || listing.machine_model) && (
+          <span className="inline-flex items-center px-2 py-0.5 text-[10px] font-medium text-gray-600 bg-gray-100 rounded-full">
+            {[listing.machine_make, listing.machine_model]
+              .filter(Boolean)
+              .join(" ")}
+          </span>
+        )}
+      </div>
+
+      {/* Includes badges */}
+      <div className="flex flex-wrap gap-3 mt-3 text-xs text-gray-500">
+        {listing.includes_card_reader && (
+          <span className="flex items-center gap-1">
+            <span className="h-1.5 w-1.5 rounded-full bg-green-500" />
+            Card reader
+          </span>
+        )}
+        {listing.includes_install && (
+          <span className="flex items-center gap-1">
+            <span className="h-1.5 w-1.5 rounded-full bg-green-500" />
+            Install incl.
+          </span>
+        )}
+        {listing.includes_delivery && (
+          <span className="flex items-center gap-1">
+            <span className="h-1.5 w-1.5 rounded-full bg-green-500" />
+            Delivery incl.
+          </span>
+        )}
+      </div>
+    </Link>
+  );
+}
+
+export default function MachinesForSalePage() {
+  const [listings, setListings] = useState<MachineListing[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [totalCount, setTotalCount] = useState(0);
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [stateFilter, setStateFilter] = useState("");
+  const [typeFilter, setTypeFilter] = useState("");
+  const [conditionFilter, setConditionFilter] = useState("");
+  const [page, setPage] = useState(0);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearch(search), 350);
+    return () => clearTimeout(timer);
+  }, [search]);
+
+  useEffect(() => {
+    setPage(0);
+  }, [debouncedSearch, stateFilter, typeFilter, conditionFilter]);
+
+  const fetchListings = useCallback(
+    async (pageNum: number, append = false) => {
+      if (append) setLoadingMore(true);
+      else setLoading(true);
+
+      try {
+        const params = new URLSearchParams();
+        if (debouncedSearch) params.set("search", debouncedSearch);
+        if (stateFilter) params.set("state", stateFilter);
+        if (typeFilter) params.set("machine_type", typeFilter);
+        if (conditionFilter) params.set("condition", conditionFilter);
+        params.set("page", String(pageNum));
+
+        const res = await fetch(`/api/machine-listings?${params}`);
+        if (!res.ok) throw new Error("Failed to fetch");
+
+        const data = await res.json();
+        const items: MachineListing[] = data.listings ?? [];
+        const total: number = data.total ?? items.length;
+
+        if (append) setListings((prev) => [...prev, ...items]);
+        else setListings(items);
+        setTotalCount(total);
+      } catch {
+        if (!append) setListings([]);
+      } finally {
+        setLoading(false);
+        setLoadingMore(false);
+      }
+    },
+    [debouncedSearch, stateFilter, typeFilter, conditionFilter]
+  );
+
+  useEffect(() => {
+    fetchListings(0);
+  }, [fetchListings]);
+
+  function handleLoadMore() {
+    const nextPage = page + 1;
+    setPage(nextPage);
+    fetchListings(nextPage, true);
+  }
+
+  const hasMore = listings.length < totalCount;
+
+  return (
+    <div className="min-h-screen bg-light">
+      {/* Hero */}
+      <section className="border-b border-green-100 bg-gradient-to-b from-light-warm to-light">
+        <div className="mx-auto max-w-7xl px-4 pb-8 pt-12 sm:px-6 lg:px-8">
+          <div className="text-center">
+            <h1 className="text-3xl font-bold tracking-tight text-black-primary sm:text-4xl">
+              Machines for Sale
+            </h1>
+            <p className="mx-auto mt-3 max-w-2xl text-base text-gray-600 sm:text-lg">
+              Browse used and refurbished vending machines from operators
+              across the country
+            </p>
+            <div className="mt-5 flex flex-wrap justify-center gap-3">
+              <Link
+                href="/post-machine"
+                className="inline-flex items-center gap-2 rounded-xl bg-green-primary px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-green-hover"
+              >
+                <Plus className="h-4 w-4" />
+                Post a Machine for Sale
+              </Link>
+              <Link
+                href="/machines"
+                className="inline-flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-5 py-2.5 text-sm font-semibold text-black-primary shadow-sm transition-colors hover:border-green-primary/40"
+              >
+                Shop New Apex Machines
+              </Link>
+            </div>
+          </div>
+
+          {/* Search */}
+          <div className="mx-auto mt-8 max-w-2xl">
+            <div className="relative">
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+              <input
+                type="text"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Search by make, model, city, state, or title..."
+                style={{ paddingLeft: "2.25rem" }}
+                className="w-full rounded-xl border border-gray-200 bg-white py-3 pr-10 text-sm shadow-sm placeholder:text-gray-400 focus:border-green-primary focus:ring-2 focus:ring-green-primary/20"
+              />
+              {search && (
+                <button
+                  type="button"
+                  onClick={() => setSearch("")}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 rounded-md p-1 text-gray-400 transition-colors hover:text-gray-600"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Filter bar */}
+      <section className="sticky top-16 z-20 border-b border-gray-200 bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/80">
+        <div className="mx-auto max-w-7xl px-4 py-3 sm:px-6 lg:px-8">
+          <div className="flex flex-wrap items-center gap-3">
+            <select
+              value={stateFilter}
+              onChange={(e) => setStateFilter(e.target.value)}
+              className="rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-black-primary focus:border-green-primary focus:ring-2 focus:ring-green-primary/20"
+            >
+              <option value="">All States</option>
+              {US_STATES.map((s) => (
+                <option key={s} value={s}>
+                  {s} - {US_STATE_NAMES[s] ?? s}
+                </option>
+              ))}
+            </select>
+
+            <select
+              value={typeFilter}
+              onChange={(e) => setTypeFilter(e.target.value)}
+              className="rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-black-primary focus:border-green-primary focus:ring-2 focus:ring-green-primary/20"
+            >
+              <option value="">All Types</option>
+              {MACHINE_TYPE_OPTIONS.map((t) => (
+                <option key={t} value={t}>
+                  {t}
+                </option>
+              ))}
+            </select>
+
+            <select
+              value={conditionFilter}
+              onChange={(e) => setConditionFilter(e.target.value)}
+              className="rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-black-primary focus:border-green-primary focus:ring-2 focus:ring-green-primary/20"
+            >
+              <option value="">Any Condition</option>
+              {Object.entries(CONDITION_LABELS).map(([v, l]) => (
+                <option key={v} value={v}>
+                  {l}
+                </option>
+              ))}
+            </select>
+
+            {(stateFilter || typeFilter || conditionFilter) && (
+              <button
+                type="button"
+                onClick={() => {
+                  setStateFilter("");
+                  setTypeFilter("");
+                  setConditionFilter("");
+                }}
+                className="flex items-center gap-1 rounded-lg px-3 py-2 text-sm font-medium text-gray-500 hover:text-red-600 transition-colors"
+              >
+                <X className="h-3.5 w-3.5" />
+                Clear filters
+              </button>
+            )}
+          </div>
+        </div>
+      </section>
+
+      {/* Content */}
+      <section className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+        {!loading && (
+          <p className="mb-6 text-sm text-gray-500">
+            {totalCount === 0
+              ? "No machines found"
+              : totalCount === 1
+              ? "1 machine found"
+              : `${totalCount.toLocaleString()} machines found`}
+            {debouncedSearch && (
+              <span>
+                {" "}
+                for &ldquo;
+                <span className="font-medium text-black-primary">
+                  {debouncedSearch}
+                </span>
+                &rdquo;
+              </span>
+            )}
+          </p>
+        )}
+
+        {loading && (
+          <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <SkeletonCard key={i} />
+            ))}
+          </div>
+        )}
+
+        {!loading && listings.length === 0 && (
+          <div className="flex flex-col items-center justify-center rounded-2xl border-2 border-dashed border-gray-200 bg-white px-6 py-16 text-center">
+            <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-green-50">
+              <SearchX className="h-7 w-7 text-green-primary" />
+            </div>
+            <h3 className="text-lg font-semibold text-black-primary">
+              No machines available
+            </h3>
+            <p className="mx-auto mt-2 max-w-sm text-sm text-gray-500">
+              There are no used vending machines for sale matching your search.
+              Check back later for new listings.
+            </p>
+            <Link
+              href="/post-machine"
+              className="mt-6 inline-flex items-center gap-2 rounded-xl bg-green-primary px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-green-hover"
+            >
+              <Plus className="h-4 w-4" />
+              Be the first to post
+            </Link>
+          </div>
+        )}
+
+        {!loading && listings.length > 0 && (
+          <>
+            <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+              {listings.map((listing) => (
+                <MachineCard key={listing.id} listing={listing} />
+              ))}
+            </div>
+
+            {hasMore && (
+              <div className="mt-10 flex justify-center">
+                <button
+                  type="button"
+                  onClick={handleLoadMore}
+                  disabled={loadingMore}
+                  className="inline-flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-8 py-3 text-sm font-semibold text-black-primary shadow-sm transition-all hover:border-green-primary/40 hover:shadow-md disabled:opacity-60"
+                >
+                  {loadingMore ? (
+                    <>
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      Loading...
+                    </>
+                  ) : (
+                    "Load More Machines"
+                  )}
+                </button>
+              </div>
+            )}
+
+            {listings.length > 0 && (
+              <p className="mt-4 text-center text-xs text-gray-400">
+                Showing {listings.length} of {totalCount.toLocaleString()}{" "}
+                machines
+              </p>
+            )}
+          </>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -224,6 +224,14 @@ export default function HomePage() {
               Shop Machines
               <ArrowRight className="h-4 w-4" />
             </Link>
+            <Link
+              href="/machines-for-sale"
+              className="inline-flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-6 py-3 text-sm font-semibold text-black-primary shadow-sm transition-all hover:-translate-y-0.5 hover:border-green-primary/40 hover:text-green-primary"
+            >
+              <Package className="h-4 w-4" />
+              Used Machines
+              <ArrowRight className="h-4 w-4" />
+            </Link>
           </div>
 
           {/* Headline */}

--- a/src/app/post-machine/page.tsx
+++ b/src/app/post-machine/page.tsx
@@ -1,0 +1,607 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import {
+  Loader2,
+  ChevronLeft,
+  AlertCircle,
+  CheckCircle2,
+} from "lucide-react";
+import { getAccessToken } from "@/lib/auth";
+import { US_STATES, US_STATE_NAMES } from "@/lib/types";
+
+const MACHINE_TYPE_OPTIONS = [
+  "Snack",
+  "Beverage",
+  "Combo",
+  "Coffee",
+  "Micro Market",
+  "Cold Food",
+  "Frozen",
+  "Healthy",
+  "Specialty",
+  "Other",
+];
+
+const CONDITION_OPTIONS: { value: string; label: string }[] = [
+  { value: "new", label: "New" },
+  { value: "like_new", label: "Like New" },
+  { value: "good", label: "Good" },
+  { value: "fair", label: "Fair" },
+  { value: "for_parts", label: "For Parts" },
+];
+
+export default function PostMachinePage() {
+  const [token, setToken] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [submitted, setSubmitted] = useState(false);
+
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [city, setCity] = useState("");
+  const [state, setState] = useState("");
+  const [machineMake, setMachineMake] = useState("");
+  const [machineModel, setMachineModel] = useState("");
+  const [machineYear, setMachineYear] = useState("");
+  const [machineType, setMachineType] = useState("");
+  const [condition, setCondition] = useState("");
+  const [quantity, setQuantity] = useState("1");
+  const [askingPrice, setAskingPrice] = useState("");
+  const [includesCardReader, setIncludesCardReader] = useState(false);
+  const [includesInstall, setIncludesInstall] = useState(false);
+  const [includesDelivery, setIncludesDelivery] = useState(false);
+  const [photosText, setPhotosText] = useState("");
+  const [contactEmail, setContactEmail] = useState("");
+  const [contactPhone, setContactPhone] = useState("");
+
+  useEffect(() => {
+    getAccessToken().then(setToken);
+  }, []);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitError(null);
+
+    if (!title.trim()) {
+      setSubmitError("Title is required");
+      return;
+    }
+    if (!city.trim()) {
+      setSubmitError("City is required");
+      return;
+    }
+    if (!state) {
+      setSubmitError("State is required");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const currentToken = token || (await getAccessToken());
+      if (!currentToken) {
+        setSubmitError("You must be logged in. Please sign in first.");
+        return;
+      }
+
+      const photos = photosText
+        .split(/\r?\n/)
+        .map((p) => p.trim())
+        .filter(Boolean)
+        .filter((p) => /^https?:\/\//.test(p))
+        .slice(0, 10);
+
+      const res = await fetch("/api/machine-listings", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${currentToken}`,
+        },
+        body: JSON.stringify({
+          title: title.trim(),
+          description: description.trim() || undefined,
+          city: city.trim(),
+          state,
+          machine_make: machineMake.trim() || undefined,
+          machine_model: machineModel.trim() || undefined,
+          machine_year: machineYear ? parseInt(machineYear) : undefined,
+          machine_type: machineType || undefined,
+          condition: condition || undefined,
+          quantity: parseInt(quantity) || 1,
+          asking_price: askingPrice ? parseFloat(askingPrice) : undefined,
+          includes_card_reader: includesCardReader,
+          includes_install: includesInstall,
+          includes_delivery: includesDelivery,
+          photos,
+          contact_email: contactEmail.trim() || undefined,
+          contact_phone: contactPhone.trim() || undefined,
+        }),
+      });
+
+      if (!res.ok) {
+        try {
+          const data = await res.json();
+          setSubmitError(
+            typeof data.error === "string"
+              ? data.error
+              : "Something went wrong."
+          );
+        } catch {
+          setSubmitError("Something went wrong.");
+        }
+        return;
+      }
+
+      setSubmitted(true);
+    } catch {
+      setSubmitError("Network error. Please check your connection.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (submitted) {
+    return (
+      <div className="min-h-[calc(100vh-160px)] px-4 py-10 sm:py-14 flex items-center justify-center">
+        <div className="mx-auto max-w-md text-center">
+          <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-2xl bg-green-50">
+            <CheckCircle2 className="h-8 w-8 text-green-primary" />
+          </div>
+          <h1 className="text-2xl font-bold text-black-primary mb-2">
+            Machine Submitted for Review
+          </h1>
+          <p className="text-black-primary/60 mb-6">
+            Your machine listing has been submitted and is pending admin
+            approval. You will be notified once it is approved and visible to
+            buyers.
+          </p>
+          <Link
+            href="/machines-for-sale"
+            className="inline-flex items-center gap-2 rounded-xl bg-green-primary px-6 py-3 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-green-hover"
+          >
+            Back to Machines for Sale
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-[calc(100vh-160px)] px-4 py-10 sm:py-14">
+      <div className="mx-auto max-w-2xl">
+        <Link
+          href="/machines-for-sale"
+          className="inline-flex items-center gap-1.5 text-sm text-black-primary/60 hover:text-green-primary transition-colors mb-6"
+        >
+          <ChevronLeft className="w-4 h-4" />
+          Back to Machines for Sale
+        </Link>
+
+        <div className="text-center mb-10">
+          <h1 className="text-3xl font-bold text-black-primary">
+            Post a Machine for Sale
+          </h1>
+          <p className="text-black-primary/60 mt-2">
+            List a used vending machine for interested buyers. All submissions
+            are reviewed by admin before going live.
+          </p>
+        </div>
+
+        <form
+          onSubmit={handleSubmit}
+          className="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 sm:p-8 space-y-6"
+        >
+          {submitError && (
+            <div className="p-4 bg-red-50 border border-red-200 rounded-xl text-red-700 text-sm flex items-start gap-3">
+              <AlertCircle className="w-5 h-5 shrink-0 mt-0.5" />
+              <span>{submitError}</span>
+            </div>
+          )}
+
+          {/* Title */}
+          <div>
+            <label
+              htmlFor="title"
+              className="block text-sm font-medium text-black-primary mb-1.5"
+            >
+              Listing Title <span className="text-red-500">*</span>
+            </label>
+            <input
+              id="title"
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="e.g. AMS 39 Combo Machine - Excellent Condition"
+              maxLength={200}
+              className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-black-primary focus:border-green-primary focus:ring-2 focus:ring-green-primary/20"
+            />
+          </div>
+
+          {/* Description */}
+          <div>
+            <label
+              htmlFor="description"
+              className="block text-sm font-medium text-black-primary mb-1.5"
+            >
+              Description{" "}
+              <span className="text-black-primary/30 font-normal">
+                (optional)
+              </span>
+            </label>
+            <textarea
+              id="description"
+              rows={4}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Describe the machine — features, age, service history, reason for selling..."
+              maxLength={5000}
+              className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-black-primary focus:border-green-primary focus:ring-2 focus:ring-green-primary/20"
+            />
+          </div>
+
+          {/* Make / Model */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label
+                htmlFor="machineMake"
+                className="block text-sm font-medium text-black-primary mb-1.5"
+              >
+                Make{" "}
+                <span className="text-black-primary/30 font-normal">
+                  (optional)
+                </span>
+              </label>
+              <input
+                id="machineMake"
+                type="text"
+                value={machineMake}
+                onChange={(e) => setMachineMake(e.target.value)}
+                placeholder="e.g. AMS, Crane, Royal"
+                maxLength={100}
+                className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-black-primary focus:border-green-primary focus:ring-2 focus:ring-green-primary/20"
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="machineModel"
+                className="block text-sm font-medium text-black-primary mb-1.5"
+              >
+                Model{" "}
+                <span className="text-black-primary/30 font-normal">
+                  (optional)
+                </span>
+              </label>
+              <input
+                id="machineModel"
+                type="text"
+                value={machineModel}
+                onChange={(e) => setMachineModel(e.target.value)}
+                placeholder="e.g. 39 VCB, BEVMAX"
+                maxLength={100}
+                className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-black-primary focus:border-green-primary focus:ring-2 focus:ring-green-primary/20"
+              />
+            </div>
+          </div>
+
+          {/* Year / Type / Condition */}
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <div>
+              <label
+                htmlFor="machineYear"
+                className="block text-sm font-medium text-black-primary mb-1.5"
+              >
+                Year{" "}
+                <span className="text-black-primary/30 font-normal">
+                  (optional)
+                </span>
+              </label>
+              <input
+                id="machineYear"
+                type="number"
+                min="1950"
+                max="2100"
+                value={machineYear}
+                onChange={(e) => setMachineYear(e.target.value)}
+                placeholder="e.g. 2020"
+                className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-black-primary focus:border-green-primary focus:ring-2 focus:ring-green-primary/20"
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="machineType"
+                className="block text-sm font-medium text-black-primary mb-1.5"
+              >
+                Type
+              </label>
+              <select
+                id="machineType"
+                value={machineType}
+                onChange={(e) => setMachineType(e.target.value)}
+                className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-black-primary focus:border-green-primary focus:ring-2 focus:ring-green-primary/20"
+              >
+                <option value="">Select type</option>
+                {MACHINE_TYPE_OPTIONS.map((t) => (
+                  <option key={t} value={t}>
+                    {t}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label
+                htmlFor="condition"
+                className="block text-sm font-medium text-black-primary mb-1.5"
+              >
+                Condition
+              </label>
+              <select
+                id="condition"
+                value={condition}
+                onChange={(e) => setCondition(e.target.value)}
+                className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-black-primary focus:border-green-primary focus:ring-2 focus:ring-green-primary/20"
+              >
+                <option value="">Select condition</option>
+                {CONDITION_OPTIONS.map((c) => (
+                  <option key={c.value} value={c.value}>
+                    {c.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          {/* City & State */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label
+                htmlFor="city"
+                className="block text-sm font-medium text-black-primary mb-1.5"
+              >
+                City <span className="text-red-500">*</span>
+              </label>
+              <input
+                id="city"
+                type="text"
+                value={city}
+                onChange={(e) => setCity(e.target.value)}
+                placeholder="e.g. Denver"
+                maxLength={100}
+                className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-black-primary focus:border-green-primary focus:ring-2 focus:ring-green-primary/20"
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="state"
+                className="block text-sm font-medium text-black-primary mb-1.5"
+              >
+                State <span className="text-red-500">*</span>
+              </label>
+              <select
+                id="state"
+                value={state}
+                onChange={(e) => setState(e.target.value)}
+                className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-black-primary focus:border-green-primary focus:ring-2 focus:ring-green-primary/20"
+              >
+                <option value="">Select state</option>
+                {US_STATES.map((s) => (
+                  <option key={s} value={s}>
+                    {s} - {US_STATE_NAMES[s] ?? s}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          {/* Quantity & Price */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label
+                htmlFor="quantity"
+                className="block text-sm font-medium text-black-primary mb-1.5"
+              >
+                Quantity <span className="text-red-500">*</span>
+              </label>
+              <input
+                id="quantity"
+                type="number"
+                min="1"
+                max="1000"
+                value={quantity}
+                onChange={(e) => setQuantity(e.target.value)}
+                className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-black-primary focus:border-green-primary focus:ring-2 focus:ring-green-primary/20"
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="askingPrice"
+                className="block text-sm font-medium text-black-primary mb-1.5"
+              >
+                Asking Price ($){" "}
+                <span className="text-black-primary/30 font-normal">
+                  (optional)
+                </span>
+              </label>
+              <input
+                id="askingPrice"
+                type="number"
+                min="0"
+                step="0.01"
+                value={askingPrice}
+                onChange={(e) => setAskingPrice(e.target.value)}
+                placeholder="e.g. 2500"
+                className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-black-primary focus:border-green-primary focus:ring-2 focus:ring-green-primary/20"
+              />
+            </div>
+          </div>
+
+          {/* Photos */}
+          <div>
+            <label
+              htmlFor="photos"
+              className="block text-sm font-medium text-black-primary mb-1.5"
+            >
+              Photo URLs{" "}
+              <span className="text-black-primary/30 font-normal">
+                (optional, one per line, max 10)
+              </span>
+            </label>
+            <textarea
+              id="photos"
+              rows={3}
+              value={photosText}
+              onChange={(e) => setPhotosText(e.target.value)}
+              placeholder="https://example.com/photo1.jpg&#10;https://example.com/photo2.jpg"
+              className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-black-primary focus:border-green-primary focus:ring-2 focus:ring-green-primary/20"
+            />
+          </div>
+
+          {/* Includes toggles */}
+          <div className="space-y-3">
+            <div className="flex items-center justify-between bg-green-50 rounded-xl p-4">
+              <div>
+                <p className="text-sm font-semibold text-black-primary">
+                  Card Reader Included?
+                </p>
+                <p className="text-xs text-black-primary/50 mt-0.5">
+                  Is a credit card reader (cashless) installed?
+                </p>
+              </div>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={includesCardReader}
+                onClick={() => setIncludesCardReader(!includesCardReader)}
+                className={`relative inline-flex h-7 w-12 shrink-0 cursor-pointer rounded-full transition-colors ${
+                  includesCardReader ? "bg-green-primary" : "bg-gray-300"
+                }`}
+              >
+                <span
+                  className={`pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow-md transform transition-transform mt-1 ${
+                    includesCardReader ? "translate-x-6" : "translate-x-1"
+                  }`}
+                />
+              </button>
+            </div>
+
+            <div className="flex items-center justify-between bg-green-50 rounded-xl p-4">
+              <div>
+                <p className="text-sm font-semibold text-black-primary">
+                  Installation Included?
+                </p>
+                <p className="text-xs text-black-primary/50 mt-0.5">
+                  Will you install the machine for the buyer?
+                </p>
+              </div>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={includesInstall}
+                onClick={() => setIncludesInstall(!includesInstall)}
+                className={`relative inline-flex h-7 w-12 shrink-0 cursor-pointer rounded-full transition-colors ${
+                  includesInstall ? "bg-green-primary" : "bg-gray-300"
+                }`}
+              >
+                <span
+                  className={`pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow-md transform transition-transform mt-1 ${
+                    includesInstall ? "translate-x-6" : "translate-x-1"
+                  }`}
+                />
+              </button>
+            </div>
+
+            <div className="flex items-center justify-between bg-green-50 rounded-xl p-4">
+              <div>
+                <p className="text-sm font-semibold text-black-primary">
+                  Delivery Included?
+                </p>
+                <p className="text-xs text-black-primary/50 mt-0.5">
+                  Will you deliver the machine to the buyer?
+                </p>
+              </div>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={includesDelivery}
+                onClick={() => setIncludesDelivery(!includesDelivery)}
+                className={`relative inline-flex h-7 w-12 shrink-0 cursor-pointer rounded-full transition-colors ${
+                  includesDelivery ? "bg-green-primary" : "bg-gray-300"
+                }`}
+              >
+                <span
+                  className={`pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow-md transform transition-transform mt-1 ${
+                    includesDelivery ? "translate-x-6" : "translate-x-1"
+                  }`}
+                />
+              </button>
+            </div>
+          </div>
+
+          {/* Contact Info */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label
+                htmlFor="contactEmail"
+                className="block text-sm font-medium text-black-primary mb-1.5"
+              >
+                Contact Email{" "}
+                <span className="text-black-primary/30 font-normal">
+                  (optional)
+                </span>
+              </label>
+              <input
+                id="contactEmail"
+                type="email"
+                value={contactEmail}
+                onChange={(e) => setContactEmail(e.target.value)}
+                placeholder="you@example.com"
+                className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-black-primary focus:border-green-primary focus:ring-2 focus:ring-green-primary/20"
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="contactPhone"
+                className="block text-sm font-medium text-black-primary mb-1.5"
+              >
+                Contact Phone{" "}
+                <span className="text-black-primary/30 font-normal">
+                  (optional)
+                </span>
+              </label>
+              <input
+                id="contactPhone"
+                type="tel"
+                value={contactPhone}
+                onChange={(e) => setContactPhone(e.target.value)}
+                placeholder="(555) 123-4567"
+                maxLength={20}
+                className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-black-primary focus:border-green-primary focus:ring-2 focus:ring-green-primary/20"
+              />
+            </div>
+          </div>
+
+          {/* Submit */}
+          <div className="pt-4 border-t border-gray-100">
+            <button
+              type="submit"
+              disabled={submitting}
+              className="w-full flex items-center justify-center gap-2 px-6 py-3 bg-green-primary hover:bg-green-hover text-white rounded-xl font-semibold transition-colors disabled:opacity-50 cursor-pointer"
+            >
+              {submitting ? (
+                <>
+                  <Loader2 className="w-5 h-5 animate-spin" />
+                  Posting Machine...
+                </>
+              ) : (
+                <>
+                  <CheckCircle2 className="w-5 h-5" />
+                  Post Machine for Sale
+                </>
+              )}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -64,8 +64,30 @@ export const createRouteSchema = z.object({
   status: z.enum(["active", "sold", "pending"]).default("pending"),
 });
 
+export const createMachineListingSchema = z.object({
+  title: z.string().min(5, "Title must be at least 5 characters").max(200),
+  description: z.string().max(5000).optional(),
+  city: z.string().min(1, "City is required").max(100),
+  state: z.string().min(2).max(2, "Use 2-letter state code"),
+  machine_make: z.string().max(100).optional(),
+  machine_model: z.string().max(100).optional(),
+  machine_year: z.number().int().min(1950).max(2100).optional(),
+  machine_type: z.string().max(50).optional(),
+  condition: z.enum(["new", "like_new", "good", "fair", "for_parts"]).optional(),
+  quantity: z.number().int().min(1).max(1000).default(1),
+  asking_price: z.number().min(0).max(10000000).optional(),
+  includes_card_reader: z.boolean().default(false),
+  includes_install: z.boolean().default(false),
+  includes_delivery: z.boolean().default(false),
+  photos: z.array(z.string().url()).max(10).default([]),
+  contact_email: z.string().email().optional().or(z.literal("")),
+  contact_phone: z.string().max(20).optional(),
+  status: z.enum(["pending", "active", "sold", "rejected"]).default("pending"),
+});
+
 export type SignupInput = z.infer<typeof signupSchema>;
 export type LoginInput = z.infer<typeof loginSchema>;
 export type CreateRequestInput = z.infer<typeof createRequestSchema>;
 export type CreateListingInput = z.infer<typeof createListingSchema>;
 export type CreateRouteInput = z.infer<typeof createRouteSchema>;
+export type CreateMachineListingInput = z.infer<typeof createMachineListingSchema>;

--- a/src/lib/tooltipCopy.ts
+++ b/src/lib/tooltipCopy.ts
@@ -43,4 +43,6 @@ export const TOOLTIP_COPY: Record<string, string> = {
     "We find high quality locations for your vending machines",
   Machines:
     "Shop new vending machines from Apex AI Vending — buy outright or finance, with optional location placement services.",
+  "Machines for Sale":
+    "Browse used and refurbished vending machines listed by operators across the country.",
 };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -138,6 +138,37 @@ export interface RouteListing {
   profiles?: Profile;
 }
 
+export type MachineListingCondition = "new" | "like_new" | "good" | "fair" | "for_parts";
+export type MachineListingStatus = "pending" | "active" | "sold" | "rejected";
+
+export interface MachineListing {
+  id: string;
+  created_by: string;
+  title: string;
+  description: string | null;
+  city: string;
+  state: string;
+  machine_make: string | null;
+  machine_model: string | null;
+  machine_year: number | null;
+  machine_type: string | null;
+  condition: MachineListingCondition | null;
+  quantity: number;
+  asking_price: number | null;
+  includes_card_reader: boolean;
+  includes_install: boolean;
+  includes_delivery: boolean;
+  photos: string[];
+  contact_email: string | null;
+  contact_phone: string | null;
+  status: MachineListingStatus;
+  admin_notes: string | null;
+  created_at: string;
+  updated_at: string;
+  // Joined
+  profiles?: Profile;
+}
+
 export interface SignedAgreement {
   id: string;
   user_id: string;

--- a/supabase/migrations/025_machine_listings.sql
+++ b/supabase/migrations/025_machine_listings.sql
@@ -1,0 +1,106 @@
+-- ==========================================================
+-- Machine Listings (User-Driven Marketplace for Used Machines)
+-- ==========================================================
+-- Mirrors the route_listings pattern. Any operator can list a
+-- used vending machine for sale. Listings start in 'pending'
+-- status and an admin approves them to make them 'active'
+-- (publicly visible on /machines-for-sale).
+-- ==========================================================
+
+CREATE TABLE IF NOT EXISTS public.machine_listings (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_by uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+
+  -- Listing copy
+  title text NOT NULL,
+  description text,
+
+  -- Location
+  city text NOT NULL,
+  state text NOT NULL,
+
+  -- Machine details
+  machine_make text,
+  machine_model text,
+  machine_year integer,
+  machine_type text,          -- e.g. "Snack", "Beverage", "Combo", "Coffee", "Micro Market"
+  condition text CHECK (condition IN ('new', 'like_new', 'good', 'fair', 'for_parts')),
+  quantity integer NOT NULL DEFAULT 1 CHECK (quantity > 0),
+
+  -- Pricing
+  asking_price numeric,
+
+  -- What's included
+  includes_card_reader boolean NOT NULL DEFAULT false,
+  includes_install boolean NOT NULL DEFAULT false,
+  includes_delivery boolean NOT NULL DEFAULT false,
+
+  -- Media
+  photos text[] NOT NULL DEFAULT '{}',
+
+  -- Contact (private — stripped from public GET responses)
+  contact_email text,
+  contact_phone text,
+
+  -- Moderation workflow
+  status text NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'active', 'sold', 'rejected')),
+  admin_notes text,
+
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_machine_listings_status ON public.machine_listings(status);
+CREATE INDEX IF NOT EXISTS idx_machine_listings_created_by ON public.machine_listings(created_by);
+CREATE INDEX IF NOT EXISTS idx_machine_listings_state ON public.machine_listings(state);
+CREATE INDEX IF NOT EXISTS idx_machine_listings_created_at ON public.machine_listings(created_at DESC);
+
+ALTER TABLE public.machine_listings ENABLE ROW LEVEL SECURITY;
+
+-- Anyone can browse (public list page filters to status='active')
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE policyname = 'machine_listings_select_public') THEN
+    CREATE POLICY machine_listings_select_public ON public.machine_listings
+      FOR SELECT USING (true);
+  END IF;
+END $$;
+
+-- Authenticated users can submit their own listings
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE policyname = 'machine_listings_insert_own') THEN
+    CREATE POLICY machine_listings_insert_own ON public.machine_listings
+      FOR INSERT WITH CHECK (auth.uid() = created_by);
+  END IF;
+END $$;
+
+-- Owners can update their own listings
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE policyname = 'machine_listings_update_own') THEN
+    CREATE POLICY machine_listings_update_own ON public.machine_listings
+      FOR UPDATE USING (auth.uid() = created_by);
+  END IF;
+END $$;
+
+-- Owners can delete their own listings
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE policyname = 'machine_listings_delete_own') THEN
+    CREATE POLICY machine_listings_delete_own ON public.machine_listings
+      FOR DELETE USING (auth.uid() = created_by);
+  END IF;
+END $$;
+
+-- Service role (admin) full access
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE policyname = 'machine_listings_service_role_all') THEN
+    CREATE POLICY machine_listings_service_role_all ON public.machine_listings
+      FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
+END $$;
+
+-- updated_at trigger (touch_updated_at() exists from 024)
+DROP TRIGGER IF EXISTS machine_listings_touch ON public.machine_listings;
+CREATE TRIGGER machine_listings_touch
+  BEFORE UPDATE ON public.machine_listings
+  FOR EACH ROW EXECUTE FUNCTION public.touch_updated_at();
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
Mirrors the routes-for-sale pattern so operators can list used vending machines with admin moderation. Listings start as 'pending' and are only public once an admin approves them.

- migration 025_machine_listings: table with RLS, status workflow (pending/active/sold/rejected), photos[], condition, machine make/model/year, contact info, admin notes
- createMachineListingSchema + MachineListing type
- public API: POST /api/machine-listings (auth, forced pending), GET list (active only, filters by state/type/condition/search), GET by id (strips contact info and created_by)
- admin API: full CRUD with PATCH for approve/reject/status
- /post-machine: operator submission form with photo URLs, condition selector, and include-toggles (card reader, install, delivery)
- /machines-for-sale: grid with search, filters, load more
- /machines-for-sale/[id]: detail page with photo gallery, mailto "Contact Admin" CTA to james@apexaivending.com, similar listings, and "What's Included" breakdown
- admin dashboard: new "Machines For Sale" tab with approve/reject actions, edit modal with status + admin notes, delete confirm
- navbar: "Machines for Sale" link for both guest and auth users
- homepage: "Used Machines" CTA alongside "Shop Machines"