### PR TITLE
Add inline doc template upload to Pipeline Doc Mapping page

### DIFF
--- a/src/app/api/onboarding/document-templates/route.ts
+++ b/src/app/api/onboarding/document-templates/route.ts
@@ -25,6 +25,13 @@ export async function GET(req: NextRequest) {
   return NextResponse.json(data || []);
 }
 
+const ALLOWED_EXTENSIONS = [".pdf", ".doc", ".docx", ".jpg", ".jpeg", ".png", ".heic", ".heif", ".webp", ".gif", ".txt", ".csv", ".xls", ".xlsx", ".rtf"];
+
+function isAllowedFile(file: File): boolean {
+  const name = file.name.toLowerCase();
+  return ALLOWED_EXTENSIONS.some((ext) => name.endsWith(ext));
+}
+
 export async function POST(req: NextRequest) {
   const user = await getSalesUser(req);
   if (!user || !isElevatedRole(user.role)) {
@@ -42,17 +49,20 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "file, name, pipeline_type, and step_key required" }, { status: 400 });
   }
 
-  if (file.type !== "application/pdf") {
-    return NextResponse.json({ error: "Only PDF files allowed" }, { status: 400 });
+  if (!isAllowedFile(file)) {
+    return NextResponse.json({ error: `File type not allowed: ${file.name}` }, { status: 400 });
   }
 
   const timestamp = Date.now();
   const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, "_");
   const filePath = `${pipeline_type}/${step_key}/${timestamp}_${safeName}`;
 
+  const buffer = Buffer.from(await file.arrayBuffer());
+  const contentType = file.type || "application/octet-stream";
+
   const { error: uploadErr } = await supabaseAdmin.storage
     .from("document-templates")
-    .upload(filePath, file, { contentType: file.type, upsert: false });
+    .upload(filePath, buffer, { contentType, upsert: false });
 
   if (uploadErr) return NextResponse.json({ error: `Upload failed: ${uploadErr.message}` }, { status: 500 });
 
@@ -64,7 +74,7 @@ export async function POST(req: NextRequest) {
       step_key,
       file_path: filePath,
       file_name: file.name,
-      mime_type: file.type,
+      mime_type: contentType,
       version: version ? parseInt(version) : 1,
       active: true,
     })

--- a/src/app/sales/admin/pipeline-doc-mapping/page.tsx
+++ b/src/app/sales/admin/pipeline-doc-mapping/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { createBrowserClient } from "@/lib/supabase";
-import { Loader2, Link2, Plus, Trash2, ChevronUp, ChevronDown, CheckCircle2, XCircle } from "lucide-react";
+import { Loader2, Link2, Plus, Trash2, ChevronUp, ChevronDown, Upload } from "lucide-react";
 
 interface DocTemplate {
   id: string;
@@ -44,6 +44,12 @@ export default function PipelineDocMappingPage() {
   const [selectedStep, setSelectedStep] = useState("interview");
   const [saving, setSaving] = useState(false);
   const [authorized, setAuthorized] = useState(false);
+  const [showUpload, setShowUpload] = useState(false);
+  const [uploadName, setUploadName] = useState("");
+  const [uploadVersion, setUploadVersion] = useState("1");
+  const [uploadFile, setUploadFile] = useState<File | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [autoAssign, setAutoAssign] = useState(true);
 
   useEffect(() => {
     const supabase = createBrowserClient();
@@ -181,20 +187,143 @@ export default function PipelineDocMappingPage() {
     loadAssignments();
   }
 
+  async function handleUpload() {
+    if (!uploadFile || !uploadName.trim() || !currentPipeline) {
+      alert("Name and file are required");
+      return;
+    }
+    const pipelineType = currentPipeline.source === "onboarding"
+      ? currentPipeline.role_type
+      : `pipeline_${currentPipeline.id}`;
+
+    setUploading(true);
+    try {
+      const fd = new FormData();
+      fd.append("file", uploadFile);
+      fd.append("name", uploadName.trim());
+      fd.append("pipeline_type", pipelineType);
+      fd.append("step_key", selectedStep);
+      fd.append("version", uploadVersion || "1");
+
+      const res = await fetch("/api/onboarding/document-templates", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+        body: fd,
+      });
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        alert(err.error || "Upload failed");
+        return;
+      }
+
+      const newTemplate = await res.json();
+
+      if (autoAssign) {
+        await fetch("/api/onboarding/step-doc-assignments", {
+          method: "POST",
+          headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+          body: JSON.stringify({
+            action: "assign",
+            pipeline_id: selectedPipeline,
+            step_key: selectedStep,
+            document_template_id: newTemplate.id,
+            required: true,
+            order_index: assignments.length,
+          }),
+        });
+      }
+
+      setUploadName("");
+      setUploadVersion("1");
+      setUploadFile(null);
+      setShowUpload(false);
+      await loadTemplates();
+      await loadAssignments();
+    } finally {
+      setUploading(false);
+    }
+  }
+
   const sortedAssignments = [...assignments].sort((a, b) => a.order_index - b.order_index);
 
   if (!authorized) return <div className="flex justify-center py-20"><Loader2 className="h-8 w-8 animate-spin text-green-600" /></div>;
 
   return (
     <div className="p-6 max-w-5xl mx-auto">
-      <div className="flex items-center gap-2 mb-6">
-        <Link2 className="h-6 w-6 text-green-600" />
-        <h1 className="text-2xl font-bold text-gray-900">Pipeline Document Mapping</h1>
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center gap-2">
+          <Link2 className="h-6 w-6 text-green-600" />
+          <h1 className="text-2xl font-bold text-gray-900">Pipeline Document Mapping</h1>
+        </div>
+        <button
+          onClick={() => setShowUpload((s) => !s)}
+          disabled={!currentPipeline}
+          className="inline-flex items-center gap-1.5 rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-50 cursor-pointer"
+        >
+          <Upload className="h-4 w-4" />
+          Upload New Template
+        </button>
       </div>
 
       <p className="text-sm text-gray-500 mb-6">
         Assign which document templates are sent at each pipeline step. Only assigned documents will be attached to emails.
       </p>
+
+      {showUpload && currentPipeline && (
+        <div className="mb-6 rounded-xl border border-green-200 bg-green-50 p-5">
+          <h3 className="text-sm font-semibold text-gray-900 mb-1">Upload Template</h3>
+          <p className="text-xs text-gray-500 mb-3">
+            Will be added to <span className="font-medium">{currentPipeline.name}</span> · step <span className="font-medium">{currentPipeline.steps.find((s) => s.key === selectedStep)?.label || selectedStep}</span>
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <input
+              placeholder="Document name *"
+              value={uploadName}
+              onChange={(e) => setUploadName(e.target.value)}
+              className="rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none"
+            />
+            <input
+              type="number"
+              min={1}
+              placeholder="Version"
+              value={uploadVersion}
+              onChange={(e) => setUploadVersion(e.target.value)}
+              className="rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none"
+            />
+          </div>
+          <input
+            type="file"
+            accept=".pdf,.doc,.docx,.jpg,.jpeg,.png,.heic,.heif,.webp,.gif,.txt,.csv,.xls,.xlsx,.rtf"
+            onChange={(e) => setUploadFile(e.target.files?.[0] || null)}
+            className="mt-3 block w-full text-sm text-gray-600 file:mr-3 file:rounded-lg file:border-0 file:bg-white file:px-4 file:py-2 file:text-sm file:font-medium hover:file:bg-gray-50"
+          />
+          <label className="mt-3 flex items-center gap-2 text-sm text-gray-700 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={autoAssign}
+              onChange={(e) => setAutoAssign(e.target.checked)}
+              className="rounded border-gray-300 cursor-pointer"
+            />
+            Assign to this step after upload
+          </label>
+          <div className="mt-4 flex gap-2">
+            <button
+              onClick={handleUpload}
+              disabled={uploading}
+              className="rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-50 cursor-pointer"
+            >
+              {uploading ? "Uploading..." : "Upload"}
+            </button>
+            <button
+              onClick={() => setShowUpload(false)}
+              className="rounded-lg border border-gray-200 bg-white px-4 py-2 text-sm text-gray-600 hover:bg-gray-50 cursor-pointer"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
 
       {/* Selectors */}
       <div className="flex gap-3 mb-6">


### PR DESCRIPTION
Adds an "Upload New Template" button on the Doc Mapping page so admins can upload, attach, and assign new templates without leaving the page. The uploaded template is auto-tagged for the currently-selected pipeline and step, and (by default) auto-assigned to that step.

Also fixes the underlying upload route to convert File to Buffer for server-side storage uploads and broadens the allowlist beyond PDF to match candidate document uploads.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2