### PR TITLE
fix: type-safe LocationPreliminary in getLocationForUser

### DIFF
--- a/src/lib/locations/access.ts
+++ b/src/lib/locations/access.ts
@@ -54,19 +54,24 @@ export async function getLocationForUser(
     return data as LocationFull;
   }
 
-  const safe: Record<string, unknown> = { ...data };
-  for (const field of SENSITIVE_FIELDS) {
-    delete safe[field];
-  }
-  return safe as LocationPreliminary;
+  return pickPreliminaryFields(data);
+}
+
+function pickPreliminaryFields(data: Record<string, unknown>): LocationPreliminary {
+  return {
+    id: data.id as string,
+    industry: (data.industry as string | null) ?? null,
+    zip: (data.zip as string | null) ?? null,
+    employee_count: (data.employee_count as number | null) ?? null,
+    traffic_count: (data.traffic_count as number | null) ?? null,
+    is_revealed: (data.is_revealed as boolean) ?? false,
+    created_at: data.created_at as string,
+    updated_at: data.updated_at as string,
+  };
 }
 
 export function stripSensitiveFields(
   location: Record<string, unknown>
 ): LocationPreliminary {
-  const safe = { ...location };
-  for (const field of SENSITIVE_FIELDS) {
-    delete safe[field];
-  }
-  return safe as unknown as LocationPreliminary;
+  return pickPreliminaryFields(location);
 }


### PR DESCRIPTION
Replace delete-from-Record-then-cast pattern with explicit field picking so TypeScript can verify the return type. Fixes Vercel production build failure on access.ts:61.

Both getLocationForUser() and stripSensitiveFields() now use a shared pickPreliminaryFields() helper that constructs the object from known fields rather than deleting from a spread copy.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2