### PR TITLE
Add candidate document submission portal with auto-advancement

### DIFF
--- a/src/app/api/onboarding/candidate-portal/[token]/download/route.ts
+++ b/src/app/api/onboarding/candidate-portal/[token]/download/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+
+export async function GET(req: NextRequest, { params }: { params: Promise<{ token: string }> }) {
+  const { token } = await params;
+
+  const { data: ct } = await supabaseAdmin
+    .from("candidate_tokens")
+    .select("id, status")
+    .eq("token", token)
+    .single();
+
+  if (!ct || ct.status === "expired") {
+    return NextResponse.json({ error: "Invalid or expired link" }, { status: 404 });
+  }
+
+  const url = new URL(req.url);
+  const filePath = url.searchParams.get("file_path");
+
+  if (!filePath) {
+    return NextResponse.json({ error: "file_path required" }, { status: 400 });
+  }
+
+  const { data: fileData, error } = await supabaseAdmin.storage
+    .from("document-templates")
+    .download(filePath);
+
+  if (error || !fileData) {
+    return NextResponse.json({ error: "File not found" }, { status: 404 });
+  }
+
+  const arrayBuffer = await fileData.arrayBuffer();
+  const fileName = filePath.split("/").pop() || "document.pdf";
+
+  return new NextResponse(arrayBuffer, {
+    headers: {
+      "Content-Type": "application/pdf",
+      "Content-Disposition": `attachment; filename="${fileName}"`,
+    },
+  });
+}

--- a/src/app/api/onboarding/candidate-portal/[token]/route.ts
+++ b/src/app/api/onboarding/candidate-portal/[token]/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+
+export async function GET(_req: NextRequest, { params }: { params: Promise<{ token: string }> }) {
+  const { token } = await params;
+
+  const { data: ct, error } = await supabaseAdmin
+    .from("candidate_tokens")
+    .select("*, candidates(id, full_name, email, role_type, status)")
+    .eq("token", token)
+    .single();
+
+  if (error || !ct) {
+    return NextResponse.json({ error: "Invalid or expired link" }, { status: 404 });
+  }
+
+  if (ct.status === "expired") {
+    return NextResponse.json({ error: "This link has expired" }, { status: 410 });
+  }
+
+  if (ct.expires_at && new Date(ct.expires_at) < new Date()) {
+    await supabaseAdmin.from("candidate_tokens").update({ status: "expired" }).eq("id", ct.id);
+    return NextResponse.json({ error: "This link has expired" }, { status: 410 });
+  }
+
+  if (ct.status === "pending") {
+    await supabaseAdmin
+      .from("candidate_tokens")
+      .update({ status: "viewed", viewed_at: new Date().toISOString() })
+      .eq("id", ct.id);
+  }
+
+  const { data: assignments } = await supabaseAdmin
+    .from("step_document_assignments")
+    .select("*, document_templates(id, name, file_name, file_path, mime_type, active)")
+    .eq("pipeline_id", ct.pipeline_id)
+    .eq("step_key", ct.step_key)
+    .order("order_index");
+
+  const requiredDocs = (assignments || []).filter(
+    (a: Record<string, unknown>) => {
+      const tmpl = a.document_templates as Record<string, unknown> | null;
+      return tmpl && tmpl.active === true;
+    }
+  );
+
+  const { data: uploaded } = await supabaseAdmin
+    .from("candidate_documents")
+    .select("id, file_name, file_url, file_type, document_template_id, completed, created_at")
+    .eq("candidate_id", ct.candidate_id)
+    .eq("candidate_token_id", ct.id)
+    .order("created_at", { ascending: false });
+
+  return NextResponse.json({
+    token: ct.token,
+    status: ct.status,
+    step_key: ct.step_key,
+    candidate_name: ct.candidates?.full_name || "",
+    required_documents: requiredDocs.map((a: Record<string, unknown>) => {
+      const tmpl = a.document_templates as Record<string, unknown>;
+      const templateId = tmpl.id as string;
+      const uploadedDoc = (uploaded || []).find(
+        (u: Record<string, unknown>) => u.document_template_id === templateId
+      );
+      return {
+        assignment_id: a.id,
+        template_id: templateId,
+        name: tmpl.name,
+        file_name: tmpl.file_name,
+        file_path: tmpl.file_path,
+        required: a.required,
+        uploaded: !!uploadedDoc,
+        uploaded_doc: uploadedDoc || null,
+      };
+    }),
+    uploaded_documents: uploaded || [],
+    submitted: ct.status === "submitted",
+  });
+}

--- a/src/app/api/onboarding/candidate-portal/[token]/upload/route.ts
+++ b/src/app/api/onboarding/candidate-portal/[token]/upload/route.ts
@@ -1,0 +1,104 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { checkAndAdvanceCandidate } from "@/lib/candidateAdvancement";
+
+const ALLOWED_EXTENSIONS = [".pdf", ".doc", ".docx", ".jpg", ".jpeg", ".png", ".heic", ".heif", ".webp"];
+const MAX_SIZE = 10 * 1024 * 1024;
+
+export async function POST(req: NextRequest, { params }: { params: Promise<{ token: string }> }) {
+  const { token } = await params;
+
+  const { data: ct, error } = await supabaseAdmin
+    .from("candidate_tokens")
+    .select("*")
+    .eq("token", token)
+    .single();
+
+  if (error || !ct) {
+    return NextResponse.json({ error: "Invalid or expired link" }, { status: 404 });
+  }
+
+  if (ct.status === "expired" || ct.status === "submitted") {
+    return NextResponse.json({ error: "This submission link is no longer active" }, { status: 410 });
+  }
+
+  if (ct.expires_at && new Date(ct.expires_at) < new Date()) {
+    await supabaseAdmin.from("candidate_tokens").update({ status: "expired" }).eq("id", ct.id);
+    return NextResponse.json({ error: "This link has expired" }, { status: 410 });
+  }
+
+  const formData = await req.formData();
+  const file = formData.get("file") as File | null;
+  const documentTemplateId = formData.get("document_template_id") as string | null;
+
+  if (!file) return NextResponse.json({ error: "File is required" }, { status: 400 });
+  if (!documentTemplateId) return NextResponse.json({ error: "document_template_id is required" }, { status: 400 });
+  if (file.size > MAX_SIZE) return NextResponse.json({ error: "File too large (max 10MB)" }, { status: 400 });
+
+  const ext = file.name.toLowerCase().split(".").pop();
+  if (!ext || !ALLOWED_EXTENSIONS.some((e) => e === `.${ext}`)) {
+    return NextResponse.json({ error: `File type .${ext} not allowed` }, { status: 400 });
+  }
+
+  const timestamp = Date.now();
+  const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, "_");
+  const filePath = `candidates/${ct.candidate_id}/${ct.step_key}/${timestamp}_${safeName}`;
+
+  const buffer = Buffer.from(await file.arrayBuffer());
+  const contentType = file.type || "application/octet-stream";
+  const { error: uploadErr } = await supabaseAdmin.storage
+    .from("sales-documents")
+    .upload(filePath, buffer, { contentType, upsert: false });
+
+  if (uploadErr) {
+    return NextResponse.json({ error: `Upload failed: ${uploadErr.message}` }, { status: 500 });
+  }
+
+  const { data: urlData } = supabaseAdmin.storage.from("sales-documents").getPublicUrl(filePath);
+
+  // Remove any previous upload for this template (replace, don't duplicate)
+  await supabaseAdmin
+    .from("candidate_documents")
+    .delete()
+    .eq("candidate_id", ct.candidate_id)
+    .eq("candidate_token_id", ct.id)
+    .eq("document_template_id", documentTemplateId);
+
+  const { data: doc, error: insertErr } = await supabaseAdmin
+    .from("candidate_documents")
+    .insert({
+      candidate_id: ct.candidate_id,
+      step_key: ct.step_key,
+      file_name: file.name,
+      file_type: contentType,
+      file_url: urlData.publicUrl || filePath,
+      document_template_id: documentTemplateId,
+      candidate_token_id: ct.id,
+      completed: true,
+    })
+    .select("*")
+    .single();
+
+  if (insertErr) return NextResponse.json({ error: insertErr.message }, { status: 500 });
+
+  // Update submitted count on token
+  const { data: uploadedCount } = await supabaseAdmin
+    .from("candidate_documents")
+    .select("id", { count: "exact" })
+    .eq("candidate_token_id", ct.id);
+
+  await supabaseAdmin
+    .from("candidate_tokens")
+    .update({ submitted_doc_count: uploadedCount?.length || 0 })
+    .eq("id", ct.id);
+
+  // Check if all required docs are now uploaded — if so, auto-advance
+  const advanceResult = await checkAndAdvanceCandidate(ct.id);
+
+  return NextResponse.json({
+    document: doc,
+    all_complete: advanceResult.allComplete,
+    advanced: advanceResult.advanced,
+    new_status: advanceResult.newStatus,
+  }, { status: 201 });
+}

--- a/src/app/api/onboarding/candidates/[id]/approve/route.ts
+++ b/src/app/api/onboarding/candidates/[id]/approve/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { getSalesUser, isElevatedRole } from "@/lib/salesAuth";
+import { sendOnboardingDocsEmail } from "@/lib/onboardingPipelineEmail";
 
 export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const user = await getSalesUser(req);
@@ -11,7 +12,7 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
 
   const { data: candidate, error: cErr } = await supabaseAdmin
     .from("candidates")
-    .select("*, onboarding_steps(id, step_key, order_index)")
+    .select("*, onboarding_pipelines(id, role_type), onboarding_steps(id, step_key, order_index)")
     .eq("id", id)
     .single();
 
@@ -36,7 +37,59 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
       })
       .eq("id", id);
 
-    return NextResponse.json({ success: true, new_status: "welcome_docs_sent" });
+    // Auto-send welcome docs with portal link if candidate has email
+    let portalUrl: string | null = null;
+    if (candidate.email) {
+      try {
+        const nextStepKey = "welcome_docs";
+        const { data: assignments } = await supabaseAdmin
+          .from("step_document_assignments")
+          .select("id, required, document_templates(id, active)")
+          .eq("pipeline_id", candidate.current_pipeline_id)
+          .eq("step_key", nextStepKey);
+
+        const requiredCount = (assignments || []).filter(
+          (a: Record<string, unknown>) => {
+            const tmpl = a.document_templates as Record<string, unknown> | null;
+            return a.required && tmpl && tmpl.active;
+          }
+        ).length;
+
+        if ((assignments || []).length > 0) {
+          const { data: tokenRecord } = await supabaseAdmin
+            .from("candidate_tokens")
+            .insert({
+              candidate_id: id,
+              step_key: nextStepKey,
+              pipeline_id: candidate.current_pipeline_id,
+              required_doc_count: requiredCount,
+            })
+            .select("token")
+            .single();
+
+          if (tokenRecord) {
+            const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || (process.env.VERCEL_URL
+              ? `https://${process.env.VERCEL_URL}`
+              : "http://localhost:3000");
+            portalUrl = `${baseUrl}/onboarding/${tokenRecord.token}`;
+          }
+
+          await sendOnboardingDocsEmail({
+            candidateId: id,
+            candidateEmail: candidate.email,
+            candidateName: candidate.full_name,
+            stepKey: nextStepKey,
+            pipelineId: candidate.current_pipeline_id,
+            roleType: candidate.onboarding_pipelines?.role_type || candidate.role_type,
+            portalUrl,
+          });
+        }
+      } catch {
+        // Don't block approval if email fails
+      }
+    }
+
+    return NextResponse.json({ success: true, new_status: "welcome_docs_sent", portal_url: portalUrl });
   }
 
   if (currentStatus === "pending_admin_review_2") {

--- a/src/app/api/onboarding/candidates/[id]/send-docs/route.ts
+++ b/src/app/api/onboarding/candidates/[id]/send-docs/route.ts
@@ -40,6 +40,40 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
   }
 
   try {
+    // Count required documents for this step
+    const { data: assignments } = await supabaseAdmin
+      .from("step_document_assignments")
+      .select("id, required, document_templates(id, active)")
+      .eq("pipeline_id", candidate.current_pipeline_id)
+      .eq("step_key", stepKey);
+
+    const requiredCount = (assignments || []).filter(
+      (a: Record<string, unknown>) => {
+        const tmpl = a.document_templates as Record<string, unknown> | null;
+        return a.required && tmpl && tmpl.active;
+      }
+    ).length;
+
+    // Create a candidate token for the submission portal
+    const { data: tokenRecord } = await supabaseAdmin
+      .from("candidate_tokens")
+      .insert({
+        candidate_id: id,
+        step_key: stepKey,
+        pipeline_id: candidate.current_pipeline_id,
+        required_doc_count: requiredCount,
+      })
+      .select("token")
+      .single();
+
+    let portalUrl: string | null = null;
+    if (tokenRecord) {
+      const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || (process.env.VERCEL_URL
+        ? `https://${process.env.VERCEL_URL}`
+        : "http://localhost:3000");
+      portalUrl = `${baseUrl}/onboarding/${tokenRecord.token}`;
+    }
+
     const result = await sendOnboardingDocsEmail({
       candidateId: id,
       candidateEmail: candidate.email,
@@ -47,6 +81,7 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
       stepKey,
       pipelineId: candidate.current_pipeline_id,
       roleType: candidate.onboarding_pipelines?.role_type || candidate.role_type,
+      portalUrl,
     });
 
     const nextStatus = stepKey === "interview" ? "pending_admin_review_1" : "pending_admin_review_2";
@@ -55,7 +90,7 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
       .update({ status: nextStatus, updated_at: new Date().toISOString() })
       .eq("id", id);
 
-    return NextResponse.json({ ...result, new_status: nextStatus });
+    return NextResponse.json({ ...result, new_status: nextStatus, portal_url: portalUrl });
   } catch (err) {
     const message = err instanceof Error ? err.message : "Email send failed";
     return NextResponse.json({ error: message }, { status: 500 });

--- a/src/app/onboarding/[token]/page.tsx
+++ b/src/app/onboarding/[token]/page.tsx
@@ -1,0 +1,296 @@
+"use client";
+
+import { useState, useEffect, useCallback, Suspense } from "react";
+import { useParams } from "next/navigation";
+import { Loader2, CheckCircle2, FileText, Upload, Download, AlertCircle } from "lucide-react";
+
+interface RequiredDoc {
+  assignment_id: string;
+  template_id: string;
+  name: string;
+  file_name: string;
+  file_path: string;
+  required: boolean;
+  uploaded: boolean;
+  uploaded_doc: {
+    id: string;
+    file_name: string;
+    file_url: string;
+    created_at: string;
+  } | null;
+}
+
+interface PortalData {
+  token: string;
+  status: string;
+  step_key: string;
+  candidate_name: string;
+  required_documents: RequiredDoc[];
+  submitted: boolean;
+}
+
+const STEP_TITLES: Record<string, string> = {
+  interview: "Interview Documents",
+  welcome_docs: "Welcome & Onboarding Documents",
+};
+
+const STEP_DESCRIPTIONS: Record<string, string> = {
+  interview: "Please review, complete, and upload the following documents to proceed with your interview process.",
+  welcome_docs: "Congratulations on moving forward! Please complete and upload these documents to finalize your onboarding.",
+};
+
+function PortalContent() {
+  const { token } = useParams<{ token: string }>();
+  const [data, setData] = useState<PortalData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [uploading, setUploading] = useState<string | null>(null);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    const res = await fetch(`/api/onboarding/candidate-portal/${token}`);
+    if (res.ok) {
+      setData(await res.json());
+    } else {
+      const err = await res.json().catch(() => ({}));
+      setError(err.error || "Portal not found");
+    }
+    setLoading(false);
+  }, [token]);
+
+  useEffect(() => { load(); }, [load]);
+
+  async function handleUpload(templateId: string, file: File) {
+    setUploading(templateId);
+    setUploadError(null);
+
+    const formData = new FormData();
+    formData.append("file", file);
+    formData.append("document_template_id", templateId);
+
+    try {
+      const res = await fetch(`/api/onboarding/candidate-portal/${token}/upload`, {
+        method: "POST",
+        body: formData,
+      });
+
+      if (res.ok) {
+        const result = await res.json();
+        if (result.advanced) {
+          setData((prev) => prev ? { ...prev, submitted: true } : prev);
+        }
+        await load();
+      } else {
+        const err = await res.json().catch(() => ({}));
+        setUploadError(err.error || "Upload failed");
+      }
+    } catch {
+      setUploadError("Network error — please try again");
+    } finally {
+      setUploading(null);
+    }
+  }
+
+  function handleFileSelect(templateId: string) {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.accept = ".pdf,.doc,.docx,.jpg,.jpeg,.png,.heic,.heif,.webp";
+    input.onchange = (e) => {
+      const file = (e.target as HTMLInputElement).files?.[0];
+      if (file) handleUpload(templateId, file);
+    };
+    input.click();
+  }
+
+  async function handleDownloadTemplate(filePath: string, fileName: string) {
+    const res = await fetch(`/api/onboarding/candidate-portal/${token}/download?file_path=${encodeURIComponent(filePath)}`);
+    if (res.ok) {
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = fileName;
+      a.click();
+      URL.revokeObjectURL(url);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <Loader2 className="h-8 w-8 animate-spin text-green-600" />
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+        <div className="text-center">
+          <FileText className="mx-auto h-12 w-12 text-gray-300 mb-4" />
+          <h1 className="text-lg font-semibold text-gray-900 mb-2">Link Not Found</h1>
+          <p className="text-sm text-gray-500">{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (data.submitted) {
+    return (
+      <div className="min-h-screen bg-gray-50 py-8 px-4">
+        <div className="mx-auto max-w-2xl text-center">
+          <div className="mb-6">
+            <h1 className="text-2xl font-bold text-green-600 mb-1">Vending Connector</h1>
+            <p className="text-sm text-gray-500">Onboarding Portal</p>
+          </div>
+          <div className="rounded-2xl border border-green-200 bg-green-50 p-8">
+            <CheckCircle2 className="mx-auto h-12 w-12 text-green-600 mb-4" />
+            <h2 className="text-xl font-bold text-gray-900 mb-2">All Documents Submitted</h2>
+            <p className="text-sm text-gray-600">
+              Thank you, {data.candidate_name}! All required documents have been received.
+              {data.step_key === "interview"
+                ? " You'll receive your next set of onboarding documents shortly."
+                : " Your onboarding is now complete."}
+            </p>
+          </div>
+          <p className="mt-8 text-xs text-gray-400">Vending Connector — vendingconnector.com</p>
+        </div>
+      </div>
+    );
+  }
+
+  const allUploaded = data.required_documents.filter((d) => d.required).every((d) => d.uploaded);
+  const uploadedCount = data.required_documents.filter((d) => d.uploaded).length;
+  const totalCount = data.required_documents.length;
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-8 px-4">
+      <div className="mx-auto max-w-2xl">
+        <div className="mb-6 text-center">
+          <h1 className="text-2xl font-bold text-green-600 mb-1">Vending Connector</h1>
+          <p className="text-sm text-gray-500">Onboarding Portal</p>
+        </div>
+
+        <div className="rounded-2xl border border-gray-200 bg-white shadow-sm overflow-hidden">
+          {/* Header */}
+          <div className="px-6 py-5 border-b border-gray-100">
+            <p className="text-xs font-medium text-gray-400 uppercase tracking-wider mb-1">Welcome</p>
+            <p className="text-lg font-bold text-gray-900">{data.candidate_name}</p>
+          </div>
+
+          {/* Step Info */}
+          <div className="px-6 py-5 border-b border-gray-100">
+            <h2 className="text-base font-semibold text-gray-900 mb-1">
+              {STEP_TITLES[data.step_key] || data.step_key}
+            </h2>
+            <p className="text-sm text-gray-500">
+              {STEP_DESCRIPTIONS[data.step_key] || "Please complete the following documents."}
+            </p>
+          </div>
+
+          {/* Progress */}
+          <div className="px-6 py-4 border-b border-gray-100 bg-gray-50/50">
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-xs font-medium text-gray-500">Progress</span>
+              <span className="text-xs font-medium text-gray-700">{uploadedCount} of {totalCount} uploaded</span>
+            </div>
+            <div className="h-2 w-full rounded-full bg-gray-200">
+              <div
+                className="h-2 rounded-full bg-green-500 transition-all"
+                style={{ width: totalCount > 0 ? `${(uploadedCount / totalCount) * 100}%` : "0%" }}
+              />
+            </div>
+          </div>
+
+          {uploadError && (
+            <div className="mx-6 mt-4 rounded-lg border border-red-200 bg-red-50 px-4 py-2 text-sm text-red-600 flex items-center gap-2">
+              <AlertCircle className="h-4 w-4 flex-shrink-0" />
+              {uploadError}
+            </div>
+          )}
+
+          {/* Document List */}
+          <div className="divide-y divide-gray-100">
+            {data.required_documents.map((doc) => (
+              <div key={doc.template_id} className="px-6 py-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      {doc.uploaded ? (
+                        <CheckCircle2 className="h-4 w-4 text-green-600 flex-shrink-0" />
+                      ) : (
+                        <FileText className="h-4 w-4 text-gray-400 flex-shrink-0" />
+                      )}
+                      <p className="text-sm font-medium text-gray-900">{doc.name}</p>
+                      {doc.required && !doc.uploaded && (
+                        <span className="rounded-full bg-amber-50 px-2 py-0.5 text-[10px] font-medium text-amber-700">Required</span>
+                      )}
+                    </div>
+                    {doc.uploaded && doc.uploaded_doc && (
+                      <p className="mt-1 ml-6 text-xs text-green-600">
+                        Uploaded: {doc.uploaded_doc.file_name}
+                      </p>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2 flex-shrink-0">
+                    <button
+                      onClick={() => handleDownloadTemplate(doc.file_path, doc.file_name)}
+                      className="flex items-center gap-1 rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-50 cursor-pointer"
+                    >
+                      <Download className="h-3 w-3" />
+                      Template
+                    </button>
+                    <button
+                      onClick={() => handleFileSelect(doc.template_id)}
+                      disabled={uploading === doc.template_id}
+                      className={`flex items-center gap-1 rounded-lg px-3 py-1.5 text-xs font-medium cursor-pointer ${
+                        doc.uploaded
+                          ? "border border-green-200 text-green-700 hover:bg-green-50"
+                          : "bg-green-600 text-white hover:bg-green-700"
+                      } disabled:opacity-50`}
+                    >
+                      {uploading === doc.template_id ? (
+                        <Loader2 className="h-3 w-3 animate-spin" />
+                      ) : (
+                        <Upload className="h-3 w-3" />
+                      )}
+                      {doc.uploaded ? "Replace" : "Upload"}
+                    </button>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Completion Banner */}
+          {allUploaded && (
+            <div className="px-6 py-5 bg-green-50 border-t border-green-200">
+              <div className="flex items-center gap-2 justify-center">
+                <CheckCircle2 className="h-5 w-5 text-green-600" />
+                <p className="text-sm font-medium text-green-800">
+                  All documents submitted — your application is moving forward!
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+
+        <div className="mt-8 text-center">
+          <p className="text-xs text-gray-400">Vending Connector — vendingconnector.com</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function OnboardingPortalPage() {
+  return (
+    <Suspense fallback={
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <Loader2 className="h-8 w-8 animate-spin text-green-600" />
+      </div>
+    }>
+      <PortalContent />
+    </Suspense>
+  );
+}

--- a/src/lib/candidateAdvancement.ts
+++ b/src/lib/candidateAdvancement.ts
@@ -1,0 +1,181 @@
+import { supabaseAdmin } from "./supabaseAdmin";
+import { sendOnboardingDocsEmail } from "./onboardingPipelineEmail";
+
+interface AdvanceResult {
+  allComplete: boolean;
+  advanced: boolean;
+  newStatus: string | null;
+  nextTokenUrl: string | null;
+}
+
+/**
+ * Check if all required documents for a candidate token have been submitted.
+ * If yes, auto-advance the candidate to the next step and send the next batch of docs.
+ */
+export async function checkAndAdvanceCandidate(tokenId: string): Promise<AdvanceResult> {
+  const { data: ct } = await supabaseAdmin
+    .from("candidate_tokens")
+    .select("*, candidates(id, full_name, email, role_type, status, current_pipeline_id, current_step_id)")
+    .eq("id", tokenId)
+    .single();
+
+  if (!ct || !ct.candidates) {
+    return { allComplete: false, advanced: false, newStatus: null, nextTokenUrl: null };
+  }
+
+  const candidate = ct.candidates as {
+    id: string;
+    full_name: string;
+    email: string;
+    role_type: string;
+    status: string;
+    current_pipeline_id: string;
+    current_step_id: string;
+  };
+
+  // Get required document assignments for this step
+  const { data: assignments } = await supabaseAdmin
+    .from("step_document_assignments")
+    .select("*, document_templates(id, active)")
+    .eq("pipeline_id", ct.pipeline_id)
+    .eq("step_key", ct.step_key);
+
+  const requiredTemplateIds = (assignments || [])
+    .filter((a: Record<string, unknown>) => {
+      const tmpl = a.document_templates as Record<string, unknown> | null;
+      return a.required && tmpl && tmpl.active;
+    })
+    .map((a: Record<string, unknown>) => (a.document_templates as Record<string, unknown>).id as string);
+
+  // Get uploaded docs for this token
+  const { data: uploaded } = await supabaseAdmin
+    .from("candidate_documents")
+    .select("document_template_id")
+    .eq("candidate_token_id", ct.id)
+    .eq("completed", true);
+
+  const uploadedTemplateIds = new Set((uploaded || []).map((u: Record<string, unknown>) => u.document_template_id));
+  const allComplete = requiredTemplateIds.every((id: string) => uploadedTemplateIds.has(id));
+
+  if (!allComplete) {
+    return { allComplete: false, advanced: false, newStatus: null, nextTokenUrl: null };
+  }
+
+  // Mark token as submitted
+  await supabaseAdmin
+    .from("candidate_tokens")
+    .update({
+      status: "submitted",
+      submitted_at: new Date().toISOString(),
+      submitted_doc_count: uploadedTemplateIds.size,
+    })
+    .eq("id", ct.id);
+
+  // Determine next status based on current step
+  const stepKey = ct.step_key;
+  let newStatus: string;
+  let nextStepKey: string | null = null;
+
+  if (stepKey === "interview") {
+    // All interview docs submitted → move to welcome_docs
+    newStatus = "welcome_docs_sent";
+    nextStepKey = "welcome_docs";
+  } else if (stepKey === "welcome_docs") {
+    // All welcome docs submitted → completed
+    newStatus = "completed";
+    nextStepKey = null;
+  } else {
+    return { allComplete: true, advanced: false, newStatus: null, nextTokenUrl: null };
+  }
+
+  // Get next step ID
+  let nextStepId = candidate.current_step_id;
+  const targetStepKey = newStatus === "completed" ? "completion" : nextStepKey;
+  if (targetStepKey) {
+    const { data: nextStep } = await supabaseAdmin
+      .from("onboarding_steps")
+      .select("id")
+      .eq("pipeline_id", candidate.current_pipeline_id)
+      .eq("step_key", targetStepKey)
+      .single();
+
+    if (nextStep) nextStepId = nextStep.id;
+  }
+
+  // Advance the candidate
+  const updateFields: Record<string, unknown> = {
+    status: newStatus,
+    current_step_id: nextStepId,
+    updated_at: new Date().toISOString(),
+  };
+  if (newStatus === "completed") {
+    updateFields.onboarding_completed_at = new Date().toISOString();
+  }
+
+  await supabaseAdmin
+    .from("candidates")
+    .update(updateFields)
+    .eq("id", candidate.id);
+
+  let nextTokenUrl: string | null = null;
+
+  // If there's a next step with documents, auto-send them
+  if (nextStepKey && candidate.email) {
+    try {
+      // Check if next step has document assignments
+      const { data: nextAssignments } = await supabaseAdmin
+        .from("step_document_assignments")
+        .select("id, document_templates(active)")
+        .eq("pipeline_id", candidate.current_pipeline_id)
+        .eq("step_key", nextStepKey);
+
+      const hasNextDocs = (nextAssignments || []).some(
+        (a: Record<string, unknown>) => {
+          const tmpl = a.document_templates as Record<string, unknown> | null;
+          return tmpl && tmpl.active;
+        }
+      );
+
+      if (hasNextDocs) {
+        // Create a new token for the next step
+        const { data: nextToken } = await supabaseAdmin
+          .from("candidate_tokens")
+          .insert({
+            candidate_id: candidate.id,
+            step_key: nextStepKey,
+            pipeline_id: candidate.current_pipeline_id,
+            required_doc_count: (nextAssignments || []).filter(
+              (a: Record<string, unknown>) => {
+                const tmpl = a.document_templates as Record<string, unknown> | null;
+                return a.required && tmpl && tmpl.active;
+              }
+            ).length,
+          })
+          .select("token")
+          .single();
+
+        if (nextToken) {
+          const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || process.env.VERCEL_URL
+            ? `https://${process.env.VERCEL_URL}`
+            : "http://localhost:3000";
+          nextTokenUrl = `${baseUrl}/onboarding/${nextToken.token}`;
+        }
+
+        // Send next round of docs with the portal link
+        await sendOnboardingDocsEmail({
+          candidateId: candidate.id,
+          candidateEmail: candidate.email,
+          candidateName: candidate.full_name,
+          stepKey: nextStepKey,
+          pipelineId: candidate.current_pipeline_id,
+          roleType: candidate.role_type,
+          portalUrl: nextTokenUrl,
+        });
+      }
+    } catch {
+      // Email send failure shouldn't block advancement
+    }
+  }
+
+  return { allComplete: true, advanced: true, newStatus, nextTokenUrl };
+}

--- a/src/lib/onboardingPipelineEmail.ts
+++ b/src/lib/onboardingPipelineEmail.ts
@@ -14,6 +14,7 @@ interface SendDocsParams {
   stepKey: string;
   pipelineId: string;
   roleType: string;
+  portalUrl?: string | null;
 }
 
 export async function sendOnboardingDocsEmail(params: SendDocsParams) {
@@ -77,8 +78,17 @@ export async function sendOnboardingDocsEmail(params: SendDocsParams) {
     .maybeSingle();
 
   const subject = emailTemplate?.subject || `Onboarding Documents — ${stepKey}`;
-  const bodyHtml = (emailTemplate?.body_html || "<p>Please find your documents attached.</p>")
+  let bodyHtml = (emailTemplate?.body_html || "<p>Please find your documents attached.</p>")
     .replace(/\{\{candidate_name\}\}/g, candidateName);
+
+  if (params.portalUrl) {
+    bodyHtml += `
+      <div style="margin-top:24px;padding:20px;background:#f0fdf4;border:1px solid #bbf7d0;border-radius:12px;text-align:center;">
+        <p style="color:#374151;font-size:14px;margin:0 0 12px;">Upload your completed documents here:</p>
+        <a href="${params.portalUrl}" style="display:inline-block;background:#16a34a;color:#ffffff;padding:12px 28px;border-radius:8px;text-decoration:none;font-weight:600;font-size:14px;">Upload Documents</a>
+        <p style="color:#6b7280;font-size:12px;margin:12px 0 0;">Or copy this link: ${params.portalUrl}</p>
+      </div>`;
+  }
 
   try {
     const { error: sendError } = await getResend().emails.send({

--- a/supabase/migrations/050_candidate_tokens.sql
+++ b/supabase/migrations/050_candidate_tokens.sql
@@ -1,0 +1,51 @@
+-- Migration 050: Candidate submission portal
+-- Mirrors agreement_tokens pattern for onboarding: token-based document submission portal
+-- that auto-advances candidates when all required docs are uploaded.
+
+-- ============================================================
+-- 1. CANDIDATE TOKENS — unique links for candidates to submit docs
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.candidate_tokens (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  token TEXT NOT NULL UNIQUE DEFAULT encode(gen_random_bytes(32), 'hex'),
+  candidate_id UUID NOT NULL REFERENCES public.candidates(id) ON DELETE CASCADE,
+  step_key TEXT NOT NULL,
+  pipeline_id UUID NOT NULL,
+
+  -- Status: pending → viewed → submitted
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'viewed', 'submitted', 'expired')),
+
+  -- Track which required docs have been uploaded
+  required_doc_count INT NOT NULL DEFAULT 0,
+  submitted_doc_count INT NOT NULL DEFAULT 0,
+
+  viewed_at TIMESTAMPTZ,
+  submitted_at TIMESTAMPTZ,
+  expires_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_candidate_tokens_token ON public.candidate_tokens(token);
+CREATE INDEX IF NOT EXISTS idx_candidate_tokens_candidate ON public.candidate_tokens(candidate_id);
+CREATE INDEX IF NOT EXISTS idx_candidate_tokens_status ON public.candidate_tokens(status);
+
+-- ============================================================
+-- 2. ADD document_template_id + completed TO candidate_documents
+-- Links each uploaded doc back to the template it fulfills
+-- ============================================================
+ALTER TABLE public.candidate_documents
+  ADD COLUMN IF NOT EXISTS document_template_id UUID REFERENCES public.document_templates(id),
+  ADD COLUMN IF NOT EXISTS candidate_token_id UUID REFERENCES public.candidate_tokens(id),
+  ADD COLUMN IF NOT EXISTS completed BOOLEAN NOT NULL DEFAULT false;
+
+CREATE INDEX IF NOT EXISTS idx_candidate_docs_template ON public.candidate_documents(candidate_id, document_template_id);
+
+-- ============================================================
+-- 3. RLS policies for service_role access
+-- ============================================================
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE policyname = 'service_role_candidate_tokens') THEN
+    ALTER TABLE public.candidate_tokens ENABLE ROW LEVEL SECURITY;
+    CREATE POLICY service_role_candidate_tokens ON public.candidate_tokens FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
+END $$;


### PR DESCRIPTION
Mirrors the agreement token pattern for onboarding: when admin sends docs, a unique token link is generated and included in the email. Candidates click the link to view required documents, download blank templates, and upload completed versions. When all required docs are submitted, the system auto-advances the candidate to the next step and sends the next batch of documents automatically.

- Migration 050: candidate_tokens table, candidate_documents.completed flag and document_template_id linking
- Candidate portal API: token-based view, upload, template download
- Candidate portal frontend: /onboarding/[token] public page
- Auto-advancement logic in candidateAdvancement.ts
- Updated send-docs to create tokens and include portal URL in emails
- Updated approve route to auto-send next docs with portal link
- Updated email template to include "Upload Documents" button

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2