### PR TITLE
Sync deals and pipeline items bidirectionally

### DIFF
--- a/src/app/api/pipeline-items/route.ts
+++ b/src/app/api/pipeline-items/route.ts
@@ -34,7 +34,12 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "pipeline_id and name required" }, { status: 400 });
   }
 
-  // Get first step of pipeline
+  const { data: pipeline } = await supabaseAdmin
+    .from("pipelines")
+    .select("id, type")
+    .eq("id", pipeline_id)
+    .single();
+
   const { data: firstStep } = await supabaseAdmin
     .from("pipeline_steps")
     .select("id")
@@ -42,6 +47,25 @@ export async function POST(req: NextRequest) {
     .order("order_index")
     .limit(1)
     .maybeSingle();
+
+  // Auto-create a deal for sales-type pipelines
+  let dealId: string | null = null;
+  if (pipeline?.type === "sales") {
+    const { data: deal } = await supabaseAdmin
+      .from("sales_deals")
+      .insert({
+        business_name: name,
+        assigned_to: assigned_to || user.id,
+        stage: "new",
+        value: value || 0,
+        lead_id: lead_id || null,
+        account_id: account_id || null,
+        pipeline_id: pipeline_id,
+      })
+      .select("id")
+      .single();
+    if (deal) dealId = deal.id;
+  }
 
   const { data, error } = await supabaseAdmin
     .from("pipeline_items")
@@ -56,10 +80,17 @@ export async function POST(req: NextRequest) {
       value: value || 0,
       notes: notes || null,
       assigned_to: assigned_to || user.id,
+      deal_id: dealId,
     })
     .select("*")
     .single();
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  // Link the deal back to the pipeline item
+  if (dealId && data) {
+    await supabaseAdmin.from("sales_deals").update({ pipeline_item_id: data.id }).eq("id", dealId);
+  }
+
   return NextResponse.json(data, { status: 201 });
 }

--- a/src/app/api/sales/deals/route.ts
+++ b/src/app/api/sales/deals/route.ts
@@ -8,7 +8,7 @@ export async function GET(req: NextRequest) {
 
   let query = supabaseAdmin
     .from("sales_deals")
-    .select("*, deal_services(*)")
+    .select("*, deal_services(*), pipelines(id, name)")
     .order("created_at", { ascending: false });
 
   if (user.role === "sales") {
@@ -42,21 +42,55 @@ export async function POST(req: NextRequest) {
   if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
 
   const body = await req.json();
-  const { lead_id, business_name, stage } = body;
+  const { lead_id, business_name, stage, pipeline_id, account_id } = body;
   if (!business_name) return NextResponse.json({ error: "business_name required" }, { status: 400 });
 
   const { data, error } = await supabaseAdmin
     .from("sales_deals")
     .insert({
       lead_id: lead_id || null,
+      account_id: account_id || null,
       assigned_to: user.id,
       stage: stage || "new",
       value: 0,
       business_name,
+      pipeline_id: pipeline_id || null,
     })
     .select("id")
     .single();
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  // Auto-create pipeline item if a pipeline was selected
+  if (pipeline_id && data) {
+    const { data: firstStep } = await supabaseAdmin
+      .from("pipeline_steps")
+      .select("id")
+      .eq("pipeline_id", pipeline_id)
+      .order("order_index")
+      .limit(1)
+      .maybeSingle();
+
+    const { data: pipelineItem } = await supabaseAdmin
+      .from("pipeline_items")
+      .insert({
+        pipeline_id,
+        name: business_name,
+        status: "active",
+        current_step_id: firstStep?.id || null,
+        value: 0,
+        assigned_to: user.id,
+        account_id: account_id || null,
+        lead_id: lead_id || null,
+        deal_id: data.id,
+      })
+      .select("id")
+      .single();
+
+    if (pipelineItem) {
+      await supabaseAdmin.from("sales_deals").update({ pipeline_item_id: pipelineItem.id }).eq("id", data.id);
+    }
+  }
+
   return NextResponse.json(data, { status: 201 });
 }

--- a/src/app/sales/deals/page.tsx
+++ b/src/app/sales/deals/page.tsx
@@ -3,9 +3,12 @@
 import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { createBrowserClient } from "@/lib/supabase";
-import { Loader2, Plus, Trash2, Lock } from "lucide-react";
-import type { SalesDeal, DealStage } from "@/lib/salesTypes";
+import { Loader2, Plus, Trash2, Lock, GitBranch } from "lucide-react";
+import type { DealStage } from "@/lib/salesTypes";
 import { DEAL_STAGES } from "@/lib/salesTypes";
+import type { SalesDeal } from "@/lib/salesTypes";
+
+type DealWithPipeline = SalesDeal & { pipelines?: { id: string; name: string } | null };
 
 const STAGE_COLORS: Record<DealStage, string> = {
   new: "border-t-blue-400",
@@ -17,14 +20,22 @@ const STAGE_COLORS: Record<DealStage, string> = {
   lost: "border-t-red-400",
 };
 
+interface SalesPipeline {
+  id: string;
+  name: string;
+  type: string;
+}
+
 export default function DealsPage() {
   const router = useRouter();
-  const [deals, setDeals] = useState<SalesDeal[]>([]);
+  const [deals, setDeals] = useState<DealWithPipeline[]>([]);
   const [loading, setLoading] = useState(true);
   const [token, setToken] = useState("");
   const [dragging, setDragging] = useState<string | null>(null);
   const [showAdd, setShowAdd] = useState(false);
   const [newName, setNewName] = useState("");
+  const [selectedPipeline, setSelectedPipeline] = useState("");
+  const [pipelines, setPipelines] = useState<SalesPipeline[]>([]);
   const [dragError, setDragError] = useState<string | null>(null);
 
   async function handleCreate() {
@@ -32,7 +43,10 @@ export default function DealsPage() {
     const res = await fetch("/api/sales/deals", {
       method: "POST",
       headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
-      body: JSON.stringify({ business_name: newName.trim() }),
+      body: JSON.stringify({
+        business_name: newName.trim(),
+        pipeline_id: selectedPipeline || null,
+      }),
     });
     if (!res.ok) {
       const err = await res.json().catch(() => ({}));
@@ -40,6 +54,7 @@ export default function DealsPage() {
       return;
     }
     setNewName("");
+    setSelectedPipeline("");
     setShowAdd(false);
     fetchDeals();
   }
@@ -63,7 +78,10 @@ export default function DealsPage() {
     const supabase = createBrowserClient();
     async function init() {
       const { data: { session } } = await supabase.auth.getSession();
-      if (session?.access_token) setToken(session.access_token);
+      if (!session?.access_token) return;
+      setToken(session.access_token);
+      const res = await fetch("/api/pipelines?type=sales", { headers: { Authorization: `Bearer ${session.access_token}` } });
+      if (res.ok) setPipelines(await res.json());
     }
     init();
   }, []);
@@ -130,17 +148,35 @@ export default function DealsPage() {
       )}
 
       {showAdd && (
-        <div className="mb-4 flex gap-2 rounded-xl border border-gray-200 bg-white p-4">
-          <input
-            autoFocus
-            value={newName}
-            onChange={(e) => setNewName(e.target.value)}
-            onKeyDown={(e) => e.key === "Enter" && handleCreate()}
-            placeholder="Business name"
-            className="flex-1 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none"
-          />
-          <button onClick={handleCreate} className="rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 cursor-pointer">Create</button>
-          <button onClick={() => { setShowAdd(false); setNewName(""); }} className="rounded-lg border border-gray-200 px-4 py-2 text-sm text-gray-600 hover:bg-gray-50 cursor-pointer">Cancel</button>
+        <div className="mb-4 rounded-xl border border-gray-200 bg-white p-4">
+          <div className="flex gap-2">
+            <input
+              autoFocus
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && handleCreate()}
+              placeholder="Business name"
+              className="flex-1 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none"
+            />
+            <div className="relative">
+              <GitBranch className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-gray-400" />
+              <select
+                value={selectedPipeline}
+                onChange={(e) => setSelectedPipeline(e.target.value)}
+                className="rounded-lg border border-gray-200 py-2 pl-8 pr-3 text-sm focus:border-green-500 focus:outline-none cursor-pointer"
+              >
+                <option value="">No pipeline</option>
+                {pipelines.map((p) => (
+                  <option key={p.id} value={p.id}>{p.name}</option>
+                ))}
+              </select>
+            </div>
+            <button onClick={handleCreate} className="rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 cursor-pointer">Create</button>
+            <button onClick={() => { setShowAdd(false); setNewName(""); setSelectedPipeline(""); }} className="rounded-lg border border-gray-200 px-4 py-2 text-sm text-gray-600 hover:bg-gray-50 cursor-pointer">Cancel</button>
+          </div>
+          {selectedPipeline && (
+            <p className="mt-2 text-xs text-gray-400">This deal will also be added to the selected pipeline automatically.</p>
+          )}
         </div>
       )}
       <div className="flex gap-3 overflow-x-auto pb-4">
@@ -195,6 +231,14 @@ export default function DealsPage() {
                         </button>
                       )}
                     </div>
+                    {deal.pipelines && (
+                      <div className="mt-1.5">
+                        <span className="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2 py-0.5 text-xs text-blue-600">
+                          <GitBranch className="h-2.5 w-2.5" />
+                          {deal.pipelines.name}
+                        </span>
+                      </div>
+                    )}
                     <div className="mt-1.5 flex items-center justify-between">
                       <span className="text-xs text-gray-500 truncate">{deal.assigned_profile?.full_name || "Unassigned"}</span>
                       <span className="text-xs font-semibold text-green-600">

--- a/supabase/migrations/038_link_deals_pipelines.sql
+++ b/supabase/migrations/038_link_deals_pipelines.sql
@@ -1,0 +1,10 @@
+-- Migration 038: Link deals and pipeline items bidirectionally
+-- When a deal is created it gets added to a pipeline, and vice versa.
+
+ALTER TABLE pipeline_items ADD COLUMN IF NOT EXISTS deal_id UUID REFERENCES sales_deals(id) ON DELETE SET NULL;
+ALTER TABLE sales_deals ADD COLUMN IF NOT EXISTS pipeline_item_id UUID REFERENCES pipeline_items(id) ON DELETE SET NULL;
+ALTER TABLE sales_deals ADD COLUMN IF NOT EXISTS pipeline_id UUID REFERENCES pipelines(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_pipeline_items_deal ON pipeline_items(deal_id);
+CREATE INDEX IF NOT EXISTS idx_sales_deals_pipeline_item ON sales_deals(pipeline_item_id);
+CREATE INDEX IF NOT EXISTS idx_sales_deals_pipeline ON sales_deals(pipeline_id);


### PR DESCRIPTION
- New pipeline item in a sales pipeline auto-creates a linked deal
- New deal with a selected pipeline auto-creates a linked pipeline item
- Pipeline selector dropdown on deal creation form
- Pipeline badge shown on deal cards in the Kanban view
- Migration adds deal_id, pipeline_item_id, and pipeline_id columns

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2