### PR TITLE
Filter portal to only show form-enabled documents

### DIFF
--- a/src/app/api/onboarding/candidate-portal/[token]/route.ts
+++ b/src/app/api/onboarding/candidate-portal/[token]/route.ts
@@ -40,7 +40,7 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ tok
   let requiredDocs = (assignments || []).filter(
     (a: Record<string, unknown>) => {
       const tmpl = a.document_templates as Record<string, unknown> | null;
-      return tmpl && tmpl.active === true;
+      return tmpl && tmpl.active === true && tmpl.form_enabled === true;
     }
   );
 

--- a/src/app/api/onboarding/candidates/[id]/approve/route.ts
+++ b/src/app/api/onboarding/candidates/[id]/approve/route.ts
@@ -51,7 +51,7 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
         let requiredCount = (assignments || []).filter(
           (a: Record<string, unknown>) => {
             const tmpl = a.document_templates as Record<string, unknown> | null;
-            return a.required && tmpl && tmpl.active;
+            return a.required && tmpl && tmpl.active && tmpl.form_enabled;
           }
         ).length;
 

--- a/src/app/api/onboarding/candidates/[id]/send-docs/route.ts
+++ b/src/app/api/onboarding/candidates/[id]/send-docs/route.ts
@@ -59,7 +59,7 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
     let requiredCount = (assignments || []).filter(
       (a: Record<string, unknown>) => {
         const tmpl = a.document_templates as Record<string, unknown> | null;
-        return a.required && tmpl && tmpl.active;
+        return a.required && tmpl && tmpl.active && tmpl.form_enabled;
       }
     ).length;
 

--- a/src/app/onboarding/[token]/page.tsx
+++ b/src/app/onboarding/[token]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef, Suspense } from "react";
+import { useState, useEffect, useCallback, Suspense } from "react";
 import { useParams } from "next/navigation";
 import { Loader2, CheckCircle2, FileText, Upload, Download, AlertCircle } from "lucide-react";
 import FormRenderer, { FormField } from "@/components/onboarding/FormRenderer";
@@ -52,8 +52,6 @@ function PortalContent() {
   const [error, setError] = useState<string | null>(null);
   const [uploading, setUploading] = useState<string | null>(null);
   const [uploadError, setUploadError] = useState<string | null>(null);
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const pendingTemplateRef = useRef<string | null>(null);
 
   const load = useCallback(async () => {
     const res = await fetch(`/api/onboarding/candidate-portal/${token}`);
@@ -97,23 +95,6 @@ function PortalContent() {
     } finally {
       setUploading(null);
     }
-  }
-
-  function handleFileSelect(templateId: string) {
-    pendingTemplateRef.current = templateId;
-    if (fileInputRef.current) {
-      fileInputRef.current.value = "";
-      fileInputRef.current.click();
-    }
-  }
-
-  function onFileInputChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const file = e.target.files?.[0];
-    const templateId = pendingTemplateRef.current;
-    if (file && templateId) {
-      handleUpload(templateId, file);
-    }
-    pendingTemplateRef.current = null;
   }
 
   async function handleDownloadTemplate(filePath: string, fileName: string) {
@@ -189,13 +170,6 @@ function PortalContent() {
 
   return (
     <div className="min-h-screen bg-gray-50 py-8 px-4">
-      <input
-        ref={fileInputRef}
-        type="file"
-        accept=".pdf,.doc,.docx,.jpg,.jpeg,.png,.heic,.heif,.webp"
-        onChange={onFileInputChange}
-        className="hidden"
-      />
       <div className="mx-auto max-w-2xl">
         {/* Header */}
         <div className="mb-6 text-center">
@@ -301,22 +275,25 @@ function PortalContent() {
                         <Download className="h-3 w-3" />
                         Template
                       </button>
-                      <button
-                        onClick={() => handleFileSelect(doc.template_id)}
-                        disabled={uploading === doc.template_id}
-                        className={`flex items-center gap-1 rounded-lg px-3 py-1.5 text-xs font-medium cursor-pointer ${
+                      <label className={`flex items-center gap-1 rounded-lg px-3 py-1.5 text-xs font-medium cursor-pointer ${
                           doc.uploaded
                             ? "border border-green-200 text-green-700 hover:bg-green-50"
                             : "bg-green-600 text-white hover:bg-green-700"
-                        } disabled:opacity-50`}
+                        }`}
                       >
+                        <input
+                          type="file"
+                          accept=".pdf,.doc,.docx,.jpg,.jpeg,.png,.heic,.heif,.webp"
+                          className="absolute w-px h-px opacity-0"
+                          onChange={(e) => { const file = e.target.files?.[0]; if (file) handleUpload(doc.template_id, file); e.target.value = ""; }}
+                        />
                         {uploading === doc.template_id ? (
                           <Loader2 className="h-3 w-3 animate-spin" />
                         ) : (
                           <Upload className="h-3 w-3" />
                         )}
                         {doc.uploaded ? "Replace" : "Upload"}
-                      </button>
+                      </label>
                     </div>
                   </div>
                 </div>

--- a/src/lib/candidateAdvancement.ts
+++ b/src/lib/candidateAdvancement.ts
@@ -44,14 +44,14 @@ export async function checkAndAdvanceCandidate(tokenId: string): Promise<Advance
   // Get required document assignments for this step
   const { data: assignments } = await supabaseAdmin
     .from("step_document_assignments")
-    .select("*, document_templates(id, active)")
+    .select("*, document_templates(id, active, form_enabled)")
     .eq("pipeline_id", ct.pipeline_id)
     .eq("step_key", ct.step_key);
 
   let requiredTemplateIds = (assignments || [])
     .filter((a: Record<string, unknown>) => {
       const tmpl = a.document_templates as Record<string, unknown> | null;
-      return a.required && tmpl && tmpl.active;
+      return a.required && tmpl && tmpl.active && tmpl.form_enabled;
     })
     .map((a: Record<string, unknown>) => (a.document_templates as Record<string, unknown>).id as string);
 
@@ -174,14 +174,14 @@ export async function checkAndAdvanceCandidate(tokenId: string): Promise<Advance
       // Check if next step has document assignments or form-enabled templates
       const { data: nextAssignments } = await supabaseAdmin
         .from("step_document_assignments")
-        .select("id, required, document_templates(active)")
+        .select("id, required, document_templates(active, form_enabled)")
         .eq("pipeline_id", candidate.current_pipeline_id)
         .eq("step_key", nextStepKey);
 
       let nextRequiredCount = (nextAssignments || []).filter(
         (a: Record<string, unknown>) => {
           const tmpl = a.document_templates as Record<string, unknown> | null;
-          return a.required && tmpl && tmpl.active;
+          return a.required && tmpl && tmpl.active && tmpl.form_enabled;
         }
       ).length;
 


### PR DESCRIPTION
The portal was showing 5 documents (3 form + 2 upload) when only the 3 form-enabled ones should appear. Non-form NDA/NCA templates were legacy entries that duplicated the inline form versions.

- Portal API: only return form-enabled templates to candidates
- send-docs/approve: set required_doc_count based on form-enabled only
- candidateAdvancement: only check form-enabled templates as required
- Portal page: fix file upload using native label-input pattern

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2