### PR TITLE
Fix PandaDoc send: poll for draft status, pass recipient explicitly

### DIFF
--- a/src/app/api/pipeline-items/[id]/send-proposal/route.ts
+++ b/src/app/api/pipeline-items/[id]/send-proposal/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { getSalesUser } from "@/lib/salesAuth";
-import { createDocumentFromTemplate, sendDocument } from "@/lib/pandadoc";
+import { createDocumentFromTemplate, sendDocument, waitForDocumentStatus } from "@/lib/pandadoc";
 import {
   calculateLocationPrice,
   BusinessHours,
@@ -181,9 +181,14 @@ export async function POST(
       pricing_tables: pricingTables,
     });
 
-    // Wait for PandaDoc to process, then send directly to the customer
-    await new Promise((r) => setTimeout(r, 3000));
-    await sendDocument(doc.id, "Please review this location placement proposal.");
+    // Wait for PandaDoc to finish processing before sending
+    await waitForDocumentStatus(doc.id, "document.draft");
+    const nameParts = recipientName.split(" ");
+    await sendDocument(doc.id, "Please review this location placement proposal.", {
+      email: recipientEmail,
+      first_name: nameParts[0],
+      last_name: nameParts.slice(1).join(" ") || "",
+    });
 
     // Create esign_documents record
     await supabaseAdmin.from("esign_documents").insert({

--- a/src/lib/pandadoc.ts
+++ b/src/lib/pandadoc.ts
@@ -101,14 +101,33 @@ export async function createDocumentFromTemplate(
   return res.json();
 }
 
+export async function waitForDocumentStatus(
+  documentId: string,
+  targetStatus: string = "document.draft",
+  maxAttempts: number = 10,
+  intervalMs: number = 2000
+): Promise<void> {
+  for (let i = 0; i < maxAttempts; i++) {
+    const doc = await getDocumentStatus(documentId);
+    if (doc.status === targetStatus) return;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  throw new Error(`Document did not reach '${targetStatus}' status in time`);
+}
+
 export async function sendDocument(
   documentId: string,
-  message?: string
+  message?: string,
+  recipient?: { email: string; first_name: string; last_name: string }
 ): Promise<{ id: string; status: string }> {
-  const body = {
+  const body: Record<string, unknown> = {
     message: message || "Please review and sign this document.",
     silent: false,
   };
+
+  if (recipient) {
+    body.recipients = [recipient];
+  }
 
   const res = await pandadocFetch(`/documents/${documentId}/send`, {
     method: "POST",


### PR DESCRIPTION
Two changes to fix the external send error:
- Replace blind 3-second wait with polling for 'document.draft' status (up to 10 attempts, 2s interval). Document must be fully processed before PandaDoc allows sending.
- Pass recipient (email, name) explicitly in the send call so PandaDoc knows exactly who to deliver to, rather than relying solely on the recipients from the create step.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2