### PR TITLE
Add pricing_tables payload to PandaDoc document creation

### DIFF
--- a/src/app/api/pipeline-items/[id]/send-proposal/route.ts
+++ b/src/app/api/pipeline-items/[id]/send-proposal/route.ts
@@ -137,12 +137,42 @@ export async function POST(
       fields.payment_amount = String(effectivePrice);
     }
 
+    const pricingTables = effectivePrice
+      ? [
+          {
+            name: "Quote 1",
+            data_merge: true,
+            options: { currency: "USD", discount: { type: "absolute", value: 0 } },
+            sections: [
+              {
+                title: "",
+                default: true,
+                rows: [
+                  {
+                    options: { optional: false, optional_selected: true, qty_editable: false },
+                    data: {
+                      name: "Location Placement",
+                      description: location.machine_type
+                        ? `${location.machine_type} — ${location.machines_requested || 1} machine(s)`
+                        : `${location.machines_requested || 1} machine(s)`,
+                      price: Number(effectivePrice),
+                      qty: 1,
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ]
+      : undefined;
+
     const doc = await createDocumentFromTemplate({
       templateId: step.pandadoc_preliminary_template_id,
       documentName: `Location Proposal — ${item.name}`,
       recipientEmail,
       recipientName,
       fields,
+      pricing_tables: pricingTables,
     });
 
     // Wait for PandaDoc to process the document before sending

--- a/src/app/api/webhooks/esign/route.ts
+++ b/src/app/api/webhooks/esign/route.ts
@@ -209,7 +209,7 @@ async function handleProposalPaymentCompletion(
 
   const { data: item } = await supabaseAdmin
     .from("pipeline_items")
-    .select("*, sales_accounts(id, business_name, contact_name, email)")
+    .select("*, sales_accounts(id, business_name, contact_name, email, phone)")
     .eq("id", itemId)
     .single();
 
@@ -230,6 +230,8 @@ async function handleProposalPaymentCompletion(
       zip: location.zip || "",
       employee_count: String(location.employee_count || ""),
       traffic_count: String(location.traffic_count || ""),
+      machine_type: location.machine_type || "",
+      machines_requested: String(location.machines_requested || ""),
       location_name: location.location_name || "",
       address: location.address || "",
       phone: location.phone || "",
@@ -237,12 +239,43 @@ async function handleProposalPaymentCompletion(
       decision_maker_email: location.decision_maker_email || "",
       customer_name: recipientName,
       customer_email: recipientEmail,
+      customer_phone: item.sales_accounts?.phone || "",
       business_name: item.sales_accounts?.business_name || "",
     };
 
-    if (step.payment_amount) {
-      fields.payment_amount = String(step.payment_amount);
+    const fullPrice = step.payment_amount ? Number(step.payment_amount) : null;
+    if (fullPrice) {
+      fields.payment_amount = String(fullPrice);
     }
+
+    const pricingTables = fullPrice
+      ? [
+          {
+            name: "Quote 1",
+            data_merge: true,
+            options: { currency: "USD", discount: { type: "absolute", value: 0 } },
+            sections: [
+              {
+                title: "",
+                default: true,
+                rows: [
+                  {
+                    options: { optional: false, optional_selected: true, qty_editable: false },
+                    data: {
+                      name: "Location Placement",
+                      description: location.machine_type
+                        ? `${location.machine_type} — ${location.machines_requested || 1} machine(s)`
+                        : `${location.machines_requested || 1} machine(s)`,
+                      price: fullPrice,
+                      qty: 1,
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ]
+      : undefined;
 
     const doc = await createDocumentFromTemplate({
       templateId: step.pandadoc_full_template_id,
@@ -250,6 +283,7 @@ async function handleProposalPaymentCompletion(
       recipientEmail,
       recipientName,
       fields,
+      pricing_tables: pricingTables,
     });
 
     await new Promise((r) => setTimeout(r, 3000));

--- a/src/lib/pandadoc.ts
+++ b/src/lib/pandadoc.ts
@@ -20,18 +20,47 @@ async function pandadocFetch(
   });
 }
 
+interface PricingTableRow {
+  options?: {
+    optional?: boolean;
+    optional_selected?: boolean;
+    qty_editable?: boolean;
+  };
+  data: {
+    name: string;
+    description?: string;
+    price: number;
+    qty: number;
+  };
+}
+
+interface PricingTable {
+  name: string;
+  data_merge?: boolean;
+  options?: {
+    currency?: string;
+    discount?: { type: string; value: number };
+  };
+  sections: {
+    title?: string;
+    default: boolean;
+    rows: PricingTableRow[];
+  }[];
+}
+
 interface CreateDocumentParams {
   templateId: string;
   documentName: string;
   recipientEmail: string;
   recipientName: string;
   fields?: Record<string, string>;
+  pricing_tables?: PricingTable[];
 }
 
 export async function createDocumentFromTemplate(
   params: CreateDocumentParams
 ): Promise<{ id: string; status: string }> {
-  const body = {
+  const body: Record<string, unknown> = {
     name: params.documentName,
     template_uuid: params.templateId,
     recipients: [
@@ -45,6 +74,10 @@ export async function createDocumentFromTemplate(
     fields: params.fields || {},
     parse_form_fields: false,
   };
+
+  if (params.pricing_tables?.length) {
+    body.pricing_tables = params.pricing_tables;
+  }
 
   const res = await pandadocFetch("/documents", {
     method: "POST",


### PR DESCRIPTION
Both preliminary (send-proposal) and full (esign webhook) document generation now send a pricing_tables array to PandaDoc with a single "Location Placement" line item. The table is named "Quote 1" to match PandaDoc's default pricing table. Price is sourced from the pricing engine or step payment_amount. Also adds customer_phone, machine_type, and machines_requested merge fields to the full proposal path.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2