### PR TITLE
Add location placement proposal flow with two-phase PandaDoc documents

### DIFF
--- a/docs/proposal-flow.md
+++ b/docs/proposal-flow.md
@@ -1,0 +1,82 @@
+# Location Placement Proposal Flow
+
+## Overview
+
+Two-phase PandaDoc document flow for location placement proposals:
+1. **Preliminary Proposal** — sent before payment with limited location info
+2. **Full Proposal** — auto-generated after payment with complete location details
+
+## Security Boundary
+
+- Customers only see preliminary fields (industry, zip, employee_count, traffic_count) before payment
+- Sensitive fields (location_name, address, phone, decision_maker_name, decision_maker_email) are stripped server-side via `getLocationForUser()` until `locations.is_revealed = true`
+- Admins and internal users always see all fields
+
+## Database Objects
+
+### `locations` table (migration 040)
+- Preliminary fields: `industry`, `zip`, `employee_count`, `traffic_count`
+- Sensitive fields: `location_name`, `address`, `phone`, `decision_maker_name`, `decision_maker_email`
+- `is_revealed` (boolean) — controls field visibility
+- `revealed_at` (timestamp) — set when payment completes
+
+### `pipeline_steps` additions
+- `pandadoc_preliminary_template_id` — PandaDoc template for Phase 1
+- `pandadoc_full_template_id` — PandaDoc template for Phase 2
+- `payment_provider` — `pandadoc_stripe`, `paypal`, or `none`
+
+### `pipeline_items` additions
+- `location_id` — references `locations.id`
+- `proposal_status` — `not_sent`, `proposal_sent`, or `paid`
+
+## Phase 1: Send Preliminary Proposal
+
+**Trigger:** Admin clicks "Send Preliminary Proposal" on pipeline item detail page
+
+**API:** `POST /api/pipeline-items/[id]/send-proposal`
+
+**Flow:**
+1. Validates item has `location_id` and step has `pandadoc_preliminary_template_id`
+2. Creates PandaDoc document from preliminary template with merge fields (industry, zip, employee/traffic counts, customer info, payment amount)
+3. Sends document immediately
+4. Creates `esign_documents` record with `metadata.type = "preliminary_proposal"`
+5. Creates `pipeline_payments` record (pending) if step uses `pandadoc_stripe`
+6. Updates `pipeline_items.proposal_status = "proposal_sent"`
+
+## Phase 2: Payment + Auto-Release
+
+**Trigger:** PandaDoc webhook fires `document_state_changed.document.completed`
+
+**Handler:** `POST /api/webhooks/esign`
+
+**Flow (when esign_document has `metadata.type = "preliminary_proposal"`):**
+1. Marks `pipeline_payments` as completed
+2. Sets `locations.is_revealed = true` and `revealed_at = now()`
+3. Generates full PandaDoc document from `pandadoc_full_template_id` with all location fields
+4. Sends full document to customer email
+5. Creates new `esign_documents` record with `metadata.type = "full_proposal"`
+6. Updates `pipeline_items.proposal_status = "paid"`
+7. If step requirements met and no admin approval required, auto-advances to next step (or marks won if last step)
+
+## Phase 3: Stripe Backup Reconciliation
+
+**Handler:** `POST /api/webhooks/stripe`
+
+Handles `payment_intent.succeeded` events with `pipeline_item_id` and `step_id` metadata — marks matching `pipeline_payments` as completed as an audit backup.
+
+## Access Control
+
+`src/lib/locations/access.ts` provides:
+- `getLocationForUser(locationId, viewerContext)` — returns full or stripped location based on viewer context and `is_revealed` status
+- `stripSensitiveFields(location)` — utility to remove sensitive fields
+
+**ViewerContext values:** `admin`, `internal_user`, `customer`
+
+## Configuration (Pipeline Edit Page)
+
+When "E-Sign" is checked on a step:
+- Two text inputs for Preliminary Template ID and Full Template ID
+
+When "Payment" is checked on a step:
+- Amount and description inputs
+- Payment Provider dropdown: PandaDoc + Stripe, PayPal, None

--- a/src/app/api/pipeline-items/[id]/send-proposal/route.ts
+++ b/src/app/api/pipeline-items/[id]/send-proposal/route.ts
@@ -1,0 +1,136 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser, isElevatedRole } from "@/lib/salesAuth";
+import { createDocumentFromTemplate, sendDocument } from "@/lib/pandadoc";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const user = await getSalesUser(req);
+  if (!user || !isElevatedRole(user.role)) {
+    return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+  }
+  const { id: itemId } = await params;
+
+  const { data: item } = await supabaseAdmin
+    .from("pipeline_items")
+    .select("*, sales_accounts(id, business_name, contact_name, email), pipelines(id, name)")
+    .eq("id", itemId)
+    .single();
+
+  if (!item) {
+    return NextResponse.json({ error: "Pipeline item not found" }, { status: 404 });
+  }
+  if (!item.location_id) {
+    return NextResponse.json({ error: "No location linked to this pipeline item" }, { status: 422 });
+  }
+  if (!item.current_step_id) {
+    return NextResponse.json({ error: "No current step" }, { status: 422 });
+  }
+
+  const { data: step } = await supabaseAdmin
+    .from("pipeline_steps")
+    .select("*")
+    .eq("id", item.current_step_id)
+    .single();
+
+  if (!step?.pandadoc_preliminary_template_id) {
+    return NextResponse.json(
+      { error: "Step has no preliminary PandaDoc template configured" },
+      { status: 422 }
+    );
+  }
+
+  const { data: location } = await supabaseAdmin
+    .from("locations")
+    .select("*")
+    .eq("id", item.location_id)
+    .single();
+
+  if (!location) {
+    return NextResponse.json({ error: "Location not found" }, { status: 404 });
+  }
+
+  const recipientEmail = item.sales_accounts?.email;
+  const recipientName = item.sales_accounts?.contact_name || item.sales_accounts?.business_name || item.name;
+
+  if (!recipientEmail) {
+    return NextResponse.json(
+      { error: "Linked account has no email — cannot send proposal" },
+      { status: 422 }
+    );
+  }
+
+  try {
+    const fields: Record<string, string> = {
+      industry: location.industry || "",
+      zip: location.zip || "",
+      employee_count: String(location.employee_count || ""),
+      traffic_count: String(location.traffic_count || ""),
+      customer_name: recipientName,
+      customer_email: recipientEmail,
+      business_name: item.sales_accounts?.business_name || "",
+    };
+
+    if (step.payment_amount) {
+      fields.payment_amount = String(step.payment_amount);
+    }
+
+    const doc = await createDocumentFromTemplate({
+      templateId: step.pandadoc_preliminary_template_id,
+      documentName: `Location Proposal — ${item.name}`,
+      recipientEmail,
+      recipientName,
+      fields,
+    });
+
+    // Wait for PandaDoc to process the document before sending
+    await new Promise((r) => setTimeout(r, 3000));
+    await sendDocument(doc.id, "Please review this location placement proposal.");
+
+    // Create esign_documents record
+    await supabaseAdmin.from("esign_documents").insert({
+      pipeline_item_id: itemId,
+      step_id: item.current_step_id,
+      provider: "pandadoc",
+      external_document_id: doc.id,
+      template_id: step.pandadoc_preliminary_template_id,
+      document_name: `Location Proposal — ${item.name}`,
+      recipient_email: recipientEmail,
+      recipient_name: recipientName,
+      status: "sent",
+      sent_at: new Date().toISOString(),
+      metadata: { type: "preliminary_proposal", location_id: item.location_id },
+    });
+
+    // Create pending payment record if payment is required via PandaDoc+Stripe
+    if (step.requires_payment && step.payment_provider === "pandadoc_stripe" && step.payment_amount) {
+      await supabaseAdmin.from("pipeline_payments").insert({
+        pipeline_item_id: itemId,
+        step_id: item.current_step_id,
+        provider: "stripe",
+        amount: step.payment_amount,
+        currency: "USD",
+        description: step.payment_description || `Proposal payment — ${item.name}`,
+        status: "pending",
+        metadata: { via: "pandadoc_stripe", pandadoc_document_id: doc.id },
+      });
+    }
+
+    // Update proposal status
+    await supabaseAdmin
+      .from("pipeline_items")
+      .update({ proposal_status: "proposal_sent", updated_at: new Date().toISOString() })
+      .eq("id", itemId);
+
+    return NextResponse.json({
+      ok: true,
+      pandadoc_document_id: doc.id,
+      proposal_status: "proposal_sent",
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/pipelines/[id]/steps/route.ts
+++ b/src/app/api/pipelines/[id]/steps/route.ts
@@ -38,6 +38,9 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
     if (body.requires_admin_approval !== undefined) updates.requires_admin_approval = body.requires_admin_approval;
     if (body.payment_amount !== undefined) updates.payment_amount = body.payment_amount;
     if (body.payment_description !== undefined) updates.payment_description = body.payment_description;
+    if (body.pandadoc_preliminary_template_id !== undefined) updates.pandadoc_preliminary_template_id = body.pandadoc_preliminary_template_id;
+    if (body.pandadoc_full_template_id !== undefined) updates.pandadoc_full_template_id = body.pandadoc_full_template_id;
+    if (body.payment_provider !== undefined) updates.payment_provider = body.payment_provider;
     const { data, error } = await supabaseAdmin
       .from("pipeline_steps")
       .update(updates)

--- a/src/app/api/webhooks/esign/route.ts
+++ b/src/app/api/webhooks/esign/route.ts
@@ -1,6 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
-import { downloadSignedPdf, verifyWebhookSignature } from "@/lib/pandadoc";
+import {
+  createDocumentFromTemplate,
+  downloadSignedPdf,
+  sendDocument,
+  verifyWebhookSignature,
+} from "@/lib/pandadoc";
+import { checkStepGating } from "@/lib/stepGating";
 
 export async function POST(req: NextRequest) {
   const rawBody = await req.text();
@@ -125,6 +131,16 @@ export async function POST(req: NextRequest) {
       } catch {
         // PDF download failure shouldn't block status update
       }
+
+      // Phase 2: If this is a preliminary proposal with PandaDoc+Stripe payment,
+      // handle location reveal and full document generation
+      const metadata = esignDoc.metadata as Record<string, unknown> | null;
+      if (metadata?.type === "preliminary_proposal" && metadata?.location_id) {
+        await handleProposalPaymentCompletion(
+          esignDoc,
+          metadata.location_id as string
+        );
+      }
     }
 
     await supabaseAdmin
@@ -134,4 +150,168 @@ export async function POST(req: NextRequest) {
   }
 
   return NextResponse.json({ ok: true });
+}
+
+async function handleProposalPaymentCompletion(
+  esignDoc: Record<string, unknown>,
+  locationId: string
+) {
+  const itemId = esignDoc.pipeline_item_id as string;
+  const stepId = esignDoc.step_id as string;
+
+  // Mark the pipeline payment as completed
+  await supabaseAdmin
+    .from("pipeline_payments")
+    .update({
+      status: "completed",
+      completed_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    })
+    .eq("pipeline_item_id", itemId)
+    .eq("step_id", stepId)
+    .eq("status", "pending");
+
+  // Reveal the location
+  await supabaseAdmin
+    .from("locations")
+    .update({
+      is_revealed: true,
+      revealed_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", locationId);
+
+  // Fetch step for full template ID
+  const { data: step } = await supabaseAdmin
+    .from("pipeline_steps")
+    .select("*")
+    .eq("id", stepId)
+    .single();
+
+  if (!step?.pandadoc_full_template_id) {
+    // No full template configured — just update status
+    await supabaseAdmin
+      .from("pipeline_items")
+      .update({
+        proposal_status: "paid",
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", itemId);
+    return;
+  }
+
+  // Fetch full location data + pipeline item for recipient info
+  const { data: location } = await supabaseAdmin
+    .from("locations")
+    .select("*")
+    .eq("id", locationId)
+    .single();
+
+  const { data: item } = await supabaseAdmin
+    .from("pipeline_items")
+    .select("*, sales_accounts(id, business_name, contact_name, email)")
+    .eq("id", itemId)
+    .single();
+
+  if (!location || !item) return;
+
+  const recipientEmail = item.sales_accounts?.email;
+  const recipientName =
+    item.sales_accounts?.contact_name ||
+    item.sales_accounts?.business_name ||
+    item.name;
+
+  if (!recipientEmail) return;
+
+  try {
+    // Generate full PandaDoc document with all location details
+    const fields: Record<string, string> = {
+      industry: location.industry || "",
+      zip: location.zip || "",
+      employee_count: String(location.employee_count || ""),
+      traffic_count: String(location.traffic_count || ""),
+      location_name: location.location_name || "",
+      address: location.address || "",
+      phone: location.phone || "",
+      decision_maker_name: location.decision_maker_name || "",
+      decision_maker_email: location.decision_maker_email || "",
+      customer_name: recipientName,
+      customer_email: recipientEmail,
+      business_name: item.sales_accounts?.business_name || "",
+    };
+
+    if (step.payment_amount) {
+      fields.payment_amount = String(step.payment_amount);
+    }
+
+    const doc = await createDocumentFromTemplate({
+      templateId: step.pandadoc_full_template_id,
+      documentName: `Full Location Details — ${item.name}`,
+      recipientEmail,
+      recipientName,
+      fields,
+    });
+
+    await new Promise((r) => setTimeout(r, 3000));
+    await sendDocument(doc.id, "Your payment has been received. Here are the full location details.");
+
+    // Record the full document
+    await supabaseAdmin.from("esign_documents").insert({
+      pipeline_item_id: itemId,
+      step_id: stepId,
+      provider: "pandadoc",
+      external_document_id: doc.id,
+      template_id: step.pandadoc_full_template_id,
+      document_name: `Full Location Details — ${item.name}`,
+      recipient_email: recipientEmail,
+      recipient_name: recipientName,
+      status: "sent",
+      sent_at: new Date().toISOString(),
+      metadata: { type: "full_proposal", location_id: locationId },
+    });
+  } catch {
+    // Full doc send failure shouldn't block payment processing
+  }
+
+  // Update proposal status
+  await supabaseAdmin
+    .from("pipeline_items")
+    .update({
+      proposal_status: "paid",
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", itemId);
+
+  // Auto-advance if all step requirements are met and no admin approval needed
+  if (!step.requires_admin_approval) {
+    const gating = await checkStepGating(itemId, stepId);
+    if (gating.canAdvance) {
+      const { data: steps } = await supabaseAdmin
+        .from("pipeline_steps")
+        .select("id")
+        .eq("pipeline_id", item.pipeline_id)
+        .order("order_index");
+
+      if (steps) {
+        const currentIdx = steps.findIndex((s) => s.id === stepId);
+        if (currentIdx === steps.length - 1) {
+          await supabaseAdmin
+            .from("pipeline_items")
+            .update({
+              status: "won",
+              updated_at: new Date().toISOString(),
+            })
+            .eq("id", itemId);
+        } else if (currentIdx >= 0 && currentIdx < steps.length - 1) {
+          await supabaseAdmin
+            .from("pipeline_items")
+            .update({
+              current_step_id: steps[currentIdx + 1].id,
+              updated_at: new Date().toISOString(),
+            })
+            .eq("id", itemId);
+        }
+      }
+    }
+  }
 }

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -137,6 +137,27 @@ export async function POST(req: NextRequest) {
     }
   }
 
+  // Pipeline payment reconciliation (backup for PandaDoc+Stripe flow)
+  if (event.type === "payment_intent.succeeded") {
+    const paymentIntent = event.data.object as Stripe.PaymentIntent;
+    const pipelineItemId = paymentIntent.metadata?.pipeline_item_id;
+    const stepId = paymentIntent.metadata?.step_id;
+
+    if (pipelineItemId && stepId) {
+      await supabaseAdmin
+        .from("pipeline_payments")
+        .update({
+          status: "completed",
+          stripe_payment_intent_id: paymentIntent.id,
+          completed_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        })
+        .eq("pipeline_item_id", pipelineItemId)
+        .eq("step_id", stepId)
+        .in("status", ["pending", "created"]);
+    }
+  }
+
   if (event.type === "checkout.session.expired") {
     const session = event.data.object as Stripe.Checkout.Session;
     await supabaseAdmin

--- a/src/app/sales/pipelines/[id]/edit/page.tsx
+++ b/src/app/sales/pipelines/[id]/edit/page.tsx
@@ -23,6 +23,9 @@ interface Step {
   requires_admin_approval: boolean;
   payment_amount: number | null;
   payment_description: string | null;
+  pandadoc_preliminary_template_id: string | null;
+  pandadoc_full_template_id: string | null;
+  payment_provider: string;
   step_documents: StepDoc[];
 }
 
@@ -145,6 +148,11 @@ export default function PipelineEditPage() {
 
   async function updatePaymentConfig(stepId: string, amount: number, description: string) {
     await fetch(`/api/pipelines/${id}/steps`, { method: "POST", headers: headers(), body: JSON.stringify({ action: "update", step_id: stepId, payment_amount: amount, payment_description: description }) });
+    load();
+  }
+
+  async function updateStepField(stepId: string, field: string, value: string) {
+    await fetch(`/api/pipelines/${id}/steps`, { method: "POST", headers: headers(), body: JSON.stringify({ action: "update", step_id: stepId, [field]: value || null }) });
     load();
   }
 
@@ -287,6 +295,42 @@ export default function PipelineEditPage() {
                     className="flex-1 rounded-lg border border-gray-200 px-2 py-1 text-xs focus:border-green-500 focus:outline-none"
                   />
                 </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-xs text-gray-500">Provider:</span>
+                  <select
+                    value={step.payment_provider || "none"}
+                    onChange={(e) => updateStepField(step.id, "payment_provider", e.target.value)}
+                    className="rounded-lg border border-gray-200 px-2 py-1 text-xs focus:border-green-500 focus:outline-none"
+                  >
+                    <option value="none">None</option>
+                    <option value="pandadoc_stripe">PandaDoc + Stripe</option>
+                    <option value="paypal">PayPal</option>
+                  </select>
+                </div>
+              </div>
+            )}
+
+            {/* PandaDoc Template IDs (for proposal flow) */}
+            {step.requires_signature && (
+              <div className="ml-12 mt-3 space-y-2">
+                <p className="text-xs font-medium text-gray-500 uppercase flex items-center gap-1"><PenTool className="h-3 w-3" /> PandaDoc Templates</p>
+                <div className="flex gap-2">
+                  <input
+                    type="text"
+                    defaultValue={step.pandadoc_preliminary_template_id || ""}
+                    onBlur={(e) => updateStepField(step.id, "pandadoc_preliminary_template_id", e.target.value)}
+                    placeholder="Preliminary Template ID"
+                    className="flex-1 rounded-lg border border-gray-200 px-2 py-1 text-xs focus:border-green-500 focus:outline-none"
+                  />
+                  <input
+                    type="text"
+                    defaultValue={step.pandadoc_full_template_id || ""}
+                    onBlur={(e) => updateStepField(step.id, "pandadoc_full_template_id", e.target.value)}
+                    placeholder="Full Template ID"
+                    className="flex-1 rounded-lg border border-gray-200 px-2 py-1 text-xs focus:border-green-500 focus:outline-none"
+                  />
+                </div>
+                <p className="text-xs text-gray-400">Preliminary = before payment · Full = after payment (includes sensitive location details)</p>
               </div>
             )}
 

--- a/src/app/sales/pipelines/[id]/items/[itemId]/page.tsx
+++ b/src/app/sales/pipelines/[id]/items/[itemId]/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { createBrowserClient } from "@/lib/supabase";
-import { ArrowLeft, Loader2, ChevronRight, Upload, CheckCircle2, Circle, AlertTriangle, FileText, Lock, Building2, Search, X, Link2, Unlink, Send, DollarSign, ShieldCheck, PenTool, CreditCard, Clock, ExternalLink } from "lucide-react";
+import { ArrowLeft, Loader2, ChevronRight, Upload, CheckCircle2, Circle, AlertTriangle, FileText, Lock, Building2, Search, X, Link2, Unlink, Send, DollarSign, ShieldCheck, PenTool, CreditCard, Clock, ExternalLink, MapPin } from "lucide-react";
 
 interface StepDoc {
   id: string;
@@ -22,6 +22,9 @@ interface Step {
   requires_admin_approval: boolean;
   payment_amount: number | null;
   payment_description: string | null;
+  pandadoc_preliminary_template_id: string | null;
+  pandadoc_full_template_id: string | null;
+  payment_provider: string;
   step_documents: StepDoc[];
 }
 
@@ -91,6 +94,8 @@ interface PipelineItem {
   current_step_id: string | null;
   pipeline_id: string;
   account_id: string | null;
+  location_id: string | null;
+  proposal_status: string;
   pipeline_steps: { id: string; name: string; order_index: number } | null;
   sales_accounts: Account | null;
   employees: { full_name: string; email: string | null } | null;
@@ -121,6 +126,7 @@ export default function PipelineItemDetailPage() {
   const [creatingPayment, setCreatingPayment] = useState(false);
   const [approvingStep, setApprovingStep] = useState(false);
   const [esignForm, setEsignForm] = useState({ document_name: "", recipient_email: "", template_id: "" });
+  const [sendingProposal, setSendingProposal] = useState(false);
 
   useEffect(() => {
     const supabase = createBrowserClient();
@@ -281,6 +287,20 @@ export default function PipelineItemDetailPage() {
     });
     setApprovingStep(false);
     loadGatingData();
+  }
+
+  async function handleSendProposal() {
+    if (!item?.current_step_id) return;
+    setSendingProposal(true);
+    const res = await fetch(`/api/pipeline-items/${itemId}/send-proposal`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+    });
+    setSendingProposal(false);
+    if (res.ok) {
+      load();
+      loadGatingData();
+    }
   }
 
   const filteredAccounts = accountSearch.length > 0
@@ -463,6 +483,50 @@ export default function PipelineItemDetailPage() {
           })}
         </div>
       </div>
+
+      {/* Location Proposal */}
+      {currentStep && item.location_id && currentStep.pandadoc_preliminary_template_id && !isCompleted && (
+        <div className="rounded-xl border border-gray-200 bg-white p-6 mb-6">
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-sm font-semibold text-gray-900 flex items-center gap-2">
+              <MapPin className="h-4 w-4 text-gray-400" />
+              Location Proposal
+            </h2>
+            <span className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${
+              item.proposal_status === "paid" ? "bg-green-100 text-green-700" :
+              item.proposal_status === "proposal_sent" ? "bg-blue-100 text-blue-600" :
+              "bg-gray-100 text-gray-500"
+            }`}>
+              {item.proposal_status === "paid" ? "Paid & Revealed" :
+               item.proposal_status === "proposal_sent" ? "Proposal Sent" :
+               "Not Sent"}
+            </span>
+          </div>
+          {item.proposal_status === "not_sent" ? (
+            <button
+              onClick={handleSendProposal}
+              disabled={sendingProposal || !item.sales_accounts?.email}
+              className="flex items-center gap-1.5 rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-50 cursor-pointer"
+            >
+              {sendingProposal ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Send className="h-3.5 w-3.5" />}
+              {sendingProposal ? "Sending Proposal..." : "Send Preliminary Proposal"}
+            </button>
+          ) : item.proposal_status === "proposal_sent" ? (
+            <p className="text-sm text-blue-600 flex items-center gap-1.5">
+              <Clock className="h-3.5 w-3.5" />
+              Proposal sent — awaiting customer payment via PandaDoc
+            </p>
+          ) : (
+            <p className="text-sm text-green-600 flex items-center gap-1.5">
+              <CheckCircle2 className="h-3.5 w-3.5" />
+              Payment received — full location details sent to customer
+            </p>
+          )}
+          {!item.sales_accounts?.email && item.proposal_status === "not_sent" && (
+            <p className="mt-2 text-xs text-red-500">Link an account with an email address to send proposals.</p>
+          )}
+        </div>
+      )}
 
       {/* Current Step Documents */}
       {currentStep && currentStep.requires_document && currentStep.step_documents.length > 0 && !isCompleted && (

--- a/src/lib/locations/access.ts
+++ b/src/lib/locations/access.ts
@@ -1,0 +1,72 @@
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+
+export type ViewerContext = "admin" | "internal_user" | "customer";
+
+interface LocationPreliminary {
+  id: string;
+  industry: string | null;
+  zip: string | null;
+  employee_count: number | null;
+  traffic_count: number | null;
+  is_revealed: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+interface LocationFull extends LocationPreliminary {
+  location_name: string | null;
+  address: string | null;
+  phone: string | null;
+  decision_maker_name: string | null;
+  decision_maker_email: string | null;
+  revealed_at: string | null;
+}
+
+export type LocationForUser = LocationPreliminary | LocationFull;
+
+const SENSITIVE_FIELDS = [
+  "location_name",
+  "address",
+  "phone",
+  "decision_maker_name",
+  "decision_maker_email",
+  "revealed_at",
+] as const;
+
+export async function getLocationForUser(
+  locationId: string,
+  viewerContext: ViewerContext
+): Promise<LocationForUser | null> {
+  const { data, error } = await supabaseAdmin
+    .from("locations")
+    .select("*")
+    .eq("id", locationId)
+    .single();
+
+  if (error || !data) return null;
+
+  if (viewerContext === "admin" || viewerContext === "internal_user") {
+    return data as LocationFull;
+  }
+
+  // Customer context: strip sensitive fields unless revealed
+  if (data.is_revealed) {
+    return data as LocationFull;
+  }
+
+  const safe: Record<string, unknown> = { ...data };
+  for (const field of SENSITIVE_FIELDS) {
+    delete safe[field];
+  }
+  return safe as LocationPreliminary;
+}
+
+export function stripSensitiveFields(
+  location: Record<string, unknown>
+): LocationPreliminary {
+  const safe = { ...location };
+  for (const field of SENSITIVE_FIELDS) {
+    delete safe[field];
+  }
+  return safe as unknown as LocationPreliminary;
+}

--- a/supabase/migrations/040_location_proposals.sql
+++ b/supabase/migrations/040_location_proposals.sql
@@ -1,0 +1,51 @@
+-- Migration 040: Location Placement Proposals
+-- Adds: locations table, proposal-related columns on pipeline_steps/items/payments
+
+-- ============================================================
+-- 1. LOCATIONS TABLE
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.locations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  is_revealed BOOLEAN NOT NULL DEFAULT false,
+  revealed_at TIMESTAMPTZ,
+  -- Preliminary fields (safe to show before payment)
+  industry TEXT,
+  zip TEXT,
+  employee_count INT,
+  traffic_count INT,
+  -- Sensitive fields (only shown after payment / to admins)
+  location_name TEXT,
+  address TEXT,
+  phone TEXT,
+  decision_maker_name TEXT,
+  decision_maker_email TEXT,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_locations_revealed ON public.locations(is_revealed);
+CREATE INDEX IF NOT EXISTS idx_locations_zip ON public.locations(zip);
+
+-- ============================================================
+-- 2. EXTEND PIPELINE_STEPS WITH PROPOSAL TEMPLATE CONFIG
+-- ============================================================
+ALTER TABLE public.pipeline_steps
+  ADD COLUMN IF NOT EXISTS pandadoc_preliminary_template_id TEXT,
+  ADD COLUMN IF NOT EXISTS pandadoc_full_template_id TEXT,
+  ADD COLUMN IF NOT EXISTS payment_provider TEXT NOT NULL DEFAULT 'none';
+
+-- ============================================================
+-- 3. EXTEND PIPELINE_ITEMS WITH LOCATION + PROPOSAL TRACKING
+-- ============================================================
+ALTER TABLE public.pipeline_items
+  ADD COLUMN IF NOT EXISTS location_id UUID REFERENCES public.locations(id),
+  ADD COLUMN IF NOT EXISTS proposal_status TEXT NOT NULL DEFAULT 'not_sent';
+
+CREATE INDEX IF NOT EXISTS idx_pipeline_items_location ON public.pipeline_items(location_id);
+
+-- ============================================================
+-- 4. EXTEND PIPELINE_PAYMENTS WITH STRIPE FIELDS
+-- ============================================================
+ALTER TABLE public.pipeline_payments
+  ADD COLUMN IF NOT EXISTS stripe_session_id TEXT,
+  ADD COLUMN IF NOT EXISTS stripe_payment_intent_id TEXT;


### PR DESCRIPTION
Implements the full location proposal lifecycle:
- Phase 1: Send preliminary proposal (limited location info) via PandaDoc
- Phase 2: On payment completion, reveal location, auto-send full details doc
- Phase 3: Stripe webhook backup for pipeline payment reconciliation

New files: migration 040 (locations table + schema extensions), send-proposal API route, location access control library, proposal flow docs.

Updated: PandaDoc webhook (Phase 2 automation + auto-advance), Stripe webhook (pipeline payment backup), pipeline steps API (template IDs + payment provider), pipeline edit page (template inputs + provider dropdown), pipeline item detail page (Send Proposal button + status badge).

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2