### PR TITLE
Use separate MARKETING_FROM_EMAIL for lead follow-up emails

### DIFF
--- a/src/app/api/sales/leads/[id]/emails/route.ts
+++ b/src/app/api/sales/leads/[id]/emails/route.ts
@@ -4,7 +4,7 @@ import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { getSalesUser } from "@/lib/salesAuth";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
-const FROM = process.env.FROM_EMAIL || "sales@bytebitevending.com";
+const FROM = process.env.MARKETING_FROM_EMAIL || "sales@vendingconnector.com";
 
 const TEMPLATES: Record<string, { subject: string; body: string }> = {
   initial_followup: {


### PR DESCRIPTION
Marketing emails from the leads page now default to sales@vendingconnector.com via MARKETING_FROM_EMAIL env var, keeping all other system emails on the existing FROM_EMAIL (sales@bytebitevending.com).

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2