### PR TITLE
Fix: wrap useSearchParams in Suspense boundary for location-intake

### DIFF
--- a/src/app/location-intake/page.tsx
+++ b/src/app/location-intake/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
 import { getGuidance, GuidanceItem } from "@/lib/sopGuidance";
 import {
@@ -92,7 +92,7 @@ function GuidanceSidebar({ items }: { items: GuidanceItem[] }) {
   );
 }
 
-export default function LocationIntakePage() {
+function LocationIntakeContent() {
   const searchParams = useSearchParams();
   const [currentSection, setCurrentSection] = useState(0);
   const [values, setValues] = useState<FormValues>({
@@ -664,5 +664,13 @@ export default function LocationIntakePage() {
         </aside>
       </div>
     </div>
+  );
+}
+
+export default function LocationIntakePage() {
+  return (
+    <Suspense fallback={<div className="flex h-screen items-center justify-center"><Loader2 className="h-8 w-8 animate-spin text-gray-400" /></div>}>
+      <LocationIntakeContent />
+    </Suspense>
   );
 }


### PR DESCRIPTION
Next.js 16.2 requires useSearchParams() to be inside a Suspense boundary during static prerendering. Extracted component into LocationIntakeContent and wrapped with Suspense in the default export.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2