### PR TITLE
Fix close rate: admins now see all deals in their metrics

### DIFF
--- a/src/app/api/sales/results/route.ts
+++ b/src/app/api/sales/results/route.ts
@@ -55,11 +55,16 @@ export async function GET(req: NextRequest) {
     .or(`assigned_to.eq.${targetUserId},created_by.eq.${targetUserId}`)
     .gte("created_at", since);
 
-  // All deals owned by user
-  const { data: allDeals } = await supabaseAdmin
+  // All deals: admins see all, sales users see their own
+  let dealsQuery = supabaseAdmin
     .from("sales_deals")
-    .select("id, stage, value, created_at, locked_at")
-    .eq("assigned_to", targetUserId);
+    .select("id, stage, value, created_at, locked_at");
+  if (user.role === "sales") {
+    dealsQuery = dealsQuery.eq("assigned_to", targetUserId);
+  } else if (targetUserId !== user.id) {
+    dealsQuery = dealsQuery.eq("assigned_to", targetUserId);
+  }
+  const { data: allDeals } = await dealsQuery;
 
   // Deals created in period (for period-specific stage counts)
   const deals = (allDeals || []).filter(


### PR DESCRIPTION
Close rate was 0% because deals were filtered by assigned_to, but the admin user created the deal without being assigned to it. Admins now see all deals in their results; when viewing a specific rep's results, deals are still filtered by that rep's assigned_to.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2