### PR TITLE
Link completion docs to pipeline and send on approval

### DIFF
--- a/src/app/api/onboarding/candidates/[id]/approve/route.ts
+++ b/src/app/api/onboarding/candidates/[id]/approve/route.ts
@@ -119,6 +119,35 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
       })
       .eq("id", id);
 
+    // Send completion documents if any are mapped
+    if (candidate.email) {
+      try {
+        const { data: resourceAssignments } = await supabaseAdmin
+          .from("step_document_assignments")
+          .select("*, document_templates(id, name, file_name, file_path, mime_type, active, form_enabled)")
+          .eq("pipeline_id", candidate.current_pipeline_id)
+          .eq("step_key", "completion");
+
+        const resourceDocs = (resourceAssignments || []).filter((a: Record<string, unknown>) => {
+          const tmpl = a.document_templates as Record<string, unknown> | null;
+          return tmpl && tmpl.active;
+        });
+
+        if (resourceDocs.length > 0) {
+          await sendOnboardingDocsEmail({
+            candidateId: id,
+            candidateEmail: candidate.email,
+            candidateName: candidate.full_name,
+            stepKey: "completion",
+            pipelineId: candidate.current_pipeline_id,
+            roleType: candidate.onboarding_pipelines?.role_type || candidate.role_type,
+          });
+        }
+      } catch {
+        // Don't block approval if email fails
+      }
+    }
+
     return NextResponse.json({ success: true, new_status: "completed" });
   }
 

--- a/src/app/api/onboarding/candidates/[id]/route.ts
+++ b/src/app/api/onboarding/candidates/[id]/route.ts
@@ -32,7 +32,20 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
     .eq("candidate_id", id)
     .order("sent_at", { ascending: false });
 
-  return NextResponse.json({ ...data, all_steps: allSteps || [], email_logs: emailLogs || [] });
+  let completionDocs: { id: string; name: string; file_name: string }[] = [];
+  if (data.current_pipeline_id) {
+    const { data: compAssignments } = await supabaseAdmin
+      .from("step_document_assignments")
+      .select("document_templates(id, name, file_name)")
+      .eq("pipeline_id", data.current_pipeline_id)
+      .eq("step_key", "completion");
+
+    completionDocs = (compAssignments || [])
+      .map((a: Record<string, unknown>) => a.document_templates as { id: string; name: string; file_name: string })
+      .filter(Boolean);
+  }
+
+  return NextResponse.json({ ...data, all_steps: allSteps || [], email_logs: emailLogs || [], completion_docs: completionDocs });
 }
 
 export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {

--- a/src/app/sales/team/[id]/page.tsx
+++ b/src/app/sales/team/[id]/page.tsx
@@ -56,6 +56,7 @@ interface Candidate {
   candidate_documents: CandidateDoc[];
   all_steps: StepInfo[];
   email_logs: EmailLog[];
+  completion_docs: { id: string; name: string; file_name: string }[];
 }
 
 interface TrainingPipeline {
@@ -567,6 +568,22 @@ export default function CandidateDetailPage() {
             )}
           </div>
         ))}
+        <div className="mb-4 last:mb-0">
+          <h3 className="text-xs font-medium text-gray-500 uppercase mb-2">Completion Documents (sent on completion)</h3>
+          {candidate.completion_docs.length === 0 ? (
+            <p className="text-xs text-gray-300 ml-2">No documents mapped to completion step</p>
+          ) : (
+            <div className="space-y-1.5">
+              {candidate.completion_docs.map((doc) => (
+                <div key={doc.id} className="flex items-center gap-2 rounded-lg border border-gray-100 px-4 py-2.5">
+                  <FileText className="h-4 w-4 text-green-500" />
+                  <span className="text-sm text-gray-900">{doc.name}</span>
+                  <span className="text-xs text-gray-400">({doc.file_name})</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
       </div>
 
       {/* Email History */}


### PR DESCRIPTION
- Candidate API now returns completion_docs (templates mapped to the completion step) so the team page can display them
- Team page shows "Completion Documents" section listing mapped docs
- Approve route now sends completion docs email when a candidate is approved to completed status (previously only candidateAdvancement sent them, not the manual approval path)

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2