### PR TITLE
Grant director_of_sales same access as admin across all pages

### DIFF
--- a/src/app/api/request-location/route.ts
+++ b/src/app/api/request-location/route.ts
@@ -71,7 +71,7 @@ export async function POST(req: Request) {
       .select("id, full_name, role")
       .eq("id", ref)
       .single();
-    if (profile && (profile.role === "sales" || profile.role === "admin")) {
+    if (profile && (profile.role === "sales" || profile.role === "admin" || profile.role === "director_of_sales" || profile.role === "market_leader")) {
       referringRep = profile.id;
       referringRepName = profile.full_name;
     }

--- a/src/app/sales/accounts/page.tsx
+++ b/src/app/sales/accounts/page.tsx
@@ -27,7 +27,7 @@ export default function AccountsPage() {
       if (res.ok) {
         const users = await res.json();
         const me = users.find((u: { id: string }) => u.id === session.user.id);
-        if (me?.role === "admin") setUserRole("admin");
+        if (me?.role === "admin" || me?.role === "director_of_sales") setUserRole("admin");
       }
     });
   }, []);

--- a/src/app/sales/call-lists/page.tsx
+++ b/src/app/sales/call-lists/page.tsx
@@ -64,7 +64,7 @@ export default function CallListsPage() {
         const users: SalesUserRow[] = await res.json();
         setSalesUsers(users);
         const me = users.find((u) => u.id === session.user.id);
-        if (me?.role === "admin") setIsAdmin(true);
+        if (me?.role === "admin" || me?.role === "director_of_sales") setIsAdmin(true);
       }
     });
   }, []);
@@ -170,7 +170,7 @@ export default function CallListsPage() {
     { value: "operators", label: "Vending Machine Operators", icon: UsersIcon },
   ];
 
-  const salesOnly = salesUsers.filter((u) => u.role === "sales" || u.role === "admin");
+  const salesOnly = salesUsers.filter((u) => u.role === "sales" || u.role === "admin" || u.role === "director_of_sales");
 
   return (
     <div className="p-6">

--- a/src/app/sales/commissions/page.tsx
+++ b/src/app/sales/commissions/page.tsx
@@ -22,7 +22,7 @@ export default function CommissionsPage() {
         });
         if (res.ok) {
           const me = await res.json();
-          setIsAdmin(me.role === "admin");
+          setIsAdmin(me.role === "admin" || me.role === "director_of_sales");
         }
       }
     }

--- a/src/app/sales/leads/page.tsx
+++ b/src/app/sales/leads/page.tsx
@@ -156,7 +156,7 @@ export default function LeadsPage() {
         const users = await usersRes.json();
         setSalesUsers(users);
         const me = users.find((u: { id: string }) => u.id === session.user.id);
-        if (me?.role === "admin") setUserRole("admin");
+        if (me?.role === "admin" || me?.role === "director_of_sales") setUserRole("admin");
       }
     }
     init();

--- a/src/app/sales/resources/page.tsx
+++ b/src/app/sales/resources/page.tsx
@@ -75,7 +75,7 @@ export default function ResourcesPage() {
       if (res.ok) {
         const users = await res.json();
         const me = users.find((u: { id: string }) => u.id === session.user.id);
-        if (me?.role === "admin") setIsAdmin(true);
+        if (me?.role === "admin" || me?.role === "director_of_sales") setIsAdmin(true);
       }
     });
   }, []);


### PR DESCRIPTION
Fixed 6 frontend pages and 1 API route that were checking for admin role only, excluding DOS from admin-level features like bulk delete, commission management, call list admin, and resource uploads.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2