### PR TITLE
Fix search bars getting squeezed by sibling dropdowns on leads and te…

### DIFF
--- a/src/app/sales/leads/page.tsx
+++ b/src/app/sales/leads/page.tsx
@@ -575,8 +575,8 @@ export default function LeadsPage() {
       )}
 
       {/* Search + state filter */}
-      <div className="mb-4 flex flex-col gap-2 sm:flex-row">
-        <div className="relative flex-1">
+      <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center">
+        <div className="relative flex-1 min-w-0 sm:min-w-[260px]">
           <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
           <input
             value={search}
@@ -593,14 +593,14 @@ export default function LeadsPage() {
         <select
           value={stateFilter}
           onChange={(e) => setStateFilter(e.target.value)}
-          className="rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm focus:border-green-500 focus:outline-none cursor-pointer"
+          className="shrink-0 w-auto rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm focus:border-green-500 focus:outline-none cursor-pointer"
         >
           <option value="">All States</option>
           {availableStates.map((s) => (
             <option key={s} value={s}>{s}</option>
           ))}
         </select>
-        <label className="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-700 cursor-pointer">
+        <label className="shrink-0 inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-700 cursor-pointer whitespace-nowrap">
           <input
             type="checkbox"
             checked={hideDnc}

--- a/src/app/sales/team/page.tsx
+++ b/src/app/sales/team/page.tsx
@@ -107,8 +107,8 @@ export default function TeamPage() {
         </Link>
       </div>
 
-      <div className="flex gap-3 mb-4">
-        <div className="relative flex-1">
+      <div className="flex gap-3 mb-4 items-center">
+        <div className="relative flex-1 min-w-0 sm:min-w-[260px]">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
           <input
             type="text"
@@ -121,7 +121,7 @@ export default function TeamPage() {
         <select
           value={statusFilter}
           onChange={(e) => setStatusFilter(e.target.value)}
-          className="rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none cursor-pointer"
+          className="shrink-0 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none cursor-pointer"
         >
           {FILTERS.map((f) => <option key={f.value} value={f.value}>{f.label}</option>)}
         </select>


### PR DESCRIPTION
…am pages

Added min-w-[260px] and min-w-0 to search bar containers so they never collapse to a few pixels when flex siblings (state filter, status filter, checkbox) take priority. Also added shrink-0 to the dropdowns and whitespace-nowrap to prevent them from causing the search input to shrink.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2