### PR TITLE
Fix candidate document upload by converting File to Buffer

### DIFF
--- a/src/app/api/onboarding/candidates/[id]/documents/route.ts
+++ b/src/app/api/onboarding/candidates/[id]/documents/route.ts
@@ -49,9 +49,10 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
   const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, "_");
   const filePath = `candidates/${id}/${stepKey}/${timestamp}_${safeName}`;
 
+  const buffer = Buffer.from(await file.arrayBuffer());
   const { error: uploadErr } = await supabaseAdmin.storage
     .from("sales-documents")
-    .upload(filePath, file, { contentType: file.type, upsert: false });
+    .upload(filePath, buffer, { contentType: file.type, upsert: false });
 
   if (uploadErr) return NextResponse.json({ error: `Upload failed: ${uploadErr.message}` }, { status: 500 });
 


### PR DESCRIPTION
The upload was passing the raw File object to Supabase Storage which doesn't work server-side. Convert to Buffer via arrayBuffer() first, matching the pattern used by all other upload routes.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2