### PR TITLE
Carry over immediate_need from lead to deal, remove Services section

### DIFF
--- a/src/app/api/sales/leads/[id]/convert/route.ts
+++ b/src/app/api/sales/leads/[id]/convert/route.ts
@@ -76,6 +76,7 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
         lead_id: leadId,
         account_id: accountId,
         pipeline_id,
+        immediate_need: lead.immediate_need || null,
       })
       .select("id")
       .single();

--- a/src/app/sales/deals/[id]/page.tsx
+++ b/src/app/sales/deals/[id]/page.tsx
@@ -3,9 +3,9 @@
 import { useState, useEffect, useCallback } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { createBrowserClient } from "@/lib/supabase";
-import { ArrowLeft, Loader2, Plus, Trash2, Send, X, Lock, DollarSign } from "lucide-react";
-import type { SalesDeal, DealService, SalesCommission } from "@/lib/salesTypes";
-import { DEAL_STAGES, SERVICE_OPTIONS } from "@/lib/salesTypes";
+import { ArrowLeft, Loader2, Lock, DollarSign } from "lucide-react";
+import type { SalesDeal, SalesCommission } from "@/lib/salesTypes";
+import { DEAL_STAGES, IMMEDIATE_NEEDS } from "@/lib/salesTypes";
 
 export default function DealDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -13,11 +13,6 @@ export default function DealDetailPage() {
   const [deal, setDeal] = useState<SalesDeal | null>(null);
   const [loading, setLoading] = useState(true);
   const [token, setToken] = useState("");
-  const [showAddService, setShowAddService] = useState(false);
-  const [newService, setNewService] = useState({ service_name: SERVICE_OPTIONS[0] as string, price: "" });
-  const [showFinalize, setShowFinalize] = useState(false);
-  const [finalizeForm, setFinalizeForm] = useState({ recipient_email: "james@apexaivending.com", notes: "" });
-  const [sending, setSending] = useState(false);
   const [stageError, setStageError] = useState<string | null>(null);
   const [commissions, setCommissions] = useState<SalesCommission[]>([]);
   const [userRole, setUserRole] = useState("");
@@ -81,75 +76,6 @@ export default function DealDetailPage() {
     fetchCommissions();
   }
 
-  async function handleAddService() {
-    if (!newService.service_name || !newService.price) return;
-    await fetch(`/api/sales/deals/${id}/services`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
-      body: JSON.stringify({ service_name: newService.service_name, price: Number(newService.price) }),
-    });
-    setNewService({ service_name: SERVICE_OPTIONS[0], price: "" });
-    setShowAddService(false);
-    fetchDeal();
-  }
-
-  async function handleDeleteService(serviceId: string) {
-    await fetch(`/api/sales/deals/${id}/services/${serviceId}`, {
-      method: "DELETE",
-      headers: { Authorization: `Bearer ${token}` },
-    });
-    fetchDeal();
-  }
-
-  async function handleServiceStatusChange(service: DealService, status: string) {
-    await fetch(`/api/sales/deals/${id}/services/${service.id}`, {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
-      body: JSON.stringify({ status }),
-    });
-    fetchDeal();
-  }
-
-  async function handleFinalize() {
-    setSending(true);
-    const createRes = await fetch(`/api/sales/deals/${id}/finalize`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
-      body: JSON.stringify(finalizeForm),
-    });
-
-    if (!createRes.ok) {
-      alert("Failed to create order");
-      setSending(false);
-      return;
-    }
-
-    const { orderId } = await createRes.json();
-
-    const sendRes = await fetch(`/api/sales/orders/${orderId}/send`, {
-      method: "POST",
-      headers: { Authorization: `Bearer ${token}` },
-    });
-
-    const result = await sendRes.json().catch(() => ({}));
-    if (result.emailSent) {
-      const ccInfo = result.cc?.length ? `\nCC: ${result.cc.join(", ")}` : "";
-      alert(`Order sent to ${result.recipient}${ccInfo}`);
-      setShowFinalize(false);
-      fetchDeal();
-    } else {
-      alert(
-        `Order was created but the email did NOT go out.\n\n` +
-        `Recipient: ${result.recipient || finalizeForm.recipient_email}\n` +
-        `From: ${result.from || "(not set)"}\n` +
-        `Reason: ${result.emailError || "Unknown error"}\n\n` +
-        `Check that RESEND_API_KEY and FROM_EMAIL are set on the server, ` +
-        `and that the FROM_EMAIL domain is verified in your Resend account.`
-      );
-    }
-    setSending(false);
-  }
-
   if (loading) {
     return <div className="flex justify-center py-20"><Loader2 className="h-8 w-8 animate-spin text-green-600" /></div>;
   }
@@ -158,8 +84,7 @@ export default function DealDetailPage() {
     return <div className="p-6 text-center text-gray-400">Deal not found</div>;
   }
 
-  const services = deal.deal_services || [];
-  const totalValue = services.reduce((s, svc) => s + Number(svc.price), 0);
+  const needLabel = IMMEDIATE_NEEDS.find((n) => n.value === deal.immediate_need)?.label;
 
   const commissionStatusColor: Record<string, string> = {
     pending: "bg-yellow-50 text-yellow-700 ring-yellow-200",
@@ -186,10 +111,11 @@ export default function DealDetailPage() {
             </div>
             <p className="text-sm text-gray-500 mt-1">Assigned to: {deal.assigned_profile?.full_name || "Unassigned"}</p>
           </div>
-          <div className="text-right">
-            <p className="text-2xl font-bold text-green-600">${totalValue.toLocaleString("en-US", { minimumFractionDigits: 2 })}</p>
-            <p className="text-xs text-gray-400 mt-1">Deal Value</p>
-          </div>
+          {needLabel && (
+            <span className="inline-flex items-center rounded-full bg-blue-50 px-3 py-1 text-sm font-medium text-blue-700 ring-1 ring-inset ring-blue-200">
+              {needLabel}
+            </span>
+          )}
         </div>
 
         {/* Stage */}
@@ -218,107 +144,13 @@ export default function DealDetailPage() {
           )}
         </div>
 
-        {/* Services */}
-        <div className="mb-6">
-          <div className="flex items-center justify-between mb-3">
-            <h2 className="text-sm font-semibold text-gray-900">Services</h2>
-            {!isLocked && (
-              <button
-                onClick={() => setShowAddService(!showAddService)}
-                className="inline-flex items-center gap-1 text-sm text-green-600 hover:text-green-700 cursor-pointer"
-              >
-                <Plus className="h-4 w-4" /> Add Service
-              </button>
-            )}
+        {/* Immediate Need */}
+        {needLabel && (
+          <div className="mb-6">
+            <h2 className="text-sm font-semibold text-gray-900 mb-2">Immediate Need</h2>
+            <p className="text-sm text-gray-700">{needLabel}</p>
           </div>
-
-          {showAddService && (
-            <div className="mb-3 flex items-end gap-2 rounded-lg border border-gray-200 bg-gray-50 p-3">
-              <div className="flex-1">
-                <label className="block text-xs text-gray-500 mb-1">Service</label>
-                <select
-                  value={newService.service_name}
-                  onChange={(e) => setNewService((f) => ({ ...f, service_name: e.target.value }))}
-                  className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm cursor-pointer"
-                >
-                  {SERVICE_OPTIONS.map((s) => (
-                    <option key={s} value={s}>{s}</option>
-                  ))}
-                </select>
-              </div>
-              <div className="w-32">
-                <label className="block text-xs text-gray-500 mb-1">Price ($)</label>
-                <input
-                  type="number"
-                  min="0"
-                  step="0.01"
-                  value={newService.price}
-                  onChange={(e) => setNewService((f) => ({ ...f, price: e.target.value }))}
-                  placeholder="0.00"
-                  className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm"
-                />
-              </div>
-              <button onClick={handleAddService} className="rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 cursor-pointer">Add</button>
-              <button onClick={() => setShowAddService(false)} className="rounded-lg border border-gray-200 px-3 py-2 text-sm text-gray-500 hover:bg-gray-100 cursor-pointer">
-                <X className="h-4 w-4" />
-              </button>
-            </div>
-          )}
-
-          {services.length === 0 ? (
-            <p className="py-6 text-center text-sm text-gray-400 rounded-lg border border-dashed border-gray-200">No services added yet</p>
-          ) : (
-            <div className="overflow-x-auto rounded-lg border border-gray-200">
-              <table className="w-full text-left text-sm">
-                <thead className="border-b border-gray-100 bg-gray-50/50">
-                  <tr>
-                    <th className="px-4 py-2.5 font-medium text-gray-500">Service</th>
-                    <th className="px-4 py-2.5 font-medium text-gray-500 text-right">Price</th>
-                    <th className="px-4 py-2.5 font-medium text-gray-500">Status</th>
-                    <th className="px-4 py-2.5 font-medium text-gray-500 w-12"></th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-gray-50">
-                  {services.map((svc) => (
-                    <tr key={svc.id} className="hover:bg-gray-50/50">
-                      <td className="px-4 py-2.5 text-gray-900">{svc.service_name}</td>
-                      <td className="px-4 py-2.5 text-right font-medium text-gray-900">${Number(svc.price).toLocaleString("en-US", { minimumFractionDigits: 2 })}</td>
-                      <td className="px-4 py-2.5">
-                        <select
-                          value={svc.status}
-                          onChange={(e) => handleServiceStatusChange(svc, e.target.value)}
-                          disabled={isLocked}
-                          className="rounded border border-gray-200 px-2 py-1 text-xs cursor-pointer disabled:opacity-50"
-                        >
-                          <option value="pending">Pending</option>
-                          <option value="sold">Sold</option>
-                          <option value="fulfilled">Fulfilled</option>
-                        </select>
-                      </td>
-                      <td className="px-4 py-2.5">
-                        {!isLocked && (
-                          <button
-                            onClick={() => handleDeleteService(svc.id)}
-                            className="rounded-lg p-1 text-gray-400 hover:bg-red-50 hover:text-red-500 cursor-pointer"
-                          >
-                            <Trash2 className="h-4 w-4" />
-                          </button>
-                        )}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-                <tfoot>
-                  <tr className="bg-gray-50/50">
-                    <td className="px-4 py-2.5 font-semibold text-gray-900">Total</td>
-                    <td className="px-4 py-2.5 text-right font-bold text-green-600">${totalValue.toLocaleString("en-US", { minimumFractionDigits: 2 })}</td>
-                    <td colSpan={2}></td>
-                  </tr>
-                </tfoot>
-              </table>
-            </div>
-          )}
-        </div>
+        )}
 
         {/* Commission Info */}
         {commissions.length > 0 && (
@@ -346,68 +178,7 @@ export default function DealDetailPage() {
           </div>
         )}
 
-        {/* Finalize button */}
-        {services.length > 0 && !isLocked && (
-          <button
-            onClick={() => setShowFinalize(true)}
-            className="inline-flex items-center gap-2 rounded-lg bg-green-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-green-700 transition-colors cursor-pointer"
-          >
-            <Send className="h-4 w-4" />
-            Finalize & Send Order
-          </button>
-        )}
       </div>
-
-      {/* Finalize modal */}
-      {showFinalize && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
-          <div className="mx-4 w-full max-w-md rounded-2xl bg-white p-6 shadow-2xl">
-            <h3 className="text-lg font-semibold text-gray-900 mb-4">Finalize & Send Order</h3>
-            <div className="space-y-3">
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Recipient Email</label>
-                <input
-                  type="email"
-                  value={finalizeForm.recipient_email}
-                  onChange={(e) => setFinalizeForm((f) => ({ ...f, recipient_email: e.target.value }))}
-                  className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none"
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Notes</label>
-                <textarea
-                  value={finalizeForm.notes}
-                  onChange={(e) => setFinalizeForm((f) => ({ ...f, notes: e.target.value }))}
-                  rows={3}
-                  className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none"
-                />
-              </div>
-              <div className="rounded-lg bg-gray-50 p-3">
-                <p className="text-sm text-gray-600">
-                  <span className="font-medium">{services.length}</span> services totaling{" "}
-                  <span className="font-bold text-green-600">${totalValue.toLocaleString("en-US", { minimumFractionDigits: 2 })}</span>
-                </p>
-              </div>
-            </div>
-            <div className="mt-5 flex gap-2">
-              <button
-                onClick={() => setShowFinalize(false)}
-                disabled={sending}
-                className="flex-1 rounded-lg border border-gray-200 px-4 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50 cursor-pointer"
-              >
-                Cancel
-              </button>
-              <button
-                onClick={handleFinalize}
-                disabled={sending}
-                className="flex-1 inline-flex items-center justify-center gap-2 rounded-lg bg-green-600 px-4 py-2.5 text-sm font-semibold text-white hover:bg-green-700 disabled:opacity-50 cursor-pointer"
-              >
-                {sending ? <><Loader2 className="h-4 w-4 animate-spin" /> Sending...</> : <><Send className="h-4 w-4" /> Send Order</>}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/src/lib/salesTypes.ts
+++ b/src/lib/salesTypes.ts
@@ -63,6 +63,7 @@ export interface SalesDeal {
   stage: DealStage;
   value: number;
   business_name: string;
+  immediate_need?: ImmediateNeed | null;
   locked_at: string | null;
   created_at: string;
   // Joined

--- a/supabase/migrations/043_deal_immediate_need.sql
+++ b/supabase/migrations/043_deal_immediate_need.sql
@@ -1,0 +1,15 @@
+-- Migration 043: Add immediate_need column to sales_deals
+-- Carries over the lead's immediate_need when converting lead → deal.
+ALTER TABLE public.sales_deals
+  ADD COLUMN IF NOT EXISTS immediate_need text
+    CHECK (immediate_need IN (
+      'location',
+      'machine',
+      'digital',
+      'llc_compliance',
+      'coffee',
+      'financing',
+      'total_operator_package'
+    ));
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
- Add immediate_need column to sales_deals (migration 043)
- Convert endpoint now passes lead.immediate_need to the new deal
- Remove Services section, Add Service, Finalize & Send Order, and Deal Value from deal detail page — lead info carries over instead
- Display immediate_need badge on deal detail header

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2