### PR TITLE
Enhance candidate document upload with view, delete, and relaxed auth

### DIFF
--- a/src/app/api/onboarding/candidates/[id]/documents/[docId]/route.ts
+++ b/src/app/api/onboarding/candidates/[id]/documents/[docId]/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser, isElevatedRole } from "@/lib/salesAuth";
+
+export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string; docId: string }> }) {
+  const user = await getSalesUser(req);
+  if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id, docId } = await params;
+
+  if (!isElevatedRole(user.role)) {
+    const { data: candidate } = await supabaseAdmin.from("candidates").select("assigned_to").eq("id", id).single();
+    if (!candidate || candidate.assigned_to !== user.id) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { data: doc } = await supabaseAdmin
+    .from("candidate_documents")
+    .select("file_url")
+    .eq("id", docId)
+    .eq("candidate_id", id)
+    .single();
+
+  if (!doc) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const storagePath = doc.file_url?.replace(/^.*\/sales-documents\//, "") || "";
+  if (storagePath) {
+    await supabaseAdmin.storage.from("sales-documents").remove([storagePath]);
+  }
+
+  const { error } = await supabaseAdmin.from("candidate_documents").delete().eq("id", docId);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/onboarding/candidates/[id]/documents/route.ts
+++ b/src/app/api/onboarding/candidates/[id]/documents/route.ts
@@ -8,8 +8,13 @@ const MAX_SIZE = 10 * 1024 * 1024;
 
 export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const user = await getSalesUser(req);
-  if (!user || !isElevatedRole(user.role)) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   const { id } = await params;
+
+  if (!isElevatedRole(user.role)) {
+    const { data: candidate } = await supabaseAdmin.from("candidates").select("assigned_to").eq("id", id).single();
+    if (!candidate || candidate.assigned_to !== user.id) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
 
   const { data, error } = await supabaseAdmin
     .from("candidate_documents")
@@ -23,8 +28,13 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
 
 export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const user = await getSalesUser(req);
-  if (!user || !isElevatedRole(user.role)) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   const { id } = await params;
+
+  if (!isElevatedRole(user.role)) {
+    const { data: candidate } = await supabaseAdmin.from("candidates").select("assigned_to").eq("id", id).single();
+    if (!candidate || candidate.assigned_to !== user.id) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
 
   const formData = await req.formData();
   const file = formData.get("file") as File | null;

--- a/src/app/api/onboarding/candidates/route.ts
+++ b/src/app/api/onboarding/candidates/route.ts
@@ -13,7 +13,7 @@ export async function GET(req: NextRequest) {
 
   let query = supabaseAdmin
     .from("candidates")
-    .select("*, candidate_documents(id, step_key, file_name), onboarding_pipelines(id, name, role_type), onboarding_steps(id, name, step_key)")
+    .select("*, candidate_documents(id, step_key, file_name, file_url, file_type), onboarding_pipelines(id, name, role_type), onboarding_steps(id, name, step_key)")
     .order("created_at", { ascending: false });
 
   if (status) query = query.eq("status", status);

--- a/src/app/sales/candidates/page.tsx
+++ b/src/app/sales/candidates/page.tsx
@@ -2,7 +2,15 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { createBrowserClient } from "@/lib/supabase";
-import { Plus, Loader2, Search, X, Upload, UserPlus, ArrowRight, Trash2, FileText, Pencil } from "lucide-react";
+import { Plus, Loader2, Search, X, Upload, UserPlus, ArrowRight, Trash2, FileText, Pencil, Download, Eye } from "lucide-react";
+
+interface CandidateDoc {
+  id: string;
+  step_key: string;
+  file_name: string;
+  file_url?: string;
+  file_type?: string;
+}
 
 interface Candidate {
   id: string;
@@ -15,7 +23,7 @@ interface Candidate {
   notes: string | null;
   application_date: string | null;
   created_at: string;
-  candidate_documents: { id: string; step_key: string; file_name: string }[];
+  candidate_documents: CandidateDoc[];
 }
 
 interface SalesUser {
@@ -39,6 +47,7 @@ export default function CandidatesPage() {
   const [editForm, setEditForm] = useState<Record<string, string>>({});
   const [editSaving, setEditSaving] = useState(false);
   const [uploadingId, setUploadingId] = useState<string | null>(null);
+  const [expandedDocsId, setExpandedDocsId] = useState<string | null>(null);
 
   useEffect(() => {
     const supabase = createBrowserClient();
@@ -133,6 +142,15 @@ export default function CandidatesPage() {
       body: formData,
     });
     setUploadingId(null);
+    fetchCandidates();
+  }
+
+  async function handleDeleteDoc(candidateId: string, docId: string) {
+    if (!confirm("Delete this document?")) return;
+    await fetch(`/api/onboarding/candidates/${candidateId}/documents/${docId}`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${token}` },
+    });
     fetchCandidates();
   }
 
@@ -267,20 +285,41 @@ export default function CandidatesPage() {
                       </div>
                     </td>
                     <td className="px-4 py-3">
-                      <div className="flex items-center gap-2">
-                        {appDocs.length > 0 ? (
-                          <span className="inline-flex items-center gap-1 text-xs text-green-600">
-                            <FileText className="h-3.5 w-3.5" />
-                            {appDocs.length} file{appDocs.length > 1 ? "s" : ""}
-                          </span>
-                        ) : (
-                          <span className="text-xs text-gray-300">None</span>
+                      <div className="space-y-1.5">
+                        <div className="flex items-center gap-2">
+                          {appDocs.length > 0 ? (
+                            <button onClick={() => setExpandedDocsId(expandedDocsId === c.id ? null : c.id)} className="inline-flex items-center gap-1 text-xs text-green-600 hover:text-green-700 cursor-pointer">
+                              <FileText className="h-3.5 w-3.5" />
+                              {appDocs.length} file{appDocs.length > 1 ? "s" : ""}
+                            </button>
+                          ) : (
+                            <span className="text-xs text-gray-300">None</span>
+                          )}
+                          <label className="inline-flex items-center gap-1 rounded-lg border border-gray-200 px-2 py-1 text-xs text-gray-500 hover:bg-gray-50 cursor-pointer">
+                            {uploadingId === c.id ? <Loader2 className="h-3 w-3 animate-spin" /> : <Upload className="h-3 w-3" />}
+                            Upload
+                            <input type="file" className="hidden" accept=".pdf,.doc,.docx,.jpg,.jpeg,.png" onChange={(e) => { if (e.target.files?.[0]) handleUploadDoc(c.id, e.target.files[0]); e.target.value = ""; }} />
+                          </label>
+                        </div>
+                        {expandedDocsId === c.id && appDocs.length > 0 && (
+                          <div className="space-y-1 rounded-lg border border-gray-100 bg-gray-50 p-2">
+                            {appDocs.map((doc) => (
+                              <div key={doc.id} className="flex items-center justify-between gap-2 text-xs">
+                                <span className="truncate max-w-[140px] text-gray-700" title={doc.file_name}>{doc.file_name}</span>
+                                <div className="flex items-center gap-1">
+                                  {doc.file_url && (
+                                    <a href={doc.file_url} target="_blank" rel="noopener noreferrer" title="View" className="rounded p-0.5 text-gray-400 hover:text-blue-600">
+                                      <Eye className="h-3 w-3" />
+                                    </a>
+                                  )}
+                                  <button onClick={() => handleDeleteDoc(c.id, doc.id)} title="Delete" className="rounded p-0.5 text-gray-400 hover:text-red-600 cursor-pointer">
+                                    <Trash2 className="h-3 w-3" />
+                                  </button>
+                                </div>
+                              </div>
+                            ))}
+                          </div>
                         )}
-                        <label className="inline-flex items-center gap-1 rounded-lg border border-gray-200 px-2 py-1 text-xs text-gray-500 hover:bg-gray-50 cursor-pointer">
-                          {uploadingId === c.id ? <Loader2 className="h-3 w-3 animate-spin" /> : <Upload className="h-3 w-3" />}
-                          Upload
-                          <input type="file" className="hidden" onChange={(e) => { if (e.target.files?.[0]) handleUploadDoc(c.id, e.target.files[0]); }} />
-                        </label>
                       </div>
                     </td>
                     <td className="px-4 py-3">


### PR DESCRIPTION
- Allow market leaders to upload/view docs for candidates assigned to them
- Add expandable document list showing file names with view and delete actions
- Add DELETE endpoint for removing individual candidate documents
- Include file_url in candidate list query for clickable document links
- Accept common file types (PDF, Word, images) with file input filter

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2