### PR TITLE
Add green lightning bolt emblem next to Vending Connector branding

### DIFF
--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { Zap } from "lucide-react";
 import { TOOLTIP_COPY } from "@/lib/tooltipCopy";
 
 const footerColumns = [
@@ -41,7 +42,8 @@ export default function Footer() {
         <div className="grid grid-cols-1 gap-10 sm:grid-cols-2 lg:grid-cols-5">
           {/* Brand Column */}
           <div className="lg:col-span-1">
-            <Link href="/" className="inline-block">
+            <Link href="/" className="inline-flex items-center gap-1.5">
+              <Zap className="h-6 w-6 text-green-primary fill-green-primary" />
               <span className="text-2xl font-bold tracking-tight text-green-primary">
                 Vending Connector
               </span>

--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { Menu, X, ChevronRight, LogOut, LayoutDashboard, User, Shield, Route, ShoppingBag, ScrollText, Heart, Briefcase } from "lucide-react";
+import { Menu, X, ChevronRight, LogOut, LayoutDashboard, User, Shield, Route, ShoppingBag, ScrollText, Heart, Briefcase, Zap } from "lucide-react";
 import { createBrowserClient } from "@/lib/supabase";
 import type { Profile } from "@/lib/types";
 import Tooltip from "@/app/components/Tooltip";
@@ -174,7 +174,8 @@ export default function Navbar() {
     >
       <nav className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
         {/* Logo */}
-        <Link href="/" className="flex items-center gap-1">
+        <Link href="/" className="flex items-center gap-1.5">
+          <Zap className="h-6 w-6 text-green-primary fill-green-primary" />
           <span className="text-2xl font-bold tracking-tight text-green-primary">
             Vending Connector
           </span>
@@ -372,7 +373,8 @@ export default function Navbar() {
       >
         {/* Drawer Header */}
         <div className="flex items-center justify-between border-b border-gray-100 px-4 py-4">
-          <span className="text-xl font-bold text-green-primary">
+          <span className="flex items-center gap-1.5 text-xl font-bold text-green-primary">
+            <Zap className="h-5 w-5 fill-green-primary" />
             Vending Connector
           </span>
           <button

--- a/src/app/sales/layout.tsx
+++ b/src/app/sales/layout.tsx
@@ -14,6 +14,7 @@ import {
   PhoneCall,
   DollarSign,
   TrendingUp,
+  Zap,
   LogOut,
   Menu,
   X,
@@ -91,7 +92,7 @@ export default function SalesLayout({ children }: { children: React.ReactNode })
       {/* Sidebar — desktop */}
       <aside className="hidden w-56 flex-col border-r border-gray-200 bg-white lg:flex">
         <div className="flex h-14 items-center gap-2 border-b border-gray-100 px-4">
-          <span className="text-lg font-bold text-green-600">Sales CRM</span>
+          <span className="flex items-center gap-1.5 text-lg font-bold text-green-600"><Zap className="h-5 w-5 fill-green-600" />Sales CRM</span>
         </div>
         <nav className="flex-1 space-y-0.5 px-2 py-3">
           {NAV_ITEMS.map((item) => {
@@ -127,7 +128,7 @@ export default function SalesLayout({ children }: { children: React.ReactNode })
       {/* Mobile header */}
       <div className="flex flex-1 flex-col overflow-hidden">
         <header className="flex h-14 items-center justify-between border-b border-gray-200 bg-white px-4 lg:hidden">
-          <span className="text-lg font-bold text-green-600">Sales CRM</span>
+          <span className="flex items-center gap-1.5 text-lg font-bold text-green-600"><Zap className="h-5 w-5 fill-green-600" />Sales CRM</span>
           <button onClick={() => setSidebarOpen(true)} className="rounded-lg p-2 text-gray-600 hover:bg-gray-100">
             <Menu className="h-5 w-5" />
           </button>
@@ -139,7 +140,7 @@ export default function SalesLayout({ children }: { children: React.ReactNode })
             <div className="fixed inset-0 z-40 bg-black/40 lg:hidden" onClick={() => setSidebarOpen(false)} />
             <div className="fixed right-0 top-0 z-50 flex h-full w-64 flex-col bg-white shadow-2xl lg:hidden">
               <div className="flex items-center justify-between border-b border-gray-100 px-4 py-4">
-                <span className="text-lg font-bold text-green-600">Sales CRM</span>
+                <span className="flex items-center gap-1.5 text-lg font-bold text-green-600"><Zap className="h-5 w-5 fill-green-600" />Sales CRM</span>
                 <button onClick={() => setSidebarOpen(false)} className="rounded-lg p-2 text-gray-600 hover:bg-gray-100">
                   <X className="h-5 w-5" />
                 </button>


### PR DESCRIPTION
Added Zap icon (filled green) beside the brand name in:
- Navbar desktop logo
- Navbar mobile drawer header
- Footer brand column
- Sales CRM sidebar (all 3 instances: desktop, mobile header, mobile drawer)

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2