### PR TITLE
Fix PandaDoc pricing table: non-blank title, remove discount object

### DIFF
--- a/src/app/api/pipeline-items/[id]/send-proposal/route.ts
+++ b/src/app/api/pipeline-items/[id]/send-proposal/route.ts
@@ -148,10 +148,10 @@ export async function POST(
       ? [
           {
             name: "Quote 1",
-            options: { currency: "USD", discount: { type: "absolute", value: 0 } },
+            options: { currency: "USD" },
             sections: [
               {
-                title: "",
+                title: "Location Placement",
                 default: true,
                 rows: [
                   {


### PR DESCRIPTION
PandaDoc requires section title to be non-blank and discount.name to be present. Set title to "Location Placement" and removed the empty discount object entirely.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2