### PR TITLE
Transfer candidate application documents to hiring pipeline resume se…

### DIFF
--- a/src/app/api/onboarding/candidates/[id]/route.ts
+++ b/src/app/api/onboarding/candidates/[id]/route.ts
@@ -86,6 +86,13 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
       .single();
 
     if (updateErr) return NextResponse.json({ error: updateErr.message }, { status: 500 });
+
+    await supabaseAdmin
+      .from("candidate_documents")
+      .update({ step_key: "resume" })
+      .eq("candidate_id", id)
+      .eq("step_key", "application");
+
     return NextResponse.json(updated);
   }
 

--- a/src/app/sales/team/[id]/page.tsx
+++ b/src/app/sales/team/[id]/page.tsx
@@ -248,7 +248,7 @@ export default function CandidateDetailPage() {
 
   const interviewDocs = candidate.candidate_documents.filter((d) => d.step_key === "interview");
   const welcomeDocs = candidate.candidate_documents.filter((d) => d.step_key === "welcome_docs");
-  const resumeDocs = candidate.candidate_documents.filter((d) => d.step_key === "resume");
+  const resumeDocs = candidate.candidate_documents.filter((d) => d.step_key === "resume" || d.step_key === "application");
 
   return (
     <div className="p-6 max-w-4xl mx-auto">


### PR DESCRIPTION
…ction

When a candidate is added to a hiring pipeline, their uploaded application documents are re-tagged from step_key "application" to "resume" so they appear in the pipeline's Resume section. The frontend also includes "application" docs as a fallback for any existing candidates.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2