### PR TITLE
Make machine_listings migration self-contained

### DIFF
--- a/supabase/migrations/025_machine_listings.sql
+++ b/supabase/migrations/025_machine_listings.sql
@@ -97,7 +97,19 @@ DO $$ BEGIN
   END IF;
 END $$;
 
--- updated_at trigger (touch_updated_at() exists from 024)
+-- updated_at trigger. Define the touch function idempotently so this
+-- migration can be applied standalone (e.g. if 024 was skipped or
+-- rolled back).
+CREATE OR REPLACE FUNCTION public.touch_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
 DROP TRIGGER IF EXISTS machine_listings_touch ON public.machine_listings;
 CREATE TRIGGER machine_listings_touch
   BEFORE UPDATE ON public.machine_listings


### PR DESCRIPTION
Migration 025 referenced touch_updated_at() as "exists from 024", which breaks if 024 hasn't been applied (or was rolled back). Define the function idempotently inside 025 so it can be applied standalone.