### PR TITLE
Fix PandaDoc API: fields must be {value} mappings, remove data_merge

### DIFF
--- a/src/app/api/pipeline-items/[id]/send-proposal/route.ts
+++ b/src/app/api/pipeline-items/[id]/send-proposal/route.ts
@@ -148,7 +148,6 @@ export async function POST(
       ? [
           {
             name: "Quote 1",
-            data_merge: true,
             options: { currency: "USD", discount: { type: "absolute", value: 0 } },
             sections: [
               {

--- a/src/lib/pandadoc.ts
+++ b/src/lib/pandadoc.ts
@@ -54,12 +54,20 @@ interface CreateDocumentParams {
   recipientEmail: string;
   recipientName: string;
   fields?: Record<string, string>;
+  tokens?: { name: string; value: string }[];
   pricing_tables?: PricingTable[];
 }
 
 export async function createDocumentFromTemplate(
   params: CreateDocumentParams
 ): Promise<{ id: string; status: string }> {
+  const fieldsMapped: Record<string, { value: string }> = {};
+  if (params.fields) {
+    for (const [k, v] of Object.entries(params.fields)) {
+      fieldsMapped[k] = { value: v };
+    }
+  }
+
   const body: Record<string, unknown> = {
     name: params.documentName,
     template_uuid: params.templateId,
@@ -71,7 +79,8 @@ export async function createDocumentFromTemplate(
         role: "signer",
       },
     ],
-    fields: params.fields || {},
+    fields: fieldsMapped,
+    tokens: params.tokens || [],
     parse_form_fields: false,
   };
 


### PR DESCRIPTION
Two PandaDoc validation errors:
- Fields were sent as plain strings ("industry": "retail") but the API requires object mappings ("industry": { "value": "retail" }). Fixed in createDocumentFromTemplate to wrap all field values.
- Pricing table had data_merge: true but it's not enabled on the template. Removed the flag so PandaDoc uses standard table merge.

Also added tokens support to CreateDocumentParams for future use.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2