### PR TITLE
Add completion step option to document templates admin page

### DIFF
--- a/src/app/sales/admin/documents/page.tsx
+++ b/src/app/sales/admin/documents/page.tsx
@@ -76,6 +76,7 @@ export default function AdminDocumentsPage() {
   const allStepOptions = [
     { value: "interview", label: "Interview" },
     { value: "welcome_docs", label: "Welcome Docs" },
+    { value: "completion", label: "Completion" },
     ...allPipelines.flatMap((p) =>
       p.pipeline_steps.map((s) => ({ value: `pipeline_${p.id}_${s.id}`, label: `${p.name} — ${s.name}` }))
     ),


### PR DESCRIPTION
Templates couldn't be created with step_key="completion" because the option was missing from the step dropdown on the documents admin page.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2