### PR TITLE
Add inline fillable form templates for onboarding documents

### DIFF
--- a/src/app/api/onboarding/candidate-portal/[token]/route.ts
+++ b/src/app/api/onboarding/candidate-portal/[token]/route.ts
@@ -32,7 +32,7 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ tok
 
   const { data: assignments } = await supabaseAdmin
     .from("step_document_assignments")
-    .select("*, document_templates(id, name, file_name, file_path, mime_type, active)")
+    .select("*, document_templates(id, name, file_name, file_path, mime_type, active, form_enabled, form_fields, description)")
     .eq("pipeline_id", ct.pipeline_id)
     .eq("step_key", ct.step_key)
     .order("order_index");
@@ -46,16 +46,19 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ tok
 
   const { data: uploaded } = await supabaseAdmin
     .from("candidate_documents")
-    .select("id, file_name, file_url, file_type, document_template_id, completed, created_at")
+    .select("id, file_name, file_url, file_type, document_template_id, completed, form_data, created_at")
     .eq("candidate_id", ct.candidate_id)
     .eq("candidate_token_id", ct.id)
     .order("created_at", { ascending: false });
+
+  const candidate = ct.candidates as Record<string, unknown> | null;
 
   return NextResponse.json({
     token: ct.token,
     status: ct.status,
     step_key: ct.step_key,
-    candidate_name: ct.candidates?.full_name || "",
+    candidate_name: candidate?.full_name || "",
+    candidate_email: candidate?.email || "",
     required_documents: requiredDocs.map((a: Record<string, unknown>) => {
       const tmpl = a.document_templates as Record<string, unknown>;
       const templateId = tmpl.id as string;
@@ -66,9 +69,12 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ tok
         assignment_id: a.id,
         template_id: templateId,
         name: tmpl.name,
+        description: tmpl.description || null,
         file_name: tmpl.file_name,
         file_path: tmpl.file_path,
         required: a.required,
+        form_enabled: tmpl.form_enabled || false,
+        form_fields: tmpl.form_fields || null,
         uploaded: !!uploadedDoc,
         uploaded_doc: uploadedDoc || null,
       };

--- a/src/app/api/onboarding/candidate-portal/[token]/submit-form/route.ts
+++ b/src/app/api/onboarding/candidate-portal/[token]/submit-form/route.ts
@@ -1,0 +1,116 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { checkAndAdvanceCandidate } from "@/lib/candidateAdvancement";
+
+interface FormField {
+  key: string;
+  label: string;
+  type: string;
+  required: boolean;
+  options?: string[];
+}
+
+export async function POST(req: NextRequest, { params }: { params: Promise<{ token: string }> }) {
+  const { token } = await params;
+
+  const { data: ct, error } = await supabaseAdmin
+    .from("candidate_tokens")
+    .select("*")
+    .eq("token", token)
+    .single();
+
+  if (error || !ct) {
+    return NextResponse.json({ error: "Invalid or expired link" }, { status: 404 });
+  }
+
+  if (ct.status === "expired" || ct.status === "submitted") {
+    return NextResponse.json({ error: "This submission link is no longer active" }, { status: 410 });
+  }
+
+  const body = await req.json();
+  const { document_template_id, form_data } = body;
+
+  if (!document_template_id) {
+    return NextResponse.json({ error: "document_template_id is required" }, { status: 400 });
+  }
+  if (!form_data || typeof form_data !== "object") {
+    return NextResponse.json({ error: "form_data is required" }, { status: 400 });
+  }
+
+  // Fetch the template to validate fields
+  const { data: template } = await supabaseAdmin
+    .from("document_templates")
+    .select("id, name, form_fields, form_enabled")
+    .eq("id", document_template_id)
+    .single();
+
+  if (!template || !template.form_enabled) {
+    return NextResponse.json({ error: "This document does not support form submission" }, { status: 400 });
+  }
+
+  // Validate required fields
+  const fields = (template.form_fields || []) as FormField[];
+  const missing: string[] = [];
+  for (const field of fields) {
+    if (field.required) {
+      const val = form_data[field.key];
+      if (val === undefined || val === null || val === "" || val === false) {
+        missing.push(field.label);
+      }
+    }
+  }
+
+  if (missing.length > 0) {
+    return NextResponse.json({
+      error: `Required fields missing: ${missing.join(", ")}`,
+    }, { status: 400 });
+  }
+
+  // Remove any previous submission for this template
+  await supabaseAdmin
+    .from("candidate_documents")
+    .delete()
+    .eq("candidate_id", ct.candidate_id)
+    .eq("candidate_token_id", ct.id)
+    .eq("document_template_id", document_template_id);
+
+  const { data: doc, error: insertErr } = await supabaseAdmin
+    .from("candidate_documents")
+    .insert({
+      candidate_id: ct.candidate_id,
+      step_key: ct.step_key,
+      file_name: `${template.name} — Completed Form`,
+      file_type: "application/json",
+      file_url: "",
+      document_template_id,
+      candidate_token_id: ct.id,
+      completed: true,
+      form_data,
+    })
+    .select("*")
+    .single();
+
+  if (insertErr) return NextResponse.json({ error: insertErr.message }, { status: 500 });
+
+  // Update submitted count on token
+  const { data: uploadedCount } = await supabaseAdmin
+    .from("candidate_documents")
+    .select("id", { count: "exact" })
+    .eq("candidate_token_id", ct.id)
+    .eq("completed", true);
+
+  await supabaseAdmin
+    .from("candidate_tokens")
+    .update({ submitted_doc_count: uploadedCount?.length || 0 })
+    .eq("id", ct.id);
+
+  // Check if all required docs are now complete — auto-advance if so
+  const advanceResult = await checkAndAdvanceCandidate(ct.id);
+
+  return NextResponse.json({
+    document: doc,
+    all_complete: advanceResult.allComplete,
+    advanced: advanceResult.advanced,
+    new_status: advanceResult.newStatus,
+  }, { status: 201 });
+}

--- a/src/app/onboarding/[token]/page.tsx
+++ b/src/app/onboarding/[token]/page.tsx
@@ -3,19 +3,24 @@
 import { useState, useEffect, useCallback, useRef, Suspense } from "react";
 import { useParams } from "next/navigation";
 import { Loader2, CheckCircle2, FileText, Upload, Download, AlertCircle } from "lucide-react";
+import FormRenderer, { FormField } from "@/components/onboarding/FormRenderer";
 
 interface RequiredDoc {
   assignment_id: string;
   template_id: string;
   name: string;
+  description: string | null;
   file_name: string;
   file_path: string;
   required: boolean;
+  form_enabled: boolean;
+  form_fields: FormField[] | null;
   uploaded: boolean;
   uploaded_doc: {
     id: string;
     file_name: string;
     file_url: string;
+    form_data: Record<string, unknown> | null;
     created_at: string;
   } | null;
 }
@@ -25,6 +30,7 @@ interface PortalData {
   status: string;
   step_key: string;
   candidate_name: string;
+  candidate_email: string;
   required_documents: RequiredDoc[];
   submitted: boolean;
 }
@@ -35,8 +41,8 @@ const STEP_TITLES: Record<string, string> = {
 };
 
 const STEP_DESCRIPTIONS: Record<string, string> = {
-  interview: "Please review, complete, and upload the following documents to proceed with your interview process.",
-  welcome_docs: "Congratulations on moving forward! Please complete and upload these documents to finalize your onboarding.",
+  interview: "Please review and complete each of the following documents to proceed with your interview process.",
+  welcome_docs: "Congratulations on moving forward! Please complete these documents to finalize your onboarding.",
 };
 
 function PortalContent() {
@@ -123,6 +129,14 @@ function PortalContent() {
     }
   }
 
+  function handleFormComplete(advanced: boolean) {
+    if (advanced) {
+      setData((prev) => prev ? { ...prev, submitted: true } : prev);
+    } else {
+      load();
+    }
+  }
+
   if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-gray-50">
@@ -167,9 +181,13 @@ function PortalContent() {
     );
   }
 
-  const allUploaded = data.required_documents.filter((d) => d.required).every((d) => d.uploaded);
-  const uploadedCount = data.required_documents.filter((d) => d.uploaded).length;
+  const completedCount = data.required_documents.filter((d) => d.uploaded).length;
   const totalCount = data.required_documents.length;
+  const allComplete = data.required_documents.filter((d) => d.required).every((d) => d.uploaded);
+
+  // Split docs into form-based and file-upload-based
+  const formDocs = data.required_documents.filter((d) => d.form_enabled && d.form_fields);
+  const uploadDocs = data.required_documents.filter((d) => !d.form_enabled || !d.form_fields);
 
   return (
     <div className="min-h-screen bg-gray-50 py-8 px-4">
@@ -186,14 +204,13 @@ function PortalContent() {
           <p className="text-sm text-gray-500">Onboarding Portal</p>
         </div>
 
-        <div className="rounded-2xl border border-gray-200 bg-white shadow-sm overflow-hidden">
-          {/* Header */}
+        {/* Welcome Card */}
+        <div className="rounded-2xl border border-gray-200 bg-white shadow-sm overflow-hidden mb-6">
           <div className="px-6 py-5 border-b border-gray-100">
             <p className="text-xs font-medium text-gray-400 uppercase tracking-wider mb-1">Welcome</p>
             <p className="text-lg font-bold text-gray-900">{data.candidate_name}</p>
           </div>
 
-          {/* Step Info */}
           <div className="px-6 py-5 border-b border-gray-100">
             <h2 className="text-base font-semibold text-gray-900 mb-1">
               {STEP_TITLES[data.step_key] || data.step_key}
@@ -204,93 +221,123 @@ function PortalContent() {
           </div>
 
           {/* Progress */}
-          <div className="px-6 py-4 border-b border-gray-100 bg-gray-50/50">
+          <div className="px-6 py-4 bg-gray-50/50">
             <div className="flex items-center justify-between mb-2">
               <span className="text-xs font-medium text-gray-500">Progress</span>
-              <span className="text-xs font-medium text-gray-700">{uploadedCount} of {totalCount} uploaded</span>
+              <span className="text-xs font-medium text-gray-700">{completedCount} of {totalCount} completed</span>
             </div>
             <div className="h-2 w-full rounded-full bg-gray-200">
               <div
                 className="h-2 rounded-full bg-green-500 transition-all"
-                style={{ width: totalCount > 0 ? `${(uploadedCount / totalCount) * 100}%` : "0%" }}
+                style={{ width: totalCount > 0 ? `${(completedCount / totalCount) * 100}%` : "0%" }}
               />
             </div>
           </div>
-
-          {uploadError && (
-            <div className="mx-6 mt-4 rounded-lg border border-red-200 bg-red-50 px-4 py-2 text-sm text-red-600 flex items-center gap-2">
-              <AlertCircle className="h-4 w-4 flex-shrink-0" />
-              {uploadError}
-            </div>
-          )}
-
-          {/* Document List */}
-          <div className="divide-y divide-gray-100">
-            {data.required_documents.map((doc) => (
-              <div key={doc.template_id} className="px-6 py-4">
-                <div className="flex items-start justify-between gap-3">
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2">
-                      {doc.uploaded ? (
-                        <CheckCircle2 className="h-4 w-4 text-green-600 flex-shrink-0" />
-                      ) : (
-                        <FileText className="h-4 w-4 text-gray-400 flex-shrink-0" />
-                      )}
-                      <p className="text-sm font-medium text-gray-900">{doc.name}</p>
-                      {doc.required && !doc.uploaded && (
-                        <span className="rounded-full bg-amber-50 px-2 py-0.5 text-[10px] font-medium text-amber-700">Required</span>
-                      )}
-                    </div>
-                    {doc.uploaded && doc.uploaded_doc && (
-                      <p className="mt-1 ml-6 text-xs text-green-600">
-                        Uploaded: {doc.uploaded_doc.file_name}
-                      </p>
-                    )}
-                  </div>
-                  <div className="flex items-center gap-2 flex-shrink-0">
-                    <button
-                      onClick={() => handleDownloadTemplate(doc.file_path, doc.file_name)}
-                      className="flex items-center gap-1 rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-50 cursor-pointer"
-                    >
-                      <Download className="h-3 w-3" />
-                      Template
-                    </button>
-                    <button
-                      onClick={() => handleFileSelect(doc.template_id)}
-                      disabled={uploading === doc.template_id}
-                      className={`flex items-center gap-1 rounded-lg px-3 py-1.5 text-xs font-medium cursor-pointer ${
-                        doc.uploaded
-                          ? "border border-green-200 text-green-700 hover:bg-green-50"
-                          : "bg-green-600 text-white hover:bg-green-700"
-                      } disabled:opacity-50`}
-                    >
-                      {uploading === doc.template_id ? (
-                        <Loader2 className="h-3 w-3 animate-spin" />
-                      ) : (
-                        <Upload className="h-3 w-3" />
-                      )}
-                      {doc.uploaded ? "Replace" : "Upload"}
-                    </button>
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-
-          {/* Completion Banner */}
-          {allUploaded && (
-            <div className="px-6 py-5 bg-green-50 border-t border-green-200">
-              <div className="flex items-center gap-2 justify-center">
-                <CheckCircle2 className="h-5 w-5 text-green-600" />
-                <p className="text-sm font-medium text-green-800">
-                  All documents submitted — your application is moving forward!
-                </p>
-              </div>
-            </div>
-          )}
         </div>
 
-        <div className="mt-8 text-center">
+        {/* Inline Forms */}
+        {formDocs.length > 0 && (
+          <div className="space-y-4 mb-6">
+            {formDocs.map((doc) => (
+              <FormRenderer
+                key={doc.template_id}
+                templateId={doc.template_id}
+                templateName={doc.name}
+                description={doc.description}
+                fields={doc.form_fields!}
+                token={token}
+                onComplete={handleFormComplete}
+                prefill={{
+                  full_name: data.candidate_name,
+                  email: data.candidate_email,
+                }}
+                alreadyCompleted={doc.uploaded}
+                existingData={doc.uploaded_doc?.form_data}
+              />
+            ))}
+          </div>
+        )}
+
+        {/* File Upload Section */}
+        {uploadDocs.length > 0 && (
+          <div className="rounded-2xl border border-gray-200 bg-white shadow-sm overflow-hidden mb-6">
+            <div className="px-6 py-4 border-b border-gray-100 bg-gray-50/50">
+              <h3 className="text-sm font-semibold text-gray-700">Additional Documents</h3>
+              <p className="text-xs text-gray-500">Download, complete, and upload these documents.</p>
+            </div>
+
+            {uploadError && (
+              <div className="mx-6 mt-4 rounded-lg border border-red-200 bg-red-50 px-4 py-2 text-sm text-red-600 flex items-center gap-2">
+                <AlertCircle className="h-4 w-4 flex-shrink-0" />
+                {uploadError}
+              </div>
+            )}
+
+            <div className="divide-y divide-gray-100">
+              {uploadDocs.map((doc) => (
+                <div key={doc.template_id} className="px-6 py-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2">
+                        {doc.uploaded ? (
+                          <CheckCircle2 className="h-4 w-4 text-green-600 flex-shrink-0" />
+                        ) : (
+                          <FileText className="h-4 w-4 text-gray-400 flex-shrink-0" />
+                        )}
+                        <p className="text-sm font-medium text-gray-900">{doc.name}</p>
+                        {doc.required && !doc.uploaded && (
+                          <span className="rounded-full bg-amber-50 px-2 py-0.5 text-[10px] font-medium text-amber-700">Required</span>
+                        )}
+                      </div>
+                      {doc.uploaded && doc.uploaded_doc && (
+                        <p className="mt-1 ml-6 text-xs text-green-600">
+                          Uploaded: {doc.uploaded_doc.file_name}
+                        </p>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-2 flex-shrink-0">
+                      <button
+                        onClick={() => handleDownloadTemplate(doc.file_path, doc.file_name)}
+                        className="flex items-center gap-1 rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-50 cursor-pointer"
+                      >
+                        <Download className="h-3 w-3" />
+                        Template
+                      </button>
+                      <button
+                        onClick={() => handleFileSelect(doc.template_id)}
+                        disabled={uploading === doc.template_id}
+                        className={`flex items-center gap-1 rounded-lg px-3 py-1.5 text-xs font-medium cursor-pointer ${
+                          doc.uploaded
+                            ? "border border-green-200 text-green-700 hover:bg-green-50"
+                            : "bg-green-600 text-white hover:bg-green-700"
+                        } disabled:opacity-50`}
+                      >
+                        {uploading === doc.template_id ? (
+                          <Loader2 className="h-3 w-3 animate-spin" />
+                        ) : (
+                          <Upload className="h-3 w-3" />
+                        )}
+                        {doc.uploaded ? "Replace" : "Upload"}
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Completion Banner */}
+        {allComplete && (
+          <div className="rounded-2xl border border-green-200 bg-green-50 p-6 text-center mb-6">
+            <CheckCircle2 className="mx-auto h-8 w-8 text-green-600 mb-2" />
+            <p className="text-sm font-medium text-green-800">
+              All documents completed — your application is moving forward!
+            </p>
+          </div>
+        )}
+
+        <div className="text-center">
           <p className="text-xs text-gray-400">Vending Connector — vendingconnector.com</p>
         </div>
       </div>

--- a/src/components/onboarding/FormRenderer.tsx
+++ b/src/components/onboarding/FormRenderer.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+import { useState } from "react";
+import { Loader2, CheckCircle2, PenTool, Eye, EyeOff } from "lucide-react";
+
+export interface FormField {
+  key: string;
+  label: string;
+  type: "text" | "email" | "phone" | "date" | "textarea" | "select" | "checkbox" | "signature" | "sensitive" | "number";
+  required: boolean;
+  placeholder?: string;
+  options?: string[];
+}
+
+interface FormRendererProps {
+  templateId: string;
+  templateName: string;
+  description: string | null;
+  fields: FormField[];
+  token: string;
+  onComplete: (advanced: boolean) => void;
+  prefill?: Record<string, string>;
+  alreadyCompleted?: boolean;
+  existingData?: Record<string, unknown> | null;
+}
+
+export default function FormRenderer({
+  templateId,
+  templateName,
+  description,
+  fields,
+  token,
+  onComplete,
+  prefill,
+  alreadyCompleted,
+  existingData,
+}: FormRendererProps) {
+  const [formData, setFormData] = useState<Record<string, unknown>>(() => {
+    if (existingData) return { ...existingData };
+    const initial: Record<string, unknown> = {};
+    for (const field of fields) {
+      if (field.type === "checkbox") {
+        initial[field.key] = false;
+      } else if (prefill?.[field.key]) {
+        initial[field.key] = prefill[field.key];
+      } else {
+        initial[field.key] = "";
+      }
+    }
+    return initial;
+  });
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [completed, setCompleted] = useState(alreadyCompleted || false);
+  const [showSensitive, setShowSensitive] = useState<Record<string, boolean>>({});
+
+  function setValue(key: string, value: unknown) {
+    setFormData((prev) => ({ ...prev, [key]: value }));
+  }
+
+  function toggleSensitive(key: string) {
+    setShowSensitive((prev) => ({ ...prev, [key]: !prev[key] }));
+  }
+
+  async function handleSubmit() {
+    setError(null);
+
+    // Client-side validation
+    for (const field of fields) {
+      if (field.required) {
+        const val = formData[field.key];
+        if (val === undefined || val === null || val === "" || val === false) {
+          setError(`"${field.label}" is required`);
+          return;
+        }
+      }
+    }
+
+    // Validate confirm fields match
+    if (formData["confirm_account_number"] !== undefined && formData["account_number"] !== undefined) {
+      if (formData["confirm_account_number"] !== formData["account_number"]) {
+        setError("Account numbers do not match");
+        return;
+      }
+    }
+
+    setSubmitting(true);
+    try {
+      const res = await fetch(`/api/onboarding/candidate-portal/${token}/submit-form`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ document_template_id: templateId, form_data: formData }),
+      });
+
+      if (res.ok) {
+        const result = await res.json();
+        setCompleted(true);
+        onComplete(result.advanced);
+      } else {
+        const err = await res.json().catch(() => ({}));
+        setError(err.error || "Submission failed");
+      }
+    } catch {
+      setError("Network error — please try again");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (completed) {
+    return (
+      <div className="rounded-xl border border-green-200 bg-green-50 p-5">
+        <div className="flex items-center gap-2 mb-1">
+          <CheckCircle2 className="h-5 w-5 text-green-600" />
+          <span className="font-medium text-green-800">{templateName} — Completed</span>
+        </div>
+        <p className="text-sm text-green-600 ml-7">This form has been submitted successfully.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white overflow-hidden">
+      {/* Form Header */}
+      <div className="px-5 py-4 border-b border-gray-100 bg-gray-50/50">
+        <h3 className="text-base font-semibold text-gray-900">{templateName}</h3>
+        {description && <p className="text-sm text-gray-500 mt-0.5">{description}</p>}
+      </div>
+
+      {/* Form Fields */}
+      <div className="px-5 py-4 space-y-4">
+        {fields.map((field) => (
+          <div key={field.key}>
+            {field.type === "checkbox" ? (
+              <label className="flex items-start gap-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={!!formData[field.key]}
+                  onChange={(e) => setValue(field.key, e.target.checked)}
+                  className="mt-1 h-4 w-4 rounded border-gray-300 text-green-600 focus:ring-green-500 cursor-pointer"
+                />
+                <span className="text-sm text-gray-700 leading-relaxed">
+                  {field.label}
+                  {field.required && <span className="text-red-400 ml-0.5">*</span>}
+                </span>
+              </label>
+            ) : field.type === "signature" ? (
+              <div>
+                <label className="flex items-center gap-1.5 text-xs font-medium text-gray-500 mb-1.5">
+                  <PenTool className="h-3 w-3" />
+                  {field.label}
+                  {field.required && <span className="text-red-400">*</span>}
+                </label>
+                <input
+                  type="text"
+                  value={(formData[field.key] as string) || ""}
+                  onChange={(e) => setValue(field.key, e.target.value)}
+                  placeholder={field.placeholder || "Type your full legal name to sign"}
+                  className="w-full rounded-lg border border-gray-300 px-4 py-3 text-lg font-serif italic text-gray-700 placeholder:text-gray-300 placeholder:not-italic focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500"
+                />
+                {formData[field.key] ? (
+                  <p className="mt-1 text-xs text-gray-400">
+                    Electronic signature: <span className="italic font-serif text-gray-600">{String(formData[field.key])}</span>
+                  </p>
+                ) : null}
+              </div>
+            ) : field.type === "select" ? (
+              <div>
+                <label className="block text-xs font-medium text-gray-500 mb-1.5">
+                  {field.label}
+                  {field.required && <span className="text-red-400 ml-0.5">*</span>}
+                </label>
+                <select
+                  value={(formData[field.key] as string) || ""}
+                  onChange={(e) => setValue(field.key, e.target.value)}
+                  className="w-full rounded-lg border border-gray-200 px-3 py-2.5 text-sm focus:border-green-500 focus:outline-none cursor-pointer"
+                >
+                  <option value="">Select...</option>
+                  {(field.options || []).map((opt) => (
+                    <option key={opt} value={opt}>{opt}</option>
+                  ))}
+                </select>
+              </div>
+            ) : field.type === "textarea" ? (
+              <div>
+                <label className="block text-xs font-medium text-gray-500 mb-1.5">
+                  {field.label}
+                  {field.required && <span className="text-red-400 ml-0.5">*</span>}
+                </label>
+                <textarea
+                  value={(formData[field.key] as string) || ""}
+                  onChange={(e) => setValue(field.key, e.target.value)}
+                  placeholder={field.placeholder}
+                  rows={3}
+                  className="w-full rounded-lg border border-gray-200 px-3 py-2.5 text-sm focus:border-green-500 focus:outline-none resize-none"
+                />
+              </div>
+            ) : field.type === "sensitive" ? (
+              <div>
+                <label className="block text-xs font-medium text-gray-500 mb-1.5">
+                  {field.label}
+                  {field.required && <span className="text-red-400 ml-0.5">*</span>}
+                </label>
+                <div className="relative">
+                  <input
+                    type={showSensitive[field.key] ? "text" : "password"}
+                    value={(formData[field.key] as string) || ""}
+                    onChange={(e) => setValue(field.key, e.target.value)}
+                    placeholder={field.placeholder}
+                    autoComplete="off"
+                    className="w-full rounded-lg border border-gray-200 px-3 py-2.5 pr-10 text-sm focus:border-green-500 focus:outline-none"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => toggleSensitive(field.key)}
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 cursor-pointer"
+                  >
+                    {showSensitive[field.key] ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <div>
+                <label className="block text-xs font-medium text-gray-500 mb-1.5">
+                  {field.label}
+                  {field.required && <span className="text-red-400 ml-0.5">*</span>}
+                </label>
+                <input
+                  type={field.type === "date" ? "date" : field.type === "email" ? "email" : field.type === "number" ? "number" : "text"}
+                  value={(formData[field.key] as string) || ""}
+                  onChange={(e) => setValue(field.key, e.target.value)}
+                  placeholder={field.placeholder}
+                  className="w-full rounded-lg border border-gray-200 px-3 py-2.5 text-sm focus:border-green-500 focus:outline-none"
+                />
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div className="mx-5 mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-2 text-sm text-red-600">
+          {error}
+        </div>
+      )}
+
+      {/* Submit */}
+      <div className="px-5 py-4 border-t border-gray-100 bg-gray-50/30">
+        <button
+          onClick={handleSubmit}
+          disabled={submitting}
+          className="w-full rounded-lg bg-green-600 px-4 py-3 text-sm font-semibold text-white hover:bg-green-700 disabled:opacity-50 transition-colors cursor-pointer"
+        >
+          {submitting ? (
+            <span className="flex items-center justify-center gap-2"><Loader2 className="h-4 w-4 animate-spin" /> Submitting...</span>
+          ) : (
+            <span className="flex items-center justify-center gap-2"><CheckCircle2 className="h-4 w-4" /> Complete & Submit</span>
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/supabase/migrations/051_inline_form_templates.sql
+++ b/supabase/migrations/051_inline_form_templates.sql
@@ -1,0 +1,108 @@
+-- Migration 051: Inline form templates
+-- Adds JSONB fields schema to document_templates so candidates can fill out
+-- forms directly in the portal instead of downloading/uploading PDFs.
+-- Also adds form_data JSONB to candidate_documents to store completed form responses.
+
+-- ============================================================
+-- 1. ADD form_fields TO document_templates
+-- JSON array defining fillable fields for each template
+-- ============================================================
+ALTER TABLE public.document_templates
+  ADD COLUMN IF NOT EXISTS form_fields JSONB,
+  ADD COLUMN IF NOT EXISTS form_enabled BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS description TEXT;
+
+-- ============================================================
+-- 2. ADD form_data TO candidate_documents
+-- Stores the candidate's filled-in form responses as JSON
+-- ============================================================
+ALTER TABLE public.candidate_documents
+  ADD COLUMN IF NOT EXISTS form_data JSONB;
+
+-- ============================================================
+-- 3. SEED common onboarding document templates with form fields
+-- These are created as form-enabled templates. Admins can also
+-- upload PDF-only templates alongside these.
+-- ============================================================
+
+-- Interview step templates
+INSERT INTO public.document_templates (name, pipeline_type, step_key, file_path, file_name, mime_type, form_enabled, description, form_fields) VALUES
+
+-- NDA
+('Non-Disclosure Agreement', 'ALL', 'interview', 'forms/nda', 'NDA.pdf', 'application/pdf', true,
+ 'Protects confidential business information shared during the onboarding process.',
+ '[
+   {"key": "full_name", "label": "Full Legal Name", "type": "text", "required": true, "placeholder": "e.g. John A. Smith"},
+   {"key": "address", "label": "Mailing Address", "type": "text", "required": true, "placeholder": "123 Main St, City, State ZIP"},
+   {"key": "email", "label": "Email Address", "type": "email", "required": true, "placeholder": "john@example.com"},
+   {"key": "phone", "label": "Phone Number", "type": "phone", "required": true, "placeholder": "(555) 123-4567"},
+   {"key": "effective_date", "label": "Effective Date", "type": "date", "required": true},
+   {"key": "agree_terms", "label": "I agree to keep all proprietary and confidential information strictly confidential and not disclose it to any third party.", "type": "checkbox", "required": true},
+   {"key": "signature", "label": "Signature", "type": "signature", "required": true, "placeholder": "Type your full legal name to sign"},
+   {"key": "signed_date", "label": "Date Signed", "type": "date", "required": true}
+ ]'::jsonb),
+
+-- NCA (Non-Compete Agreement)
+('Non-Compete Agreement', 'ALL', 'interview', 'forms/nca', 'NCA.pdf', 'application/pdf', true,
+ 'Restricts competitive activities during and after the business relationship.',
+ '[
+   {"key": "full_name", "label": "Full Legal Name", "type": "text", "required": true, "placeholder": "e.g. John A. Smith"},
+   {"key": "address", "label": "Mailing Address", "type": "text", "required": true, "placeholder": "123 Main St, City, State ZIP"},
+   {"key": "email", "label": "Email Address", "type": "email", "required": true, "placeholder": "john@example.com"},
+   {"key": "effective_date", "label": "Effective Date", "type": "date", "required": true},
+   {"key": "territory", "label": "Territory / Market Area", "type": "text", "required": false, "placeholder": "e.g. Greater Chicago Area"},
+   {"key": "agree_terms", "label": "I agree not to engage in competing business activities within the specified territory for the duration of this agreement.", "type": "checkbox", "required": true},
+   {"key": "signature", "label": "Signature", "type": "signature", "required": true, "placeholder": "Type your full legal name to sign"},
+   {"key": "signed_date", "label": "Date Signed", "type": "date", "required": true}
+ ]'::jsonb),
+
+-- Independent Contractor Agreement
+('Independent Contractor Agreement', 'ALL', 'interview', 'forms/ica', 'ICA.pdf', 'application/pdf', true,
+ 'Defines the working relationship, compensation, and responsibilities.',
+ '[
+   {"key": "full_name", "label": "Full Legal Name", "type": "text", "required": true, "placeholder": "e.g. John A. Smith"},
+   {"key": "business_name", "label": "Business Name (if applicable)", "type": "text", "required": false, "placeholder": "e.g. Smith Vending LLC"},
+   {"key": "address", "label": "Mailing Address", "type": "text", "required": true, "placeholder": "123 Main St, City, State ZIP"},
+   {"key": "email", "label": "Email Address", "type": "email", "required": true, "placeholder": "john@example.com"},
+   {"key": "phone", "label": "Phone Number", "type": "phone", "required": true, "placeholder": "(555) 123-4567"},
+   {"key": "ssn_ein", "label": "SSN or EIN", "type": "sensitive", "required": true, "placeholder": "XXX-XX-XXXX or XX-XXXXXXX"},
+   {"key": "start_date", "label": "Start Date", "type": "date", "required": true},
+   {"key": "agree_terms", "label": "I acknowledge that I am an independent contractor and not an employee. I am responsible for my own taxes, insurance, and business expenses.", "type": "checkbox", "required": true},
+   {"key": "signature", "label": "Signature", "type": "signature", "required": true, "placeholder": "Type your full legal name to sign"},
+   {"key": "signed_date", "label": "Date Signed", "type": "date", "required": true}
+ ]'::jsonb),
+
+-- Welcome docs step templates
+
+-- W9 Tax Form
+('W-9 Tax Information', 'ALL', 'welcome_docs', 'forms/w9', 'W9.pdf', 'application/pdf', true,
+ 'Required tax identification form for independent contractors.',
+ '[
+   {"key": "full_name", "label": "Full Legal Name (as shown on your tax return)", "type": "text", "required": true, "placeholder": "e.g. John A. Smith"},
+   {"key": "business_name", "label": "Business Name / DBA (if different)", "type": "text", "required": false, "placeholder": "e.g. Smith Vending LLC"},
+   {"key": "tax_classification", "label": "Federal Tax Classification", "type": "select", "required": true, "options": ["Individual/Sole Proprietor", "Single-Member LLC", "C Corporation", "S Corporation", "Partnership", "Trust/Estate", "LLC - C Corp", "LLC - S Corp", "LLC - Partnership"]},
+   {"key": "address", "label": "Street Address", "type": "text", "required": true, "placeholder": "123 Main St"},
+   {"key": "city_state_zip", "label": "City, State, and ZIP Code", "type": "text", "required": true, "placeholder": "Chicago, IL 60601"},
+   {"key": "ssn_ein", "label": "Taxpayer Identification Number (SSN or EIN)", "type": "sensitive", "required": true, "placeholder": "XXX-XX-XXXX or XX-XXXXXXX"},
+   {"key": "exempt_payee", "label": "Exempt Payee Code (if applicable)", "type": "text", "required": false, "placeholder": "Leave blank if not applicable"},
+   {"key": "agree_certification", "label": "Under penalties of perjury, I certify that the number shown on this form is my correct taxpayer identification number, and I am not subject to backup withholding.", "type": "checkbox", "required": true},
+   {"key": "signature", "label": "Signature", "type": "signature", "required": true, "placeholder": "Type your full legal name to sign"},
+   {"key": "signed_date", "label": "Date Signed", "type": "date", "required": true}
+ ]'::jsonb),
+
+-- ACH Direct Deposit Form
+('ACH Direct Deposit Authorization', 'ALL', 'welcome_docs', 'forms/ach', 'ACH.pdf', 'application/pdf', true,
+ 'Authorize direct deposit payments to your bank account.',
+ '[
+   {"key": "full_name", "label": "Account Holder Name", "type": "text", "required": true, "placeholder": "e.g. John A. Smith"},
+   {"key": "bank_name", "label": "Bank Name", "type": "text", "required": true, "placeholder": "e.g. Chase Bank"},
+   {"key": "account_type", "label": "Account Type", "type": "select", "required": true, "options": ["Checking", "Savings"]},
+   {"key": "routing_number", "label": "Routing Number (9 digits)", "type": "text", "required": true, "placeholder": "XXXXXXXXX"},
+   {"key": "account_number", "label": "Account Number", "type": "sensitive", "required": true, "placeholder": "Enter your account number"},
+   {"key": "confirm_account_number", "label": "Confirm Account Number", "type": "sensitive", "required": true, "placeholder": "Re-enter your account number"},
+   {"key": "agree_terms", "label": "I authorize Vending Connector to initiate direct deposit payments to the bank account listed above. This authorization remains in effect until I provide written notice of cancellation.", "type": "checkbox", "required": true},
+   {"key": "signature", "label": "Signature", "type": "signature", "required": true, "placeholder": "Type your full legal name to sign"},
+   {"key": "signed_date", "label": "Date Signed", "type": "date", "required": true}
+ ]'::jsonb)
+
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
Candidates now fill out NDA, NCA, W9, ACH, and contractor agreements directly in the portal as web forms instead of downloading/uploading PDFs. Each document template has a form_fields JSONB schema defining the fields (text, date, signature, sensitive, select, checkbox). When a candidate submits a form, the data saves to their profile and auto-advancement kicks in for the next pipeline step.

- Migration 051: form_fields/form_enabled on document_templates, form_data on candidate_documents, seeds 5 common templates
- FormRenderer component: renders fields by type with validation, signature field, sensitive field toggle, and submit handler
- Submit-form API endpoint: validates required fields, saves form_data
- Portal page: renders inline forms for form-enabled templates, file upload for PDF-only templates, prefills name/email

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2