### PR TITLE
Handle PandaDoc send restriction gracefully

### DIFF
--- a/src/app/api/pipeline-items/[id]/send-proposal/route.ts
+++ b/src/app/api/pipeline-items/[id]/send-proposal/route.ts
@@ -181,9 +181,18 @@ export async function POST(
       pricing_tables: pricingTables,
     });
 
-    // Wait for PandaDoc to process the document before sending
+    // Attempt to send — may fail on plans that restrict external sends
+    let sendFailed = false;
     await new Promise((r) => setTimeout(r, 3000));
-    await sendDocument(doc.id, "Please review this location placement proposal.");
+    try {
+      await sendDocument(doc.id, "Please review this location placement proposal.");
+    } catch {
+      sendFailed = true;
+    }
+
+    const docStatus = sendFailed ? "draft" : "sent";
+    const proposalStatus = sendFailed ? "document_created" : "proposal_sent";
+    const pandadocUrl = `https://app.pandadoc.com/a/#/documents/${doc.id}`;
 
     // Create esign_documents record
     await supabaseAdmin.from("esign_documents").insert({
@@ -195,8 +204,8 @@ export async function POST(
       document_name: `Location Proposal — ${item.name}`,
       recipient_email: recipientEmail,
       recipient_name: recipientName,
-      status: "sent",
-      sent_at: new Date().toISOString(),
+      status: docStatus,
+      sent_at: sendFailed ? null : new Date().toISOString(),
       metadata: { type: "preliminary_proposal", location_id: item.location_id },
     });
 
@@ -217,13 +226,15 @@ export async function POST(
     // Update proposal status
     await supabaseAdmin
       .from("pipeline_items")
-      .update({ proposal_status: "proposal_sent", updated_at: new Date().toISOString() })
+      .update({ proposal_status: proposalStatus, updated_at: new Date().toISOString() })
       .eq("id", itemId);
 
     return NextResponse.json({
       ok: true,
       pandadoc_document_id: doc.id,
-      proposal_status: "proposal_sent",
+      pandadoc_url: pandadocUrl,
+      proposal_status: proposalStatus,
+      send_failed: sendFailed,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error";

--- a/src/app/sales/pipelines/[id]/items/[itemId]/page.tsx
+++ b/src/app/sales/pipelines/[id]/items/[itemId]/page.tsx
@@ -158,6 +158,7 @@ export default function PipelineItemDetailPage() {
   const [esignForm, setEsignForm] = useState({ document_name: "", recipient_email: "", template_id: "" });
   const [sendingProposal, setSendingProposal] = useState(false);
   const [proposalError, setProposalError] = useState<string | null>(null);
+  const [pandadocUrl, setPandadocUrl] = useState<string | null>(null);
   const [pricingData, setPricingData] = useState<PricingData | null>(null);
   const [pricingInputs, setPricingInputs] = useState({ employees: 0, foot_traffic: 0, business_hours: "low" as string, machines_requested: 1 });
   const [calculatingPricing, setCalculatingPricing] = useState(false);
@@ -441,7 +442,9 @@ export default function PipelineItemDetailPage() {
         headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
       });
       if (res.ok) {
-        setItem((prev) => prev ? { ...prev, proposal_status: "proposal_sent" } : prev);
+        const data = await res.json();
+        setItem((prev) => prev ? { ...prev, proposal_status: data.proposal_status } : prev);
+        if (data.pandadoc_url) setPandadocUrl(data.pandadoc_url);
         load();
         loadGatingData();
         loadLocationPricing();
@@ -868,10 +871,12 @@ export default function PipelineItemDetailPage() {
             <span className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${
               item.proposal_status === "paid" ? "bg-green-100 text-green-700" :
               item.proposal_status === "proposal_sent" ? "bg-blue-100 text-blue-600" :
+              item.proposal_status === "document_created" ? "bg-yellow-100 text-yellow-700" :
               "bg-gray-100 text-gray-500"
             }`}>
               {item.proposal_status === "paid" ? "Signed & Paid" :
                item.proposal_status === "proposal_sent" ? "Sent" :
+               item.proposal_status === "document_created" ? "Created" :
                "Not Sent"}
             </span>
           </div>
@@ -917,6 +922,27 @@ export default function PipelineItemDetailPage() {
               <Clock className="h-3.5 w-3.5" />
               Agreement sent — waiting for customer signature &amp; payment
             </p>
+          ) : item.proposal_status === "document_created" ? (
+            <div>
+              <p className="text-sm text-yellow-700 flex items-center gap-1.5 mb-2">
+                <FileText className="h-3.5 w-3.5" />
+                Document created — send manually from PandaDoc
+              </p>
+              {pandadocUrl && (
+                <a href={pandadocUrl} target="_blank" rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700">
+                  <ExternalLink className="h-4 w-4" />
+                  Open in PandaDoc
+                </a>
+              )}
+              {esignDocs.filter(d => d.status === "draft").map((doc) => (
+                <a key={doc.id} href={`https://app.pandadoc.com/a/#/documents/${doc.id}`} target="_blank" rel="noopener noreferrer"
+                  className={`inline-flex items-center gap-1.5 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 ${pandadocUrl ? "hidden" : ""}`}>
+                  <ExternalLink className="h-4 w-4" />
+                  Open in PandaDoc
+                </a>
+              ))}
+            </div>
           ) : (
             <>
               <button


### PR DESCRIPTION
PandaDoc free/Essentials plans block sending to external emails. Now the document is still created and saved even if the send fails. The UI shows a "document_created" status with an "Open in PandaDoc" button so the user can send manually from the PandaDoc dashboard.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2