### PR TITLE
Fix double-login: redirect authenticated users away from /login

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,15 +1,29 @@
 "use client";
 
-import { Suspense, useState } from "react";
+import { Suspense, useState, useEffect } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { Loader2 } from "lucide-react";
 import { signInWithGoogle, signInWithMicrosoft, storeRedirectAfterLogin } from "@/lib/auth";
+import { createBrowserClient } from "@/lib/supabase";
 
 function LoginContent() {
   const searchParams = useSearchParams();
   const [loading, setLoading] = useState<"google" | "microsoft" | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [checking, setChecking] = useState(true);
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (session?.user) {
+        const redirect = searchParams.get("redirect") || "/dashboard";
+        window.location.href = redirect;
+      } else {
+        setChecking(false);
+      }
+    });
+  }, [searchParams]);
 
   async function handleGoogleLogin() {
     setLoading("google");
@@ -35,6 +49,14 @@ function LoginContent() {
       setError("Failed to start Microsoft login. Please try again.");
       setLoading(null);
     }
+  }
+
+  if (checking) {
+    return (
+      <div className="min-h-[calc(100vh-160px)] flex items-center justify-center px-4">
+        <Loader2 className="w-8 h-8 animate-spin text-green-primary" />
+      </div>
+    );
   }
 
   return (

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -37,11 +37,14 @@ export async function middleware(req: NextRequest) {
     return NextResponse.redirect(url, 301);
   }
 
-  // Only check protected paths
+  // Redirect authenticated users away from auth pages
+  const isAuthPage = pathname === "/login" || pathname === "/signup";
+
+  // Only check protected paths (and auth pages for reverse redirect)
   const isProtected = PROTECTED_PATHS.some(
     (p) => pathname === p || pathname.startsWith(p + "/")
   );
-  if (!isProtected) return NextResponse.next();
+  if (!isProtected && !isAuthPage) return NextResponse.next();
 
   // Create a Supabase server client that reads/writes cookies on the request/response
   let response = NextResponse.next({ request: req });
@@ -74,8 +77,14 @@ export async function middleware(req: NextRequest) {
     data: { user },
   } = await supabase.auth.getUser();
 
-  if (!user) {
-    // Redirect to login with a return-to URL so they come back after auth
+  if (isAuthPage && user) {
+    const dashboardUrl = req.nextUrl.clone();
+    dashboardUrl.pathname = "/dashboard";
+    dashboardUrl.search = "";
+    return NextResponse.redirect(dashboardUrl);
+  }
+
+  if (!user && isProtected) {
     const loginUrl = req.nextUrl.clone();
     loginUrl.pathname = "/login";
     loginUrl.searchParams.set("redirect", pathname);


### PR DESCRIPTION
Two fixes:
1. Login page now checks for an existing session on mount and immediately redirects to /dashboard (or the ?redirect param) if the user is already authenticated.
2. Middleware now intercepts /login and /signup — if the user has a valid session, they get redirected to /dashboard instead of seeing the login buttons again.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2