### PR TITLE
Add location pricing engine with score-based tier mapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "eslint": "^9",
     "eslint-config-next": "16.2.0",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.1.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       typescript:
         specifier: ^5
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@20.19.37)(vite@8.0.10(@types/node@20.19.37)(jiti@2.6.1))
 
 packages:
 
@@ -150,14 +153,23 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
   '@emnapi/core@1.9.1':
     resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
   '@emnapi/runtime@1.9.1':
     resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
 
   '@emnapi/wasi-threads@1.2.0':
     resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -385,6 +397,12 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@next/env@16.2.0':
     resolution: {integrity: sha512-OZIbODWWAi0epQRCRjNe1VO45LOFBzgiyqmTLzIqWq6u1wrxKnAyz1HH6tgY/Mc81YzIjRPoYsPAEr4QV4l9TA==}
 
@@ -459,11 +477,115 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.17':
+    resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@supabase/auth-js@2.103.3':
     resolution: {integrity: sha512-SMDJ4vg5jLXNEHdhN4J4ujSb203WangbDw1n3VaARH0ZqM51E6lJnoUAHlpQU9N7SzP0hfgghA9IvT8c7tGRfg==}
@@ -594,6 +716,12 @@ packages:
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -789,6 +917,35 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vitest/expect@4.1.5':
+    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+
+  '@vitest/mocker@4.1.5':
+    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.5':
+    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+
+  '@vitest/runner@4.1.5':
+    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
+
+  '@vitest/snapshot@4.1.5':
+    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
+
+  '@vitest/spy@4.1.5':
+    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
+
+  '@vitest/utils@4.1.5':
+    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -844,6 +1001,10 @@ packages:
   arraybuffer.prototype.slice@1.0.4:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
@@ -918,6 +1079,10 @@ packages:
   canvg@3.0.11:
     resolution: {integrity: sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==}
     engines: {node: '>=10.0.0'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1043,6 +1208,9 @@ packages:
   es-iterator-helpers@1.3.1:
     resolution: {integrity: sha512-zWwRvqWiuBPr0muUG/78cW3aHROFCNIQ3zpmYDpwdbnt2m+xlNyRWpHBpa2lJjSBit7BQ+RXA1iwbSmu5yJ/EQ==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -1184,9 +1352,16 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1244,6 +1419,11 @@ packages:
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -1731,6 +1911,9 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -1765,6 +1948,9 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   performance-now@2.1.0:
     resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
 
@@ -1779,6 +1965,10 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
@@ -1788,6 +1978,10 @@ packages:
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.12:
+    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.8:
@@ -1868,6 +2062,11 @@ packages:
     resolution: {integrity: sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==}
     engines: {node: '>= 0.8.15'}
 
+  rolldown@1.0.0-rc.17:
+    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -1935,6 +2134,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1942,12 +2144,18 @@ packages:
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stackblur-canvas@2.7.0:
     resolution: {integrity: sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==}
     engines: {node: '>=0.1.14'}
 
   standardwebhooks@1.0.0:
     resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -2034,9 +2242,24 @@ packages:
   text-segmentation@1.0.3:
     resolution: {integrity: sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.1.1:
+    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -2112,6 +2335,90 @@ packages:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
     hasBin: true
 
+  vite@8.0.10:
+    resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.5:
+    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.5
+      '@vitest/browser-preview': 4.1.5
+      '@vitest/browser-webdriverio': 4.1.5
+      '@vitest/coverage-istanbul': 4.1.5
+      '@vitest/coverage-v8': 4.1.5
+      '@vitest/ui': 4.1.5
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -2131,6 +2438,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -2271,9 +2583,20 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/core@1.9.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
       tslib: 2.8.1
     optional: true
 
@@ -2283,6 +2606,11 @@ snapshots:
     optional: true
 
   '@emnapi/wasi-threads@1.2.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -2466,6 +2794,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@next/env@16.2.0': {}
 
   '@next/eslint-plugin-next@16.2.0':
@@ -2510,9 +2845,64 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@oxc-project/types@0.127.0': {}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.17': {}
+
   '@rtsao/scc@1.1.0': {}
 
   '@stablelib/base64@1.0.1': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@supabase/auth-js@2.103.3':
     dependencies:
@@ -2636,6 +3026,13 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
@@ -2817,6 +3214,47 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@vitest/expect@4.1.5':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@20.19.37)(jiti@2.6.1))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.10(@types/node@20.19.37)(jiti@2.6.1)
+
+  '@vitest/pretty-format@4.1.5':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.5':
+    dependencies:
+      '@vitest/utils': 4.1.5
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/utils': 4.1.5
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.5': {}
+
+  '@vitest/utils@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -2905,6 +3343,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
@@ -2979,6 +3419,8 @@ snapshots:
       stackblur-canvas: 2.7.0
       svg-pathdata: 6.0.3
     optional: true
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -3165,6 +3607,8 @@ snapshots:
       iterator.prototype: 1.1.5
       math-intrinsics: 1.1.0
       safe-array-concat: 1.1.3
+
+  es-module-lexer@2.1.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -3394,7 +3838,13 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
+
+  expect-type@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -3426,6 +3876,10 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
   fflate@0.8.2: {}
 
   file-entry-cache@8.0.0:
@@ -3451,6 +3905,9 @@ snapshots:
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  fsevents@2.3.3:
+    optional: true
 
   function-bind@1.1.2: {}
 
@@ -3926,6 +4383,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  obug@2.1.1: {}
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -3961,6 +4420,8 @@ snapshots:
 
   path-parse@1.0.7: {}
 
+  pathe@2.0.3: {}
+
   performance-now@2.1.0:
     optional: true
 
@@ -3970,11 +4431,19 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  picomatch@4.0.4: {}
+
   possible-typed-array-names@1.1.0: {}
 
   postal-mime@2.7.3: {}
 
   postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.12:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -4063,6 +4532,27 @@ snapshots:
 
   rgbcolor@1.0.1:
     optional: true
+
+  rolldown@1.0.0-rc.17:
+    dependencies:
+      '@oxc-project/types': 0.127.0
+      '@rolldown/pluginutils': 1.0.0-rc.17
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
 
   run-parallel@1.2.0:
     dependencies:
@@ -4180,9 +4670,13 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.1: {}
 
   stable-hash@0.0.5: {}
+
+  stackback@0.0.2: {}
 
   stackblur-canvas@2.7.0:
     optional: true
@@ -4191,6 +4685,8 @@ snapshots:
     dependencies:
       '@stablelib/base64': 1.0.1
       fast-sha256: 1.3.0
+
+  std-env@4.1.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -4287,10 +4783,21 @@ snapshots:
       utrie: 1.0.2
     optional: true
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.1.1: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -4409,6 +4916,45 @@ snapshots:
 
   uuid@10.0.0: {}
 
+  vite@8.0.10(@types/node@20.19.37)(jiti@2.6.1):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.12
+      rolldown: 1.0.0-rc.17
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 20.19.37
+      fsevents: 2.3.3
+      jiti: 2.6.1
+
+  vitest@4.1.5(@types/node@20.19.37)(vite@8.0.10(@types/node@20.19.37)(jiti@2.6.1)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@20.19.37)(jiti@2.6.1))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.0.10(@types/node@20.19.37)(jiti@2.6.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.37
+    transitivePeerDependencies:
+      - msw
+
   which-boxed-primitive@1.1.1:
     dependencies:
       is-bigint: 1.1.0
@@ -4453,6 +4999,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/src/app/api/locations/[id]/calculate-pricing/route.ts
+++ b/src/app/api/locations/[id]/calculate-pricing/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser, isElevatedRole } from "@/lib/salesAuth";
+import {
+  calculateLocationPrice,
+  BusinessHours,
+  MachinesRequested,
+} from "@/lib/pricing/locationPricing";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const user = await getSalesUser(req);
+  if (!user || !isElevatedRole(user.role)) {
+    return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+  }
+
+  const { id: locationId } = await params;
+  const body = await req.json();
+
+  const { data: location } = await supabaseAdmin
+    .from("locations")
+    .select("*")
+    .eq("id", locationId)
+    .single();
+
+  if (!location) {
+    return NextResponse.json({ error: "Location not found" }, { status: 404 });
+  }
+
+  const employees = body.employees ?? location.employee_count ?? 0;
+  const foot_traffic = body.foot_traffic ?? location.traffic_count ?? 0;
+  const business_hours: BusinessHours = body.business_hours ?? location.business_hours ?? "low";
+  const machines_requested: MachinesRequested = body.machines_requested ?? location.machines_requested ?? 1;
+
+  try {
+    const result = calculateLocationPrice({
+      employees,
+      foot_traffic,
+      business_hours,
+      machines_requested,
+    });
+
+    await supabaseAdmin
+      .from("locations")
+      .update({
+        employee_count: employees,
+        traffic_count: foot_traffic,
+        business_hours,
+        machines_requested,
+        pricing_score: result.total_score,
+        pricing_tier: result.tier,
+        pricing_price: result.price,
+        pricing_calculated_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", locationId);
+
+    return NextResponse.json(result);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Invalid input";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/src/app/api/pipeline-items/[id]/send-proposal/route.ts
+++ b/src/app/api/pipeline-items/[id]/send-proposal/route.ts
@@ -2,6 +2,12 @@ import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { getSalesUser, isElevatedRole } from "@/lib/salesAuth";
 import { createDocumentFromTemplate, sendDocument } from "@/lib/pandadoc";
+import {
+  calculateLocationPrice,
+  BusinessHours,
+  MachinesRequested,
+  PricingResult,
+} from "@/lib/pricing/locationPricing";
 
 export async function POST(
   req: NextRequest,
@@ -52,6 +58,45 @@ export async function POST(
     return NextResponse.json({ error: "Location not found" }, { status: 404 });
   }
 
+  // Auto-calculate pricing if missing or stale
+  let pricing: PricingResult | null = null;
+  const pricingStale =
+    !location.pricing_calculated_at ||
+    !location.pricing_score ||
+    (location.updated_at && new Date(location.pricing_calculated_at) < new Date(location.updated_at));
+
+  if (pricingStale && location.business_hours && location.machines_requested) {
+    try {
+      pricing = calculateLocationPrice({
+        employees: location.employee_count ?? 0,
+        foot_traffic: location.traffic_count ?? 0,
+        business_hours: location.business_hours as BusinessHours,
+        machines_requested: location.machines_requested as MachinesRequested,
+      });
+      await supabaseAdmin
+        .from("locations")
+        .update({
+          pricing_score: pricing.total_score,
+          pricing_tier: pricing.tier,
+          pricing_price: pricing.price,
+          pricing_calculated_at: new Date().toISOString(),
+        })
+        .eq("id", location.id);
+    } catch {
+      // Pricing calculation failed — continue without it
+    }
+  } else if (location.pricing_score != null) {
+    pricing = {
+      total_score: location.pricing_score,
+      traffic_score: Math.min(((location.employee_count ?? 0) + (location.traffic_count ?? 0)) / 500 * 70, 70),
+      hours_score: ({ low: 5, medium: 10, high: 15, "24/7": 20 } as Record<string, number>)[location.business_hours ?? "low"] ?? 5,
+      machine_score: ({ 1: 3, 2: 6, 3: 8, 4: 10 } as Record<number, number>)[location.machines_requested ?? 1] ?? 3,
+      tier: location.pricing_tier as 1 | 2 | 3 | 4 | 5,
+      tier_label: `Tier ${location.pricing_tier}`,
+      price: Number(location.pricing_price),
+    };
+  }
+
   const recipientEmail = item.sales_accounts?.email;
   const recipientName = item.sales_accounts?.contact_name || item.sales_accounts?.business_name || item.name;
 
@@ -61,6 +106,9 @@ export async function POST(
       { status: 422 }
     );
   }
+
+  // Use pricing_price when available, otherwise fall back to step.payment_amount
+  const effectivePrice = pricing?.price ?? step.payment_amount;
 
   try {
     const fields: Record<string, string> = {
@@ -73,8 +121,17 @@ export async function POST(
       business_name: item.sales_accounts?.business_name || "",
     };
 
-    if (step.payment_amount) {
-      fields.payment_amount = String(step.payment_amount);
+    if (pricing) {
+      fields.ProposalPrice = String(pricing.price);
+      fields.ProposalTier = pricing.tier_label;
+      fields.ProposalScore = String(pricing.total_score);
+      fields.TrafficScore = String(pricing.traffic_score);
+      fields.HoursScore = String(pricing.hours_score);
+      fields.MachineScore = String(pricing.machine_score);
+    }
+
+    if (effectivePrice) {
+      fields.payment_amount = String(effectivePrice);
     }
 
     const doc = await createDocumentFromTemplate({
@@ -105,12 +162,12 @@ export async function POST(
     });
 
     // Create pending payment record if payment is required via PandaDoc+Stripe
-    if (step.requires_payment && step.payment_provider === "pandadoc_stripe" && step.payment_amount) {
+    if (step.requires_payment && step.payment_provider === "pandadoc_stripe" && effectivePrice) {
       await supabaseAdmin.from("pipeline_payments").insert({
         pipeline_item_id: itemId,
         step_id: item.current_step_id,
         provider: "stripe",
-        amount: step.payment_amount,
+        amount: effectivePrice,
         currency: "USD",
         description: step.payment_description || `Proposal payment — ${item.name}`,
         status: "pending",

--- a/src/app/sales/pipelines/[id]/items/[itemId]/page.tsx
+++ b/src/app/sales/pipelines/[id]/items/[itemId]/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { createBrowserClient } from "@/lib/supabase";
-import { ArrowLeft, Loader2, ChevronRight, Upload, CheckCircle2, Circle, AlertTriangle, FileText, Lock, Building2, Search, X, Link2, Unlink, Send, DollarSign, ShieldCheck, PenTool, CreditCard, Clock, ExternalLink, MapPin } from "lucide-react";
+import { ArrowLeft, Loader2, ChevronRight, Upload, CheckCircle2, Circle, AlertTriangle, FileText, Lock, Building2, Search, X, Link2, Unlink, Send, DollarSign, ShieldCheck, PenTool, CreditCard, Clock, ExternalLink, MapPin, Calculator } from "lucide-react";
 
 interface StepDoc {
   id: string;
@@ -64,6 +64,16 @@ interface GatingStatus {
     adminApproval: { required: boolean; completed: boolean };
   };
   blockers: string[];
+}
+
+interface PricingData {
+  total_score: number;
+  traffic_score: number;
+  hours_score: number;
+  machine_score: number;
+  tier: number;
+  tier_label: string;
+  price: number;
 }
 
 interface ItemDoc {
@@ -127,6 +137,9 @@ export default function PipelineItemDetailPage() {
   const [approvingStep, setApprovingStep] = useState(false);
   const [esignForm, setEsignForm] = useState({ document_name: "", recipient_email: "", template_id: "" });
   const [sendingProposal, setSendingProposal] = useState(false);
+  const [pricingData, setPricingData] = useState<PricingData | null>(null);
+  const [pricingInputs, setPricingInputs] = useState({ employees: 0, foot_traffic: 0, business_hours: "low" as string, machines_requested: 1 });
+  const [calculatingPricing, setCalculatingPricing] = useState(false);
 
   useEffect(() => {
     const supabase = createBrowserClient();
@@ -300,7 +313,38 @@ export default function PipelineItemDetailPage() {
     if (res.ok) {
       load();
       loadGatingData();
+      loadLocationPricing();
     }
+  }
+
+  const loadLocationPricing = useCallback(async () => {
+    if (!token || !item?.location_id) return;
+    const res = await fetch(`/api/locations/${item.location_id}/calculate-pricing`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({}),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setPricingData(data);
+    }
+  }, [token, item?.location_id]);
+
+  useEffect(() => { loadLocationPricing(); }, [loadLocationPricing]);
+
+  async function handleRecalculatePricing() {
+    if (!item?.location_id) return;
+    setCalculatingPricing(true);
+    const res = await fetch(`/api/locations/${item.location_id}/calculate-pricing`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify(pricingInputs),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setPricingData(data);
+    }
+    setCalculatingPricing(false);
   }
 
   const filteredAccounts = accountSearch.length > 0
@@ -483,6 +527,96 @@ export default function PipelineItemDetailPage() {
           })}
         </div>
       </div>
+
+      {/* Pricing Engine */}
+      {item.location_id && !isCompleted && (
+        <div className="rounded-xl border border-gray-200 bg-white p-6 mb-6">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-sm font-semibold text-gray-900 flex items-center gap-2">
+              <Calculator className="h-4 w-4 text-gray-400" />
+              Pricing Engine
+            </h2>
+            {pricingData && (
+              <div className="flex items-center gap-2">
+                <span className="rounded-full bg-green-100 text-green-700 px-2.5 py-0.5 text-xs font-bold">
+                  ${pricingData.price.toLocaleString()}
+                </span>
+                <span className="rounded-full bg-gray-100 text-gray-600 px-2 py-0.5 text-xs font-medium">
+                  {pricingData.tier_label}
+                </span>
+                <span className="text-xs text-gray-400">Score: {pricingData.total_score}/100</span>
+              </div>
+            )}
+          </div>
+
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
+            <div>
+              <label className="text-xs text-gray-500 block mb-1">Employees</label>
+              <input
+                type="number"
+                min="0"
+                value={pricingInputs.employees}
+                onChange={(e) => setPricingInputs((p) => ({ ...p, employees: Number(e.target.value) || 0 }))}
+                className="w-full rounded-lg border border-gray-200 px-2.5 py-1.5 text-sm focus:border-green-500 focus:outline-none"
+              />
+            </div>
+            <div>
+              <label className="text-xs text-gray-500 block mb-1">Foot Traffic</label>
+              <input
+                type="number"
+                min="0"
+                value={pricingInputs.foot_traffic}
+                onChange={(e) => setPricingInputs((p) => ({ ...p, foot_traffic: Number(e.target.value) || 0 }))}
+                className="w-full rounded-lg border border-gray-200 px-2.5 py-1.5 text-sm focus:border-green-500 focus:outline-none"
+              />
+            </div>
+            <div>
+              <label className="text-xs text-gray-500 block mb-1">Business Hours</label>
+              <select
+                value={pricingInputs.business_hours}
+                onChange={(e) => setPricingInputs((p) => ({ ...p, business_hours: e.target.value }))}
+                className="w-full rounded-lg border border-gray-200 px-2.5 py-1.5 text-sm focus:border-green-500 focus:outline-none"
+              >
+                <option value="low">Low</option>
+                <option value="medium">Medium</option>
+                <option value="high">High</option>
+                <option value="24/7">24/7</option>
+              </select>
+            </div>
+            <div>
+              <label className="text-xs text-gray-500 block mb-1">Machines</label>
+              <select
+                value={pricingInputs.machines_requested}
+                onChange={(e) => setPricingInputs((p) => ({ ...p, machines_requested: Number(e.target.value) }))}
+                className="w-full rounded-lg border border-gray-200 px-2.5 py-1.5 text-sm focus:border-green-500 focus:outline-none"
+              >
+                <option value={1}>1</option>
+                <option value={2}>2</option>
+                <option value={3}>3</option>
+                <option value={4}>4</option>
+              </select>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-4">
+            <button
+              onClick={handleRecalculatePricing}
+              disabled={calculatingPricing}
+              className="flex items-center gap-1.5 rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-50 cursor-pointer"
+            >
+              {calculatingPricing ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Calculator className="h-3.5 w-3.5" />}
+              {calculatingPricing ? "Calculating..." : "Recalculate"}
+            </button>
+            {pricingData && (
+              <div className="flex gap-4 text-xs text-gray-500">
+                <span>Traffic: {pricingData.traffic_score}</span>
+                <span>Hours: {pricingData.hours_score}</span>
+                <span>Machines: {pricingData.machine_score}</span>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
 
       {/* Location Proposal */}
       {currentStep && item.location_id && currentStep.pandadoc_preliminary_template_id && !isCompleted && (

--- a/src/lib/pricing/locationPricing.test.ts
+++ b/src/lib/pricing/locationPricing.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect } from "vitest";
+import { calculateLocationPrice, PricingInput } from "./locationPricing";
+
+function make(overrides: Partial<PricingInput> = {}): PricingInput {
+  return {
+    employees: 0,
+    foot_traffic: 0,
+    business_hours: "low",
+    machines_requested: 1,
+    ...overrides,
+  };
+}
+
+describe("calculateLocationPrice", () => {
+  describe("tier boundaries", () => {
+    it("score 0 → Tier 1, $400", () => {
+      // employees=0, foot_traffic=0 → traffic=0, hours=low(5), machines=1(3) → total=8
+      // To get score 0 we need traffic=0, hours=low(5), machines=1(3) → 8, not 0
+      // Minimum possible score is 5+3=8 → Tier 1
+      const result = calculateLocationPrice(make());
+      expect(result.total_score).toBe(8);
+      expect(result.tier).toBe(1);
+      expect(result.price).toBe(400);
+    });
+
+    it("score 30 → Tier 1, $400", () => {
+      // Need traffic_score + 5 + 3 = 30 → traffic_score = 22
+      // traffic_score = (total_traffic / 500) * 70 = 22 → total_traffic = 22*500/70 ≈ 157.14
+      const result = calculateLocationPrice(make({ employees: 100, foot_traffic: 57 }));
+      // (157/500)*70 = 21.98, + 5 + 3 = 29.98, round = 30
+      expect(result.total_score).toBe(30);
+      expect(result.tier).toBe(1);
+      expect(result.price).toBe(400);
+    });
+
+    it("score 31 → Tier 2, $500", () => {
+      // Need traffic_score + 5 + 3 = 31 → traffic_score = 23
+      // total_traffic = 23*500/70 ≈ 164.28
+      const result = calculateLocationPrice(make({ employees: 100, foot_traffic: 64 }));
+      // (164/500)*70 = 22.96, + 5 + 3 = 30.96, round = 31
+      expect(result.total_score).toBe(31);
+      expect(result.tier).toBe(2);
+      expect(result.price).toBe(500);
+    });
+
+    it("score 45 → Tier 2, $500", () => {
+      // traffic_score + 5 + 3 = 45 → traffic_score = 37
+      // total_traffic = 37*500/70 ≈ 264.28
+      const result = calculateLocationPrice(make({ employees: 200, foot_traffic: 64 }));
+      // (264/500)*70 = 36.96, + 5 + 3 = 44.96, round = 45
+      expect(result.total_score).toBe(45);
+      expect(result.tier).toBe(2);
+      expect(result.price).toBe(500);
+    });
+
+    it("score 46 → Tier 3, $750", () => {
+      // traffic_score + 5 + 3 = 46 → traffic_score = 38
+      // total_traffic = 38*500/70 ≈ 271.43
+      const result = calculateLocationPrice(make({ employees: 200, foot_traffic: 71 }));
+      // (271/500)*70 = 37.94, + 5 + 3 = 45.94, round = 46
+      expect(result.total_score).toBe(46);
+      expect(result.tier).toBe(3);
+      expect(result.price).toBe(750);
+    });
+
+    it("score 65 → Tier 3, $750", () => {
+      // traffic_score + 5 + 3 = 65 → traffic_score = 57
+      // total_traffic = 57*500/70 ≈ 407.14
+      const result = calculateLocationPrice(make({ employees: 350, foot_traffic: 57 }));
+      // (407/500)*70 = 56.98, + 5 + 3 = 64.98, round = 65
+      expect(result.total_score).toBe(65);
+      expect(result.tier).toBe(3);
+      expect(result.price).toBe(750);
+    });
+
+    it("score 66 → Tier 4, $1000", () => {
+      // traffic_score + 5 + 3 = 66 → traffic_score ≈ 58
+      // total_traffic = 58*500/70 ≈ 414.29
+      const result = calculateLocationPrice(make({ employees: 350, foot_traffic: 64 }));
+      // (414/500)*70 = 57.96, + 5 + 3 = 65.96, round = 66
+      expect(result.total_score).toBe(66);
+      expect(result.tier).toBe(4);
+      expect(result.price).toBe(1000);
+    });
+
+    it("score 85 → Tier 4, $1000", () => {
+      // traffic_score + 5 + 3 = 85 → traffic_score = 70 (cap) + 5 + 3 = 78, not 85
+      // Use higher hours/machines: traffic(70) + high(15) + 1(3) = 88 ≠ 85
+      // traffic + medium(10) + 4(10) = traffic + 20. Need traffic = 65
+      // total_traffic = 65*500/70 ≈ 464.29
+      const result = calculateLocationPrice(
+        make({ employees: 400, foot_traffic: 64, business_hours: "medium", machines_requested: 4 })
+      );
+      // (464/500)*70 = 64.96, + 10 + 10 = 84.96, round = 85
+      expect(result.total_score).toBe(85);
+      expect(result.tier).toBe(4);
+      expect(result.price).toBe(1000);
+    });
+
+    it("score 86 → Tier 5, $1200", () => {
+      // traffic + medium(10) + 4(10) = traffic + 20. Need traffic = 66
+      // total_traffic = 66*500/70 ≈ 471.43
+      const result = calculateLocationPrice(
+        make({ employees: 400, foot_traffic: 71, business_hours: "medium", machines_requested: 4 })
+      );
+      // (471/500)*70 = 65.94, + 10 + 10 = 85.94, round = 86
+      expect(result.total_score).toBe(86);
+      expect(result.tier).toBe(5);
+      expect(result.price).toBe(1200);
+    });
+
+    it("score 100 (capped) → Tier 5, $1200", () => {
+      const result = calculateLocationPrice(
+        make({ employees: 5000, foot_traffic: 5000, business_hours: "24/7", machines_requested: 4 })
+      );
+      expect(result.total_score).toBe(100);
+      expect(result.tier).toBe(5);
+      expect(result.price).toBe(1200);
+    });
+  });
+
+  describe("business_hours scoring", () => {
+    it("low → 5", () => {
+      const result = calculateLocationPrice(make({ business_hours: "low" }));
+      expect(result.hours_score).toBe(5);
+    });
+
+    it("medium → 10", () => {
+      const result = calculateLocationPrice(make({ business_hours: "medium" }));
+      expect(result.hours_score).toBe(10);
+    });
+
+    it("high → 15", () => {
+      const result = calculateLocationPrice(make({ business_hours: "high" }));
+      expect(result.hours_score).toBe(15);
+    });
+
+    it("24/7 → 20", () => {
+      const result = calculateLocationPrice(make({ business_hours: "24/7" }));
+      expect(result.hours_score).toBe(20);
+    });
+  });
+
+  describe("machines_requested scoring", () => {
+    it("1 → 3", () => {
+      const result = calculateLocationPrice(make({ machines_requested: 1 }));
+      expect(result.machine_score).toBe(3);
+    });
+
+    it("2 → 6", () => {
+      const result = calculateLocationPrice(make({ machines_requested: 2 }));
+      expect(result.machine_score).toBe(6);
+    });
+
+    it("3 → 8", () => {
+      const result = calculateLocationPrice(make({ machines_requested: 3 }));
+      expect(result.machine_score).toBe(8);
+    });
+
+    it("4 → 10", () => {
+      const result = calculateLocationPrice(make({ machines_requested: 4 }));
+      expect(result.machine_score).toBe(10);
+    });
+  });
+
+  describe("traffic score cap at 70", () => {
+    it("caps traffic_score at 70 for very high traffic", () => {
+      const result = calculateLocationPrice(make({ employees: 1000, foot_traffic: 1000 }));
+      expect(result.traffic_score).toBe(70);
+    });
+  });
+
+  describe("total score cap at 100", () => {
+    it("caps total_score at 100", () => {
+      const result = calculateLocationPrice(
+        make({ employees: 5000, foot_traffic: 5000, business_hours: "24/7", machines_requested: 4 })
+      );
+      // traffic(70) + hours(20) + machine(10) = 100
+      expect(result.total_score).toBe(100);
+    });
+  });
+
+  describe("input validation", () => {
+    it("throws on negative employees", () => {
+      expect(() => calculateLocationPrice(make({ employees: -1 }))).toThrow("employees must be >= 0");
+    });
+
+    it("throws on negative foot_traffic", () => {
+      expect(() => calculateLocationPrice(make({ foot_traffic: -5 }))).toThrow("foot_traffic must be >= 0");
+    });
+
+    it("throws on invalid business_hours", () => {
+      expect(() =>
+        calculateLocationPrice(make({ business_hours: "invalid" as never }))
+      ).toThrow("Invalid business_hours");
+    });
+
+    it("throws on invalid machines_requested", () => {
+      expect(() =>
+        calculateLocationPrice(make({ machines_requested: 5 as never }))
+      ).toThrow("Invalid machines_requested");
+    });
+  });
+
+  describe("output shape", () => {
+    it("returns all expected fields", () => {
+      const result = calculateLocationPrice(make({ employees: 100, foot_traffic: 200, business_hours: "high", machines_requested: 2 }));
+      expect(result).toHaveProperty("total_score");
+      expect(result).toHaveProperty("traffic_score");
+      expect(result).toHaveProperty("hours_score");
+      expect(result).toHaveProperty("machine_score");
+      expect(result).toHaveProperty("tier");
+      expect(result).toHaveProperty("tier_label");
+      expect(result).toHaveProperty("price");
+      expect(typeof result.total_score).toBe("number");
+      expect(typeof result.price).toBe("number");
+      expect(result.tier_label).toMatch(/^Tier [1-5]$/);
+    });
+  });
+});

--- a/src/lib/pricing/locationPricing.ts
+++ b/src/lib/pricing/locationPricing.ts
@@ -1,0 +1,74 @@
+export type BusinessHours = "low" | "medium" | "high" | "24/7";
+export type MachinesRequested = 1 | 2 | 3 | 4;
+
+export interface PricingInput {
+  employees: number;
+  foot_traffic: number;
+  business_hours: BusinessHours;
+  machines_requested: MachinesRequested;
+}
+
+export interface PricingResult {
+  total_score: number;
+  traffic_score: number;
+  hours_score: number;
+  machine_score: number;
+  tier: 1 | 2 | 3 | 4 | 5;
+  tier_label: string;
+  price: number;
+}
+
+const HOURS_SCORES: Record<BusinessHours, number> = {
+  low: 5,
+  medium: 10,
+  high: 15,
+  "24/7": 20,
+};
+
+const MACHINE_SCORES: Record<MachinesRequested, number> = {
+  1: 3,
+  2: 6,
+  3: 8,
+  4: 10,
+};
+
+const TIERS: { min: number; tier: 1 | 2 | 3 | 4 | 5; label: string; price: number }[] = [
+  { min: 86, tier: 5, label: "Tier 5", price: 1200 },
+  { min: 66, tier: 4, label: "Tier 4", price: 1000 },
+  { min: 46, tier: 3, label: "Tier 3", price: 750 },
+  { min: 31, tier: 2, label: "Tier 2", price: 500 },
+  { min: 0, tier: 1, label: "Tier 1", price: 400 },
+];
+
+export function calculateLocationPrice(input: PricingInput): PricingResult {
+  if (input.employees < 0) throw new Error("employees must be >= 0");
+  if (input.foot_traffic < 0) throw new Error("foot_traffic must be >= 0");
+
+  const hoursScore = HOURS_SCORES[input.business_hours];
+  if (hoursScore === undefined) {
+    throw new Error(`Invalid business_hours: ${input.business_hours}. Must be one of: low, medium, high, 24/7`);
+  }
+
+  const machineScore = MACHINE_SCORES[input.machines_requested];
+  if (machineScore === undefined) {
+    throw new Error(`Invalid machines_requested: ${input.machines_requested}. Must be 1, 2, 3, or 4`);
+  }
+
+  const totalTraffic = input.employees + input.foot_traffic;
+  const trafficScore = Math.min((totalTraffic / 500) * 70, 70);
+
+  const rawTotal = trafficScore + hoursScore + machineScore;
+  const totalScore = Math.round(Math.min(rawTotal, 100));
+
+  const matched = TIERS.find((t) => totalScore >= t.min)!;
+
+  return {
+    total_score: totalScore,
+    traffic_score: Math.round(trafficScore * 100) / 100,
+    hours_score: hoursScore,
+    machine_score: machineScore,
+    tier: matched.tier,
+    tier_label: matched.label,
+    price: matched.price,
+  };
+}

--- a/supabase/migrations/041_location_pricing.sql
+++ b/supabase/migrations/041_location_pricing.sql
@@ -1,0 +1,10 @@
+-- Migration 041: Location Pricing Engine
+-- Adds pricing score/tier/price columns and input fields to locations table
+
+ALTER TABLE public.locations
+  ADD COLUMN IF NOT EXISTS pricing_score INT,
+  ADD COLUMN IF NOT EXISTS pricing_tier INT,
+  ADD COLUMN IF NOT EXISTS pricing_price NUMERIC(10,2),
+  ADD COLUMN IF NOT EXISTS pricing_calculated_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS business_hours TEXT,
+  ADD COLUMN IF NOT EXISTS machines_requested INT;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src"),
+    },
+  },
+});


### PR DESCRIPTION
Pure deterministic pricing function that scores locations on traffic (employees + foot_traffic), business hours, and machines requested, then maps to 5 price tiers ($400–$1200). Price auto-populates into PandaDoc proposals as merge fields at send time.

New: pricing function + 25 unit tests, migration 041 (pricing columns), calculate-pricing API route, pricing engine UI card on item detail page.

Updated: send-proposal route auto-recalculates stale pricing and passes ProposalPrice/ProposalTier/ProposalScore/TrafficScore/HoursScore/MachineScore merge fields to PandaDoc. pricing_price overrides step.payment_amount when present.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2