### PR TITLE
Add production onboarding pipeline system with PDF email attachments

### DIFF
--- a/src/app/api/onboarding/candidates/[id]/approve/route.ts
+++ b/src/app/api/onboarding/candidates/[id]/approve/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser, isElevatedRole } from "@/lib/salesAuth";
+
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const user = await getSalesUser(req);
+  if (!user || !isElevatedRole(user.role)) {
+    return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+  }
+  const { id } = await params;
+
+  const { data: candidate, error: cErr } = await supabaseAdmin
+    .from("candidates")
+    .select("*, onboarding_steps(id, step_key, order_index)")
+    .eq("id", id)
+    .single();
+
+  if (cErr || !candidate) return NextResponse.json({ error: "Candidate not found" }, { status: 404 });
+
+  const currentStatus = candidate.status;
+
+  if (currentStatus === "pending_admin_review_1") {
+    const { data: nextStep } = await supabaseAdmin
+      .from("onboarding_steps")
+      .select("id")
+      .eq("pipeline_id", candidate.current_pipeline_id)
+      .eq("step_key", "welcome_docs")
+      .single();
+
+    await supabaseAdmin
+      .from("candidates")
+      .update({
+        status: "welcome_docs_sent",
+        current_step_id: nextStep?.id || candidate.current_step_id,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", id);
+
+    return NextResponse.json({ success: true, new_status: "welcome_docs_sent" });
+  }
+
+  if (currentStatus === "pending_admin_review_2") {
+    const { data: finalStep } = await supabaseAdmin
+      .from("onboarding_steps")
+      .select("id")
+      .eq("pipeline_id", candidate.current_pipeline_id)
+      .eq("step_key", "completion")
+      .single();
+
+    await supabaseAdmin
+      .from("candidates")
+      .update({
+        status: "completed",
+        current_step_id: finalStep?.id || candidate.current_step_id,
+        onboarding_completed_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", id);
+
+    return NextResponse.json({ success: true, new_status: "completed" });
+  }
+
+  return NextResponse.json({ error: `Cannot approve candidate in status: ${currentStatus}` }, { status: 400 });
+}

--- a/src/app/api/onboarding/candidates/[id]/assign-training/route.ts
+++ b/src/app/api/onboarding/candidates/[id]/assign-training/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser } from "@/lib/salesAuth";
+
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const user = await getSalesUser(req);
+  if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id } = await params;
+  const body = await req.json();
+  const { pipeline_id } = body;
+
+  if (!pipeline_id) return NextResponse.json({ error: "pipeline_id required" }, { status: 400 });
+
+  const { data: candidate } = await supabaseAdmin
+    .from("candidates")
+    .select("id, status")
+    .eq("id", id)
+    .single();
+
+  if (!candidate) return NextResponse.json({ error: "Candidate not found" }, { status: 404 });
+
+  if (candidate.status !== "completed") {
+    return NextResponse.json({ error: "Candidate must be in completed status" }, { status: 400 });
+  }
+
+  await supabaseAdmin
+    .from("candidates")
+    .update({
+      status: "assigned_to_training",
+      assigned_training_pipeline_id: pipeline_id,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", id);
+
+  return NextResponse.json({ success: true, new_status: "assigned_to_training" });
+}

--- a/src/app/api/onboarding/candidates/[id]/documents/route.ts
+++ b/src/app/api/onboarding/candidates/[id]/documents/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser } from "@/lib/salesAuth";
+
+const ALLOWED_TYPES = ["application/pdf", "image/jpeg", "image/png", "image/jpg",
+  "application/msword", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"];
+const MAX_SIZE = 10 * 1024 * 1024;
+
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const user = await getSalesUser(req);
+  if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id } = await params;
+
+  const { data, error } = await supabaseAdmin
+    .from("candidate_documents")
+    .select("*")
+    .eq("candidate_id", id)
+    .order("created_at", { ascending: false });
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json(data || []);
+}
+
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const user = await getSalesUser(req);
+  if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id } = await params;
+
+  const formData = await req.formData();
+  const file = formData.get("file") as File | null;
+  const stepKey = formData.get("step_key") as string | null;
+
+  if (!file) return NextResponse.json({ error: "file required" }, { status: 400 });
+  if (!stepKey) return NextResponse.json({ error: "step_key required" }, { status: 400 });
+  if (file.size > MAX_SIZE) return NextResponse.json({ error: "File too large (max 10MB)" }, { status: 400 });
+  if (!ALLOWED_TYPES.includes(file.type)) return NextResponse.json({ error: "File type not allowed" }, { status: 400 });
+
+  const timestamp = Date.now();
+  const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, "_");
+  const filePath = `candidates/${id}/${stepKey}/${timestamp}_${safeName}`;
+
+  const { error: uploadErr } = await supabaseAdmin.storage
+    .from("sales-documents")
+    .upload(filePath, file, { contentType: file.type, upsert: false });
+
+  if (uploadErr) return NextResponse.json({ error: `Upload failed: ${uploadErr.message}` }, { status: 500 });
+
+  const { data: urlData } = supabaseAdmin.storage.from("sales-documents").getPublicUrl(filePath);
+
+  const { data, error } = await supabaseAdmin
+    .from("candidate_documents")
+    .insert({
+      candidate_id: id,
+      step_key: stepKey,
+      file_name: file.name,
+      file_type: file.type,
+      file_url: urlData.publicUrl || filePath,
+      uploaded_by: user.id,
+    })
+    .select("*")
+    .single();
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json(data, { status: 201 });
+}

--- a/src/app/api/onboarding/candidates/[id]/route.ts
+++ b/src/app/api/onboarding/candidates/[id]/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser } from "@/lib/salesAuth";
+
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const user = await getSalesUser(req);
+  if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id } = await params;
+
+  const { data, error } = await supabaseAdmin
+    .from("candidates")
+    .select(`
+      *,
+      candidate_documents(id, step_key, file_name, file_type, file_url, created_at, uploaded_by),
+      onboarding_pipelines(id, name, role_type),
+      onboarding_steps(id, name, step_key, order_index)
+    `)
+    .eq("id", id)
+    .single();
+
+  if (error || !data) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const { data: allSteps } = await supabaseAdmin
+    .from("onboarding_steps")
+    .select("id, name, step_key, order_index")
+    .eq("pipeline_id", data.current_pipeline_id)
+    .order("order_index");
+
+  const { data: emailLogs } = await supabaseAdmin
+    .from("email_logs")
+    .select("*")
+    .eq("candidate_id", id)
+    .order("sent_at", { ascending: false });
+
+  return NextResponse.json({ ...data, all_steps: allSteps || [], email_logs: emailLogs || [] });
+}
+
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const user = await getSalesUser(req);
+  if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id } = await params;
+  const body = await req.json();
+
+  const allowed = ["full_name", "phone", "email", "application_date", "interview_date", "interview_time", "status"];
+  const updates: Record<string, unknown> = { updated_at: new Date().toISOString() };
+  for (const key of allowed) {
+    if (body[key] !== undefined) updates[key] = body[key];
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from("candidates")
+    .update(updates)
+    .eq("id", id)
+    .select("*")
+    .single();
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json(data);
+}

--- a/src/app/api/onboarding/candidates/[id]/send-docs/route.ts
+++ b/src/app/api/onboarding/candidates/[id]/send-docs/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser } from "@/lib/salesAuth";
+import { sendOnboardingDocsEmail } from "@/lib/onboardingPipelineEmail";
+
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const user = await getSalesUser(req);
+  if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id } = await params;
+
+  const { data: candidate, error: cErr } = await supabaseAdmin
+    .from("candidates")
+    .select("*, onboarding_pipelines(id, role_type), onboarding_steps(step_key)")
+    .eq("id", id)
+    .single();
+
+  if (cErr || !candidate) return NextResponse.json({ error: "Candidate not found" }, { status: 404 });
+
+  if (!candidate.email) {
+    return NextResponse.json({ error: "Candidate has no email address" }, { status: 400 });
+  }
+
+  const stepKey = candidate.onboarding_steps?.step_key;
+  if (!stepKey || (stepKey !== "interview" && stepKey !== "welcome_docs")) {
+    return NextResponse.json({ error: "Cannot send documents for current step" }, { status: 400 });
+  }
+
+  if (stepKey === "interview" && candidate.status !== "interview") {
+    return NextResponse.json({ error: "Candidate is not in interview step" }, { status: 400 });
+  }
+
+  if (stepKey === "welcome_docs" && candidate.status !== "welcome_docs_sent") {
+    return NextResponse.json({ error: "Candidate is not in welcome docs step" }, { status: 400 });
+  }
+
+  if (!candidate.full_name || !candidate.interview_date || !candidate.interview_time || !candidate.phone) {
+    if (stepKey === "interview") {
+      return NextResponse.json({ error: "Please complete all required fields (name, phone, interview date/time) before sending documents" }, { status: 400 });
+    }
+  }
+
+  try {
+    const result = await sendOnboardingDocsEmail({
+      candidateId: id,
+      candidateEmail: candidate.email,
+      candidateName: candidate.full_name,
+      stepKey,
+      pipelineId: candidate.current_pipeline_id,
+      roleType: candidate.onboarding_pipelines?.role_type || candidate.role_type,
+    });
+
+    const nextStatus = stepKey === "interview" ? "pending_admin_review_1" : "pending_admin_review_2";
+    await supabaseAdmin
+      .from("candidates")
+      .update({ status: nextStatus, updated_at: new Date().toISOString() })
+      .eq("id", id);
+
+    return NextResponse.json({ ...result, new_status: nextStatus });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Email send failed";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/onboarding/candidates/[id]/terminate/route.ts
+++ b/src/app/api/onboarding/candidates/[id]/terminate/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser, isElevatedRole } from "@/lib/salesAuth";
+
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const user = await getSalesUser(req);
+  if (!user || !isElevatedRole(user.role)) {
+    return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+  }
+  const { id } = await params;
+  const body = await req.json().catch(() => ({}));
+
+  const { data: candidate, error: cErr } = await supabaseAdmin
+    .from("candidates")
+    .select("id, status")
+    .eq("id", id)
+    .single();
+
+  if (cErr || !candidate) return NextResponse.json({ error: "Candidate not found" }, { status: 404 });
+
+  if (candidate.status === "terminated") {
+    return NextResponse.json({ error: "Already terminated" }, { status: 400 });
+  }
+
+  const now = new Date().toISOString();
+
+  await supabaseAdmin.from("termination_logs").insert({
+    candidate_id: id,
+    terminated_by: user.id,
+    reason: body.reason || null,
+    terminated_at: now,
+  });
+
+  await supabaseAdmin
+    .from("candidates")
+    .update({ status: "terminated", terminated_at: now, updated_at: now })
+    .eq("id", id);
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/onboarding/candidates/route.ts
+++ b/src/app/api/onboarding/candidates/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser } from "@/lib/salesAuth";
+
+export async function GET(req: NextRequest) {
+  const user = await getSalesUser(req);
+  if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const url = new URL(req.url);
+  const status = url.searchParams.get("status");
+  const role_type = url.searchParams.get("role_type");
+  const pipeline_id = url.searchParams.get("pipeline_id");
+
+  let query = supabaseAdmin
+    .from("candidates")
+    .select("*, candidate_documents(id, step_key, file_name), onboarding_pipelines(id, name, role_type), onboarding_steps(id, name, step_key)")
+    .order("created_at", { ascending: false });
+
+  if (status) query = query.eq("status", status);
+  if (role_type) query = query.eq("role_type", role_type);
+  if (pipeline_id) query = query.eq("current_pipeline_id", pipeline_id);
+
+  const { data, error } = await query;
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  return NextResponse.json(data || []);
+}
+
+export async function POST(req: NextRequest) {
+  const user = await getSalesUser(req);
+  if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const body = await req.json();
+  const { full_name, phone, email, role_type, application_date, interview_date, interview_time } = body;
+
+  if (!full_name || !role_type) {
+    return NextResponse.json({ error: "full_name and role_type required" }, { status: 400 });
+  }
+
+  const { data: pipeline } = await supabaseAdmin
+    .from("onboarding_pipelines")
+    .select("id")
+    .eq("role_type", role_type)
+    .single();
+
+  if (!pipeline) return NextResponse.json({ error: "Pipeline not found for role type" }, { status: 400 });
+
+  const { data: firstStep } = await supabaseAdmin
+    .from("onboarding_steps")
+    .select("id")
+    .eq("pipeline_id", pipeline.id)
+    .order("order_index")
+    .limit(1)
+    .single();
+
+  const { data, error } = await supabaseAdmin
+    .from("candidates")
+    .insert({
+      full_name,
+      phone: phone || null,
+      email: email || null,
+      role_type,
+      application_date: application_date || new Date().toISOString().split("T")[0],
+      interview_date: interview_date || null,
+      interview_time: interview_time || null,
+      status: "interview",
+      current_pipeline_id: pipeline.id,
+      current_step_id: firstStep?.id || null,
+    })
+    .select("*")
+    .single();
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json(data, { status: 201 });
+}

--- a/src/app/api/onboarding/dashboard/route.ts
+++ b/src/app/api/onboarding/dashboard/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser } from "@/lib/salesAuth";
+
+export async function GET(req: NextRequest) {
+  const user = await getSalesUser(req);
+  if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const { data: candidates, error } = await supabaseAdmin
+    .from("candidates")
+    .select("id, status, role_type, created_at, onboarding_completed_at, terminated_at, application_date");
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  const all = candidates || [];
+  const total = all.length;
+  const interviewing = all.filter((c) => c.status === "interview").length;
+  const pendingReview = all.filter((c) => c.status === "pending_admin_review_1" || c.status === "pending_admin_review_2").length;
+  const welcomeDocs = all.filter((c) => c.status === "welcome_docs_sent").length;
+  const completed = all.filter((c) => c.status === "completed").length;
+  const assignedToTraining = all.filter((c) => c.status === "assigned_to_training").length;
+  const terminated = all.filter((c) => c.status === "terminated").length;
+  const onboarded = all.filter((c) =>
+    c.status === "completed" || c.status === "assigned_to_training"
+  ).length;
+  const active = all.filter((c) => c.status !== "terminated").length;
+
+  const turnoverRate = onboarded > 0 ? Math.round((terminated / (onboarded + terminated)) * 100) : 0;
+
+  const stageCounts = [
+    { stage: "Interview", count: interviewing },
+    { stage: "Pending Review", count: pendingReview },
+    { stage: "Welcome Docs", count: welcomeDocs },
+    { stage: "Completed", count: completed },
+    { stage: "Training", count: assignedToTraining },
+    { stage: "Terminated", count: terminated },
+  ];
+
+  const byRole = {
+    BDP: all.filter((c) => c.role_type === "BDP").length,
+    MARKET_LEADER: all.filter((c) => c.role_type === "MARKET_LEADER").length,
+  };
+
+  const durations: number[] = [];
+  for (const c of all) {
+    if (c.onboarding_completed_at && c.created_at) {
+      const days = Math.round(
+        (new Date(c.onboarding_completed_at).getTime() - new Date(c.created_at).getTime()) / (1000 * 60 * 60 * 24)
+      );
+      durations.push(days);
+    }
+  }
+  const avgOnboardingDays = durations.length > 0
+    ? Math.round(durations.reduce((a, b) => a + b, 0) / durations.length)
+    : 0;
+
+  return NextResponse.json({
+    total,
+    interviewing,
+    pendingReview,
+    welcomeDocs,
+    onboarded,
+    completed,
+    assignedToTraining,
+    active,
+    terminated,
+    turnoverRate,
+    stageCounts,
+    byRole,
+    avgOnboardingDays,
+  });
+}

--- a/src/app/api/onboarding/document-templates/[id]/route.ts
+++ b/src/app/api/onboarding/document-templates/[id]/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser, isElevatedRole } from "@/lib/salesAuth";
+
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const user = await getSalesUser(req);
+  if (!user || !isElevatedRole(user.role)) {
+    return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+  }
+  const { id } = await params;
+  const body = await req.json();
+
+  const allowed = ["name", "active", "pipeline_type", "step_key"];
+  const updates: Record<string, unknown> = {};
+  for (const key of allowed) {
+    if (body[key] !== undefined) updates[key] = body[key];
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from("document_templates")
+    .update(updates)
+    .eq("id", id)
+    .select("*")
+    .single();
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json(data);
+}

--- a/src/app/api/onboarding/document-templates/route.ts
+++ b/src/app/api/onboarding/document-templates/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser, isElevatedRole } from "@/lib/salesAuth";
+
+export async function GET(req: NextRequest) {
+  const user = await getSalesUser(req);
+  if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const url = new URL(req.url);
+  const pipeline_type = url.searchParams.get("pipeline_type");
+  const step_key = url.searchParams.get("step_key");
+  const active_only = url.searchParams.get("active_only");
+
+  let query = supabaseAdmin
+    .from("document_templates")
+    .select("*")
+    .order("created_at", { ascending: false });
+
+  if (pipeline_type) query = query.eq("pipeline_type", pipeline_type);
+  if (step_key) query = query.eq("step_key", step_key);
+  if (active_only === "true") query = query.eq("active", true);
+
+  const { data, error } = await query;
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json(data || []);
+}
+
+export async function POST(req: NextRequest) {
+  const user = await getSalesUser(req);
+  if (!user || !isElevatedRole(user.role)) {
+    return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+  }
+
+  const formData = await req.formData();
+  const file = formData.get("file") as File | null;
+  const name = formData.get("name") as string | null;
+  const pipeline_type = formData.get("pipeline_type") as string | null;
+  const step_key = formData.get("step_key") as string | null;
+  const version = formData.get("version") as string | null;
+
+  if (!file || !name || !pipeline_type || !step_key) {
+    return NextResponse.json({ error: "file, name, pipeline_type, and step_key required" }, { status: 400 });
+  }
+
+  if (file.type !== "application/pdf") {
+    return NextResponse.json({ error: "Only PDF files allowed" }, { status: 400 });
+  }
+
+  const timestamp = Date.now();
+  const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, "_");
+  const filePath = `${pipeline_type}/${step_key}/${timestamp}_${safeName}`;
+
+  const { error: uploadErr } = await supabaseAdmin.storage
+    .from("document-templates")
+    .upload(filePath, file, { contentType: file.type, upsert: false });
+
+  if (uploadErr) return NextResponse.json({ error: `Upload failed: ${uploadErr.message}` }, { status: 500 });
+
+  const { data, error } = await supabaseAdmin
+    .from("document_templates")
+    .insert({
+      name,
+      pipeline_type,
+      step_key,
+      file_path: filePath,
+      file_name: file.name,
+      mime_type: file.type,
+      version: version ? parseInt(version) : 1,
+      active: true,
+    })
+    .select("*")
+    .single();
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json(data, { status: 201 });
+}

--- a/src/app/api/onboarding/email-logs/route.ts
+++ b/src/app/api/onboarding/email-logs/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser } from "@/lib/salesAuth";
+
+export async function GET(req: NextRequest) {
+  const user = await getSalesUser(req);
+  if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const url = new URL(req.url);
+  const candidate_id = url.searchParams.get("candidate_id");
+
+  let query = supabaseAdmin
+    .from("email_logs")
+    .select("*")
+    .order("sent_at", { ascending: false })
+    .limit(100);
+
+  if (candidate_id) query = query.eq("candidate_id", candidate_id);
+
+  const { data, error } = await query;
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json(data || []);
+}

--- a/src/app/api/onboarding/email-templates/[id]/route.ts
+++ b/src/app/api/onboarding/email-templates/[id]/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser, isElevatedRole } from "@/lib/salesAuth";
+
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const user = await getSalesUser(req);
+  if (!user || !isElevatedRole(user.role)) {
+    return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+  }
+  const { id } = await params;
+  const body = await req.json();
+
+  const updates: Record<string, unknown> = { updated_at: new Date().toISOString() };
+  if (body.subject !== undefined) updates.subject = body.subject;
+  if (body.body_html !== undefined) updates.body_html = body.body_html;
+
+  const { data, error } = await supabaseAdmin
+    .from("email_templates_v2")
+    .update(updates)
+    .eq("id", id)
+    .select("*")
+    .single();
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json(data);
+}

--- a/src/app/api/onboarding/email-templates/route.ts
+++ b/src/app/api/onboarding/email-templates/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser } from "@/lib/salesAuth";
+
+export async function GET(req: NextRequest) {
+  const user = await getSalesUser(req);
+  if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const { data, error } = await supabaseAdmin
+    .from("email_templates_v2")
+    .select("*")
+    .order("pipeline_type")
+    .order("step_key");
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json(data || []);
+}

--- a/src/app/api/onboarding/ob-pipelines/route.ts
+++ b/src/app/api/onboarding/ob-pipelines/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser } from "@/lib/salesAuth";
+
+export async function GET(req: NextRequest) {
+  const user = await getSalesUser(req);
+  if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const { data, error } = await supabaseAdmin
+    .from("onboarding_pipelines")
+    .select("*, onboarding_steps(id, name, step_key, order_index)")
+    .order("name");
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  const sorted = (data || []).map((p) => ({
+    ...p,
+    onboarding_steps: (p.onboarding_steps || []).sort(
+      (a: { order_index: number }, b: { order_index: number }) => a.order_index - b.order_index
+    ),
+  }));
+
+  return NextResponse.json(sorted);
+}

--- a/src/app/api/onboarding/step-doc-assignments/route.ts
+++ b/src/app/api/onboarding/step-doc-assignments/route.ts
@@ -1,0 +1,95 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser, isElevatedRole } from "@/lib/salesAuth";
+
+export async function GET(req: NextRequest) {
+  const user = await getSalesUser(req);
+  if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const url = new URL(req.url);
+  const pipeline_id = url.searchParams.get("pipeline_id");
+  const step_key = url.searchParams.get("step_key");
+
+  let query = supabaseAdmin
+    .from("step_document_assignments")
+    .select("*, document_templates(id, name, pipeline_type, step_key, file_name, version, active)")
+    .order("order_index");
+
+  if (pipeline_id) query = query.eq("pipeline_id", pipeline_id);
+  if (step_key) query = query.eq("step_key", step_key);
+
+  const { data, error } = await query;
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json(data || []);
+}
+
+export async function POST(req: NextRequest) {
+  const user = await getSalesUser(req);
+  if (!user || !isElevatedRole(user.role)) {
+    return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+  }
+
+  const body = await req.json();
+  const { action } = body;
+
+  if (action === "assign") {
+    const { pipeline_id, step_key, document_template_id, required, order_index } = body;
+    if (!pipeline_id || !step_key || !document_template_id) {
+      return NextResponse.json({ error: "pipeline_id, step_key, document_template_id required" }, { status: 400 });
+    }
+
+    const { data: existing } = await supabaseAdmin
+      .from("step_document_assignments")
+      .select("id")
+      .eq("pipeline_id", pipeline_id)
+      .eq("step_key", step_key)
+      .eq("document_template_id", document_template_id)
+      .maybeSingle();
+
+    if (existing) return NextResponse.json({ error: "Already assigned" }, { status: 400 });
+
+    const { data, error } = await supabaseAdmin
+      .from("step_document_assignments")
+      .insert({
+        pipeline_id,
+        step_key,
+        document_template_id,
+        required: required !== false,
+        order_index: order_index || 0,
+      })
+      .select("*, document_templates(id, name, file_name, version, active)")
+      .single();
+
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json(data, { status: 201 });
+  }
+
+  if (action === "remove") {
+    const { assignment_id } = body;
+    if (!assignment_id) return NextResponse.json({ error: "assignment_id required" }, { status: 400 });
+
+    const { error } = await supabaseAdmin
+      .from("step_document_assignments")
+      .delete()
+      .eq("id", assignment_id);
+
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ success: true });
+  }
+
+  if (action === "reorder") {
+    const { assignments } = body;
+    if (!Array.isArray(assignments)) return NextResponse.json({ error: "assignments array required" }, { status: 400 });
+
+    for (const item of assignments) {
+      await supabaseAdmin
+        .from("step_document_assignments")
+        .update({ order_index: item.order_index })
+        .eq("id", item.id);
+    }
+
+    return NextResponse.json({ success: true });
+  }
+
+  return NextResponse.json({ error: "Invalid action" }, { status: 400 });
+}

--- a/src/app/sales/admin/documents/page.tsx
+++ b/src/app/sales/admin/documents/page.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { createBrowserClient } from "@/lib/supabase";
+import { Loader2, Upload, FileText, CheckCircle2, XCircle, Plus } from "lucide-react";
+
+interface DocTemplate {
+  id: string;
+  name: string;
+  pipeline_type: string;
+  step_key: string;
+  file_path: string;
+  file_name: string;
+  mime_type: string;
+  version: number;
+  active: boolean;
+  created_at: string;
+}
+
+export default function AdminDocumentsPage() {
+  const [token, setToken] = useState("");
+  const [templates, setTemplates] = useState<DocTemplate[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showUpload, setShowUpload] = useState(false);
+  const [form, setForm] = useState({ name: "", pipeline_type: "ALL", step_key: "interview", version: "1" });
+  const [file, setFile] = useState<File | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [filterType, setFilterType] = useState("");
+  const [filterStep, setFilterStep] = useState("");
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (session?.access_token) setToken(session.access_token);
+    });
+  }, []);
+
+  const load = useCallback(async () => {
+    if (!token) return;
+    setLoading(true);
+    let url = "/api/onboarding/document-templates?";
+    if (filterType) url += `pipeline_type=${filterType}&`;
+    if (filterStep) url += `step_key=${filterStep}&`;
+    const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+    if (res.ok) setTemplates(await res.json());
+    setLoading(false);
+  }, [token, filterType, filterStep]);
+
+  useEffect(() => { load(); }, [load]);
+
+  async function handleUpload() {
+    if (!file || !form.name) return;
+    setUploading(true);
+    const formData = new FormData();
+    formData.append("file", file);
+    formData.append("name", form.name);
+    formData.append("pipeline_type", form.pipeline_type);
+    formData.append("step_key", form.step_key);
+    formData.append("version", form.version);
+    await fetch("/api/onboarding/document-templates", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+      body: formData,
+    });
+    setFile(null);
+    setForm({ name: "", pipeline_type: "ALL", step_key: "interview", version: "1" });
+    setShowUpload(false);
+    setUploading(false);
+    load();
+  }
+
+  async function toggleActive(id: string, active: boolean) {
+    await fetch(`/api/onboarding/document-templates/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ active }),
+    });
+    load();
+  }
+
+  return (
+    <div className="p-6 max-w-5xl mx-auto">
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center gap-2">
+          <FileText className="h-6 w-6 text-green-600" />
+          <h1 className="text-2xl font-bold text-gray-900">Document Templates</h1>
+        </div>
+        <button onClick={() => setShowUpload(true)} className="flex items-center gap-1.5 rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 cursor-pointer">
+          <Plus className="h-4 w-4" /> Upload Template
+        </button>
+      </div>
+
+      {/* Upload form */}
+      {showUpload && (
+        <div className="mb-6 rounded-xl border border-gray-200 bg-white p-6">
+          <h3 className="text-sm font-semibold text-gray-900 mb-4">Upload New Template</h3>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <input placeholder="Document Name *" value={form.name} onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))} className="rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none" />
+            <select value={form.pipeline_type} onChange={(e) => setForm((f) => ({ ...f, pipeline_type: e.target.value }))} className="rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none cursor-pointer">
+              <option value="ALL">All Pipelines</option>
+              <option value="BDP">BDP Only</option>
+              <option value="MARKET_LEADER">Market Leader Only</option>
+            </select>
+            <select value={form.step_key} onChange={(e) => setForm((f) => ({ ...f, step_key: e.target.value }))} className="rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none cursor-pointer">
+              <option value="interview">Interview</option>
+              <option value="welcome_docs">Welcome Docs</option>
+            </select>
+            <input placeholder="Version" type="number" value={form.version} onChange={(e) => setForm((f) => ({ ...f, version: e.target.value }))} className="rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none" />
+            <label className="flex items-center gap-2 rounded-lg border border-dashed border-gray-300 px-4 py-3 cursor-pointer hover:border-green-400">
+              <Upload className="h-4 w-4 text-gray-400" />
+              <span className="text-sm text-gray-500">{file ? file.name : "Choose PDF file *"}</span>
+              <input type="file" accept=".pdf" className="hidden" onChange={(e) => setFile(e.target.files?.[0] || null)} />
+            </label>
+          </div>
+          <div className="flex gap-2 mt-4">
+            <button onClick={handleUpload} disabled={uploading || !file || !form.name} className="rounded-lg bg-green-600 px-4 py-2 text-sm text-white hover:bg-green-700 disabled:opacity-50 cursor-pointer">
+              {uploading ? "Uploading..." : "Upload"}
+            </button>
+            <button onClick={() => setShowUpload(false)} className="rounded-lg border border-gray-200 px-4 py-2 text-sm text-gray-600 hover:bg-gray-50 cursor-pointer">Cancel</button>
+          </div>
+        </div>
+      )}
+
+      {/* Filters */}
+      <div className="flex gap-3 mb-4">
+        <select value={filterType} onChange={(e) => setFilterType(e.target.value)} className="rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none cursor-pointer">
+          <option value="">All Types</option>
+          <option value="ALL">ALL</option>
+          <option value="BDP">BDP</option>
+          <option value="MARKET_LEADER">Market Leader</option>
+        </select>
+        <select value={filterStep} onChange={(e) => setFilterStep(e.target.value)} className="rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none cursor-pointer">
+          <option value="">All Steps</option>
+          <option value="interview">Interview</option>
+          <option value="welcome_docs">Welcome Docs</option>
+        </select>
+      </div>
+
+      {loading ? (
+        <div className="flex justify-center py-20"><Loader2 className="h-8 w-8 animate-spin text-green-600" /></div>
+      ) : (
+        <div className="rounded-xl border border-gray-200 bg-white overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50 border-b border-gray-100">
+              <tr>
+                <th className="text-left px-4 py-3 font-medium text-gray-500">Name</th>
+                <th className="text-left px-4 py-3 font-medium text-gray-500">Pipeline</th>
+                <th className="text-left px-4 py-3 font-medium text-gray-500">Step</th>
+                <th className="text-left px-4 py-3 font-medium text-gray-500">File</th>
+                <th className="text-left px-4 py-3 font-medium text-gray-500">Version</th>
+                <th className="text-left px-4 py-3 font-medium text-gray-500">Active</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-50">
+              {templates.map((t) => (
+                <tr key={t.id} className="hover:bg-gray-50/50">
+                  <td className="px-4 py-3 font-medium text-gray-900">{t.name}</td>
+                  <td className="px-4 py-3">
+                    <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                      t.pipeline_type === "BDP" ? "bg-blue-50 text-blue-600" :
+                      t.pipeline_type === "MARKET_LEADER" ? "bg-purple-50 text-purple-600" :
+                      "bg-gray-100 text-gray-600"
+                    }`}>{t.pipeline_type}</span>
+                  </td>
+                  <td className="px-4 py-3 text-gray-600 capitalize">{t.step_key.replace(/_/g, " ")}</td>
+                  <td className="px-4 py-3 text-gray-500 text-xs">{t.file_name}</td>
+                  <td className="px-4 py-3 text-gray-500">v{t.version}</td>
+                  <td className="px-4 py-3">
+                    <button
+                      onClick={() => toggleActive(t.id, !t.active)}
+                      className="cursor-pointer"
+                    >
+                      {t.active
+                        ? <CheckCircle2 className="h-5 w-5 text-green-600" />
+                        : <XCircle className="h-5 w-5 text-gray-300" />
+                      }
+                    </button>
+                  </td>
+                </tr>
+              ))}
+              {templates.length === 0 && (
+                <tr><td colSpan={6} className="px-4 py-8 text-center text-gray-400">No templates uploaded yet.</td></tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/sales/admin/email-templates/page.tsx
+++ b/src/app/sales/admin/email-templates/page.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { createBrowserClient } from "@/lib/supabase";
+import { Loader2, Mail, Save, Eye } from "lucide-react";
+
+interface EmailTemplate {
+  id: string;
+  pipeline_type: string;
+  step_key: string;
+  subject: string;
+  body_html: string;
+  updated_at: string;
+}
+
+export default function AdminEmailTemplatesPage() {
+  const [token, setToken] = useState("");
+  const [templates, setTemplates] = useState<EmailTemplate[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editSubject, setEditSubject] = useState("");
+  const [editBody, setEditBody] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [previewId, setPreviewId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (session?.access_token) setToken(session.access_token);
+    });
+  }, []);
+
+  const load = useCallback(async () => {
+    if (!token) return;
+    setLoading(true);
+    const res = await fetch("/api/onboarding/email-templates", { headers: { Authorization: `Bearer ${token}` } });
+    if (res.ok) setTemplates(await res.json());
+    setLoading(false);
+  }, [token]);
+
+  useEffect(() => { load(); }, [load]);
+
+  function startEdit(t: EmailTemplate) {
+    setEditingId(t.id);
+    setEditSubject(t.subject);
+    setEditBody(t.body_html);
+  }
+
+  async function handleSave(id: string) {
+    setSaving(true);
+    await fetch(`/api/onboarding/email-templates/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ subject: editSubject, body_html: editBody }),
+    });
+    setEditingId(null);
+    setSaving(false);
+    load();
+  }
+
+  return (
+    <div className="p-6 max-w-5xl mx-auto">
+      <div className="flex items-center gap-2 mb-6">
+        <Mail className="h-6 w-6 text-green-600" />
+        <h1 className="text-2xl font-bold text-gray-900">Email Templates</h1>
+      </div>
+
+      {loading ? (
+        <div className="flex justify-center py-20"><Loader2 className="h-8 w-8 animate-spin text-green-600" /></div>
+      ) : (
+        <div className="space-y-4">
+          {templates.map((t) => (
+            <div key={t.id} className="rounded-xl border border-gray-200 bg-white p-6">
+              <div className="flex items-center justify-between mb-3">
+                <div className="flex items-center gap-2">
+                  <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                    t.pipeline_type === "BDP" ? "bg-blue-50 text-blue-600" : "bg-purple-50 text-purple-600"
+                  }`}>{t.pipeline_type}</span>
+                  <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600 capitalize">{t.step_key.replace(/_/g, " ")}</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  {editingId !== t.id && (
+                    <>
+                      <button onClick={() => setPreviewId(previewId === t.id ? null : t.id)} className="flex items-center gap-1 text-xs text-gray-500 hover:text-gray-700 cursor-pointer">
+                        <Eye className="h-3.5 w-3.5" /> Preview
+                      </button>
+                      <button onClick={() => startEdit(t)} className="rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-50 cursor-pointer">Edit</button>
+                    </>
+                  )}
+                </div>
+              </div>
+
+              {editingId === t.id ? (
+                <div className="space-y-3">
+                  <div>
+                    <label className="text-xs text-gray-500 mb-1 block">Subject</label>
+                    <input value={editSubject} onChange={(e) => setEditSubject(e.target.value)} className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none" />
+                  </div>
+                  <div>
+                    <label className="text-xs text-gray-500 mb-1 block">Body HTML</label>
+                    <textarea value={editBody} onChange={(e) => setEditBody(e.target.value)} rows={10} className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm font-mono focus:border-green-500 focus:outline-none" />
+                  </div>
+                  <div className="flex gap-2">
+                    <button onClick={() => handleSave(t.id)} disabled={saving} className="flex items-center gap-1 rounded-lg bg-green-600 px-4 py-2 text-sm text-white hover:bg-green-700 disabled:opacity-50 cursor-pointer">
+                      {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Save className="h-3.5 w-3.5" />}
+                      Save
+                    </button>
+                    <button onClick={() => setEditingId(null)} className="rounded-lg border border-gray-200 px-4 py-2 text-sm text-gray-600 hover:bg-gray-50 cursor-pointer">Cancel</button>
+                  </div>
+                </div>
+              ) : (
+                <>
+                  <p className="text-sm font-medium text-gray-900">{t.subject}</p>
+                  <p className="text-xs text-gray-400 mt-1">Updated: {new Date(t.updated_at).toLocaleDateString()}</p>
+                </>
+              )}
+
+              {previewId === t.id && editingId !== t.id && (
+                <div className="mt-4 rounded-lg border border-gray-200 bg-gray-50 p-4">
+                  <p className="text-xs text-gray-500 mb-2">Preview ({"{{candidate_name}}"} will be replaced):</p>
+                  <div className="text-sm" dangerouslySetInnerHTML={{ __html: t.body_html.replace(/\{\{candidate_name\}\}/g, "John Doe") }} />
+                </div>
+              )}
+            </div>
+          ))}
+          {templates.length === 0 && (
+            <p className="text-center text-gray-400 py-12">No email templates found.</p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/sales/admin/pipeline-doc-mapping/page.tsx
+++ b/src/app/sales/admin/pipeline-doc-mapping/page.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { createBrowserClient } from "@/lib/supabase";
+import { Loader2, Link2, Plus, Trash2, ChevronUp, ChevronDown, CheckCircle2, XCircle } from "lucide-react";
+
+interface DocTemplate {
+  id: string;
+  name: string;
+  pipeline_type: string;
+  step_key: string;
+  file_name: string;
+  version: number;
+  active: boolean;
+}
+
+interface Assignment {
+  id: string;
+  pipeline_id: string;
+  step_key: string;
+  document_template_id: string;
+  required: boolean;
+  order_index: number;
+  document_templates: DocTemplate | null;
+}
+
+interface Pipeline {
+  id: string;
+  name: string;
+  role_type: string;
+}
+
+export default function PipelineDocMappingPage() {
+  const [token, setToken] = useState("");
+  const [pipelines, setPipelines] = useState<Pipeline[]>([]);
+  const [allTemplates, setAllTemplates] = useState<DocTemplate[]>([]);
+  const [assignments, setAssignments] = useState<Assignment[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selectedPipeline, setSelectedPipeline] = useState("");
+  const [selectedStep, setSelectedStep] = useState("interview");
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (session?.access_token) setToken(session.access_token);
+    });
+  }, []);
+
+  const loadPipelines = useCallback(async () => {
+    if (!token) return;
+    const res = await fetch("/api/onboarding/ob-pipelines", { headers: { Authorization: `Bearer ${token}` } });
+    if (res.ok) {
+      const data = await res.json();
+      setPipelines(data);
+      if (data.length > 0 && !selectedPipeline) setSelectedPipeline(data[0].id);
+    }
+  }, [token, selectedPipeline]);
+
+  const loadTemplates = useCallback(async () => {
+    if (!token) return;
+    const res = await fetch("/api/onboarding/document-templates", { headers: { Authorization: `Bearer ${token}` } });
+    if (res.ok) setAllTemplates(await res.json());
+  }, [token]);
+
+  const loadAssignments = useCallback(async () => {
+    if (!token || !selectedPipeline) return;
+    setLoading(true);
+    const res = await fetch(`/api/onboarding/step-doc-assignments?pipeline_id=${selectedPipeline}&step_key=${selectedStep}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.ok) setAssignments(await res.json());
+    setLoading(false);
+  }, [token, selectedPipeline, selectedStep]);
+
+  useEffect(() => { loadPipelines(); loadTemplates(); }, [loadPipelines, loadTemplates]);
+  useEffect(() => { loadAssignments(); }, [loadAssignments]);
+
+  const assignedIds = new Set(assignments.map((a) => a.document_template_id));
+  const currentPipeline = pipelines.find((p) => p.id === selectedPipeline);
+  const availableTemplates = allTemplates.filter((t) =>
+    !assignedIds.has(t.id) &&
+    t.active &&
+    (t.pipeline_type === currentPipeline?.role_type || t.pipeline_type === "ALL") &&
+    t.step_key === selectedStep
+  );
+
+  async function handleAssign(templateId: string) {
+    setSaving(true);
+    await fetch("/api/onboarding/step-doc-assignments", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({
+        action: "assign",
+        pipeline_id: selectedPipeline,
+        step_key: selectedStep,
+        document_template_id: templateId,
+        required: true,
+        order_index: assignments.length,
+      }),
+    });
+    setSaving(false);
+    loadAssignments();
+  }
+
+  async function handleRemove(assignmentId: string) {
+    await fetch("/api/onboarding/step-doc-assignments", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ action: "remove", assignment_id: assignmentId }),
+    });
+    loadAssignments();
+  }
+
+  async function handleReorder(assignmentId: string, direction: "up" | "down") {
+    const sorted = [...assignments].sort((a, b) => a.order_index - b.order_index);
+    const idx = sorted.findIndex((a) => a.id === assignmentId);
+    if (direction === "up" && idx > 0) {
+      [sorted[idx - 1], sorted[idx]] = [sorted[idx], sorted[idx - 1]];
+    } else if (direction === "down" && idx < sorted.length - 1) {
+      [sorted[idx], sorted[idx + 1]] = [sorted[idx + 1], sorted[idx]];
+    } else return;
+
+    const reordered = sorted.map((a, i) => ({ id: a.id, order_index: i }));
+    await fetch("/api/onboarding/step-doc-assignments", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ action: "reorder", assignments: reordered }),
+    });
+    loadAssignments();
+  }
+
+  const sortedAssignments = [...assignments].sort((a, b) => a.order_index - b.order_index);
+
+  return (
+    <div className="p-6 max-w-5xl mx-auto">
+      <div className="flex items-center gap-2 mb-6">
+        <Link2 className="h-6 w-6 text-green-600" />
+        <h1 className="text-2xl font-bold text-gray-900">Pipeline Document Mapping</h1>
+      </div>
+
+      <p className="text-sm text-gray-500 mb-6">
+        Assign which document templates are sent at each pipeline step. Only assigned documents will be attached to emails.
+      </p>
+
+      {/* Selectors */}
+      <div className="flex gap-3 mb-6">
+        <div>
+          <label className="text-xs text-gray-500 mb-1 block">Pipeline</label>
+          <select
+            value={selectedPipeline}
+            onChange={(e) => setSelectedPipeline(e.target.value)}
+            className="rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none cursor-pointer"
+          >
+            {pipelines.map((p) => <option key={p.id} value={p.id}>{p.name} ({p.role_type})</option>)}
+          </select>
+        </div>
+        <div>
+          <label className="text-xs text-gray-500 mb-1 block">Step</label>
+          <select
+            value={selectedStep}
+            onChange={(e) => setSelectedStep(e.target.value)}
+            className="rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none cursor-pointer"
+          >
+            <option value="interview">Interview</option>
+            <option value="welcome_docs">Welcome Docs</option>
+          </select>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Assigned documents */}
+        <div className="rounded-xl border border-gray-200 bg-white p-6">
+          <h2 className="text-sm font-semibold text-gray-900 mb-4">
+            Assigned Documents ({sortedAssignments.length})
+          </h2>
+          {loading ? (
+            <div className="flex justify-center py-8"><Loader2 className="h-6 w-6 animate-spin text-green-600" /></div>
+          ) : sortedAssignments.length === 0 ? (
+            <p className="text-sm text-gray-400 py-4">No documents assigned to this step yet.</p>
+          ) : (
+            <div className="space-y-2">
+              {sortedAssignments.map((a, i) => (
+                <div key={a.id} className="flex items-center justify-between rounded-lg border border-green-200 bg-green-50 px-4 py-3">
+                  <div className="flex items-center gap-3">
+                    <div className="flex flex-col gap-0.5">
+                      <button onClick={() => handleReorder(a.id, "up")} disabled={i === 0} className="text-gray-300 hover:text-gray-600 disabled:opacity-20 cursor-pointer"><ChevronUp className="h-3 w-3" /></button>
+                      <button onClick={() => handleReorder(a.id, "down")} disabled={i === sortedAssignments.length - 1} className="text-gray-300 hover:text-gray-600 disabled:opacity-20 cursor-pointer"><ChevronDown className="h-3 w-3" /></button>
+                    </div>
+                    <div>
+                      <p className="text-sm font-medium text-gray-900">{a.document_templates?.name || "Unknown"}</p>
+                      <p className="text-xs text-gray-500">
+                        {a.document_templates?.file_name} · v{a.document_templates?.version}
+                        {a.document_templates?.active
+                          ? <span className="ml-1 text-green-600">Active</span>
+                          : <span className="ml-1 text-red-500">Inactive</span>
+                        }
+                      </p>
+                    </div>
+                  </div>
+                  <button onClick={() => handleRemove(a.id)} className="text-gray-300 hover:text-red-500 cursor-pointer">
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Available documents */}
+        <div className="rounded-xl border border-gray-200 bg-white p-6">
+          <h2 className="text-sm font-semibold text-gray-900 mb-4">
+            Available Templates ({availableTemplates.length})
+          </h2>
+          {availableTemplates.length === 0 ? (
+            <p className="text-sm text-gray-400 py-4">No unassigned templates available for this step/pipeline.</p>
+          ) : (
+            <div className="space-y-2">
+              {availableTemplates.map((t) => (
+                <div key={t.id} className="flex items-center justify-between rounded-lg border border-gray-200 px-4 py-3">
+                  <div>
+                    <p className="text-sm font-medium text-gray-900">{t.name}</p>
+                    <p className="text-xs text-gray-500">{t.file_name} · v{t.version} · {t.pipeline_type}</p>
+                  </div>
+                  <button
+                    onClick={() => handleAssign(t.id)}
+                    disabled={saving}
+                    className="flex items-center gap-1 rounded-lg bg-green-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-green-700 disabled:opacity-50 cursor-pointer"
+                  >
+                    <Plus className="h-3 w-3" /> Assign
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/sales/hiring-dashboard/page.tsx
+++ b/src/app/sales/hiring-dashboard/page.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { createBrowserClient } from "@/lib/supabase";
+import {
+  Loader2, Users, UserCheck, Clock, GraduationCap, UserX, TrendingUp, BarChart3, Timer,
+} from "lucide-react";
+
+interface DashboardData {
+  total: number;
+  interviewing: number;
+  pendingReview: number;
+  welcomeDocs: number;
+  onboarded: number;
+  completed: number;
+  assignedToTraining: number;
+  active: number;
+  terminated: number;
+  turnoverRate: number;
+  stageCounts: { stage: string; count: number }[];
+  byRole: { BDP: number; MARKET_LEADER: number };
+  avgOnboardingDays: number;
+}
+
+export default function HiringDashboardPage() {
+  const [token, setToken] = useState("");
+  const [data, setData] = useState<DashboardData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (session?.access_token) setToken(session.access_token);
+    });
+  }, []);
+
+  const load = useCallback(async () => {
+    if (!token) return;
+    setLoading(true);
+    const res = await fetch("/api/onboarding/dashboard", { headers: { Authorization: `Bearer ${token}` } });
+    if (res.ok) setData(await res.json());
+    setLoading(false);
+  }, [token]);
+
+  useEffect(() => { load(); }, [load]);
+
+  if (loading) return <div className="flex justify-center py-20"><Loader2 className="h-8 w-8 animate-spin text-green-600" /></div>;
+  if (!data) return <p className="p-6 text-gray-400">Unable to load dashboard.</p>;
+
+  const maxStageCount = Math.max(...data.stageCounts.map((s) => s.count), 1);
+
+  const kpis = [
+    { label: "Total Candidates", value: data.total, icon: Users, color: "text-gray-900" },
+    { label: "Interviewing", value: data.interviewing, icon: Clock, color: "text-blue-600" },
+    { label: "Pending Review", value: data.pendingReview, icon: Clock, color: "text-amber-600" },
+    { label: "Onboarded", value: data.onboarded, icon: UserCheck, color: "text-green-600" },
+    { label: "In Training", value: data.assignedToTraining, icon: GraduationCap, color: "text-emerald-600" },
+    { label: "Active", value: data.active, icon: TrendingUp, color: "text-green-700" },
+    { label: "Terminated", value: data.terminated, icon: UserX, color: "text-red-600" },
+  ];
+
+  const stageColors: Record<string, string> = {
+    Interview: "bg-blue-500",
+    "Pending Review": "bg-amber-500",
+    "Welcome Docs": "bg-purple-500",
+    Completed: "bg-green-500",
+    Training: "bg-emerald-500",
+    Terminated: "bg-red-500",
+  };
+
+  return (
+    <div className="p-6 max-w-6xl mx-auto">
+      <div className="flex items-center gap-2 mb-6">
+        <BarChart3 className="h-6 w-6 text-green-600" />
+        <h1 className="text-2xl font-bold text-gray-900">Hiring Dashboard</h1>
+      </div>
+
+      {/* KPIs */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-7 gap-3 mb-8">
+        {kpis.map((kpi) => (
+          <div key={kpi.label} className="rounded-xl border border-gray-200 bg-white p-4">
+            <div className="flex items-center gap-1.5 mb-2">
+              <kpi.icon className={`h-4 w-4 ${kpi.color}`} />
+              <span className="text-xs text-gray-500">{kpi.label}</span>
+            </div>
+            <p className={`text-2xl font-bold ${kpi.color}`}>{kpi.value}</p>
+          </div>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
+        {/* Turnover & Metrics */}
+        <div className="rounded-xl border border-gray-200 bg-white p-6">
+          <h2 className="text-sm font-semibold text-gray-900 mb-4">Key Metrics</h2>
+          <div className="space-y-4">
+            <div>
+              <div className="flex items-center justify-between mb-1">
+                <span className="text-sm text-gray-600">Turnover Rate</span>
+                <span className={`text-sm font-bold ${data.turnoverRate > 30 ? "text-red-600" : data.turnoverRate > 15 ? "text-amber-600" : "text-green-600"}`}>
+                  {data.turnoverRate}%
+                </span>
+              </div>
+              <div className="h-2 rounded-full bg-gray-100">
+                <div
+                  className={`h-2 rounded-full ${data.turnoverRate > 30 ? "bg-red-500" : data.turnoverRate > 15 ? "bg-amber-500" : "bg-green-500"}`}
+                  style={{ width: `${Math.min(data.turnoverRate, 100)}%` }}
+                />
+              </div>
+              <p className="text-xs text-gray-400 mt-1">terminated / (onboarded + terminated)</p>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="rounded-lg bg-gray-50 p-3">
+                <p className="text-xs text-gray-500">Avg Onboarding Duration</p>
+                <div className="flex items-center gap-1 mt-1">
+                  <Timer className="h-4 w-4 text-green-600" />
+                  <span className="text-lg font-bold text-gray-900">{data.avgOnboardingDays}</span>
+                  <span className="text-xs text-gray-500">days</span>
+                </div>
+              </div>
+              <div className="rounded-lg bg-gray-50 p-3">
+                <p className="text-xs text-gray-500">By Role</p>
+                <div className="flex gap-3 mt-1">
+                  <div>
+                    <span className="text-lg font-bold text-gray-900">{data.byRole.BDP}</span>
+                    <span className="text-xs text-gray-500 ml-1">BDP</span>
+                  </div>
+                  <div>
+                    <span className="text-lg font-bold text-gray-900">{data.byRole.MARKET_LEADER}</span>
+                    <span className="text-xs text-gray-500 ml-1">ML</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Candidates by Stage */}
+        <div className="rounded-xl border border-gray-200 bg-white p-6">
+          <h2 className="text-sm font-semibold text-gray-900 mb-4">Candidates by Stage</h2>
+          <div className="space-y-3">
+            {data.stageCounts.map((s) => (
+              <div key={s.stage}>
+                <div className="flex items-center justify-between mb-1">
+                  <span className="text-xs text-gray-600">{s.stage}</span>
+                  <span className="text-xs font-medium text-gray-900">{s.count}</span>
+                </div>
+                <div className="h-6 rounded bg-gray-100">
+                  <div
+                    className={`h-6 rounded flex items-center px-2 text-xs font-medium text-white ${stageColors[s.stage] || "bg-gray-400"}`}
+                    style={{ width: `${Math.max((s.count / maxStageCount) * 100, s.count > 0 ? 10 : 0)}%` }}
+                  >
+                    {s.count > 0 ? s.count : ""}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Summary cards */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <div className="rounded-xl border border-green-200 bg-green-50 p-6 text-center">
+          <p className="text-3xl font-bold text-green-700">{data.onboarded}</p>
+          <p className="text-sm text-green-600">Successfully Onboarded</p>
+        </div>
+        <div className="rounded-xl border border-red-200 bg-red-50 p-6 text-center">
+          <p className="text-3xl font-bold text-red-600">{data.terminated}</p>
+          <p className="text-sm text-red-500">Terminated</p>
+        </div>
+        <div className="rounded-xl border border-gray-200 bg-white p-6 text-center">
+          <p className="text-3xl font-bold text-gray-900">{data.active}</p>
+          <p className="text-sm text-gray-500">Currently Active</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/sales/layout.tsx
+++ b/src/app/sales/layout.tsx
@@ -21,6 +21,10 @@ import {
   Menu,
   X,
   Loader2,
+  BarChart3,
+  FileText,
+  Mail,
+  Link2,
 } from "lucide-react";
 
 const NAV_ITEMS = [
@@ -35,6 +39,10 @@ const NAV_ITEMS = [
   { href: "/sales/commissions", label: "Commissions", icon: DollarSign },
   { href: "/sales/call-lists", label: "Call Lists", icon: PhoneCall },
   { href: "/sales/resources", label: "Resources", icon: FolderOpen },
+  { href: "/sales/hiring-dashboard", label: "Hiring", icon: BarChart3 },
+  { href: "/sales/admin/documents", label: "Doc Templates", icon: FileText },
+  { href: "/sales/admin/email-templates", label: "Email Templates", icon: Mail },
+  { href: "/sales/admin/pipeline-doc-mapping", label: "Doc Mapping", icon: Link2 },
 ];
 
 export default function SalesLayout({ children }: { children: React.ReactNode }) {

--- a/src/app/sales/pipelines/onboarding/page.tsx
+++ b/src/app/sales/pipelines/onboarding/page.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+import { createBrowserClient } from "@/lib/supabase";
+import { Loader2, Plus, Users, Briefcase, ChevronRight, CheckCircle2, Clock, AlertTriangle, UserX } from "lucide-react";
+
+interface Candidate {
+  id: string;
+  full_name: string;
+  email: string | null;
+  phone: string | null;
+  role_type: string;
+  status: string;
+  interview_date: string | null;
+  created_at: string;
+  onboarding_pipelines: { id: string; name: string } | null;
+  onboarding_steps: { id: string; name: string; step_key: string } | null;
+}
+
+interface Pipeline {
+  id: string;
+  name: string;
+  role_type: string;
+  onboarding_steps: { id: string; name: string; step_key: string; order_index: number }[];
+}
+
+const STATUS_CONFIG: Record<string, { label: string; color: string }> = {
+  interview: { label: "Interview", color: "bg-blue-50 text-blue-700" },
+  pending_admin_review_1: { label: "Pending Review", color: "bg-amber-50 text-amber-700" },
+  welcome_docs_sent: { label: "Welcome Docs", color: "bg-purple-50 text-purple-700" },
+  pending_admin_review_2: { label: "Pending Review", color: "bg-amber-50 text-amber-700" },
+  completed: { label: "Completed", color: "bg-green-50 text-green-700" },
+  assigned_to_training: { label: "Training", color: "bg-emerald-50 text-emerald-700" },
+  terminated: { label: "Terminated", color: "bg-red-50 text-red-600" },
+};
+
+export default function OnboardingPipelinePage() {
+  const [token, setToken] = useState("");
+  const [pipelines, setPipelines] = useState<Pipeline[]>([]);
+  const [candidates, setCandidates] = useState<Candidate[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selectedPipeline, setSelectedPipeline] = useState<string>("");
+  const [showAdd, setShowAdd] = useState(false);
+  const [form, setForm] = useState({ full_name: "", email: "", phone: "", role_type: "BDP" });
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (session?.access_token) setToken(session.access_token);
+    });
+  }, []);
+
+  const loadPipelines = useCallback(async () => {
+    if (!token) return;
+    const res = await fetch("/api/onboarding/ob-pipelines", { headers: { Authorization: `Bearer ${token}` } });
+    if (res.ok) {
+      const data = await res.json();
+      setPipelines(data);
+      if (data.length > 0 && !selectedPipeline) setSelectedPipeline(data[0].id);
+    }
+  }, [token, selectedPipeline]);
+
+  const loadCandidates = useCallback(async () => {
+    if (!token) return;
+    setLoading(true);
+    const url = selectedPipeline
+      ? `/api/onboarding/candidates?pipeline_id=${selectedPipeline}`
+      : "/api/onboarding/candidates";
+    const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+    if (res.ok) setCandidates(await res.json());
+    setLoading(false);
+  }, [token, selectedPipeline]);
+
+  useEffect(() => { loadPipelines(); }, [loadPipelines]);
+  useEffect(() => { loadCandidates(); }, [loadCandidates]);
+
+  const currentPipeline = pipelines.find((p) => p.id === selectedPipeline);
+
+  async function handleCreate() {
+    if (!form.full_name) return;
+    setSaving(true);
+    await fetch("/api/onboarding/candidates", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify(form),
+    });
+    setForm({ full_name: "", email: "", phone: "", role_type: currentPipeline?.role_type || "BDP" });
+    setShowAdd(false);
+    setSaving(false);
+    loadCandidates();
+  }
+
+  const statusIcon = (status: string) => {
+    if (status === "completed" || status === "assigned_to_training") return <CheckCircle2 className="h-3.5 w-3.5 text-green-600" />;
+    if (status.includes("pending")) return <Clock className="h-3.5 w-3.5 text-amber-500" />;
+    if (status === "terminated") return <UserX className="h-3.5 w-3.5 text-red-500" />;
+    return <AlertTriangle className="h-3.5 w-3.5 text-blue-500" />;
+  };
+
+  const groupedByStep: Record<string, Candidate[]> = {};
+  const stepKeys = ["interview", "pending_review_1", "welcome_docs", "pending_review_2", "completed", "terminated"];
+  const stepLabels: Record<string, string> = {
+    interview: "Interview",
+    pending_review_1: "Admin Review 1",
+    welcome_docs: "Welcome Docs",
+    pending_review_2: "Admin Review 2",
+    completed: "Completed / Training",
+    terminated: "Terminated",
+  };
+
+  for (const key of stepKeys) groupedByStep[key] = [];
+
+  for (const c of candidates) {
+    if (c.status === "interview") groupedByStep["interview"].push(c);
+    else if (c.status === "pending_admin_review_1") groupedByStep["pending_review_1"].push(c);
+    else if (c.status === "welcome_docs_sent") groupedByStep["welcome_docs"].push(c);
+    else if (c.status === "pending_admin_review_2") groupedByStep["pending_review_2"].push(c);
+    else if (c.status === "completed" || c.status === "assigned_to_training") groupedByStep["completed"].push(c);
+    else if (c.status === "terminated") groupedByStep["terminated"].push(c);
+  }
+
+  return (
+    <div className="p-6 max-w-7xl mx-auto">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <Link href="/sales/pipelines" className="text-xs text-gray-400 hover:text-gray-600">Pipelines</Link>
+          <h1 className="text-2xl font-bold text-gray-900">Onboarding Pipelines</h1>
+        </div>
+        <button
+          onClick={() => { setShowAdd(true); setForm((f) => ({ ...f, role_type: currentPipeline?.role_type || "BDP" })); }}
+          className="flex items-center gap-1.5 rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 cursor-pointer"
+        >
+          <Plus className="h-4 w-4" /> New Candidate
+        </button>
+      </div>
+
+      {/* Pipeline selector */}
+      <div className="flex gap-2 mb-6">
+        {pipelines.map((p) => (
+          <button
+            key={p.id}
+            onClick={() => setSelectedPipeline(p.id)}
+            className={`flex items-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium transition-colors cursor-pointer ${
+              selectedPipeline === p.id
+                ? "bg-green-600 text-white"
+                : "bg-white border border-gray-200 text-gray-700 hover:bg-gray-50"
+            }`}
+          >
+            {p.role_type === "BDP" ? <Briefcase className="h-4 w-4" /> : <Users className="h-4 w-4" />}
+            {p.name}
+          </button>
+        ))}
+      </div>
+
+      {/* Add candidate form */}
+      {showAdd && (
+        <div className="mb-6 rounded-xl border border-gray-200 bg-white p-6">
+          <h3 className="text-sm font-semibold text-gray-900 mb-4">New Candidate</h3>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <input placeholder="Full Name *" value={form.full_name} onChange={(e) => setForm((f) => ({ ...f, full_name: e.target.value }))} className="rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none" />
+            <input placeholder="Email" value={form.email} onChange={(e) => setForm((f) => ({ ...f, email: e.target.value }))} className="rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none" />
+            <input placeholder="Phone" value={form.phone} onChange={(e) => setForm((f) => ({ ...f, phone: e.target.value }))} className="rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none" />
+            <select value={form.role_type} onChange={(e) => setForm((f) => ({ ...f, role_type: e.target.value }))} className="rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none cursor-pointer">
+              <option value="BDP">Business Development Partner</option>
+              <option value="MARKET_LEADER">Market Leader</option>
+            </select>
+          </div>
+          <div className="flex gap-2 mt-4">
+            <button onClick={handleCreate} disabled={saving} className="rounded-lg bg-green-600 px-4 py-2 text-sm text-white hover:bg-green-700 disabled:opacity-50 cursor-pointer">{saving ? "Creating..." : "Create"}</button>
+            <button onClick={() => setShowAdd(false)} className="rounded-lg border border-gray-200 px-4 py-2 text-sm text-gray-600 hover:bg-gray-50 cursor-pointer">Cancel</button>
+          </div>
+        </div>
+      )}
+
+      {/* Pipeline progress steps */}
+      {currentPipeline && (
+        <div className="flex items-center gap-1 mb-6 overflow-x-auto pb-2">
+          {currentPipeline.onboarding_steps.map((step, i) => (
+            <div key={step.id} className="flex items-center gap-1 flex-shrink-0">
+              {i > 0 && <ChevronRight className="h-4 w-4 text-gray-300" />}
+              <div className="rounded-full bg-green-50 px-3 py-1.5 text-xs font-medium text-green-700">
+                {step.name}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex justify-center py-20"><Loader2 className="h-8 w-8 animate-spin text-green-600" /></div>
+      ) : (
+        <div className="flex gap-4 overflow-x-auto pb-4">
+          {stepKeys.map((key) => {
+            const items = groupedByStep[key];
+            if (key === "terminated" && items.length === 0) return null;
+            return (
+              <div key={key} className="min-w-[260px] flex-shrink-0">
+                <div className="flex items-center justify-between mb-2">
+                  <h3 className="text-xs font-semibold text-gray-500 uppercase">{stepLabels[key]}</h3>
+                  <span className="text-xs text-gray-300">{items.length}</span>
+                </div>
+                <div className="space-y-2">
+                  {items.map((c) => (
+                    <Link
+                      key={c.id}
+                      href={`/sales/team/${c.id}`}
+                      className="block rounded-lg border border-gray-200 bg-white p-3 hover:border-green-200 transition-colors"
+                    >
+                      <div className="flex items-center gap-2 mb-1">
+                        {statusIcon(c.status)}
+                        <p className="text-sm font-medium text-gray-900">{c.full_name}</p>
+                      </div>
+                      {c.email && <p className="text-xs text-gray-400 mb-1">{c.email}</p>}
+                      <div className="flex items-center justify-between">
+                        <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_CONFIG[c.status]?.color || "bg-gray-100 text-gray-500"}`}>
+                          {STATUS_CONFIG[c.status]?.label || c.status}
+                        </span>
+                        {c.interview_date && <span className="text-xs text-gray-400">{c.interview_date}</span>}
+                      </div>
+                    </Link>
+                  ))}
+                  {items.length === 0 && <p className="text-xs text-gray-300 text-center py-4">Empty</p>}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/sales/team/[id]/page.tsx
+++ b/src/app/sales/team/[id]/page.tsx
@@ -3,46 +3,97 @@
 import { useState, useEffect, useCallback } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { createBrowserClient } from "@/lib/supabase";
-import { ArrowLeft, Loader2, Upload, FileText, Trash2, CheckCircle2 } from "lucide-react";
+import {
+  ArrowLeft, Loader2, Upload, FileText, CheckCircle2, Circle, Clock,
+  Send, ShieldCheck, GraduationCap, UserX, AlertTriangle, Mail, XCircle,
+} from "lucide-react";
 
-interface EmployeeDoc {
+interface CandidateDoc {
   id: string;
+  step_key: string;
   file_name: string;
   file_type: string | null;
   file_url: string;
   created_at: string;
 }
 
-interface Employee {
+interface EmailLog {
   id: string;
-  full_name: string;
-  email: string | null;
-  phone: string | null;
-  role: string;
+  step_key: string;
+  recipient_email: string;
+  subject: string | null;
   status: string;
-  employee_documents: EmployeeDoc[];
-  created_at: string;
+  error_message: string | null;
+  attachment_count: number;
+  sent_at: string;
 }
 
-const ROLES = [
-  { value: "sales_rep", label: "Sales Rep" },
-  { value: "market_leader", label: "Market Leader" },
-  { value: "admin", label: "Admin" },
-  { value: "director_of_sales", label: "Director of Sales" },
-  { value: "operations", label: "Operations" },
-  { value: "support", label: "Support" },
-];
+interface StepInfo {
+  id: string;
+  name: string;
+  step_key: string;
+  order_index: number;
+}
 
-export default function TeamMemberPage() {
+interface Candidate {
+  id: string;
+  full_name: string;
+  phone: string | null;
+  email: string | null;
+  role_type: string;
+  application_date: string | null;
+  interview_date: string | null;
+  interview_time: string | null;
+  status: string;
+  current_pipeline_id: string | null;
+  current_step_id: string | null;
+  onboarding_completed_at: string | null;
+  assigned_training_pipeline_id: string | null;
+  terminated_at: string | null;
+  created_at: string;
+  onboarding_pipelines: { id: string; name: string; role_type: string } | null;
+  onboarding_steps: StepInfo | null;
+  candidate_documents: CandidateDoc[];
+  all_steps: StepInfo[];
+  email_logs: EmailLog[];
+}
+
+interface TrainingPipeline {
+  id: string;
+  name: string;
+  type: string;
+}
+
+const STATUS_CONFIG: Record<string, { label: string; color: string }> = {
+  interview: { label: "Interview", color: "bg-blue-50 text-blue-700" },
+  pending_admin_review_1: { label: "Pending Admin Review", color: "bg-amber-50 text-amber-700" },
+  welcome_docs_sent: { label: "Welcome Docs Step", color: "bg-purple-50 text-purple-700" },
+  pending_admin_review_2: { label: "Pending Admin Review", color: "bg-amber-50 text-amber-700" },
+  completed: { label: "Onboarding Complete", color: "bg-green-50 text-green-700" },
+  assigned_to_training: { label: "Assigned to Training", color: "bg-emerald-50 text-emerald-700" },
+  terminated: { label: "Terminated", color: "bg-red-50 text-red-600" },
+};
+
+export default function CandidateDetailPage() {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const [token, setToken] = useState("");
-  const [employee, setEmployee] = useState<Employee | null>(null);
+  const [candidate, setCandidate] = useState<Candidate | null>(null);
   const [loading, setLoading] = useState(true);
+  const [sending, setSending] = useState(false);
+  const [approving, setApproving] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [actionSuccess, setActionSuccess] = useState<string | null>(null);
+  const [uploadingStep, setUploadingStep] = useState<string | null>(null);
   const [editing, setEditing] = useState(false);
-  const [form, setForm] = useState({ full_name: "", email: "", phone: "", role: "", status: "" });
+  const [form, setForm] = useState({ full_name: "", phone: "", email: "", interview_date: "", interview_time: "" });
   const [saving, setSaving] = useState(false);
-  const [uploading, setUploading] = useState(false);
+  const [trainingPipelines, setTrainingPipelines] = useState<TrainingPipeline[]>([]);
+  const [selectedTraining, setSelectedTraining] = useState("");
+  const [assigning, setAssigning] = useState(false);
+  const [showTerminate, setShowTerminate] = useState(false);
+  const [terminateReason, setTerminateReason] = useState("");
+  const [terminating, setTerminating] = useState(false);
 
   useEffect(() => {
     const supabase = createBrowserClient();
@@ -54,16 +105,16 @@ export default function TeamMemberPage() {
   const load = useCallback(async () => {
     if (!token || !id) return;
     setLoading(true);
-    const res = await fetch(`/api/team/${id}`, { headers: { Authorization: `Bearer ${token}` } });
+    const res = await fetch(`/api/onboarding/candidates/${id}`, { headers: { Authorization: `Bearer ${token}` } });
     if (res.ok) {
       const data = await res.json();
-      setEmployee(data);
+      setCandidate(data);
       setForm({
-        full_name: data.full_name,
-        email: data.email || "",
+        full_name: data.full_name || "",
         phone: data.phone || "",
-        role: data.role,
-        status: data.status,
+        email: data.email || "",
+        interview_date: data.interview_date || "",
+        interview_time: data.interview_time || "",
       });
     }
     setLoading(false);
@@ -71,9 +122,16 @@ export default function TeamMemberPage() {
 
   useEffect(() => { load(); }, [load]);
 
+  useEffect(() => {
+    if (!token || !candidate || candidate.status !== "completed") return;
+    fetch("/api/pipelines", { headers: { Authorization: `Bearer ${token}` } })
+      .then((r) => r.ok ? r.json() : [])
+      .then((data) => setTrainingPipelines(data));
+  }, [token, candidate]);
+
   async function handleSave() {
     setSaving(true);
-    await fetch(`/api/team/${id}`, {
+    await fetch(`/api/onboarding/candidates/${id}`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
       body: JSON.stringify(form),
@@ -83,92 +141,483 @@ export default function TeamMemberPage() {
     load();
   }
 
-  async function handleUpload(e: React.ChangeEvent<HTMLInputElement>) {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    setUploading(true);
+  async function handleSendDocs() {
+    setSending(true);
+    setActionError(null);
+    setActionSuccess(null);
+    const res = await fetch(`/api/onboarding/candidates/${id}/send-docs`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const data = await res.json();
+    if (res.ok) {
+      setActionSuccess(`Documents sent successfully (${data.attachmentCount} attachments)`);
+      load();
+    } else {
+      setActionError(data.error || "Failed to send documents");
+    }
+    setSending(false);
+  }
+
+  async function handleApprove() {
+    setApproving(true);
+    setActionError(null);
+    setActionSuccess(null);
+    const res = await fetch(`/api/onboarding/candidates/${id}/approve`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const data = await res.json();
+    if (res.ok) {
+      setActionSuccess("Approved! Step unlocked.");
+      load();
+    } else {
+      setActionError(data.error || "Approval failed");
+    }
+    setApproving(false);
+  }
+
+  async function handleUploadDoc(stepKey: string, file: File) {
+    setUploadingStep(stepKey);
     const formData = new FormData();
     formData.append("file", file);
-    await fetch(`/api/team/${id}/documents`, { method: "POST", headers: { Authorization: `Bearer ${token}` }, body: formData });
-    setUploading(false);
+    formData.append("step_key", stepKey);
+    await fetch(`/api/onboarding/candidates/${id}/documents`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+      body: formData,
+    });
+    setUploadingStep(null);
     load();
   }
 
+  async function handleAssignTraining() {
+    if (!selectedTraining) return;
+    setAssigning(true);
+    setActionError(null);
+    const res = await fetch(`/api/onboarding/candidates/${id}/assign-training`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ pipeline_id: selectedTraining }),
+    });
+    if (res.ok) {
+      setActionSuccess("Assigned to training pipeline!");
+      load();
+    } else {
+      const data = await res.json();
+      setActionError(data.error || "Failed to assign");
+    }
+    setAssigning(false);
+  }
+
+  async function handleTerminate() {
+    setTerminating(true);
+    setActionError(null);
+    const res = await fetch(`/api/onboarding/candidates/${id}/terminate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ reason: terminateReason }),
+    });
+    if (res.ok) {
+      setShowTerminate(false);
+      load();
+    } else {
+      const data = await res.json();
+      setActionError(data.error || "Termination failed");
+    }
+    setTerminating(false);
+  }
+
   if (loading) return <div className="flex justify-center py-20"><Loader2 className="h-8 w-8 animate-spin text-green-600" /></div>;
-  if (!employee) return <p className="p-6 text-gray-400">Employee not found.</p>;
+  if (!candidate) return <p className="p-6 text-gray-400">Candidate not found.</p>;
+
+  const currentStepIdx = candidate.all_steps.findIndex((s) => s.id === candidate.current_step_id);
+  const isTerminated = candidate.status === "terminated";
+
+  const interviewDocs = candidate.candidate_documents.filter((d) => d.step_key === "interview");
+  const welcomeDocs = candidate.candidate_documents.filter((d) => d.step_key === "welcome_docs");
+  const resumeDocs = candidate.candidate_documents.filter((d) => d.step_key === "resume");
 
   return (
-    <div className="p-6 max-w-3xl mx-auto">
+    <div className="p-6 max-w-4xl mx-auto">
       <button onClick={() => router.push("/sales/team")} className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 mb-4 cursor-pointer">
         <ArrowLeft className="h-4 w-4" /> Back to Team
       </button>
 
+      {/* Header */}
       <div className="rounded-xl border border-gray-200 bg-white p-6 mb-6">
-        <div className="flex items-center justify-between mb-4">
-          <h1 className="text-xl font-bold text-gray-900">{employee.full_name}</h1>
-          <div className="flex gap-2">
-            {!editing ? (
+        <div className="flex items-center justify-between mb-3">
+          <div>
+            <h1 className="text-xl font-bold text-gray-900">{candidate.full_name}</h1>
+            <p className="text-sm text-gray-500">{candidate.role_type === "BDP" ? "Business Development Partner" : "Market Leader"}</p>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className={`rounded-full px-3 py-1 text-xs font-medium ${STATUS_CONFIG[candidate.status]?.color || "bg-gray-100 text-gray-500"}`}>
+              {STATUS_CONFIG[candidate.status]?.label || candidate.status}
+            </span>
+            {!editing && !isTerminated && (
               <button onClick={() => setEditing(true)} className="rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-50 cursor-pointer">Edit</button>
-            ) : (
-              <>
-                <button onClick={handleSave} disabled={saving} className="rounded-lg bg-green-600 px-3 py-1.5 text-xs text-white hover:bg-green-700 disabled:opacity-50 cursor-pointer">{saving ? "Saving..." : "Save"}</button>
-                <button onClick={() => setEditing(false)} className="rounded-lg border border-gray-200 px-3 py-1.5 text-xs text-gray-600 hover:bg-gray-50 cursor-pointer">Cancel</button>
-              </>
             )}
           </div>
         </div>
 
         {editing ? (
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <input value={form.full_name} onChange={(e) => setForm((f) => ({ ...f, full_name: e.target.value }))} className="rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none" placeholder="Full Name" />
-            <input value={form.email} onChange={(e) => setForm((f) => ({ ...f, email: e.target.value }))} className="rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none" placeholder="Email" />
-            <input value={form.phone} onChange={(e) => setForm((f) => ({ ...f, phone: e.target.value }))} className="rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none" placeholder="Phone" />
-            <select value={form.role} onChange={(e) => setForm((f) => ({ ...f, role: e.target.value }))} className="rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none cursor-pointer">
-              {ROLES.map((r) => <option key={r.value} value={r.value}>{r.label}</option>)}
-            </select>
-            <select value={form.status} onChange={(e) => setForm((f) => ({ ...f, status: e.target.value }))} className="rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none cursor-pointer">
-              <option value="active">Active</option>
-              <option value="inactive">Inactive</option>
-            </select>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-4">
+            <div>
+              <label className="text-xs text-gray-500 mb-1 block">Full Name *</label>
+              <input value={form.full_name} onChange={(e) => setForm((f) => ({ ...f, full_name: e.target.value }))} className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none" />
+            </div>
+            <div>
+              <label className="text-xs text-gray-500 mb-1 block">Email</label>
+              <input value={form.email} onChange={(e) => setForm((f) => ({ ...f, email: e.target.value }))} className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none" />
+            </div>
+            <div>
+              <label className="text-xs text-gray-500 mb-1 block">Phone</label>
+              <input value={form.phone} onChange={(e) => setForm((f) => ({ ...f, phone: e.target.value }))} className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none" />
+            </div>
+            <div>
+              <label className="text-xs text-gray-500 mb-1 block">Interview Date</label>
+              <input type="date" value={form.interview_date} onChange={(e) => setForm((f) => ({ ...f, interview_date: e.target.value }))} className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none" />
+            </div>
+            <div>
+              <label className="text-xs text-gray-500 mb-1 block">Interview Time</label>
+              <input type="time" value={form.interview_time} onChange={(e) => setForm((f) => ({ ...f, interview_time: e.target.value }))} className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none" />
+            </div>
+            <div className="flex items-end gap-2">
+              <button onClick={handleSave} disabled={saving} className="rounded-lg bg-green-600 px-4 py-2 text-sm text-white hover:bg-green-700 disabled:opacity-50 cursor-pointer">{saving ? "Saving..." : "Save"}</button>
+              <button onClick={() => setEditing(false)} className="rounded-lg border border-gray-200 px-4 py-2 text-sm text-gray-600 hover:bg-gray-50 cursor-pointer">Cancel</button>
+            </div>
           </div>
         ) : (
-          <div className="grid grid-cols-2 gap-4 text-sm">
-            <div><p className="text-gray-400">Email</p><p className="font-medium text-gray-900">{employee.email || "—"}</p></div>
-            <div><p className="text-gray-400">Phone</p><p className="font-medium text-gray-900">{employee.phone || "—"}</p></div>
-            <div><p className="text-gray-400">Role</p><p className="font-medium text-gray-900 capitalize">{employee.role.replace(/_/g, " ")}</p></div>
-            <div><p className="text-gray-400">Status</p><p className={`font-medium ${employee.status === "active" ? "text-green-600" : "text-gray-400"}`}>{employee.status}</p></div>
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-4 text-sm mt-2">
+            <div><p className="text-gray-400">Email</p><p className="font-medium text-gray-900">{candidate.email || "—"}</p></div>
+            <div><p className="text-gray-400">Phone</p><p className="font-medium text-gray-900">{candidate.phone || "—"}</p></div>
+            <div><p className="text-gray-400">Application Date</p><p className="font-medium text-gray-900">{candidate.application_date || "—"}</p></div>
+            <div><p className="text-gray-400">Interview Date</p><p className="font-medium text-gray-900">{candidate.interview_date || "—"}</p></div>
+            <div><p className="text-gray-400">Interview Time</p><p className="font-medium text-gray-900">{candidate.interview_time || "—"}</p></div>
+            <div><p className="text-gray-400">Pipeline</p><p className="font-medium text-gray-900">{candidate.onboarding_pipelines?.name || "—"}</p></div>
           </div>
         )}
       </div>
 
-      {/* Documents */}
-      <div className="rounded-xl border border-gray-200 bg-white p-6">
-        <div className="flex items-center justify-between mb-4">
-          <h2 className="text-base font-semibold text-gray-900">Documents</h2>
-          <label className="flex items-center gap-1.5 rounded-lg bg-green-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-green-700 cursor-pointer">
-            <Upload className="h-3 w-3" />
-            {uploading ? "Uploading..." : "Upload"}
-            <input type="file" className="hidden" onChange={handleUpload} accept=".pdf,.jpg,.jpeg,.png,.doc,.docx" />
-          </label>
+      {/* Pipeline Progress */}
+      <div className="rounded-xl border border-gray-200 bg-white p-6 mb-6">
+        <h2 className="text-sm font-semibold text-gray-900 mb-4">Onboarding Progress</h2>
+        <div className="flex items-center gap-1 overflow-x-auto pb-2">
+          {candidate.all_steps.map((step, i) => {
+            const isCurrent = step.id === candidate.current_step_id;
+            const isPast = i < currentStepIdx;
+            return (
+              <div key={step.id} className="flex items-center gap-1 flex-shrink-0">
+                {i > 0 && <div className={`h-0.5 w-8 ${isPast || isCurrent ? "bg-green-400" : "bg-gray-200"}`} />}
+                <div className={`flex items-center gap-1.5 rounded-full px-4 py-2 text-xs font-medium ${
+                  isCurrent ? "bg-green-600 text-white" :
+                  isPast ? "bg-green-100 text-green-700" :
+                  "bg-gray-100 text-gray-400"
+                }`}>
+                  {isPast ? <CheckCircle2 className="h-3.5 w-3.5" /> : isCurrent ? <Circle className="h-3.5 w-3.5 fill-white" /> : <Circle className="h-3.5 w-3.5" />}
+                  {step.name}
+                </div>
+              </div>
+            );
+          })}
         </div>
+      </div>
 
-        {employee.employee_documents.length === 0 ? (
-          <p className="text-sm text-gray-400">No documents uploaded yet.</p>
+      {/* Action messages */}
+      {actionError && (
+        <div className="rounded-xl border border-red-200 bg-red-50 p-4 mb-6">
+          <div className="flex items-center gap-2 text-sm text-red-700">
+            <AlertTriangle className="h-4 w-4" />
+            <span>{actionError}</span>
+          </div>
+        </div>
+      )}
+      {actionSuccess && (
+        <div className="rounded-xl border border-green-200 bg-green-50 p-4 mb-6">
+          <div className="flex items-center gap-2 text-sm text-green-700">
+            <CheckCircle2 className="h-4 w-4" />
+            <span>{actionSuccess}</span>
+          </div>
+        </div>
+      )}
+
+      {/* Step Actions */}
+      {!isTerminated && (
+        <div className="rounded-xl border border-gray-200 bg-white p-6 mb-6">
+          <h2 className="text-sm font-semibold text-gray-900 mb-4">Current Step Actions</h2>
+
+          {/* STEP 1: Interview */}
+          {candidate.status === "interview" && (
+            <div className="space-y-4">
+              <p className="text-sm text-gray-600">Complete candidate details and upload resume, then send NDA / NCA / Agreement documents.</p>
+              <div className="flex items-center gap-2">
+                <label className="flex items-center gap-1.5 rounded-lg border border-gray-200 px-3 py-2 text-xs font-medium text-gray-700 hover:bg-gray-50 cursor-pointer">
+                  <Upload className="h-3.5 w-3.5" />
+                  {uploadingStep === "resume" ? "Uploading..." : "Upload Resume"}
+                  <input type="file" className="hidden" onChange={(e) => { if (e.target.files?.[0]) handleUploadDoc("resume", e.target.files[0]); }} />
+                </label>
+                {resumeDocs.length > 0 && (
+                  <span className="text-xs text-green-600 flex items-center gap-1"><CheckCircle2 className="h-3 w-3" /> Resume uploaded</span>
+                )}
+              </div>
+              <button
+                onClick={handleSendDocs}
+                disabled={sending}
+                className="flex items-center gap-2 rounded-lg bg-green-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-50 cursor-pointer"
+              >
+                {sending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
+                Send NDA / NCA / Agreement
+              </button>
+            </div>
+          )}
+
+          {/* ADMIN REVIEW 1 */}
+          {candidate.status === "pending_admin_review_1" && (
+            <div className="space-y-4">
+              <div className="rounded-lg bg-amber-50 border border-amber-200 p-4">
+                <div className="flex items-center gap-2 text-sm font-medium text-amber-800 mb-2">
+                  <Clock className="h-4 w-4" />
+                  Waiting for signed documents
+                </div>
+                <p className="text-xs text-amber-700">Upload the returned NDA, NCA, and Agreement documents, then approve to unlock the next step.</p>
+              </div>
+              <div className="space-y-2">
+                {["NDA", "NCA", "Agreement"].map((docName) => {
+                  const found = interviewDocs.find((d) => d.file_name.toLowerCase().includes(docName.toLowerCase()));
+                  return (
+                    <div key={docName} className={`flex items-center justify-between rounded-lg border px-4 py-3 ${found ? "border-green-200 bg-green-50" : "border-gray-200"}`}>
+                      <div className="flex items-center gap-2">
+                        {found ? <CheckCircle2 className="h-4 w-4 text-green-600" /> : <FileText className="h-4 w-4 text-gray-400" />}
+                        <span className="text-sm text-gray-900">{docName}</span>
+                        {found && <span className="text-xs text-green-600">{found.file_name}</span>}
+                      </div>
+                      {!found && (
+                        <label className="flex items-center gap-1 rounded-lg bg-green-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-green-700 cursor-pointer">
+                          {uploadingStep === "interview" ? <Loader2 className="h-3 w-3 animate-spin" /> : <Upload className="h-3 w-3" />}
+                          Upload
+                          <input type="file" className="hidden" onChange={(e) => { if (e.target.files?.[0]) handleUploadDoc("interview", e.target.files[0]); }} />
+                        </label>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+              <button
+                onClick={handleApprove}
+                disabled={approving}
+                className="flex items-center gap-2 rounded-lg bg-green-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-50 cursor-pointer"
+              >
+                {approving ? <Loader2 className="h-4 w-4 animate-spin" /> : <ShieldCheck className="h-4 w-4" />}
+                Approve and Unlock Next Step
+              </button>
+            </div>
+          )}
+
+          {/* STEP 2: Welcome Docs */}
+          {candidate.status === "welcome_docs_sent" && (
+            <div className="space-y-4">
+              <p className="text-sm text-gray-600">Send the welcome email with ACH and W9 form attachments.</p>
+              <button
+                onClick={handleSendDocs}
+                disabled={sending}
+                className="flex items-center gap-2 rounded-lg bg-green-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-50 cursor-pointer"
+              >
+                {sending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
+                Send Welcome Email with ACH and W9
+              </button>
+            </div>
+          )}
+
+          {/* ADMIN REVIEW 2 */}
+          {candidate.status === "pending_admin_review_2" && (
+            <div className="space-y-4">
+              <div className="rounded-lg bg-amber-50 border border-amber-200 p-4">
+                <div className="flex items-center gap-2 text-sm font-medium text-amber-800 mb-2">
+                  <Clock className="h-4 w-4" />
+                  Waiting for completed ACH and W9
+                </div>
+                <p className="text-xs text-amber-700">Upload the returned ACH and W9 forms, then approve to complete onboarding.</p>
+              </div>
+              <div className="space-y-2">
+                {["ACH", "W9"].map((docName) => {
+                  const found = welcomeDocs.find((d) => d.file_name.toLowerCase().includes(docName.toLowerCase()));
+                  return (
+                    <div key={docName} className={`flex items-center justify-between rounded-lg border px-4 py-3 ${found ? "border-green-200 bg-green-50" : "border-gray-200"}`}>
+                      <div className="flex items-center gap-2">
+                        {found ? <CheckCircle2 className="h-4 w-4 text-green-600" /> : <FileText className="h-4 w-4 text-gray-400" />}
+                        <span className="text-sm text-gray-900">{docName}</span>
+                        {found && <span className="text-xs text-green-600">{found.file_name}</span>}
+                      </div>
+                      {!found && (
+                        <label className="flex items-center gap-1 rounded-lg bg-green-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-green-700 cursor-pointer">
+                          {uploadingStep === "welcome_docs" ? <Loader2 className="h-3 w-3 animate-spin" /> : <Upload className="h-3 w-3" />}
+                          Upload
+                          <input type="file" className="hidden" onChange={(e) => { if (e.target.files?.[0]) handleUploadDoc("welcome_docs", e.target.files[0]); }} />
+                        </label>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+              <button
+                onClick={handleApprove}
+                disabled={approving}
+                className="flex items-center gap-2 rounded-lg bg-green-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-50 cursor-pointer"
+              >
+                {approving ? <Loader2 className="h-4 w-4 animate-spin" /> : <ShieldCheck className="h-4 w-4" />}
+                Approve and Complete Onboarding
+              </button>
+            </div>
+          )}
+
+          {/* STEP 3: Completion */}
+          {candidate.status === "completed" && (
+            <div className="space-y-4">
+              <div className="rounded-lg bg-green-50 border border-green-200 p-4">
+                <div className="flex items-center gap-2 text-sm font-medium text-green-800">
+                  <CheckCircle2 className="h-4 w-4" />
+                  Success! You have successfully onboarded {candidate.full_name}.
+                </div>
+              </div>
+              <div>
+                <label className="text-xs text-gray-500 mb-1 block">Assign to Training Pipeline</label>
+                <div className="flex gap-2">
+                  <select
+                    value={selectedTraining}
+                    onChange={(e) => setSelectedTraining(e.target.value)}
+                    className="flex-1 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none cursor-pointer"
+                  >
+                    <option value="">Select a pipeline...</option>
+                    {trainingPipelines.map((p) => (
+                      <option key={p.id} value={p.id}>{p.name}</option>
+                    ))}
+                  </select>
+                  <button
+                    onClick={handleAssignTraining}
+                    disabled={assigning || !selectedTraining}
+                    className="flex items-center gap-2 rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-50 cursor-pointer"
+                  >
+                    {assigning ? <Loader2 className="h-4 w-4 animate-spin" /> : <GraduationCap className="h-4 w-4" />}
+                    Assign to Training
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Assigned to training */}
+          {candidate.status === "assigned_to_training" && (
+            <div className="rounded-lg bg-emerald-50 border border-emerald-200 p-4">
+              <div className="flex items-center gap-2 text-sm font-medium text-emerald-800">
+                <GraduationCap className="h-4 w-4" />
+                Assigned to training pipeline.
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Documents */}
+      <div className="rounded-xl border border-gray-200 bg-white p-6 mb-6">
+        <h2 className="text-sm font-semibold text-gray-900 mb-4">Documents</h2>
+        {[
+          { key: "resume", label: "Resume", docs: resumeDocs },
+          { key: "interview", label: "Interview Documents (NDA, NCA, Agreement)", docs: interviewDocs },
+          { key: "welcome_docs", label: "Welcome Documents (ACH, W9)", docs: welcomeDocs },
+        ].map((group) => (
+          <div key={group.key} className="mb-4 last:mb-0">
+            <h3 className="text-xs font-medium text-gray-500 uppercase mb-2">{group.label}</h3>
+            {group.docs.length === 0 ? (
+              <p className="text-xs text-gray-300 ml-2">No documents uploaded</p>
+            ) : (
+              <div className="space-y-1.5">
+                {group.docs.map((doc) => (
+                  <div key={doc.id} className="flex items-center justify-between rounded-lg border border-gray-100 px-4 py-2.5">
+                    <div className="flex items-center gap-2">
+                      <FileText className="h-4 w-4 text-gray-400" />
+                      <span className="text-sm text-gray-900">{doc.file_name}</span>
+                    </div>
+                    <span className="text-xs text-gray-400">{new Date(doc.created_at).toLocaleDateString()}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* Email History */}
+      <div className="rounded-xl border border-gray-200 bg-white p-6 mb-6">
+        <h2 className="text-sm font-semibold text-gray-900 mb-4">Email History</h2>
+        {candidate.email_logs.length === 0 ? (
+          <p className="text-sm text-gray-400">No emails sent yet.</p>
         ) : (
           <div className="space-y-2">
-            {employee.employee_documents.map((doc) => (
-              <div key={doc.id} className="flex items-center justify-between rounded-lg border border-gray-100 px-4 py-2.5">
+            {candidate.email_logs.map((log) => (
+              <div key={log.id} className={`flex items-center justify-between rounded-lg border px-4 py-3 ${log.status === "success" ? "border-green-100" : "border-red-100 bg-red-50/50"}`}>
                 <div className="flex items-center gap-2">
-                  <FileText className="h-4 w-4 text-gray-400" />
-                  <span className="text-sm text-gray-900">{doc.file_name}</span>
-                  <span className="text-xs text-gray-400">{doc.file_type}</span>
+                  {log.status === "success" ? <Mail className="h-4 w-4 text-green-600" /> : <XCircle className="h-4 w-4 text-red-500" />}
+                  <div>
+                    <p className="text-sm text-gray-900">{log.subject || log.step_key}</p>
+                    <p className="text-xs text-gray-400">{log.recipient_email} · {log.attachment_count} attachments</p>
+                  </div>
                 </div>
-                <span className="text-xs text-gray-400">{new Date(doc.created_at).toLocaleDateString()}</span>
+                <div className="text-right">
+                  <span className={`text-xs font-medium ${log.status === "success" ? "text-green-600" : "text-red-500"}`}>{log.status}</span>
+                  <p className="text-xs text-gray-400">{new Date(log.sent_at).toLocaleString()}</p>
+                </div>
               </div>
             ))}
           </div>
         )}
       </div>
+
+      {/* Terminate */}
+      {!isTerminated && candidate.status !== "assigned_to_training" && (
+        <div className="rounded-xl border border-red-200 bg-white p-6">
+          {!showTerminate ? (
+            <button
+              onClick={() => setShowTerminate(true)}
+              className="flex items-center gap-2 text-sm text-red-500 hover:text-red-700 cursor-pointer"
+            >
+              <UserX className="h-4 w-4" /> Terminate Candidate
+            </button>
+          ) : (
+            <div className="space-y-3">
+              <h3 className="text-sm font-semibold text-red-700">Terminate {candidate.full_name}?</h3>
+              <p className="text-xs text-gray-500">This will remove the candidate from active onboarding. The record will be preserved for reporting.</p>
+              <textarea
+                value={terminateReason}
+                onChange={(e) => setTerminateReason(e.target.value)}
+                placeholder="Reason for termination (optional)"
+                className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-red-400 focus:outline-none"
+                rows={2}
+              />
+              <div className="flex gap-2">
+                <button
+                  onClick={handleTerminate}
+                  disabled={terminating}
+                  className="flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm text-white hover:bg-red-700 disabled:opacity-50 cursor-pointer"
+                >
+                  {terminating ? <Loader2 className="h-4 w-4 animate-spin" /> : <UserX className="h-4 w-4" />}
+                  Confirm Termination
+                </button>
+                <button onClick={() => setShowTerminate(false)} className="rounded-lg border border-gray-200 px-4 py-2 text-sm text-gray-600 hover:bg-gray-50 cursor-pointer">Cancel</button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {isTerminated && (
+        <div className="rounded-xl border border-red-200 bg-red-50 p-6">
+          <div className="flex items-center gap-2 text-sm font-medium text-red-700">
+            <UserX className="h-4 w-4" />
+            Terminated on {candidate.terminated_at ? new Date(candidate.terminated_at).toLocaleDateString() : "—"}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/sales/team/page.tsx
+++ b/src/app/sales/team/page.tsx
@@ -3,36 +3,47 @@
 import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import { createBrowserClient } from "@/lib/supabase";
-import { Users, Plus, Loader2, Search, UserCheck, UserX } from "lucide-react";
+import { Users, Loader2, Search, CheckCircle2, Clock, UserX, AlertTriangle } from "lucide-react";
 
-interface Employee {
+interface Candidate {
   id: string;
   full_name: string;
   email: string | null;
   phone: string | null;
-  role: string;
+  role_type: string;
   status: string;
-  employee_documents: { id: string }[];
   created_at: string;
+  onboarding_pipelines: { name: string } | null;
+  onboarding_steps: { name: string } | null;
 }
 
-const ROLES = [
-  { value: "sales_rep", label: "Sales Rep" },
-  { value: "market_leader", label: "Market Leader" },
-  { value: "admin", label: "Admin" },
-  { value: "director_of_sales", label: "Director of Sales" },
-  { value: "operations", label: "Operations" },
-  { value: "support", label: "Support" },
+const STATUS_CONFIG: Record<string, { label: string; color: string }> = {
+  interview: { label: "Interview", color: "bg-blue-50 text-blue-700" },
+  pending_admin_review_1: { label: "Pending Review", color: "bg-amber-50 text-amber-700" },
+  welcome_docs_sent: { label: "Welcome Docs", color: "bg-purple-50 text-purple-700" },
+  pending_admin_review_2: { label: "Pending Review", color: "bg-amber-50 text-amber-700" },
+  completed: { label: "Completed", color: "bg-green-50 text-green-700" },
+  assigned_to_training: { label: "Training", color: "bg-emerald-50 text-emerald-700" },
+  terminated: { label: "Terminated", color: "bg-red-50 text-red-600" },
+};
+
+const FILTERS = [
+  { value: "", label: "All" },
+  { value: "interview", label: "Interviewing" },
+  { value: "pending_admin_review_1", label: "Pending Review 1" },
+  { value: "welcome_docs_sent", label: "Welcome Docs" },
+  { value: "pending_admin_review_2", label: "Pending Review 2" },
+  { value: "completed", label: "Completed" },
+  { value: "assigned_to_training", label: "Training" },
+  { value: "terminated", label: "Terminated" },
 ];
 
 export default function TeamPage() {
   const [token, setToken] = useState("");
-  const [employees, setEmployees] = useState<Employee[]>([]);
+  const [candidates, setCandidates] = useState<Candidate[]>([]);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");
-  const [showAdd, setShowAdd] = useState(false);
-  const [form, setForm] = useState({ full_name: "", email: "", phone: "", role: "sales_rep" });
-  const [saving, setSaving] = useState(false);
+  const [statusFilter, setStatusFilter] = useState("");
 
   useEffect(() => {
     const supabase = createBrowserClient();
@@ -44,31 +55,25 @@ export default function TeamPage() {
   const load = useCallback(async () => {
     if (!token) return;
     setLoading(true);
-    const res = await fetch("/api/team", { headers: { Authorization: `Bearer ${token}` } });
-    if (res.ok) setEmployees(await res.json());
+    const params = statusFilter ? `?status=${statusFilter}` : "";
+    const res = await fetch(`/api/onboarding/candidates${params}`, { headers: { Authorization: `Bearer ${token}` } });
+    if (res.ok) setCandidates(await res.json());
     setLoading(false);
-  }, [token]);
+  }, [token, statusFilter]);
 
   useEffect(() => { load(); }, [load]);
 
-  async function handleAdd() {
-    if (!form.full_name) return;
-    setSaving(true);
-    await fetch("/api/team", {
-      method: "POST",
-      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
-      body: JSON.stringify(form),
-    });
-    setForm({ full_name: "", email: "", phone: "", role: "sales_rep" });
-    setShowAdd(false);
-    setSaving(false);
-    load();
-  }
-
-  const filtered = employees.filter((e) =>
-    e.full_name.toLowerCase().includes(search.toLowerCase()) ||
-    (e.email || "").toLowerCase().includes(search.toLowerCase())
+  const filtered = candidates.filter((c) =>
+    c.full_name.toLowerCase().includes(search.toLowerCase()) ||
+    (c.email || "").toLowerCase().includes(search.toLowerCase())
   );
+
+  const statusIcon = (status: string) => {
+    if (status === "completed" || status === "assigned_to_training") return <CheckCircle2 className="h-3.5 w-3.5 text-green-600" />;
+    if (status.includes("pending")) return <Clock className="h-3.5 w-3.5 text-amber-500" />;
+    if (status === "terminated") return <UserX className="h-3.5 w-3.5 text-red-500" />;
+    return <AlertTriangle className="h-3.5 w-3.5 text-blue-500" />;
+  };
 
   return (
     <div className="p-6 max-w-5xl mx-auto">
@@ -76,69 +81,35 @@ export default function TeamPage() {
         <div className="flex items-center gap-2">
           <Users className="h-6 w-6 text-green-600" />
           <h1 className="text-2xl font-bold text-gray-900">Team</h1>
-          <span className="text-sm text-gray-400 ml-2">{employees.length} members</span>
+          <span className="text-sm text-gray-400 ml-2">{candidates.length} members</span>
         </div>
-        <button
-          onClick={() => setShowAdd(true)}
-          className="flex items-center gap-1.5 rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 cursor-pointer"
+        <Link
+          href="/sales/pipelines/onboarding"
+          className="flex items-center gap-1.5 rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700"
         >
-          <Plus className="h-4 w-4" /> Add Member
-        </button>
+          View Onboarding Pipeline
+        </Link>
       </div>
 
-      {/* Search */}
-      <div className="relative mb-4">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
-        <input
-          type="text"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          placeholder="Search team..."
-          className="w-full rounded-lg border border-gray-200 bg-white pl-10 pr-4 py-2.5 text-sm focus:border-green-500 focus:outline-none"
-        />
-      </div>
-
-      {/* Add modal */}
-      {showAdd && (
-        <div className="mb-6 rounded-xl border border-gray-200 bg-white p-6">
-          <h3 className="text-sm font-semibold text-gray-900 mb-4">New Team Member</h3>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <input
-              placeholder="Full Name *"
-              value={form.full_name}
-              onChange={(e) => setForm((f) => ({ ...f, full_name: e.target.value }))}
-              className="rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none"
-            />
-            <input
-              placeholder="Email"
-              value={form.email}
-              onChange={(e) => setForm((f) => ({ ...f, email: e.target.value }))}
-              className="rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none"
-            />
-            <input
-              placeholder="Phone"
-              value={form.phone}
-              onChange={(e) => setForm((f) => ({ ...f, phone: e.target.value }))}
-              className="rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none"
-            />
-            <select
-              value={form.role}
-              onChange={(e) => setForm((f) => ({ ...f, role: e.target.value }))}
-              className="rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none cursor-pointer"
-            >
-              {ROLES.map((r) => <option key={r.value} value={r.value}>{r.label}</option>)}
-            </select>
-          </div>
-          <div className="flex gap-2 mt-4">
-            <button onClick={handleAdd} disabled={saving} className="rounded-lg bg-green-600 px-4 py-2 text-sm text-white hover:bg-green-700 disabled:opacity-50 cursor-pointer">
-              {saving ? "Saving..." : "Save"}
-            </button>
-            <button onClick={() => setShowAdd(false)} className="rounded-lg border border-gray-200 px-4 py-2 text-sm text-gray-600 hover:bg-gray-50 cursor-pointer">
-              Cancel
-            </button>
-          </div>
+      <div className="flex gap-3 mb-4">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search team..."
+            className="w-full rounded-lg border border-gray-200 bg-white pl-10 pr-4 py-2.5 text-sm focus:border-green-500 focus:outline-none"
+          />
         </div>
-      )}
+        <select
+          value={statusFilter}
+          onChange={(e) => setStatusFilter(e.target.value)}
+          className="rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none cursor-pointer"
+        >
+          {FILTERS.map((f) => <option key={f.value} value={f.value}>{f.label}</option>)}
+        </select>
+      </div>
 
       {loading ? (
         <div className="flex justify-center py-20"><Loader2 className="h-8 w-8 animate-spin text-green-600" /></div>
@@ -150,27 +121,29 @@ export default function TeamPage() {
                 <th className="text-left px-4 py-3 font-medium text-gray-500">Name</th>
                 <th className="text-left px-4 py-3 font-medium text-gray-500">Role</th>
                 <th className="text-left px-4 py-3 font-medium text-gray-500">Email</th>
+                <th className="text-left px-4 py-3 font-medium text-gray-500">Current Step</th>
                 <th className="text-left px-4 py-3 font-medium text-gray-500">Status</th>
-                <th className="text-left px-4 py-3 font-medium text-gray-500">Docs</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-50">
-              {filtered.map((emp) => (
-                <tr key={emp.id} className="hover:bg-gray-50/50">
+              {filtered.map((c) => (
+                <tr key={c.id} className="hover:bg-gray-50/50">
                   <td className="px-4 py-3">
-                    <Link href={`/sales/team/${emp.id}`} className="font-medium text-gray-900 hover:text-green-600">
-                      {emp.full_name}
+                    <Link href={`/sales/team/${c.id}`} className="font-medium text-gray-900 hover:text-green-600">
+                      {c.full_name}
                     </Link>
                   </td>
-                  <td className="px-4 py-3 text-gray-600 capitalize">{emp.role.replace(/_/g, " ")}</td>
-                  <td className="px-4 py-3 text-gray-500">{emp.email || "—"}</td>
+                  <td className="px-4 py-3 text-gray-600">
+                    {c.role_type === "BDP" ? "Business Dev Partner" : "Market Leader"}
+                  </td>
+                  <td className="px-4 py-3 text-gray-500">{c.email || "—"}</td>
+                  <td className="px-4 py-3 text-gray-500">{c.onboarding_steps?.name || "—"}</td>
                   <td className="px-4 py-3">
-                    <span className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${emp.status === "active" ? "bg-green-50 text-green-700" : "bg-gray-100 text-gray-500"}`}>
-                      {emp.status === "active" ? <UserCheck className="h-3 w-3" /> : <UserX className="h-3 w-3" />}
-                      {emp.status}
+                    <span className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_CONFIG[c.status]?.color || "bg-gray-100 text-gray-500"}`}>
+                      {statusIcon(c.status)}
+                      {STATUS_CONFIG[c.status]?.label || c.status}
                     </span>
                   </td>
-                  <td className="px-4 py-3 text-gray-500">{emp.employee_documents?.length || 0}</td>
                 </tr>
               ))}
               {filtered.length === 0 && (

--- a/src/lib/onboardingPipelineEmail.ts
+++ b/src/lib/onboardingPipelineEmail.ts
@@ -1,0 +1,122 @@
+import { Resend } from "resend";
+import { supabaseAdmin } from "./supabaseAdmin";
+
+const FROM_EMAIL = process.env.FROM_EMAIL || "onboarding@bytebitevending.com";
+
+function getResend() {
+  return new Resend(process.env.RESEND_API_KEY);
+}
+
+interface SendDocsParams {
+  candidateId: string;
+  candidateEmail: string;
+  candidateName: string;
+  stepKey: string;
+  pipelineId: string;
+  roleType: string;
+}
+
+export async function sendOnboardingDocsEmail(params: SendDocsParams) {
+  const { candidateId, candidateEmail, candidateName, stepKey, pipelineId, roleType } = params;
+
+  const { data: assignments, error: assignErr } = await supabaseAdmin
+    .from("step_document_assignments")
+    .select("*, document_templates(*)")
+    .eq("pipeline_id", pipelineId)
+    .eq("step_key", stepKey)
+    .order("order_index");
+
+  if (assignErr) throw new Error(`Failed to fetch assignments: ${assignErr.message}`);
+  if (!assignments || assignments.length === 0) {
+    throw new Error("No documents assigned to this pipeline step. Please configure document mappings first.");
+  }
+
+  const activeAssignments = assignments.filter(
+    (a: Record<string, unknown>) => {
+      const tmpl = a.document_templates as Record<string, unknown> | null;
+      return tmpl && tmpl.active === true;
+    }
+  );
+
+  if (activeAssignments.length === 0) {
+    throw new Error("No active document templates found for this step.");
+  }
+
+  const attachments: { filename: string; content: Buffer; contentType: string }[] = [];
+
+  for (const assignment of activeAssignments) {
+    const template = assignment.document_templates as {
+      file_path: string;
+      file_name: string;
+      mime_type: string;
+    };
+
+    const { data: fileData, error: downloadError } = await supabaseAdmin.storage
+      .from("document-templates")
+      .download(template.file_path);
+
+    if (downloadError || !fileData) {
+      throw new Error(`Failed to download ${template.file_name}: ${downloadError?.message || "unknown error"}`);
+    }
+
+    const arrayBuffer = await fileData.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+
+    attachments.push({
+      filename: template.file_name,
+      content: buffer,
+      contentType: template.mime_type || "application/pdf",
+    });
+  }
+
+  const { data: emailTemplate } = await supabaseAdmin
+    .from("email_templates_v2")
+    .select("*")
+    .eq("pipeline_type", roleType)
+    .eq("step_key", stepKey)
+    .maybeSingle();
+
+  const subject = emailTemplate?.subject || `Onboarding Documents — ${stepKey}`;
+  const bodyHtml = (emailTemplate?.body_html || "<p>Please find your documents attached.</p>")
+    .replace(/\{\{candidate_name\}\}/g, candidateName);
+
+  try {
+    const { error: sendError } = await getResend().emails.send({
+      from: FROM_EMAIL,
+      to: candidateEmail,
+      subject,
+      html: bodyHtml,
+      attachments,
+    });
+
+    await supabaseAdmin.from("email_logs").insert({
+      candidate_id: candidateId,
+      step_key: stepKey,
+      recipient_email: candidateEmail,
+      subject,
+      status: sendError ? "failure" : "success",
+      error_message: sendError?.message || null,
+      attachment_count: attachments.length,
+    });
+
+    if (sendError) {
+      throw new Error(`Email send failed: ${sendError.message}`);
+    }
+
+    return { success: true, attachmentCount: attachments.length };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown email error";
+
+    await supabaseAdmin.from("email_logs").insert({
+      candidate_id: candidateId,
+      step_key: stepKey,
+      recipient_email: candidateEmail,
+      subject,
+      status: "failure",
+      error_message: message,
+      attachment_count: 0,
+    });
+
+    throw err;
+  }
+}

--- a/supabase/migrations/034_onboarding_system.sql
+++ b/supabase/migrations/034_onboarding_system.sql
@@ -1,0 +1,207 @@
+-- Migration 034: Onboarding Pipeline System
+-- Candidates, document templates, email templates, step-document assignments, email logs
+
+-- ============================================================
+-- 1. ONBOARDING PIPELINES (fixed: BDP + Market Leader)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.onboarding_pipelines (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL,
+  role_type TEXT NOT NULL CHECK (role_type IN ('BDP', 'MARKET_LEADER')),
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.onboarding_steps (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  pipeline_id UUID NOT NULL REFERENCES public.onboarding_pipelines(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  step_key TEXT NOT NULL CHECK (step_key IN ('interview', 'welcome_docs', 'completion')),
+  order_index INT NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_onboarding_steps_pipeline ON public.onboarding_steps(pipeline_id, order_index);
+
+-- ============================================================
+-- 2. CANDIDATES
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.candidates (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  full_name TEXT NOT NULL,
+  phone TEXT,
+  email TEXT,
+  role_type TEXT NOT NULL CHECK (role_type IN ('BDP', 'MARKET_LEADER')),
+  application_date DATE,
+  interview_date DATE,
+  interview_time TEXT,
+  status TEXT NOT NULL DEFAULT 'interview' CHECK (status IN (
+    'interview',
+    'pending_admin_review_1',
+    'welcome_docs_sent',
+    'pending_admin_review_2',
+    'completed',
+    'assigned_to_training',
+    'terminated'
+  )),
+  current_pipeline_id UUID REFERENCES public.onboarding_pipelines(id),
+  current_step_id UUID REFERENCES public.onboarding_steps(id),
+  onboarding_completed_at TIMESTAMPTZ,
+  assigned_training_pipeline_id UUID,
+  terminated_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_candidates_status ON public.candidates(status);
+CREATE INDEX IF NOT EXISTS idx_candidates_role ON public.candidates(role_type);
+CREATE INDEX IF NOT EXISTS idx_candidates_pipeline ON public.candidates(current_pipeline_id);
+
+-- ============================================================
+-- 3. CANDIDATE DOCUMENTS
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.candidate_documents (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  candidate_id UUID NOT NULL REFERENCES public.candidates(id) ON DELETE CASCADE,
+  step_key TEXT NOT NULL,
+  file_name TEXT NOT NULL,
+  file_type TEXT,
+  file_url TEXT NOT NULL,
+  uploaded_by UUID REFERENCES auth.users(id),
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_candidate_docs_candidate ON public.candidate_documents(candidate_id);
+CREATE INDEX IF NOT EXISTS idx_candidate_docs_step ON public.candidate_documents(candidate_id, step_key);
+
+-- ============================================================
+-- 4. DOCUMENT TEMPLATES
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.document_templates (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL,
+  pipeline_type TEXT NOT NULL CHECK (pipeline_type IN ('BDP', 'MARKET_LEADER', 'ALL')),
+  step_key TEXT NOT NULL CHECK (step_key IN ('interview', 'welcome_docs')),
+  file_path TEXT NOT NULL,
+  file_name TEXT NOT NULL,
+  mime_type TEXT NOT NULL DEFAULT 'application/pdf',
+  version INT NOT NULL DEFAULT 1,
+  active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_doc_templates_active ON public.document_templates(active, pipeline_type, step_key);
+
+-- ============================================================
+-- 5. EMAIL TEMPLATES
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.email_templates_v2 (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  pipeline_type TEXT NOT NULL,
+  step_key TEXT NOT NULL,
+  subject TEXT NOT NULL,
+  body_html TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- ============================================================
+-- 6. EMAIL LOGS
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.email_logs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  candidate_id UUID REFERENCES public.candidates(id),
+  step_key TEXT NOT NULL,
+  recipient_email TEXT NOT NULL,
+  subject TEXT,
+  status TEXT NOT NULL CHECK (status IN ('success', 'failure')),
+  error_message TEXT,
+  attachment_count INT DEFAULT 0,
+  sent_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_email_logs_candidate ON public.email_logs(candidate_id);
+
+-- ============================================================
+-- 7. STEP DOCUMENT ASSIGNMENTS
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.step_document_assignments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  pipeline_id UUID NOT NULL REFERENCES public.onboarding_pipelines(id) ON DELETE CASCADE,
+  step_key TEXT NOT NULL,
+  document_template_id UUID NOT NULL REFERENCES public.document_templates(id) ON DELETE CASCADE,
+  required BOOLEAN NOT NULL DEFAULT true,
+  order_index INT NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_step_doc_assign_pipeline ON public.step_document_assignments(pipeline_id, step_key);
+
+-- ============================================================
+-- 8. TERMINATION LOGS
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.termination_logs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  candidate_id UUID NOT NULL REFERENCES public.candidates(id),
+  terminated_by UUID REFERENCES auth.users(id),
+  reason TEXT,
+  terminated_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_termination_logs_candidate ON public.termination_logs(candidate_id);
+
+-- ============================================================
+-- 9. SEED ONBOARDING PIPELINES
+-- ============================================================
+INSERT INTO public.onboarding_pipelines (id, name, role_type) VALUES
+  ('b0000000-0000-0000-0000-000000000001', 'Business Development Partner', 'BDP'),
+  ('b0000000-0000-0000-0000-000000000002', 'Market Leader', 'MARKET_LEADER')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO public.onboarding_steps (pipeline_id, name, step_key, order_index) VALUES
+  ('b0000000-0000-0000-0000-000000000001', 'Interview', 'interview', 0),
+  ('b0000000-0000-0000-0000-000000000001', 'Welcome Docs', 'welcome_docs', 1),
+  ('b0000000-0000-0000-0000-000000000001', 'Completion / Training Assignment', 'completion', 2),
+  ('b0000000-0000-0000-0000-000000000002', 'Interview', 'interview', 0),
+  ('b0000000-0000-0000-0000-000000000002', 'Welcome Docs', 'welcome_docs', 1),
+  ('b0000000-0000-0000-0000-000000000002', 'Completion / Training Assignment', 'completion', 2)
+ON CONFLICT DO NOTHING;
+
+-- ============================================================
+-- 10. SEED DEFAULT EMAIL TEMPLATES
+-- ============================================================
+INSERT INTO public.email_templates_v2 (pipeline_type, step_key, subject, body_html) VALUES
+  ('BDP', 'interview', 'Interview Documents — Business Development Partner',
+   '<div style="font-family:-apple-system,BlinkMacSystemFont,''Segoe UI'',Roboto,sans-serif;max-width:560px;margin:0 auto;padding:32px 24px;">
+     <h1 style="color:#111827;font-size:22px;margin:0 0 24px;">Interview Documents</h1>
+     <p style="color:#374151;font-size:14px;line-height:1.6;">Hello {{candidate_name}},</p>
+     <p style="color:#374151;font-size:14px;line-height:1.6;">Thank you for your interest in the Business Development Partner position. Please find attached the NDA, NCA, and Agreement documents for your review.</p>
+     <p style="color:#374151;font-size:14px;line-height:1.6;">Please sign and return these documents at your earliest convenience.</p>
+     <p style="color:#374151;font-size:14px;line-height:1.6;margin-top:24px;">Best regards,<br/>Vending Connector Team</p>
+   </div>'),
+  ('MARKET_LEADER', 'interview', 'Interview Documents — Market Leader',
+   '<div style="font-family:-apple-system,BlinkMacSystemFont,''Segoe UI'',Roboto,sans-serif;max-width:560px;margin:0 auto;padding:32px 24px;">
+     <h1 style="color:#111827;font-size:22px;margin:0 0 24px;">Interview Documents</h1>
+     <p style="color:#374151;font-size:14px;line-height:1.6;">Hello {{candidate_name}},</p>
+     <p style="color:#374151;font-size:14px;line-height:1.6;">Thank you for your interest in the Market Leader position. Please find attached the NDA, NCA, and Agreement documents for your review.</p>
+     <p style="color:#374151;font-size:14px;line-height:1.6;">Please sign and return these documents at your earliest convenience.</p>
+     <p style="color:#374151;font-size:14px;line-height:1.6;margin-top:24px;">Best regards,<br/>Vending Connector Team</p>
+   </div>'),
+  ('BDP', 'welcome_docs', 'Welcome — ACH & W9 Forms',
+   '<div style="font-family:-apple-system,BlinkMacSystemFont,''Segoe UI'',Roboto,sans-serif;max-width:560px;margin:0 auto;padding:32px 24px;">
+     <h1 style="color:#111827;font-size:22px;margin:0 0 24px;">Welcome Aboard!</h1>
+     <p style="color:#374151;font-size:14px;line-height:1.6;">Hello {{candidate_name}},</p>
+     <p style="color:#374151;font-size:14px;line-height:1.6;">Congratulations on moving forward! Please find attached your ACH and W9 forms.</p>
+     <p style="color:#374151;font-size:14px;line-height:1.6;">Please complete and return these at your earliest convenience.</p>
+     <p style="color:#374151;font-size:14px;line-height:1.6;margin-top:24px;">Best regards,<br/>Vending Connector Team</p>
+   </div>'),
+  ('MARKET_LEADER', 'welcome_docs', 'Welcome — ACH & W9 Forms',
+   '<div style="font-family:-apple-system,BlinkMacSystemFont,''Segoe UI'',Roboto,sans-serif;max-width:560px;margin:0 auto;padding:32px 24px;">
+     <h1 style="color:#111827;font-size:22px;margin:0 0 24px;">Welcome Aboard!</h1>
+     <p style="color:#374151;font-size:14px;line-height:1.6;">Hello {{candidate_name}},</p>
+     <p style="color:#374151;font-size:14px;line-height:1.6;">Congratulations on moving forward to the Market Leader role! Please find attached your ACH and W9 forms.</p>
+     <p style="color:#374151;font-size:14px;line-height:1.6;">Please complete and return these at your earliest convenience.</p>
+     <p style="color:#374151;font-size:14px;line-height:1.6;margin-top:24px;">Best regards,<br/>Vending Connector Team</p>
+   </div>')
+ON CONFLICT DO NOTHING;
+
+-- NOTE: Create a Supabase Storage bucket named "document-templates" via the dashboard.
+-- This bucket stores the PDF templates that get attached to onboarding emails.


### PR DESCRIPTION
- Migration 034: candidates, document_templates, email_templates_v2, email_logs, step_document_assignments, termination_logs, onboarding pipelines (BDP + Market Leader) with 3-step workflows
- Email utility: downloads PDFs from Supabase Storage, attaches as real buffers via Resend (no links), logs success/failure
- 15 API routes: candidate CRUD, send-docs, approve, terminate, assign-training, document upload, template management, step-doc assignments, dashboard stats, email logs
- Onboarding pipeline page: kanban by status, pipeline selector
- Candidate detail page: full workflow with step gating, admin approval gates, document upload, email history, terminate
- Hiring dashboard: KPIs, turnover rate, stage chart, metrics
- Admin pages: document templates, email templates, pipeline-doc mapping with assign/remove/reorder
- Updated sales layout with Hiring, Doc Templates, Email Templates, Doc Mapping nav items

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2