### PR TITLE
Fix file upload error handling and add missing storage buckets

### DIFF
--- a/src/app/sales/accounts/[id]/page.tsx
+++ b/src/app/sales/accounts/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { createBrowserClient } from "@/lib/supabase";
-import { ArrowLeft, Loader2, FileText, Upload, Trash2 } from "lucide-react";
+import { ArrowLeft, Loader2, FileText, Upload, Trash2, X } from "lucide-react";
 import type { SalesAccount, SalesDeal, SalesOrder, SalesDocument, SalesLead } from "@/lib/salesTypes";
 
 interface AccountDetail extends SalesAccount {
@@ -20,6 +20,7 @@ export default function AccountDetailPage() {
   const [loading, setLoading] = useState(true);
   const [token, setToken] = useState("");
   const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
 
   useEffect(() => {
     const supabase = createBrowserClient();
@@ -44,6 +45,7 @@ export default function AccountDetailPage() {
     const file = e.target.files?.[0];
     if (!file || !token) return;
     setUploading(true);
+    setUploadError(null);
 
     try {
       const supabase = (await import("@/lib/supabase")).createBrowserClient();
@@ -54,7 +56,7 @@ export default function AccountDetailPage() {
         .upload(filePath, file, { upsert: false, contentType: file.type || undefined });
 
       if (uploadErr) {
-        alert(`Upload failed: ${uploadErr.message}`);
+        setUploadError(`Upload failed: ${uploadErr.message}`);
         return;
       }
 
@@ -72,7 +74,7 @@ export default function AccountDetailPage() {
 
       if (!res.ok) {
         const err = await res.json().catch(() => ({}));
-        alert(`Saved file but could not record document: ${err.error || res.statusText}`);
+        setUploadError(`Saved file but could not record document: ${err.error || res.statusText}`);
       }
     } finally {
       setUploading(false);
@@ -181,6 +183,12 @@ export default function AccountDetailPage() {
             <input type="file" className="hidden" onChange={handleFileUpload} disabled={uploading} />
           </label>
         </div>
+        {uploadError && (
+          <div className="mb-3 flex items-center justify-between rounded-lg border border-red-200 bg-red-50 px-4 py-2.5 text-sm text-red-700">
+            <span>{uploadError}</span>
+            <button onClick={() => setUploadError(null)} className="ml-3 text-red-400 hover:text-red-600 cursor-pointer"><X className="h-4 w-4" /></button>
+          </div>
+        )}
         {account.documents.length === 0 ? (
           <p className="text-sm text-gray-400">No documents yet</p>
         ) : (

--- a/src/app/sales/candidates/page.tsx
+++ b/src/app/sales/candidates/page.tsx
@@ -49,6 +49,7 @@ export default function CandidatesPage() {
   const [editSaving, setEditSaving] = useState(false);
   const [uploadingId, setUploadingId] = useState<string | null>(null);
   const [expandedDocsId, setExpandedDocsId] = useState<string | null>(null);
+  const [uploadError, setUploadError] = useState<string | null>(null);
 
   useEffect(() => {
     const supabase = createBrowserClient();
@@ -109,7 +110,7 @@ export default function CandidatesPage() {
           }
         }
         if (failures.length > 0) {
-          alert(`Some uploads failed:\n${failures.join("\n")}`);
+          setUploadError(`Some uploads failed: ${failures.join("; ")}`);
         }
       }
       setForm({ full_name: "", email: "", phone: "", role_type: "BDP", assigned_to: "", notes: "" });
@@ -156,6 +157,7 @@ export default function CandidatesPage() {
 
   async function handleUploadDoc(candidateId: string, file: File) {
     setUploadingId(candidateId);
+    setUploadError(null);
     const formData = new FormData();
     formData.append("file", file);
     formData.append("step_key", "application");
@@ -166,7 +168,7 @@ export default function CandidatesPage() {
     });
     if (!res.ok) {
       const err = await res.json().catch(() => ({}));
-      alert(err.error || `Upload failed (${res.status})`);
+      setUploadError(err.error || `Upload failed (${res.status})`);
     }
     setUploadingId(null);
     fetchCandidates();
@@ -287,6 +289,13 @@ export default function CandidatesPage() {
           </button>
         )}
       </div>
+
+      {uploadError && (
+        <div className="mb-4 flex items-center justify-between rounded-lg border border-red-200 bg-red-50 px-4 py-2.5 text-sm text-red-700">
+          <span>{uploadError}</span>
+          <button onClick={() => setUploadError(null)} className="ml-3 text-red-400 hover:text-red-600 cursor-pointer"><X className="h-4 w-4" /></button>
+        </div>
+      )}
 
       {loading ? (
         <div className="flex justify-center py-16"><Loader2 className="h-6 w-6 animate-spin text-green-600" /></div>

--- a/src/app/sales/pipelines/[id]/items/[itemId]/page.tsx
+++ b/src/app/sales/pipelines/[id]/items/[itemId]/page.tsx
@@ -693,7 +693,19 @@ export default function PipelineItemDetailPage() {
                       <input type="file" className="hidden" onChange={(e) => { if (e.target.files?.[0]) handleUploadDoc(doc.id, e.target.files[0]); }} />
                     </label>
                   ) : (
-                    <span className="text-xs text-green-600 font-medium">Completed</span>
+                    <div className="flex items-center gap-2">
+                      {uploadedDoc?.file_url && (
+                        <a
+                          href={uploadedDoc.file_url.startsWith("http") ? uploadedDoc.file_url : `${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/sales-documents/${uploadedDoc.file_url}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="flex items-center gap-1 text-xs text-blue-600 hover:text-blue-700"
+                        >
+                          <ExternalLink className="h-3 w-3" /> View
+                        </a>
+                      )}
+                      <span className="text-xs text-green-600 font-medium">Completed</span>
+                    </div>
                   )}
                 </div>
               );

--- a/src/app/sales/resources/page.tsx
+++ b/src/app/sales/resources/page.tsx
@@ -15,6 +15,7 @@ import {
   DollarSign,
   GraduationCap,
   File,
+  X,
 } from "lucide-react";
 
 interface Resource {
@@ -57,6 +58,7 @@ export default function ResourcesPage() {
   const [filter, setFilter] = useState("all");
   const [showUpload, setShowUpload] = useState(false);
   const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
   const [form, setForm] = useState({
     title: "",
     description: "",
@@ -96,10 +98,11 @@ export default function ResourcesPage() {
 
   async function handleUpload() {
     if (!form.file || !form.title.trim()) {
-      alert("Title and file are required");
+      setUploadError("Title and file are required");
       return;
     }
     setUploading(true);
+    setUploadError(null);
     try {
       const supabase = (await import("@/lib/supabase")).createBrowserClient();
       const safeName = form.file.name.replace(/[^a-zA-Z0-9._-]/g, "_");
@@ -111,7 +114,7 @@ export default function ResourcesPage() {
           contentType: form.file.type || undefined,
         });
       if (upErr) {
-        alert(`Upload failed: ${upErr.message}`);
+        setUploadError(`Upload failed: ${upErr.message}`);
         return;
       }
       const { data: urlData } = supabase.storage
@@ -135,7 +138,7 @@ export default function ResourcesPage() {
       });
       if (!res.ok) {
         const err = await res.json().catch(() => ({}));
-        alert(err.error || "Failed to save resource");
+        setUploadError(err.error || "Failed to save resource");
         return;
       }
       setForm({ title: "", description: "", category: "marketing", file: null });
@@ -214,6 +217,12 @@ export default function ResourcesPage() {
             onChange={(e) => setForm((f) => ({ ...f, file: e.target.files?.[0] || null }))}
             className="mt-3 block w-full text-sm text-gray-600 file:mr-3 file:rounded-lg file:border-0 file:bg-gray-100 file:px-4 file:py-2 file:text-sm file:font-medium hover:file:bg-gray-200"
           />
+          {uploadError && (
+            <div className="mt-3 flex items-center justify-between rounded-lg border border-red-200 bg-red-50 px-4 py-2.5 text-sm text-red-700">
+              <span>{uploadError}</span>
+              <button onClick={() => setUploadError(null)} className="ml-3 text-red-400 hover:text-red-600 cursor-pointer"><X className="h-4 w-4" /></button>
+            </div>
+          )}
           <div className="mt-4 flex gap-2">
             <button
               onClick={handleUpload}
@@ -223,7 +232,7 @@ export default function ResourcesPage() {
               {uploading ? "Uploading..." : "Upload"}
             </button>
             <button
-              onClick={() => setShowUpload(false)}
+              onClick={() => { setShowUpload(false); setUploadError(null); }}
               className="rounded-lg border border-gray-200 px-4 py-2 text-sm text-gray-600 hover:bg-gray-50 cursor-pointer"
             >
               Cancel

--- a/src/app/sales/team/[id]/page.tsx
+++ b/src/app/sales/team/[id]/page.tsx
@@ -191,14 +191,19 @@ export default function CandidateDetailPage() {
 
   async function handleUploadDoc(stepKey: string, file: File) {
     setUploadingStep(stepKey);
+    setActionError(null);
     const formData = new FormData();
     formData.append("file", file);
     formData.append("step_key", stepKey);
-    await fetch(`/api/onboarding/candidates/${id}/documents`, {
+    const res = await fetch(`/api/onboarding/candidates/${id}/documents`, {
       method: "POST",
       headers: { Authorization: `Bearer ${token}` },
       body: formData,
     });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      setActionError(err.error || `Upload failed (${res.status})`);
+    }
     setUploadingStep(null);
     load();
   }

--- a/supabase/migrations/042_storage_buckets.sql
+++ b/supabase/migrations/042_storage_buckets.sql
@@ -1,0 +1,103 @@
+-- Migration 042: Create missing storage buckets with RLS policies
+-- sales-documents: used by candidates, pipeline items, team docs, intake uploads, esign PDFs
+-- document-templates: used by onboarding document template admin
+
+-- ============================================================
+-- 1. SALES-DOCUMENTS BUCKET
+-- ============================================================
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('sales-documents', 'sales-documents', true)
+ON CONFLICT (id) DO UPDATE SET public = true;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'storage' AND tablename = 'objects'
+      AND policyname = 'sales_documents_authenticated_insert'
+  ) THEN
+    CREATE POLICY sales_documents_authenticated_insert
+      ON storage.objects FOR INSERT TO authenticated
+      WITH CHECK (bucket_id = 'sales-documents');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'storage' AND tablename = 'objects'
+      AND policyname = 'sales_documents_authenticated_select'
+  ) THEN
+    CREATE POLICY sales_documents_authenticated_select
+      ON storage.objects FOR SELECT TO authenticated
+      USING (bucket_id = 'sales-documents');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'storage' AND tablename = 'objects'
+      AND policyname = 'sales_documents_public_select'
+  ) THEN
+    CREATE POLICY sales_documents_public_select
+      ON storage.objects FOR SELECT TO anon
+      USING (bucket_id = 'sales-documents');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'storage' AND tablename = 'objects'
+      AND policyname = 'sales_documents_service_role_all'
+  ) THEN
+    CREATE POLICY sales_documents_service_role_all
+      ON storage.objects FOR ALL TO service_role
+      USING (bucket_id = 'sales-documents')
+      WITH CHECK (bucket_id = 'sales-documents');
+  END IF;
+END $$;
+
+-- ============================================================
+-- 2. DOCUMENT-TEMPLATES BUCKET
+-- ============================================================
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('document-templates', 'document-templates', true)
+ON CONFLICT (id) DO UPDATE SET public = true;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'storage' AND tablename = 'objects'
+      AND policyname = 'doc_templates_authenticated_insert'
+  ) THEN
+    CREATE POLICY doc_templates_authenticated_insert
+      ON storage.objects FOR INSERT TO authenticated
+      WITH CHECK (bucket_id = 'document-templates');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'storage' AND tablename = 'objects'
+      AND policyname = 'doc_templates_authenticated_select'
+  ) THEN
+    CREATE POLICY doc_templates_authenticated_select
+      ON storage.objects FOR SELECT TO authenticated
+      USING (bucket_id = 'document-templates');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'storage' AND tablename = 'objects'
+      AND policyname = 'doc_templates_public_select'
+  ) THEN
+    CREATE POLICY doc_templates_public_select
+      ON storage.objects FOR SELECT TO anon
+      USING (bucket_id = 'document-templates');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'storage' AND tablename = 'objects'
+      AND policyname = 'doc_templates_service_role_all'
+  ) THEN
+    CREATE POLICY doc_templates_service_role_all
+      ON storage.objects FOR ALL TO service_role
+      USING (bucket_id = 'document-templates')
+      WITH CHECK (bucket_id = 'document-templates');
+  END IF;
+END $$;


### PR DESCRIPTION
Replace silent alert() failures with inline error banners across all upload UIs (candidates, accounts, resources, team detail). Add view link for pipeline item uploaded documents. Create migration for sales-documents and document-templates storage buckets with RLS policies.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2