### PR TITLE
Add completion step to pipeline doc mapping admin UI

### DIFF
--- a/src/app/sales/admin/pipeline-doc-mapping/page.tsx
+++ b/src/app/sales/admin/pipeline-doc-mapping/page.tsx
@@ -87,6 +87,7 @@ export default function PipelineDocMappingPage() {
           steps: [
             { key: "interview", label: "Interview" },
             { key: "welcome_docs", label: "Welcome Docs" },
+            { key: "completion", label: "Completion" },
           ],
         });
       }


### PR DESCRIPTION
The completion step was missing from the onboarding pipeline step options, preventing admins from assigning documents that get sent to candidates when they finish all onboarding docs.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2