### PR TITLE
Refactor onboarding pipeline to form-signing flow (no uploads required)

### DIFF
--- a/src/app/api/onboarding/candidate-portal/[token]/route.ts
+++ b/src/app/api/onboarding/candidate-portal/[token]/route.ts
@@ -37,12 +37,35 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ tok
     .eq("step_key", ct.step_key)
     .order("order_index");
 
-  const requiredDocs = (assignments || []).filter(
+  let requiredDocs = (assignments || []).filter(
     (a: Record<string, unknown>) => {
       const tmpl = a.document_templates as Record<string, unknown> | null;
       return tmpl && tmpl.active === true;
     }
   );
+
+  // Fallback: if no assignments exist, load form-enabled templates for this step directly
+  if (requiredDocs.length === 0) {
+    const { data: formTemplates } = await supabaseAdmin
+      .from("document_templates")
+      .select("id, name, file_name, file_path, mime_type, active, form_enabled, form_fields, description")
+      .eq("step_key", ct.step_key)
+      .eq("form_enabled", true)
+      .eq("active", true)
+      .order("created_at");
+
+    if (formTemplates && formTemplates.length > 0) {
+      requiredDocs = formTemplates.map((tmpl, idx) => ({
+        id: `fallback-${tmpl.id}`,
+        pipeline_id: ct.pipeline_id,
+        step_key: ct.step_key,
+        document_template_id: tmpl.id,
+        required: true,
+        order_index: idx,
+        document_templates: tmpl,
+      }));
+    }
+  }
 
   const { data: uploaded } = await supabaseAdmin
     .from("candidate_documents")

--- a/src/app/api/onboarding/candidates/[id]/approve/route.ts
+++ b/src/app/api/onboarding/candidates/[id]/approve/route.ts
@@ -48,14 +48,25 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
           .eq("pipeline_id", candidate.current_pipeline_id)
           .eq("step_key", nextStepKey);
 
-        const requiredCount = (assignments || []).filter(
+        let requiredCount = (assignments || []).filter(
           (a: Record<string, unknown>) => {
             const tmpl = a.document_templates as Record<string, unknown> | null;
             return a.required && tmpl && tmpl.active;
           }
         ).length;
 
-        if ((assignments || []).length > 0) {
+        // Fallback: count form-enabled templates if no assignments
+        if (requiredCount === 0) {
+          const { count } = await supabaseAdmin
+            .from("document_templates")
+            .select("id", { count: "exact", head: true })
+            .eq("step_key", nextStepKey)
+            .eq("form_enabled", true)
+            .eq("active", true);
+          requiredCount = count || 0;
+        }
+
+        if (requiredCount > 0) {
           const { data: tokenRecord } = await supabaseAdmin
             .from("candidate_tokens")
             .insert({

--- a/src/app/api/onboarding/candidates/[id]/send-docs/route.ts
+++ b/src/app/api/onboarding/candidates/[id]/send-docs/route.ts
@@ -47,12 +47,23 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
       .eq("pipeline_id", candidate.current_pipeline_id)
       .eq("step_key", stepKey);
 
-    const requiredCount = (assignments || []).filter(
+    let requiredCount = (assignments || []).filter(
       (a: Record<string, unknown>) => {
         const tmpl = a.document_templates as Record<string, unknown> | null;
         return a.required && tmpl && tmpl.active;
       }
     ).length;
+
+    // Fallback: count form-enabled templates for this step if no assignments
+    if (requiredCount === 0) {
+      const { count } = await supabaseAdmin
+        .from("document_templates")
+        .select("id", { count: "exact", head: true })
+        .eq("step_key", stepKey)
+        .eq("form_enabled", true)
+        .eq("active", true);
+      requiredCount = count || 0;
+    }
 
     // Create a candidate token for the submission portal
     const { data: tokenRecord } = await supabaseAdmin

--- a/src/app/onboarding/[token]/page.tsx
+++ b/src/app/onboarding/[token]/page.tsx
@@ -41,8 +41,8 @@ const STEP_TITLES: Record<string, string> = {
 };
 
 const STEP_DESCRIPTIONS: Record<string, string> = {
-  interview: "Please review and complete each of the following documents to proceed with your interview process.",
-  welcome_docs: "Congratulations on moving forward! Please complete these documents to finalize your onboarding.",
+  interview: "Please review and sign each of the following documents to proceed with your interview process.",
+  welcome_docs: "Congratulations on moving forward! Please complete and sign these documents to finalize your onboarding.",
 };
 
 function PortalContent() {
@@ -167,9 +167,9 @@ function PortalContent() {
           </div>
           <div className="rounded-2xl border border-green-200 bg-green-50 p-8">
             <CheckCircle2 className="mx-auto h-12 w-12 text-green-600 mb-4" />
-            <h2 className="text-xl font-bold text-gray-900 mb-2">All Documents Submitted</h2>
+            <h2 className="text-xl font-bold text-gray-900 mb-2">All Documents Completed</h2>
             <p className="text-sm text-gray-600">
-              Thank you, {data.candidate_name}! All required documents have been received.
+              Thank you, {data.candidate_name}! All required documents have been signed and submitted.
               {data.step_key === "interview"
                 ? " You'll receive your next set of onboarding documents shortly."
                 : " Your onboarding is now complete."}
@@ -181,13 +181,11 @@ function PortalContent() {
     );
   }
 
+  const formDocs = data.required_documents.filter((d) => d.form_enabled && d.form_fields);
+  const uploadDocs = data.required_documents.filter((d) => !d.form_enabled || !d.form_fields);
   const completedCount = data.required_documents.filter((d) => d.uploaded).length;
   const totalCount = data.required_documents.length;
   const allComplete = data.required_documents.filter((d) => d.required).every((d) => d.uploaded);
-
-  // Split docs into form-based and file-upload-based
-  const formDocs = data.required_documents.filter((d) => d.form_enabled && d.form_fields);
-  const uploadDocs = data.required_documents.filter((d) => !d.form_enabled || !d.form_fields);
 
   return (
     <div className="min-h-screen bg-gray-50 py-8 px-4">
@@ -199,12 +197,13 @@ function PortalContent() {
         className="hidden"
       />
       <div className="mx-auto max-w-2xl">
+        {/* Header */}
         <div className="mb-6 text-center">
           <h1 className="text-2xl font-bold text-green-600 mb-1">Vending Connector</h1>
           <p className="text-sm text-gray-500">Onboarding Portal</p>
         </div>
 
-        {/* Welcome Card */}
+        {/* Welcome & Progress Card */}
         <div className="rounded-2xl border border-gray-200 bg-white shadow-sm overflow-hidden mb-6">
           <div className="px-6 py-5 border-b border-gray-100">
             <p className="text-xs font-medium text-gray-400 uppercase tracking-wider mb-1">Welcome</p>
@@ -220,11 +219,10 @@ function PortalContent() {
             </p>
           </div>
 
-          {/* Progress */}
           <div className="px-6 py-4 bg-gray-50/50">
             <div className="flex items-center justify-between mb-2">
               <span className="text-xs font-medium text-gray-500">Progress</span>
-              <span className="text-xs font-medium text-gray-700">{completedCount} of {totalCount} completed</span>
+              <span className="text-xs font-medium text-gray-700">{completedCount} of {totalCount} signed</span>
             </div>
             <div className="h-2 w-full rounded-full bg-gray-200">
               <div
@@ -235,7 +233,7 @@ function PortalContent() {
           </div>
         </div>
 
-        {/* Inline Forms */}
+        {/* Form Documents — primary experience */}
         {formDocs.length > 0 && (
           <div className="space-y-4 mb-6">
             {formDocs.map((doc) => (
@@ -258,7 +256,7 @@ function PortalContent() {
           </div>
         )}
 
-        {/* File Upload Section */}
+        {/* File Upload Section — only for non-form documents added via doc mapping */}
         {uploadDocs.length > 0 && (
           <div className="rounded-2xl border border-gray-200 bg-white shadow-sm overflow-hidden mb-6">
             <div className="px-6 py-4 border-b border-gray-100 bg-gray-50/50">
@@ -332,7 +330,7 @@ function PortalContent() {
           <div className="rounded-2xl border border-green-200 bg-green-50 p-6 text-center mb-6">
             <CheckCircle2 className="mx-auto h-8 w-8 text-green-600 mb-2" />
             <p className="text-sm font-medium text-green-800">
-              All documents completed — your application is moving forward!
+              All documents signed — your application is moving forward!
             </p>
           </div>
         )}

--- a/src/lib/candidateAdvancement.ts
+++ b/src/lib/candidateAdvancement.ts
@@ -40,12 +40,24 @@ export async function checkAndAdvanceCandidate(tokenId: string): Promise<Advance
     .eq("pipeline_id", ct.pipeline_id)
     .eq("step_key", ct.step_key);
 
-  const requiredTemplateIds = (assignments || [])
+  let requiredTemplateIds = (assignments || [])
     .filter((a: Record<string, unknown>) => {
       const tmpl = a.document_templates as Record<string, unknown> | null;
       return a.required && tmpl && tmpl.active;
     })
     .map((a: Record<string, unknown>) => (a.document_templates as Record<string, unknown>).id as string);
+
+  // Fallback: if no assignments, use form-enabled templates for this step
+  if (requiredTemplateIds.length === 0) {
+    const { data: formTemplates } = await supabaseAdmin
+      .from("document_templates")
+      .select("id")
+      .eq("step_key", ct.step_key)
+      .eq("form_enabled", true)
+      .eq("active", true);
+
+    requiredTemplateIds = (formTemplates || []).map((t: { id: string }) => t.id);
+  }
 
   // Get uploaded docs for this token
   const { data: uploaded } = await supabaseAdmin
@@ -122,21 +134,32 @@ export async function checkAndAdvanceCandidate(tokenId: string): Promise<Advance
   // If there's a next step with documents, auto-send them
   if (nextStepKey && candidate.email) {
     try {
-      // Check if next step has document assignments
+      // Check if next step has document assignments or form-enabled templates
       const { data: nextAssignments } = await supabaseAdmin
         .from("step_document_assignments")
-        .select("id, document_templates(active)")
+        .select("id, required, document_templates(active)")
         .eq("pipeline_id", candidate.current_pipeline_id)
         .eq("step_key", nextStepKey);
 
-      const hasNextDocs = (nextAssignments || []).some(
+      let nextRequiredCount = (nextAssignments || []).filter(
         (a: Record<string, unknown>) => {
           const tmpl = a.document_templates as Record<string, unknown> | null;
-          return tmpl && tmpl.active;
+          return a.required && tmpl && tmpl.active;
         }
-      );
+      ).length;
 
-      if (hasNextDocs) {
+      // Fallback: count form-enabled templates if no assignments
+      if (nextRequiredCount === 0) {
+        const { count } = await supabaseAdmin
+          .from("document_templates")
+          .select("id", { count: "exact", head: true })
+          .eq("step_key", nextStepKey)
+          .eq("form_enabled", true)
+          .eq("active", true);
+        nextRequiredCount = count || 0;
+      }
+
+      if (nextRequiredCount > 0) {
         // Create a new token for the next step
         const { data: nextToken } = await supabaseAdmin
           .from("candidate_tokens")
@@ -144,12 +167,7 @@ export async function checkAndAdvanceCandidate(tokenId: string): Promise<Advance
             candidate_id: candidate.id,
             step_key: nextStepKey,
             pipeline_id: candidate.current_pipeline_id,
-            required_doc_count: (nextAssignments || []).filter(
-              (a: Record<string, unknown>) => {
-                const tmpl = a.document_templates as Record<string, unknown> | null;
-                return a.required && tmpl && tmpl.active;
-              }
-            ).length,
+            required_doc_count: nextRequiredCount,
           })
           .select("token")
           .single();

--- a/src/lib/onboardingPipelineEmail.ts
+++ b/src/lib/onboardingPipelineEmail.ts
@@ -28,24 +28,27 @@ export async function sendOnboardingDocsEmail(params: SendDocsParams) {
     .order("order_index");
 
   if (assignErr) throw new Error(`Failed to fetch assignments: ${assignErr.message}`);
-  if (!assignments || assignments.length === 0) {
-    throw new Error("No documents assigned to this pipeline step. Please configure document mappings first.");
-  }
 
-  const activeAssignments = assignments.filter(
+  const activeAssignments = (assignments || []).filter(
     (a: Record<string, unknown>) => {
       const tmpl = a.document_templates as Record<string, unknown> | null;
       return tmpl && tmpl.active === true;
     }
   );
 
-  if (activeAssignments.length === 0) {
-    throw new Error("No active document templates found for this step.");
+  if (activeAssignments.length === 0 && !params.portalUrl) {
+    throw new Error("No documents assigned to this pipeline step. Please configure document mappings first.");
   }
 
   const attachments: { filename: string; content: Buffer; contentType: string }[] = [];
 
-  for (const assignment of activeAssignments) {
+  // Only attach PDFs for non-form templates (form templates are filled out in the portal)
+  const pdfAssignments = activeAssignments.filter((a: Record<string, unknown>) => {
+    const tmpl = a.document_templates as Record<string, unknown> | null;
+    return tmpl && !tmpl.form_enabled;
+  });
+
+  for (const assignment of pdfAssignments) {
     const template = assignment.document_templates as {
       file_path: string;
       file_name: string;
@@ -84,8 +87,8 @@ export async function sendOnboardingDocsEmail(params: SendDocsParams) {
   if (params.portalUrl) {
     bodyHtml += `
       <div style="margin-top:24px;padding:20px;background:#f0fdf4;border:1px solid #bbf7d0;border-radius:12px;text-align:center;">
-        <p style="color:#374151;font-size:14px;margin:0 0 12px;">Upload your completed documents here:</p>
-        <a href="${params.portalUrl}" style="display:inline-block;background:#16a34a;color:#ffffff;padding:12px 28px;border-radius:8px;text-decoration:none;font-weight:600;font-size:14px;">Upload Documents</a>
+        <p style="color:#374151;font-size:14px;margin:0 0 12px;">Please review and sign your documents using the link below:</p>
+        <a href="${params.portalUrl}" style="display:inline-block;background:#16a34a;color:#ffffff;padding:12px 28px;border-radius:8px;text-decoration:none;font-weight:600;font-size:14px;">Complete & Sign Documents</a>
         <p style="color:#6b7280;font-size:12px;margin:12px 0 0;">Or copy this link: ${params.portalUrl}</p>
       </div>`;
   }

--- a/supabase/migrations/052_seed_onboarding_doc_assignments.sql
+++ b/supabase/migrations/052_seed_onboarding_doc_assignments.sql
@@ -1,0 +1,33 @@
+-- Migration 052: Auto-assign form-enabled document templates to onboarding pipeline steps
+-- This wires up the NDA, NCA, ICA templates to the interview step and W9, ACH to welcome_docs
+-- for both BDP and Market Leader pipelines so the candidate portal shows forms automatically.
+
+-- BDP pipeline (b0000000-0000-0000-0000-000000000001)
+INSERT INTO public.step_document_assignments (pipeline_id, step_key, document_template_id, required, order_index)
+SELECT
+  'b0000000-0000-0000-0000-000000000001',
+  dt.step_key,
+  dt.id,
+  true,
+  ROW_NUMBER() OVER (PARTITION BY dt.step_key ORDER BY dt.created_at) - 1
+FROM public.document_templates dt
+WHERE dt.form_enabled = true
+  AND dt.active = true
+  AND dt.step_key IN ('interview', 'welcome_docs')
+  AND dt.pipeline_type IN ('ALL', 'BDP')
+ON CONFLICT DO NOTHING;
+
+-- Market Leader pipeline (b0000000-0000-0000-0000-000000000002)
+INSERT INTO public.step_document_assignments (pipeline_id, step_key, document_template_id, required, order_index)
+SELECT
+  'b0000000-0000-0000-0000-000000000002',
+  dt.step_key,
+  dt.id,
+  true,
+  ROW_NUMBER() OVER (PARTITION BY dt.step_key ORDER BY dt.created_at) - 1
+FROM public.document_templates dt
+WHERE dt.form_enabled = true
+  AND dt.active = true
+  AND dt.step_key IN ('interview', 'welcome_docs')
+  AND dt.pipeline_type IN ('ALL', 'MARKET_LEADER')
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
- Forms (NDA, NCA, ICA, W9, ACH) are now the primary candidate experience
- Email skips PDF attachments for form-enabled templates, sends portal link
- Email CTA updated to "Complete & Sign Documents" instead of upload
- Portal API falls back to form-enabled templates if no step_document_assignments
- Auto-advancement checks form templates as fallback when no assignments exist
- Upload section only appears for non-form docs added via optional doc mapping
- Migration 052 seeds step_document_assignments for both BDP + Market Leader pipelines

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2