### PR TITLE
Rebalance placement scoring: traffic 30%, hours 40%, machines 30%

### DIFF
--- a/src/app/api/pipeline-items/[id]/send-proposal/route.ts
+++ b/src/app/api/pipeline-items/[id]/send-proposal/route.ts
@@ -90,9 +90,9 @@ export async function POST(
   } else if (location.pricing_score != null) {
     pricing = {
       total_score: location.pricing_score,
-      traffic_score: Math.min(((location.employee_count ?? 0) + (location.traffic_count ?? 0)) / 500 * 70, 70),
-      hours_score: ({ low: 5, medium: 10, high: 15, "24/7": 20 } as Record<string, number>)[location.business_hours ?? "low"] ?? 5,
-      machine_score: ({ 1: 3, 2: 6, 3: 8, 4: 10 } as Record<number, number>)[location.machines_requested ?? 1] ?? 3,
+      traffic_score: Math.min(((location.employee_count ?? 0) + (location.traffic_count ?? 0)) / 500 * 30, 30),
+      hours_score: ({ low: 10, medium: 20, high: 30, "24/7": 40 } as Record<string, number>)[location.business_hours ?? "low"] ?? 10,
+      machine_score: ({ 1: 8, 2: 15, 3: 23, 4: 30 } as Record<number, number>)[location.machines_requested ?? 1] ?? 8,
       tier: location.pricing_tier as 1 | 2 | 3 | 4 | 5,
       tier_label: `Tier ${location.pricing_tier}`,
       price: Number(location.pricing_price),

--- a/src/lib/pricing/locationPricing.ts
+++ b/src/lib/pricing/locationPricing.ts
@@ -19,17 +19,17 @@ export interface PricingResult {
 }
 
 const HOURS_SCORES: Record<BusinessHours, number> = {
-  low: 5,
-  medium: 10,
-  high: 15,
-  "24/7": 20,
+  low: 10,
+  medium: 20,
+  high: 30,
+  "24/7": 40,
 };
 
 const MACHINE_SCORES: Record<MachinesRequested, number> = {
-  1: 3,
-  2: 6,
-  3: 8,
-  4: 10,
+  1: 8,
+  2: 15,
+  3: 23,
+  4: 30,
 };
 
 const TIERS: { min: number; tier: 1 | 2 | 3 | 4 | 5; label: string; price: number }[] = [
@@ -55,7 +55,7 @@ export function calculateLocationPrice(input: PricingInput): PricingResult {
   }
 
   const totalTraffic = input.employees + input.foot_traffic;
-  const trafficScore = Math.min((totalTraffic / 500) * 70, 70);
+  const trafficScore = Math.min((totalTraffic / 500) * 30, 30);
 
   const rawTotal = trafficScore + hoursScore + machineScore;
   const totalScore = Math.round(Math.min(rawTotal, 100));


### PR DESCRIPTION
Traffic was 70% of the score, making small locations score very low (e.g. 8/100) despite reasonable hours and machine counts. Rebalanced so hours and machines have more weight.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2