### PR TITLE
Add multi-ZIP and state field to request-location form

### DIFF
--- a/src/app/api/request-location/route.ts
+++ b/src/app/api/request-location/route.ts
@@ -23,8 +23,12 @@ export async function POST(req: Request) {
   const phone = clean(body.phone);
   const email = clean(body.email);
   const address = clean(body.address);
-  const zip_code = clean(body.zip_code);
+  const state = clean(body.state);
   const machine_count_raw = body.machine_count;
+
+  const rawZips = Array.isArray(body.zip_codes) ? body.zip_codes : body.zip_code ? [body.zip_code] : [];
+  const zip_codes: string[] = rawZips.map((z: unknown) => (typeof z === "string" ? z.trim() : "")).filter(Boolean);
+  const zip_code = zip_codes.join(", ");
 
   if (
     !business_name ||
@@ -32,7 +36,8 @@ export async function POST(req: Request) {
     !phone ||
     !email ||
     !address ||
-    !zip_code ||
+    !state ||
+    zip_codes.length === 0 ||
     machine_count_raw === undefined ||
     machine_count_raw === null ||
     machine_count_raw === ""
@@ -79,10 +84,11 @@ export async function POST(req: Request) {
     email,
     address,
     zip_code,
+    state,
     machine_count,
     status: "new",
     source: referringRep ? "request-location-referral" : "request-location",
-    notes: `Location services request — ${machine_count} machine(s) requested for ZIP ${zip_code}${referringRepName ? ` (referred by ${referringRepName})` : ""}`,
+    notes: `Location services request — ${machine_count} machine(s) requested for ZIP(s) ${zip_code} in ${state}${referringRepName ? ` (referred by ${referringRepName})` : ""}`,
     created_by: referringRep,
     assigned_to: referringRep,
   }).select("id").single();
@@ -101,7 +107,7 @@ export async function POST(req: Request) {
     phone,
     email,
     address,
-    notes: `Auto-created from location services request — ${machine_count} machine(s), ZIP ${zip_code}`,
+    notes: `Auto-created from location services request — ${machine_count} machine(s), ZIP(s) ${zip_code}, ${state}`,
     assigned_to: referringRep,
     created_by: referringRep,
   });
@@ -122,7 +128,8 @@ export async function POST(req: Request) {
           <tr><td style="padding:6px 0;color:#6b7280;">Phone</td><td style="padding:6px 0;color:#111827;">${phone}</td></tr>
           <tr><td style="padding:6px 0;color:#6b7280;">Email</td><td style="padding:6px 0;color:#111827;">${email}</td></tr>
           <tr><td style="padding:6px 0;color:#6b7280;">Address</td><td style="padding:6px 0;color:#111827;">${address}</td></tr>
-          <tr><td style="padding:6px 0;color:#6b7280;">ZIP Code</td><td style="padding:6px 0;color:#111827;">${zip_code}</td></tr>
+          <tr><td style="padding:6px 0;color:#6b7280;">State</td><td style="padding:6px 0;color:#111827;">${state}</td></tr>
+          <tr><td style="padding:6px 0;color:#6b7280;">ZIP Code(s)</td><td style="padding:6px 0;color:#111827;">${zip_code}</td></tr>
           <tr><td style="padding:6px 0;color:#6b7280;">Machines Requested</td><td style="padding:6px 0;color:#111827;font-weight:600;">${machine_count}</td></tr>
         </table>
       </div>

--- a/src/app/request-location/page.tsx
+++ b/src/app/request-location/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
-import { MapPin } from "lucide-react";
+import { MapPin, Plus, X } from "lucide-react";
 
 interface FormState {
   business_name: string;
@@ -10,7 +10,8 @@ interface FormState {
   phone: string;
   email: string;
   address: string;
-  zip_code: string;
+  state: string;
+  zip_codes: string[];
   machine_count: string;
 }
 
@@ -20,9 +21,17 @@ const initial: FormState = {
   phone: "",
   email: "",
   address: "",
-  zip_code: "",
+  state: "",
+  zip_codes: [""],
   machine_count: "",
 };
+
+const US_STATES = [
+  "AL","AK","AZ","AR","CA","CO","CT","DE","FL","GA","HI","ID","IL","IN","IA",
+  "KS","KY","LA","ME","MD","MA","MI","MN","MS","MO","MT","NE","NV","NH","NJ",
+  "NM","NY","NC","ND","OH","OK","OR","PA","RI","SC","SD","TN","TX","UT","VT",
+  "VA","WA","WV","WI","WY","DC",
+];
 
 export default function RequestLocationPage() {
   return (
@@ -45,20 +54,42 @@ function RequestLocationInner() {
     if (r) setRef(r);
   }, [searchParams]);
 
-  function update<K extends keyof FormState>(key: K, value: string) {
+  function update<K extends keyof FormState>(key: K, value: FormState[K]) {
     setForm((f) => ({ ...f, [key]: value }));
+  }
+
+  function updateZip(index: number, value: string) {
+    setForm((f) => {
+      const zips = [...f.zip_codes];
+      zips[index] = value;
+      return { ...f, zip_codes: zips };
+    });
+  }
+
+  function addZip() {
+    setForm((f) => ({ ...f, zip_codes: [...f.zip_codes, ""] }));
+  }
+
+  function removeZip(index: number) {
+    setForm((f) => ({
+      ...f,
+      zip_codes: f.zip_codes.filter((_, i) => i !== index),
+    }));
   }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError(null);
 
-    for (const [k, v] of Object.entries(form)) {
-      if (!v.trim()) {
-        setError(`Please fill in ${k.replace(/_/g, " ")}.`);
-        return;
-      }
-    }
+    if (!form.business_name.trim()) { setError("Please fill in business name."); return; }
+    if (!form.contact_name.trim()) { setError("Please fill in contact name."); return; }
+    if (!form.phone.trim()) { setError("Please fill in phone number."); return; }
+    if (!form.email.trim()) { setError("Please fill in email."); return; }
+    if (!form.address.trim()) { setError("Please fill in address."); return; }
+    if (!form.state) { setError("Please select a state."); return; }
+    const validZips = form.zip_codes.map((z) => z.trim()).filter(Boolean);
+    if (validZips.length === 0) { setError("Please enter at least one ZIP code."); return; }
+    if (!form.machine_count.trim()) { setError("Please fill in number of machines."); return; }
 
     setSubmitting(true);
     try {
@@ -66,7 +97,13 @@ function RequestLocationInner() {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          ...form,
+          business_name: form.business_name,
+          contact_name: form.contact_name,
+          phone: form.phone,
+          email: form.email,
+          address: form.address,
+          state: form.state,
+          zip_codes: validZips,
           machine_count: Number(form.machine_count),
           ref: ref || undefined,
         }),
@@ -130,9 +167,59 @@ function RequestLocationInner() {
                 <Field label="Email" type="email" value={form.email} onChange={(v) => update("email", v)} />
               </div>
               <Field label="Full Address" value={form.address} onChange={(v) => update("address", v)} />
+
               <div className="grid gap-4 sm:grid-cols-2">
-                <Field label="ZIP Code (target placement area)" value={form.zip_code} onChange={(v) => update("zip_code", v)} />
+                <label className="block">
+                  <span className="mb-1.5 block text-sm font-medium text-black-primary">State</span>
+                  <select
+                    value={form.state}
+                    onChange={(e) => update("state", e.target.value)}
+                    required
+                    className="w-full rounded-lg border border-gray-200 px-4 py-2.5 text-sm text-black-primary outline-none transition-colors focus:border-green-primary focus:ring-2 focus:ring-green-100 cursor-pointer"
+                  >
+                    <option value="">Select State</option>
+                    {US_STATES.map((s) => (
+                      <option key={s} value={s}>{s}</option>
+                    ))}
+                  </select>
+                </label>
                 <Field label="Number of Machines Needed" type="number" value={form.machine_count} onChange={(v) => update("machine_count", v)} />
+              </div>
+
+              <div>
+                <div className="flex items-center justify-between mb-1.5">
+                  <span className="text-sm font-medium text-black-primary">Target ZIP Codes</span>
+                  <button
+                    type="button"
+                    onClick={addZip}
+                    className="inline-flex items-center gap-1 text-xs font-medium text-green-primary hover:text-green-hover cursor-pointer"
+                  >
+                    <Plus className="h-3.5 w-3.5" /> Add ZIP
+                  </button>
+                </div>
+                <div className="space-y-2">
+                  {form.zip_codes.map((zip, i) => (
+                    <div key={i} className="flex gap-2">
+                      <input
+                        type="text"
+                        value={zip}
+                        onChange={(e) => updateZip(i, e.target.value)}
+                        placeholder={`ZIP code ${i + 1}`}
+                        required={i === 0}
+                        className="flex-1 rounded-lg border border-gray-200 px-4 py-2.5 text-sm text-black-primary outline-none transition-colors focus:border-green-primary focus:ring-2 focus:ring-green-100"
+                      />
+                      {form.zip_codes.length > 1 && (
+                        <button
+                          type="button"
+                          onClick={() => removeZip(i)}
+                          className="rounded-lg border border-gray-200 px-2.5 text-gray-400 hover:text-red-500 hover:border-red-200 cursor-pointer"
+                        >
+                          <X className="h-4 w-4" />
+                        </button>
+                      )}
+                    </div>
+                  ))}
+                </div>
               </div>
 
               {error && (


### PR DESCRIPTION
Upgrade the location services request form to accept multiple ZIP codes (with dynamic add/remove) and a US state dropdown. Both fields flow into the CRM lead and auto-created account records.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2