### PR TITLE
Surface candidate upload errors and broaden file type allowlist

### DIFF
--- a/src/app/api/onboarding/candidates/[id]/documents/route.ts
+++ b/src/app/api/onboarding/candidates/[id]/documents/route.ts
@@ -2,9 +2,13 @@ import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { getSalesUser, isElevatedRole } from "@/lib/salesAuth";
 
-const ALLOWED_TYPES = ["application/pdf", "image/jpeg", "image/png", "image/jpg",
-  "application/msword", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"];
+const ALLOWED_EXTENSIONS = [".pdf", ".doc", ".docx", ".jpg", ".jpeg", ".png", ".heic", ".heif", ".webp", ".gif", ".txt", ".csv", ".xls", ".xlsx", ".rtf"];
 const MAX_SIZE = 10 * 1024 * 1024;
+
+function isAllowedFile(file: File): boolean {
+  const name = file.name.toLowerCase();
+  return ALLOWED_EXTENSIONS.some((ext) => name.endsWith(ext));
+}
 
 export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const user = await getSalesUser(req);
@@ -43,16 +47,17 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
   if (!file) return NextResponse.json({ error: "file required" }, { status: 400 });
   if (!stepKey) return NextResponse.json({ error: "step_key required" }, { status: 400 });
   if (file.size > MAX_SIZE) return NextResponse.json({ error: "File too large (max 10MB)" }, { status: 400 });
-  if (!ALLOWED_TYPES.includes(file.type)) return NextResponse.json({ error: "File type not allowed" }, { status: 400 });
+  if (!isAllowedFile(file)) return NextResponse.json({ error: `File type not allowed: ${file.name}` }, { status: 400 });
 
   const timestamp = Date.now();
   const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, "_");
   const filePath = `candidates/${id}/${stepKey}/${timestamp}_${safeName}`;
 
   const buffer = Buffer.from(await file.arrayBuffer());
+  const contentType = file.type || "application/octet-stream";
   const { error: uploadErr } = await supabaseAdmin.storage
     .from("sales-documents")
-    .upload(filePath, buffer, { contentType: file.type, upsert: false });
+    .upload(filePath, buffer, { contentType, upsert: false });
 
   if (uploadErr) return NextResponse.json({ error: `Upload failed: ${uploadErr.message}` }, { status: 500 });
 
@@ -64,7 +69,7 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
       candidate_id: id,
       step_key: stepKey,
       file_name: file.name,
-      file_type: file.type,
+      file_type: contentType,
       file_url: urlData.publicUrl || filePath,
       uploaded_by: user.id,
     })

--- a/src/app/sales/candidates/page.tsx
+++ b/src/app/sales/candidates/page.tsx
@@ -93,15 +93,23 @@ export default function CandidatesPage() {
     } else {
       const candidate = await res.json();
       if (addFiles.length > 0) {
+        const failures: string[] = [];
         for (const file of addFiles) {
           const fd = new FormData();
           fd.append("file", file);
           fd.append("step_key", "application");
-          await fetch(`/api/onboarding/candidates/${candidate.id}/documents`, {
+          const upRes = await fetch(`/api/onboarding/candidates/${candidate.id}/documents`, {
             method: "POST",
             headers: { Authorization: `Bearer ${token}` },
             body: fd,
           });
+          if (!upRes.ok) {
+            const upErr = await upRes.json().catch(() => ({}));
+            failures.push(`${file.name}: ${upErr.error || `HTTP ${upRes.status}`}`);
+          }
+        }
+        if (failures.length > 0) {
+          alert(`Some uploads failed:\n${failures.join("\n")}`);
         }
       }
       setForm({ full_name: "", email: "", phone: "", role_type: "BDP", assigned_to: "", notes: "" });
@@ -151,11 +159,15 @@ export default function CandidatesPage() {
     const formData = new FormData();
     formData.append("file", file);
     formData.append("step_key", "application");
-    await fetch(`/api/onboarding/candidates/${candidateId}/documents`, {
+    const res = await fetch(`/api/onboarding/candidates/${candidateId}/documents`, {
       method: "POST",
       headers: { Authorization: `Bearer ${token}` },
       body: formData,
     });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      alert(err.error || `Upload failed (${res.status})`);
+    }
     setUploadingId(null);
     fetchCandidates();
   }
@@ -235,7 +247,7 @@ export default function CandidatesPage() {
             <label className="inline-flex items-center gap-1.5 rounded-lg border border-dashed border-gray-300 px-4 py-2.5 text-sm text-gray-500 hover:border-green-400 hover:text-green-600 hover:bg-green-50/30 cursor-pointer transition-colors">
               <Upload className="h-4 w-4" />
               Choose Files
-              <input type="file" multiple accept=".pdf,.doc,.docx,.jpg,.jpeg,.png" className="hidden" onChange={(e) => { if (e.target.files) setAddFiles((prev) => [...prev, ...Array.from(e.target.files!)]); e.target.value = ""; }} />
+              <input type="file" multiple accept=".pdf,.doc,.docx,.jpg,.jpeg,.png,.heic,.heif,.webp,.gif,.txt,.csv,.xls,.xlsx,.rtf" className="hidden" onChange={(e) => { if (e.target.files) setAddFiles((prev) => [...prev, ...Array.from(e.target.files!)]); e.target.value = ""; }} />
             </label>
             {addFiles.length > 0 && (
               <div className="mt-2 space-y-1">
@@ -337,7 +349,7 @@ export default function CandidatesPage() {
                           <label className="inline-flex items-center gap-1 rounded-lg border border-gray-200 px-2 py-1 text-xs text-gray-500 hover:bg-gray-50 cursor-pointer">
                             {uploadingId === c.id ? <Loader2 className="h-3 w-3 animate-spin" /> : <Upload className="h-3 w-3" />}
                             Upload
-                            <input type="file" className="hidden" accept=".pdf,.doc,.docx,.jpg,.jpeg,.png" onChange={(e) => { if (e.target.files?.[0]) handleUploadDoc(c.id, e.target.files[0]); e.target.value = ""; }} />
+                            <input type="file" className="hidden" accept=".pdf,.doc,.docx,.jpg,.jpeg,.png,.heic,.heif,.webp,.gif,.txt,.csv,.xls,.xlsx,.rtf" onChange={(e) => { if (e.target.files?.[0]) handleUploadDoc(c.id, e.target.files[0]); e.target.value = ""; }} />
                           </label>
                         </div>
                         {expandedDocsId === c.id && appDocs.length > 0 && (


### PR DESCRIPTION
- Show alert with actual error message when an upload fails (was silently swallowed before)
- Switch from MIME-type allowlist to extension allowlist (more reliable across browsers); add HEIC, WEBP, GIF, TXT, CSV, XLS, XLSX, RTF
- Default contentType to application/octet-stream when browser sends none

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2