### PR TITLE
Auto-create sales account when location services request is submitted

### DIFF
--- a/src/app/api/request-location/route.ts
+++ b/src/app/api/request-location/route.ts
@@ -72,7 +72,7 @@ export async function POST(req: Request) {
     }
   }
 
-  const { error: dbError } = await supabaseAdmin.from("sales_leads").insert({
+  const { data: lead, error: dbError } = await supabaseAdmin.from("sales_leads").insert({
     business_name,
     contact_name,
     phone,
@@ -85,7 +85,7 @@ export async function POST(req: Request) {
     notes: `Location services request — ${machine_count} machine(s) requested for ZIP ${zip_code}${referringRepName ? ` (referred by ${referringRepName})` : ""}`,
     created_by: referringRep,
     assigned_to: referringRep,
-  });
+  }).select("id").single();
 
   if (dbError) {
     console.error("[request-location] db error", dbError);
@@ -93,6 +93,21 @@ export async function POST(req: Request) {
       { error: "Failed to save request" },
       { status: 500 }
     );
+  }
+
+  const { error: accountError } = await supabaseAdmin.from("sales_accounts").insert({
+    business_name,
+    contact_name,
+    phone,
+    email,
+    address,
+    notes: `Auto-created from location services request — ${machine_count} machine(s), ZIP ${zip_code}`,
+    assigned_to: referringRep,
+    created_by: referringRep,
+  });
+
+  if (accountError) {
+    console.error("[request-location] account creation error", accountError);
   }
 
   // Fire email — log but do not fail the request if email errors.


### PR DESCRIPTION
The request-location API now creates a sales_accounts record alongside the sales_leads record, carrying over business name, contact, phone, email, address, and referring rep assignment.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2