### PR TITLE
Increase search bar padding on accounts and leads pages for readability

### DIFF
--- a/src/app/sales/accounts/page.tsx
+++ b/src/app/sales/accounts/page.tsx
@@ -121,7 +121,7 @@ export default function AccountsPage() {
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           placeholder="Search accounts..."
-          className="w-full rounded-lg border border-gray-200 bg-white py-2 pl-9 pr-9 text-sm placeholder:text-gray-400 focus:border-green-500 focus:outline-none"
+          className="w-full rounded-lg border border-gray-200 bg-white py-2.5 pl-9 pr-9 text-sm placeholder:text-gray-400 focus:border-green-500 focus:outline-none"
         />
         {search && (
           <button onClick={() => setSearch("")} className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600">

--- a/src/app/sales/leads/page.tsx
+++ b/src/app/sales/leads/page.tsx
@@ -582,7 +582,7 @@ export default function LeadsPage() {
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder="Search by business, contact, city, or state..."
-            className="w-full rounded-lg border border-gray-200 bg-white py-2 pl-9 pr-9 text-sm placeholder:text-gray-400 focus:border-green-500 focus:outline-none"
+            className="w-full rounded-lg border border-gray-200 bg-white py-2.5 pl-9 pr-9 text-sm placeholder:text-gray-400 focus:border-green-500 focus:outline-none"
           />
           {search && (
             <button onClick={() => setSearch("")} className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600">


### PR DESCRIPTION
Bumped py-2 to py-2.5 on the two CRM search inputs that had the tightest vertical padding, making typed text more visible and consistent with the rest of the search bars across the site.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2