### PR TITLE
Fix PandaDoc recipient role: use 'Client' instead of 'signer'

### DIFF
--- a/src/lib/pandadoc.ts
+++ b/src/lib/pandadoc.ts
@@ -76,7 +76,7 @@ export async function createDocumentFromTemplate(
         email: params.recipientEmail,
         first_name: params.recipientName.split(" ")[0],
         last_name: params.recipientName.split(" ").slice(1).join(" ") || "",
-        role: "signer",
+        role: "Client",
       },
     ],
     fields: fieldsMapped,


### PR DESCRIPTION
The template defines a 'Client' role, not 'signer'. PandaDoc validates recipient roles against the template's defined roles.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2