### PR TITLE
Add operator account linking to sales pipeline items

### DIFF
--- a/src/app/api/pipeline-items/[id]/route.ts
+++ b/src/app/api/pipeline-items/[id]/route.ts
@@ -9,7 +9,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
 
   const { data, error } = await supabaseAdmin
     .from("pipeline_items")
-    .select("*, pipelines(id, name, type), pipeline_steps!pipeline_items_current_step_id_fkey(id, name, order_index), sales_accounts(business_name, email), employees(full_name, email), pipeline_item_documents(*, step_documents(*))")
+    .select("*, pipelines(id, name, type), pipeline_steps!pipeline_items_current_step_id_fkey(id, name, order_index), sales_accounts(id, business_name, contact_name, phone, email, address, entity_type), employees(full_name, email), pipeline_item_documents(*, step_documents(*))")
     .eq("id", id)
     .single();
 

--- a/src/app/sales/pipelines/[id]/items/[itemId]/page.tsx
+++ b/src/app/sales/pipelines/[id]/items/[itemId]/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { createBrowserClient } from "@/lib/supabase";
-import { ArrowLeft, Loader2, ChevronRight, Upload, CheckCircle2, Circle, AlertTriangle, FileText, Lock } from "lucide-react";
+import { ArrowLeft, Loader2, ChevronRight, Upload, CheckCircle2, Circle, AlertTriangle, FileText, Lock, Building2, Search, X, Link2, Unlink } from "lucide-react";
 
 interface StepDoc {
   id: string;
@@ -29,6 +29,16 @@ interface ItemDoc {
   step_documents: StepDoc | null;
 }
 
+interface Account {
+  id: string;
+  business_name: string;
+  contact_name: string | null;
+  phone: string | null;
+  email: string | null;
+  address: string | null;
+  entity_type: string | null;
+}
+
 interface PipelineItem {
   id: string;
   name: string;
@@ -37,8 +47,9 @@ interface PipelineItem {
   notes: string | null;
   current_step_id: string | null;
   pipeline_id: string;
+  account_id: string | null;
   pipeline_steps: { id: string; name: string; order_index: number } | null;
-  sales_accounts: { business_name: string; email: string | null } | null;
+  sales_accounts: Account | null;
   employees: { full_name: string; email: string | null } | null;
   pipeline_item_documents: ItemDoc[];
   all_steps: Step[];
@@ -55,11 +66,19 @@ export default function PipelineItemDetailPage() {
   const [moveError, setMoveError] = useState<string | null>(null);
   const [missingDocs, setMissingDocs] = useState<{ id: string; name: string }[]>([]);
   const [uploadingDocId, setUploadingDocId] = useState<string | null>(null);
+  const [accounts, setAccounts] = useState<Account[]>([]);
+  const [accountSearch, setAccountSearch] = useState("");
+  const [showAccountSearch, setShowAccountSearch] = useState(false);
+  const [showAccountDropdown, setShowAccountDropdown] = useState(false);
+  const [linkingAccount, setLinkingAccount] = useState(false);
 
   useEffect(() => {
     const supabase = createBrowserClient();
-    supabase.auth.getSession().then(({ data: { session } }) => {
-      if (session?.access_token) setToken(session.access_token);
+    supabase.auth.getSession().then(async ({ data: { session } }) => {
+      if (!session?.access_token) return;
+      setToken(session.access_token);
+      const res = await fetch("/api/sales/accounts", { headers: { Authorization: `Bearer ${session.access_token}` } });
+      if (res.ok) setAccounts(await res.json());
     });
   }, []);
 
@@ -117,6 +136,38 @@ export default function PipelineItemDetailPage() {
     load();
   }
 
+  async function handleLinkAccount(accountId: string) {
+    setLinkingAccount(true);
+    await fetch(`/api/pipeline-items/${itemId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ account_id: accountId }),
+    });
+    setShowAccountSearch(false);
+    setAccountSearch("");
+    setShowAccountDropdown(false);
+    setLinkingAccount(false);
+    load();
+  }
+
+  async function handleUnlinkAccount() {
+    if (!confirm("Unlink this account from the pipeline item?")) return;
+    await fetch(`/api/pipeline-items/${itemId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ account_id: null }),
+    });
+    load();
+  }
+
+  const filteredAccounts = accountSearch.length > 0
+    ? accounts.filter((a) =>
+        a.business_name.toLowerCase().includes(accountSearch.toLowerCase()) ||
+        (a.contact_name || "").toLowerCase().includes(accountSearch.toLowerCase()) ||
+        (a.email || "").toLowerCase().includes(accountSearch.toLowerCase())
+      ).slice(0, 8)
+    : [];
+
   if (loading) return <div className="flex justify-center py-20"><Loader2 className="h-8 w-8 animate-spin text-green-600" /></div>;
   if (!item) return <p className="p-6 text-gray-400">Item not found.</p>;
 
@@ -148,10 +199,118 @@ export default function PipelineItemDetailPage() {
           }`}>{item.status}</span>
         </div>
         <div className="flex gap-6 text-sm text-gray-500">
-          {item.sales_accounts && <span>Account: {item.sales_accounts.business_name}</span>}
           {item.employees && <span>Employee: {item.employees.full_name}</span>}
           {item.value > 0 && <span className="text-green-600 font-medium">${Number(item.value).toLocaleString()}</span>}
         </div>
+      </div>
+
+      {/* Linked Account */}
+      <div className="rounded-xl border border-gray-200 bg-white p-6 mb-6">
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-sm font-semibold text-gray-900 flex items-center gap-2">
+            <Building2 className="h-4 w-4 text-gray-400" />
+            Operator Account
+          </h2>
+          {item.sales_accounts ? (
+            <div className="flex items-center gap-2">
+              <button onClick={() => { setShowAccountSearch(true); }} className="flex items-center gap-1 text-xs text-blue-600 hover:text-blue-700 cursor-pointer">
+                <Link2 className="h-3 w-3" /> Change
+              </button>
+              <button onClick={handleUnlinkAccount} className="flex items-center gap-1 text-xs text-red-500 hover:text-red-600 cursor-pointer">
+                <Unlink className="h-3 w-3" /> Unlink
+              </button>
+            </div>
+          ) : (
+            <button onClick={() => setShowAccountSearch(!showAccountSearch)} className="flex items-center gap-1 rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-50 cursor-pointer">
+              <Link2 className="h-3 w-3" /> Link Account
+            </button>
+          )}
+        </div>
+
+        {showAccountSearch && (
+          <div className="relative mb-3">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+            <input
+              value={accountSearch}
+              onChange={(e) => { setAccountSearch(e.target.value); setShowAccountDropdown(true); }}
+              onFocus={() => { if (accountSearch) setShowAccountDropdown(true); }}
+              placeholder="Search accounts by name, contact, or email..."
+              className="w-full rounded-lg border border-gray-200 py-2.5 pl-10 pr-9 text-sm focus:border-green-500 focus:outline-none"
+              autoFocus
+            />
+            {accountSearch && (
+              <button onClick={() => { setAccountSearch(""); setShowAccountSearch(false); setShowAccountDropdown(false); }} className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600">
+                <X className="h-4 w-4" />
+              </button>
+            )}
+            {showAccountDropdown && filteredAccounts.length > 0 && (
+              <div className="absolute z-10 mt-1 w-full rounded-lg border border-gray-200 bg-white shadow-lg max-h-48 overflow-y-auto">
+                {filteredAccounts.map((a) => (
+                  <button
+                    key={a.id}
+                    onClick={() => handleLinkAccount(a.id)}
+                    disabled={linkingAccount}
+                    className="flex w-full items-center gap-3 px-3 py-2.5 text-left text-sm hover:bg-gray-50 cursor-pointer disabled:opacity-50"
+                  >
+                    <Building2 className="h-4 w-4 text-gray-400 flex-shrink-0" />
+                    <div className="min-w-0">
+                      <p className="font-medium text-gray-900 truncate">{a.business_name}</p>
+                      <p className="text-xs text-gray-400 truncate">
+                        {[a.contact_name, a.email, a.phone].filter(Boolean).join(" · ") || "No contact info"}
+                      </p>
+                    </div>
+                  </button>
+                ))}
+              </div>
+            )}
+            {showAccountDropdown && accountSearch.length > 0 && filteredAccounts.length === 0 && (
+              <div className="absolute z-10 mt-1 w-full rounded-lg border border-gray-200 bg-white shadow-lg p-3 text-sm text-gray-400 text-center">
+                No accounts found
+              </div>
+            )}
+          </div>
+        )}
+
+        {item.sales_accounts ? (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            <div>
+              <p className="text-xs text-gray-400">Business Name</p>
+              <p className="text-sm font-medium text-gray-900">{item.sales_accounts.business_name}</p>
+            </div>
+            {item.sales_accounts.contact_name && (
+              <div>
+                <p className="text-xs text-gray-400">Contact Name</p>
+                <p className="text-sm text-gray-700">{item.sales_accounts.contact_name}</p>
+              </div>
+            )}
+            {item.sales_accounts.email && (
+              <div>
+                <p className="text-xs text-gray-400">Email</p>
+                <p className="text-sm text-gray-700">{item.sales_accounts.email}</p>
+              </div>
+            )}
+            {item.sales_accounts.phone && (
+              <div>
+                <p className="text-xs text-gray-400">Phone</p>
+                <p className="text-sm text-gray-700">{item.sales_accounts.phone}</p>
+              </div>
+            )}
+            {item.sales_accounts.address && (
+              <div className="sm:col-span-2">
+                <p className="text-xs text-gray-400">Address</p>
+                <p className="text-sm text-gray-700">{item.sales_accounts.address}</p>
+              </div>
+            )}
+            {item.sales_accounts.entity_type && (
+              <div>
+                <p className="text-xs text-gray-400">Entity Type</p>
+                <p className="text-sm text-gray-700">{item.sales_accounts.entity_type}</p>
+              </div>
+            )}
+          </div>
+        ) : (
+          <p className="text-sm text-gray-400">No account linked. Link an account to auto-populate operator info.</p>
+        )}
       </div>
 
       {/* Step Progress */}

--- a/src/app/sales/pipelines/[id]/items/page.tsx
+++ b/src/app/sales/pipelines/[id]/items/page.tsx
@@ -4,7 +4,16 @@ import { useState, useEffect, useCallback } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
 import { createBrowserClient } from "@/lib/supabase";
-import { Loader2, Plus, ChevronRight } from "lucide-react";
+import { Loader2, Plus, ChevronRight, Search, Building2, X } from "lucide-react";
+
+interface Account {
+  id: string;
+  business_name: string;
+  contact_name: string | null;
+  phone: string | null;
+  email: string | null;
+  address: string | null;
+}
 
 interface PipelineItem {
   id: string;
@@ -28,6 +37,10 @@ export default function PipelineItemsPage() {
   const [showAdd, setShowAdd] = useState(false);
   const [form, setForm] = useState({ name: "", value: "" });
   const [saving, setSaving] = useState(false);
+  const [accounts, setAccounts] = useState<Account[]>([]);
+  const [accountSearch, setAccountSearch] = useState("");
+  const [selectedAccount, setSelectedAccount] = useState<Account | null>(null);
+  const [showAccountDropdown, setShowAccountDropdown] = useState(false);
 
   useEffect(() => {
     const supabase = createBrowserClient();
@@ -39,12 +52,14 @@ export default function PipelineItemsPage() {
   const load = useCallback(async () => {
     if (!token || !pipelineId) return;
     setLoading(true);
-    const [pRes, iRes] = await Promise.all([
+    const [pRes, iRes, aRes] = await Promise.all([
       fetch(`/api/pipelines/${pipelineId}`, { headers: { Authorization: `Bearer ${token}` } }),
       fetch(`/api/pipeline-items?pipeline_id=${pipelineId}`, { headers: { Authorization: `Bearer ${token}` } }),
+      fetch("/api/sales/accounts", { headers: { Authorization: `Bearer ${token}` } }),
     ]);
     if (pRes.ok) setPipeline(await pRes.json());
     if (iRes.ok) setItems(await iRes.json());
+    if (aRes.ok) setAccounts(await aRes.json());
     setLoading(false);
   }, [token, pipelineId]);
 
@@ -56,13 +71,35 @@ export default function PipelineItemsPage() {
     await fetch("/api/pipeline-items", {
       method: "POST",
       headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
-      body: JSON.stringify({ pipeline_id: pipelineId, name: form.name, value: Number(form.value) || 0 }),
+      body: JSON.stringify({
+        pipeline_id: pipelineId,
+        name: form.name,
+        value: Number(form.value) || 0,
+        account_id: selectedAccount?.id || null,
+      }),
     });
     setForm({ name: "", value: "" });
+    setSelectedAccount(null);
+    setAccountSearch("");
     setShowAdd(false);
     setSaving(false);
     load();
   }
+
+  function selectAccount(account: Account) {
+    setSelectedAccount(account);
+    setAccountSearch("");
+    setShowAccountDropdown(false);
+    if (!form.name) setForm((f) => ({ ...f, name: account.business_name }));
+  }
+
+  const filteredAccounts = accountSearch.length > 0
+    ? accounts.filter((a) =>
+        a.business_name.toLowerCase().includes(accountSearch.toLowerCase()) ||
+        (a.contact_name || "").toLowerCase().includes(accountSearch.toLowerCase()) ||
+        (a.email || "").toLowerCase().includes(accountSearch.toLowerCase())
+      ).slice(0, 8)
+    : [];
 
   const statusColor = (s: string) => {
     if (s === "won") return "bg-green-50 text-green-700";
@@ -89,11 +126,60 @@ export default function PipelineItemsPage() {
 
       {showAdd && (
         <div className="mb-6 rounded-xl border border-gray-200 bg-white p-5">
+          <h3 className="text-sm font-semibold text-gray-900 mb-3">New Pipeline Item</h3>
+          {/* Account Search */}
+          <div className="mb-3">
+            <label className="mb-1 block text-xs font-medium text-gray-500">Link Account (optional)</label>
+            {selectedAccount ? (
+              <div className="flex items-center justify-between rounded-lg border border-green-200 bg-green-50 px-3 py-2">
+                <div className="flex items-center gap-2">
+                  <Building2 className="h-4 w-4 text-green-600" />
+                  <div>
+                    <span className="text-sm font-medium text-gray-900">{selectedAccount.business_name}</span>
+                    {selectedAccount.contact_name && <span className="text-xs text-gray-500 ml-2">{selectedAccount.contact_name}</span>}
+                  </div>
+                </div>
+                <button onClick={() => { setSelectedAccount(null); setForm((f) => ({ ...f, name: "" })); }} className="text-gray-400 hover:text-red-500 cursor-pointer">
+                  <X className="h-4 w-4" />
+                </button>
+              </div>
+            ) : (
+              <div className="relative">
+                <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+                <input
+                  value={accountSearch}
+                  onChange={(e) => { setAccountSearch(e.target.value); setShowAccountDropdown(true); }}
+                  onFocus={() => { if (accountSearch) setShowAccountDropdown(true); }}
+                  placeholder="Search accounts by name, contact, or email..."
+                  className="w-full rounded-lg border border-gray-200 py-2 pl-10 pr-3 text-sm focus:border-green-500 focus:outline-none"
+                />
+                {showAccountDropdown && filteredAccounts.length > 0 && (
+                  <div className="absolute z-10 mt-1 w-full rounded-lg border border-gray-200 bg-white shadow-lg max-h-48 overflow-y-auto">
+                    {filteredAccounts.map((a) => (
+                      <button
+                        key={a.id}
+                        onClick={() => selectAccount(a)}
+                        className="flex w-full items-center gap-3 px-3 py-2.5 text-left text-sm hover:bg-gray-50 cursor-pointer"
+                      >
+                        <Building2 className="h-4 w-4 text-gray-400 flex-shrink-0" />
+                        <div className="min-w-0">
+                          <p className="font-medium text-gray-900 truncate">{a.business_name}</p>
+                          <p className="text-xs text-gray-400 truncate">
+                            {[a.contact_name, a.email, a.phone].filter(Boolean).join(" · ") || "No contact info"}
+                          </p>
+                        </div>
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
           <div className="flex gap-3">
-            <input placeholder="Name / Business" value={form.name} onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))} className="flex-1 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none" />
+            <input placeholder="Name / Business *" value={form.name} onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))} className="flex-1 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none" />
             <input placeholder="Value ($)" type="number" value={form.value} onChange={(e) => setForm((f) => ({ ...f, value: e.target.value }))} className="w-32 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none" />
             <button onClick={handleAdd} disabled={saving} className="rounded-lg bg-green-600 px-4 py-2 text-sm text-white hover:bg-green-700 disabled:opacity-50 cursor-pointer">{saving ? "Adding..." : "Add"}</button>
-            <button onClick={() => setShowAdd(false)} className="rounded-lg border border-gray-200 px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 cursor-pointer">Cancel</button>
+            <button onClick={() => { setShowAdd(false); setSelectedAccount(null); setAccountSearch(""); }} className="rounded-lg border border-gray-200 px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 cursor-pointer">Cancel</button>
           </div>
         </div>
       )}


### PR DESCRIPTION
- Search and link an existing account when adding a new pipeline item (auto-fills item name from account business name)
- Pipeline item detail page shows full account info card with business name, contact, phone, email, address, and entity type
- Link/change/unlink account from the detail page with search dropdown
- API returns full account fields on pipeline item detail endpoint

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2