### PR TITLE
Add bulk delete for leads with checkbox selection (admin only)

### DIFF
--- a/src/app/api/sales/leads/bulk-delete/route.ts
+++ b/src/app/api/sales/leads/bulk-delete/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser, isElevatedRole } from "@/lib/salesAuth";
+
+export async function POST(req: NextRequest) {
+  const user = await getSalesUser(req);
+  if (!user || !isElevatedRole(user.role)) {
+    return NextResponse.json({ error: "Admin only" }, { status: 403 });
+  }
+
+  const body = await req.json();
+  const { ids } = body;
+
+  if (!Array.isArray(ids) || ids.length === 0) {
+    return NextResponse.json({ error: "ids array required" }, { status: 400 });
+  }
+
+  if (ids.length > 500) {
+    return NextResponse.json({ error: "Max 500 leads per request" }, { status: 400 });
+  }
+
+  await supabaseAdmin
+    .from("sales_deals")
+    .update({ lead_id: null })
+    .in("lead_id", ids);
+
+  const { error, count } = await supabaseAdmin
+    .from("sales_leads")
+    .delete({ count: "exact" })
+    .in("id", ids);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ deleted: count || ids.length });
+}

--- a/src/app/sales/leads/page.tsx
+++ b/src/app/sales/leads/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { createBrowserClient } from "@/lib/supabase";
-import { Plus, Loader2, Search, X, UserPlus, ArrowRight, Trash2, PhoneOff, Phone, Upload, FileSpreadsheet, AlertCircle, CheckCircle2, AlertTriangle } from "lucide-react";
+import { Plus, Loader2, Search, X, UserPlus, ArrowRight, Trash2, PhoneOff, Phone, Upload, FileSpreadsheet, AlertCircle, CheckCircle2, AlertTriangle, CheckSquare } from "lucide-react";
 import { ENTITY_TYPES, IMMEDIATE_NEEDS, type SalesLead, type EntityType, type ImmediateNeed } from "@/lib/salesTypes";
 
 const LEAD_FIELDS: { key: LeadFieldKey; label: string; required?: boolean }[] = [
@@ -129,6 +129,8 @@ export default function LeadsPage() {
   const [sortBy, setSortBy] = useState<"newest" | "oldest" | "urgent" | "type">("newest");
   const [hideDnc, setHideDnc] = useState(false);
   const [addForm, setAddForm] = useState({ business_name: "", contact_name: "", phone: "", email: "", address: "", city: "", state: "", source: "", notes: "", do_not_call: false, entity_type: "location" as EntityType, immediate_need: "" as ImmediateNeed | "" });
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [bulkDeleting, setBulkDeleting] = useState(false);
 
   // CSV Import state
   const [showImport, setShowImport] = useState(false);
@@ -327,6 +329,41 @@ export default function LeadsPage() {
     setColumnMapping({});
     setImportResult(null);
     setShowImport(false);
+  }
+
+  function toggleSelect(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  }
+
+  function toggleSelectAll() {
+    if (selected.size === filtered.length) {
+      setSelected(new Set());
+    } else {
+      setSelected(new Set(filtered.map((l) => l.id)));
+    }
+  }
+
+  async function handleBulkDelete() {
+    if (selected.size === 0) return;
+    if (!confirm(`Delete ${selected.size} selected lead${selected.size > 1 ? "s" : ""}? This cannot be undone.`)) return;
+    setBulkDeleting(true);
+    const ids = Array.from(selected);
+    const res = await fetch("/api/sales/leads/bulk-delete", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ ids }),
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      alert(err.error || "Bulk delete failed");
+    }
+    setSelected(new Set());
+    setBulkDeleting(false);
+    fetchLeads();
   }
 
   async function handleStatusChange(id: string, status: string) {
@@ -657,6 +694,27 @@ export default function LeadsPage() {
         </label>
       </div>
 
+      {selected.size > 0 && (
+        <div className="mb-3 flex items-center gap-3 rounded-lg border border-red-200 bg-red-50 px-4 py-2.5">
+          <CheckSquare className="h-4 w-4 text-red-600 shrink-0" />
+          <span className="text-sm font-medium text-red-800">{selected.size} lead{selected.size > 1 ? "s" : ""} selected</span>
+          <button
+            onClick={handleBulkDelete}
+            disabled={bulkDeleting}
+            className="ml-auto inline-flex items-center gap-1.5 rounded-lg bg-red-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-700 disabled:opacity-50 cursor-pointer"
+          >
+            {bulkDeleting ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Trash2 className="h-3.5 w-3.5" />}
+            Delete Selected
+          </button>
+          <button
+            onClick={() => setSelected(new Set())}
+            className="rounded-lg border border-red-200 px-3 py-1.5 text-xs font-medium text-red-700 hover:bg-red-100 cursor-pointer"
+          >
+            Clear
+          </button>
+        </div>
+      )}
+
       {loading ? (
         <div className="flex justify-center py-16"><Loader2 className="h-6 w-6 animate-spin text-green-600" /></div>
       ) : filtered.length === 0 ? (
@@ -666,6 +724,16 @@ export default function LeadsPage() {
           <table className="w-full text-left text-sm">
             <thead className="border-b border-gray-100 bg-gray-50/50">
               <tr>
+                {userRole === "admin" && (
+                  <th className="px-3 py-3 w-10">
+                    <input
+                      type="checkbox"
+                      checked={filtered.length > 0 && selected.size === filtered.length}
+                      onChange={toggleSelectAll}
+                      className="h-4 w-4 rounded border-gray-300 text-green-600 focus:ring-green-500 cursor-pointer"
+                    />
+                  </th>
+                )}
                 <th className="px-4 py-3 font-medium text-gray-500">Business</th>
                 <th className="px-4 py-3 font-medium text-gray-500">Type</th>
                 <th className="px-4 py-3 font-medium text-gray-500">Immediate Need</th>
@@ -680,6 +748,16 @@ export default function LeadsPage() {
             <tbody className="divide-y divide-gray-50">
               {filtered.map((lead) => (
                 <tr key={lead.id} className={lead.urgent ? "bg-orange-50/50 hover:bg-orange-50" : "hover:bg-gray-50/50"}>
+                  {userRole === "admin" && (
+                    <td className="px-3 py-3 w-10">
+                      <input
+                        type="checkbox"
+                        checked={selected.has(lead.id)}
+                        onChange={() => toggleSelect(lead.id)}
+                        className="h-4 w-4 rounded border-gray-300 text-green-600 focus:ring-green-500 cursor-pointer"
+                      />
+                    </td>
+                  )}
                   <td className="px-4 py-3 font-medium text-gray-900">
                     <div className="flex items-center gap-1.5">
                       {lead.urgent && <AlertTriangle className="h-4 w-4 text-orange-500 shrink-0" />}


### PR DESCRIPTION
Admins can now select leads via checkboxes (including select-all), then delete them in bulk from a red action bar. The bulk delete API endpoint detaches linked deals before deleting, matching the single-delete behavior. Limited to 500 leads per request.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2