### PR TITLE
Implement 4-level RBAC system with market-based data filtering

### DIFF
--- a/src/app/api/onboarding/document-templates/[id]/route.ts
+++ b/src/app/api/onboarding/document-templates/[id]/route.ts
@@ -4,7 +4,7 @@ import { getSalesUser, isElevatedRole } from "@/lib/salesAuth";
 
 export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const user = await getSalesUser(req);
-  if (!user || !isElevatedRole(user.role)) {
+  if (!user || user.role !== "admin") {
     return NextResponse.json({ error: "Admin access required" }, { status: 403 });
   }
   const { id } = await params;

--- a/src/app/api/onboarding/document-templates/route.ts
+++ b/src/app/api/onboarding/document-templates/route.ts
@@ -4,7 +4,7 @@ import { getSalesUser, isElevatedRole } from "@/lib/salesAuth";
 
 export async function GET(req: NextRequest) {
   const user = await getSalesUser(req);
-  if (!user || !isElevatedRole(user.role)) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  if (!user || user.role !== "admin") return NextResponse.json({ error: "Forbidden" }, { status: 403 });
 
   const url = new URL(req.url);
   const pipeline_type = url.searchParams.get("pipeline_type");

--- a/src/app/api/onboarding/email-templates/[id]/route.ts
+++ b/src/app/api/onboarding/email-templates/[id]/route.ts
@@ -4,7 +4,7 @@ import { getSalesUser, isElevatedRole } from "@/lib/salesAuth";
 
 export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const user = await getSalesUser(req);
-  if (!user || !isElevatedRole(user.role)) {
+  if (!user || user.role !== "admin") {
     return NextResponse.json({ error: "Admin access required" }, { status: 403 });
   }
   const { id } = await params;

--- a/src/app/api/onboarding/email-templates/route.ts
+++ b/src/app/api/onboarding/email-templates/route.ts
@@ -4,7 +4,7 @@ import { getSalesUser, isElevatedRole } from "@/lib/salesAuth";
 
 export async function GET(req: NextRequest) {
   const user = await getSalesUser(req);
-  if (!user || !isElevatedRole(user.role)) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  if (!user || user.role !== "admin") return NextResponse.json({ error: "Forbidden" }, { status: 403 });
 
   const { data, error } = await supabaseAdmin
     .from("email_templates_v2")
@@ -18,7 +18,7 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   const user = await getSalesUser(req);
-  if (!user || !isElevatedRole(user.role)) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  if (!user || user.role !== "admin") return NextResponse.json({ error: "Forbidden" }, { status: 403 });
 
   const body = await req.json();
   const { pipeline_type, step_key, subject, body_html } = body;

--- a/src/app/api/onboarding/step-doc-assignments/route.ts
+++ b/src/app/api/onboarding/step-doc-assignments/route.ts
@@ -4,7 +4,7 @@ import { getSalesUser, isElevatedRole } from "@/lib/salesAuth";
 
 export async function GET(req: NextRequest) {
   const user = await getSalesUser(req);
-  if (!user || !isElevatedRole(user.role)) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  if (!user || user.role !== "admin") return NextResponse.json({ error: "Forbidden" }, { status: 403 });
 
   const url = new URL(req.url);
   const pipeline_id = url.searchParams.get("pipeline_id");

--- a/src/app/api/pipeline-items/route.ts
+++ b/src/app/api/pipeline-items/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { getSalesUser } from "@/lib/salesAuth";
+import { filterByRole } from "@/lib/permissions";
 
 export async function GET(req: NextRequest) {
   const user = await getSalesUser(req);
@@ -17,6 +18,8 @@ export async function GET(req: NextRequest) {
 
   if (pipelineId) query = query.eq("pipeline_id", pipelineId);
   if (status) query = query.eq("status", status);
+
+  query = await filterByRole(query, user, { creatorCol: "assigned_to" }) as typeof query;
 
   const { data, error } = await query;
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });

--- a/src/app/api/sales/accounts/route.ts
+++ b/src/app/api/sales/accounts/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { getSalesUser } from "@/lib/salesAuth";
+import { filterByRole } from "@/lib/permissions";
 
 export async function GET(req: NextRequest) {
   const user = await getSalesUser(req);
@@ -11,10 +12,7 @@ export async function GET(req: NextRequest) {
     .select("*")
     .order("created_at", { ascending: false });
 
-  // Sales reps see accounts they own or created (admin sees all)
-  if (user.role === "sales") {
-    query = query.or(`assigned_to.eq.${user.id},created_by.eq.${user.id}`);
-  }
+  query = await filterByRole(query, user) as typeof query;
 
   const { data, error } = await query.limit(500);
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });

--- a/src/app/api/sales/commissions/route.ts
+++ b/src/app/api/sales/commissions/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { getSalesUser, isElevatedRole } from "@/lib/salesAuth";
+import { filterCommissionsByRole, getRoleLevel } from "@/lib/permissions";
 
 export async function GET(req: NextRequest) {
   const user = await getSalesUser(req);
@@ -14,10 +15,10 @@ export async function GET(req: NextRequest) {
     .select("*, sales_deals:deal_id(business_name)")
     .order("created_at", { ascending: false });
 
-  if (user.role === "sales") {
-    query = query.eq("user_id", user.id);
-  } else if (userId) {
+  if (userId && getRoleLevel(user.role) <= 2) {
     query = query.eq("user_id", userId);
+  } else {
+    query = await filterCommissionsByRole(query, user) as typeof query;
   }
 
   const { data, error } = await query.limit(200);

--- a/src/app/api/sales/deals/route.ts
+++ b/src/app/api/sales/deals/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { getSalesUser } from "@/lib/salesAuth";
+import { filterByRole } from "@/lib/permissions";
 
 export async function GET(req: NextRequest) {
   const user = await getSalesUser(req);
@@ -11,9 +12,7 @@ export async function GET(req: NextRequest) {
     .select("*, deal_services(*), pipelines(id, name)")
     .order("created_at", { ascending: false });
 
-  if (user.role === "sales") {
-    query = query.eq("assigned_to", user.id);
-  }
+  query = await filterByRole(query, user) as typeof query;
 
   const { data, error } = await query.limit(500);
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });

--- a/src/app/api/sales/leads/route.ts
+++ b/src/app/api/sales/leads/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { getSalesUser } from "@/lib/salesAuth";
+import { filterByRole } from "@/lib/permissions";
 
 export async function GET(req: NextRequest) {
   const user = await getSalesUser(req);
@@ -11,12 +12,7 @@ export async function GET(req: NextRequest) {
     .select("*")
     .order("created_at", { ascending: false });
 
-  // Sales users see leads assigned to them, unassigned leads, or leads they created
-  if (user.role === "sales") {
-    query = query.or(
-      `assigned_to.eq.${user.id},assigned_to.is.null,created_by.eq.${user.id}`
-    );
-  }
+  query = await filterByRole(query, user) as typeof query;
 
   const { data, error } = await query.limit(500);
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });

--- a/src/app/sales/admin/documents/page.tsx
+++ b/src/app/sales/admin/documents/page.tsx
@@ -48,7 +48,7 @@ export default function AdminDocumentsPage() {
         .then((r) => r.ok ? r.json() : [])
         .then((users: { id: string; role: string }[]) => {
           const me = users.find((u) => u.id === session.user.id);
-          if (!me || (me.role !== "admin" && me.role !== "director_of_sales" && me.role !== "market_leader")) {
+          if (!me || me.role !== "admin") {
             router.push("/sales");
           } else {
             setAuthorized(true);

--- a/src/app/sales/admin/email-templates/page.tsx
+++ b/src/app/sales/admin/email-templates/page.tsx
@@ -46,7 +46,7 @@ export default function AdminEmailTemplatesPage() {
         .then((r) => r.ok ? r.json() : [])
         .then((users: { id: string; role: string }[]) => {
           const me = users.find((u) => u.id === session.user.id);
-          if (!me || (me.role !== "admin" && me.role !== "director_of_sales" && me.role !== "market_leader")) {
+          if (!me || me.role !== "admin") {
             router.push("/sales");
           } else {
             setAuthorized(true);

--- a/src/app/sales/admin/pipeline-doc-mapping/page.tsx
+++ b/src/app/sales/admin/pipeline-doc-mapping/page.tsx
@@ -60,7 +60,7 @@ export default function PipelineDocMappingPage() {
         .then((r) => r.ok ? r.json() : [])
         .then((users: { id: string; role: string }[]) => {
           const me = users.find((u) => u.id === session.user.id);
-          if (!me || (me.role !== "admin" && me.role !== "director_of_sales" && me.role !== "market_leader")) {
+          if (!me || me.role !== "admin") {
             router.push("/sales");
           } else {
             setAuthorized(true);

--- a/src/app/sales/layout.tsx
+++ b/src/app/sales/layout.tsx
@@ -28,24 +28,34 @@ import {
   Link2,
 } from "lucide-react";
 
+// minLevel: 1=Admin, 2=DOS, 3=Market Leader, 4=BDP/Sales
 const NAV_ITEMS = [
-  { href: "/sales", label: "Dashboard", icon: LayoutDashboard, elevated: false },
-  { href: "/sales/results", label: "Results", icon: TrendingUp, elevated: false },
-  { href: "/sales/leads", label: "Leads", icon: Users, elevated: false },
-  { href: "/sales/pipelines", label: "Pipelines", icon: GitBranch, elevated: false },
-  { href: "/sales/deals", label: "Deal Dashboard", icon: Kanban, elevated: false },
-  { href: "/sales/accounts", label: "Accounts", icon: Building2, elevated: false },
-  { href: "/sales/orders", label: "Orders", icon: ClipboardList, elevated: false },
-  { href: "/sales/team", label: "Team", icon: UserCog, elevated: true },
-  { href: "/sales/commissions", label: "Commissions", icon: DollarSign, elevated: false },
-  { href: "/sales/call-lists", label: "Call Lists", icon: PhoneCall, elevated: false },
-  { href: "/sales/resources", label: "Resources", icon: FolderOpen, elevated: false },
-  { href: "/sales/candidates", label: "Candidates", icon: UserPlus, elevated: false },
-  { href: "/sales/hiring-dashboard", label: "Hiring & Onboarding", icon: BarChart3, elevated: true },
-  { href: "/sales/admin/documents", label: "Doc Templates", icon: FileText, elevated: true },
-  { href: "/sales/admin/email-templates", label: "Email Templates", icon: Mail, elevated: true },
-  { href: "/sales/admin/pipeline-doc-mapping", label: "Doc Mapping", icon: Link2, elevated: true },
+  { href: "/sales", label: "Dashboard", icon: LayoutDashboard, minLevel: 4 as const },
+  { href: "/sales/results", label: "Results", icon: TrendingUp, minLevel: 4 as const },
+  { href: "/sales/leads", label: "Leads", icon: Users, minLevel: 4 as const },
+  { href: "/sales/pipelines", label: "Pipelines", icon: GitBranch, minLevel: 4 as const },
+  { href: "/sales/deals", label: "Deal Dashboard", icon: Kanban, minLevel: 4 as const },
+  { href: "/sales/accounts", label: "Accounts", icon: Building2, minLevel: 4 as const },
+  { href: "/sales/orders", label: "Orders", icon: ClipboardList, minLevel: 4 as const },
+  { href: "/sales/team", label: "Team", icon: UserCog, minLevel: 3 as const },
+  { href: "/sales/commissions", label: "Commissions", icon: DollarSign, minLevel: 4 as const },
+  { href: "/sales/call-lists", label: "Call Lists", icon: PhoneCall, minLevel: 4 as const },
+  { href: "/sales/resources", label: "Resources", icon: FolderOpen, minLevel: 4 as const },
+  { href: "/sales/candidates", label: "Candidates", icon: UserPlus, minLevel: 4 as const },
+  { href: "/sales/hiring-dashboard", label: "Hiring & Onboarding", icon: BarChart3, minLevel: 3 as const },
+  { href: "/sales/admin/documents", label: "Doc Templates", icon: FileText, minLevel: 1 as const },
+  { href: "/sales/admin/email-templates", label: "Email Templates", icon: Mail, minLevel: 1 as const },
+  { href: "/sales/admin/pipeline-doc-mapping", label: "Doc Mapping", icon: Link2, minLevel: 1 as const },
 ];
+
+function getUserLevel(role: string): number {
+  switch (role) {
+    case "admin": return 1;
+    case "director_of_sales": return 2;
+    case "market_leader": return 3;
+    default: return 4;
+  }
+}
 
 export default function SalesLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
@@ -103,8 +113,8 @@ export default function SalesLayout({ children }: { children: React.ReactNode })
 
   if (!authorized) return null;
 
-  const isElevated = userRole === "admin" || userRole === "director_of_sales" || userRole === "market_leader";
-  const visibleNav = NAV_ITEMS.filter((item) => !item.elevated || isElevated);
+  const level = getUserLevel(userRole);
+  const visibleNav = NAV_ITEMS.filter((item) => level <= item.minLevel);
 
   return (
     <div className="flex h-screen bg-gray-50">

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -1,0 +1,149 @@
+import { SalesRole } from "./salesAuth";
+import { supabaseAdmin } from "./supabaseAdmin";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+type QueryBuilder = any;
+
+export type RoleLevel = 1 | 2 | 3 | 4;
+
+export function getRoleLevel(role: SalesRole): RoleLevel {
+  switch (role) {
+    case "admin": return 1;
+    case "director_of_sales": return 2;
+    case "market_leader": return 3;
+    case "sales": return 4;
+    default: return 4;
+  }
+}
+
+export type CrmSection =
+  | "dashboard"
+  | "results"
+  | "leads"
+  | "pipelines"
+  | "deals"
+  | "accounts"
+  | "orders"
+  | "team"
+  | "commissions"
+  | "call_lists"
+  | "resources"
+  | "candidates"
+  | "hiring_dashboard"
+  | "doc_templates"
+  | "email_templates"
+  | "doc_mapping";
+
+const SECTION_MIN_LEVEL: Record<CrmSection, RoleLevel> = {
+  dashboard: 4,
+  results: 4,
+  leads: 4,
+  pipelines: 4,
+  deals: 4,
+  accounts: 4,
+  orders: 4,
+  commissions: 4,
+  call_lists: 4,
+  resources: 4,
+  candidates: 4,
+  team: 3,
+  hiring_dashboard: 3,
+  doc_templates: 1,
+  email_templates: 1,
+  doc_mapping: 1,
+};
+
+export function canAccessSection(role: SalesRole, section: CrmSection): boolean {
+  return getRoleLevel(role) <= SECTION_MIN_LEVEL[section];
+}
+
+/**
+ * Get user IDs that a market leader can see (their own market members).
+ * Returns null for admin/DOS (no filtering needed).
+ */
+async function getMarketMemberIds(userId: string): Promise<string[]> {
+  const { data: leaderMarkets } = await supabaseAdmin
+    .from("market_leaders")
+    .select("market_id")
+    .eq("user_id", userId);
+
+  if (!leaderMarkets || leaderMarkets.length === 0) return [userId];
+
+  const marketIds = leaderMarkets.map((m) => m.market_id);
+
+  const { data: members } = await supabaseAdmin
+    .from("market_members")
+    .select("user_id")
+    .in("market_id", marketIds);
+
+  const ids = new Set<string>([userId]);
+  (members || []).forEach((m) => ids.add(m.user_id));
+  return Array.from(ids);
+}
+
+export interface FilterContext {
+  id: string;
+  role: SalesRole;
+}
+
+/**
+ * Apply role-based row filtering to a Supabase query.
+ *
+ * - Admin/DOS: no filter (see everything)
+ * - Market Leader: see records where market_assignment = 'ALL' or own user_id,
+ *   OR assigned_to/created_by is a member of their market
+ * - Sales (BDP): see only own records (assigned_to or created_by = user.id)
+ *
+ * @param query - Supabase query builder (must have assigned_to column)
+ * @param ctx - User context with id and role
+ * @param opts - Column name overrides
+ */
+export async function filterByRole(
+  query: QueryBuilder,
+  ctx: FilterContext,
+  opts?: { ownerCol?: string; creatorCol?: string; marketCol?: string }
+) {
+  const ownerCol = opts?.ownerCol ?? "assigned_to";
+  const creatorCol = opts?.creatorCol ?? "created_by";
+  const marketCol = opts?.marketCol ?? "market_assignment";
+  const level = getRoleLevel(ctx.role);
+
+  // Admin and DOS see everything
+  if (level <= 2) return query;
+
+  // Market Leader: see their market + ALL
+  if (level === 3) {
+    const memberIds = await getMarketMemberIds(ctx.id);
+    const idList = memberIds.map((id) => `"${id}"`).join(",");
+    return query.or(
+      `${marketCol}.eq.ALL,${marketCol}.eq.${ctx.id},${ownerCol}.in.(${idList}),${creatorCol}.in.(${idList})`
+    );
+  }
+
+  // BDP (sales): own records only
+  return query.or(
+    `${ownerCol}.eq.${ctx.id},${creatorCol}.eq.${ctx.id}`
+  );
+}
+
+/**
+ * Filter commissions by role hierarchy.
+ * - Admin/DOS: see all
+ * - Market Leader: see own team's commissions
+ * - BDP: see only own commissions
+ */
+export async function filterCommissionsByRole(
+  query: QueryBuilder,
+  ctx: FilterContext
+) {
+  const level = getRoleLevel(ctx.role);
+
+  if (level <= 2) return query;
+
+  if (level === 3) {
+    const memberIds = await getMarketMemberIds(ctx.id);
+    return query.in("user_id", memberIds);
+  }
+
+  return query.eq("user_id", ctx.id);
+}

--- a/supabase/migrations/049_rbac_market_assignment.sql
+++ b/supabase/migrations/049_rbac_market_assignment.sql
@@ -1,0 +1,12 @@
+-- RBAC: Add market_assignment to deals, pipeline_items, leads, and accounts
+-- Values: NULL (unassigned), 'ALL' (visible to all market leaders), or a market leader's user_id
+
+ALTER TABLE public.sales_deals ADD COLUMN IF NOT EXISTS market_assignment TEXT;
+ALTER TABLE public.pipeline_items ADD COLUMN IF NOT EXISTS market_assignment TEXT;
+ALTER TABLE public.sales_leads ADD COLUMN IF NOT EXISTS market_assignment TEXT;
+ALTER TABLE public.sales_accounts ADD COLUMN IF NOT EXISTS market_assignment TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_sales_deals_market ON public.sales_deals(market_assignment);
+CREATE INDEX IF NOT EXISTS idx_pipeline_items_market ON public.pipeline_items(market_assignment);
+CREATE INDEX IF NOT EXISTS idx_sales_leads_market ON public.sales_leads(market_assignment);
+CREATE INDEX IF NOT EXISTS idx_sales_accounts_market ON public.sales_accounts(market_assignment);


### PR DESCRIPTION
Roles: Admin (L1) > DOS (L2) > Market Leader (L3) > BDP/Sales (L4)

- Centralized permissions module (src/lib/permissions.ts) with filterByRole() and filterCommissionsByRole() for query-level row filtering
- Admin-only: doc templates, email templates, doc mapping (API + frontend)
- DOS: full visibility except admin sections
- Market Leader: sees records assigned to ALL or their market members
- BDP/Sales: sees only own records (assigned_to or created_by)
- Commission hierarchy: admin/DOS see all, ML sees team, BDP sees own
- Navigation gated by role level instead of binary elevated flag
- Migration adds market_assignment column to deals, pipeline_items, leads, accounts

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2