### PR TITLE
Stop auto-sending W9/ACH on interview completion, require manual trigger

### DIFF
--- a/src/app/api/onboarding/candidates/[id]/send-docs/route.ts
+++ b/src/app/api/onboarding/candidates/[id]/send-docs/route.ts
@@ -102,6 +102,14 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
       portalUrl,
     });
 
+    // When welcome docs are manually sent, advance status from interview_complete
+    if (stepKey === "welcome_docs" && candidate.status === "interview_complete") {
+      await supabaseAdmin
+        .from("candidates")
+        .update({ status: "welcome_docs_sent", updated_at: new Date().toISOString() })
+        .eq("id", id);
+    }
+
     return NextResponse.json({ ...result, portal_url: portalUrl });
   } catch (err) {
     const message = err instanceof Error ? err.message : "Email send failed";

--- a/src/app/sales/team/[id]/page.tsx
+++ b/src/app/sales/team/[id]/page.tsx
@@ -68,7 +68,8 @@ interface TrainingPipeline {
 const STATUS_CONFIG: Record<string, { label: string; color: string }> = {
   interview: { label: "Interview", color: "bg-blue-50 text-blue-700" },
   pending_admin_review_1: { label: "Pending Admin Review", color: "bg-amber-50 text-amber-700" },
-  welcome_docs_sent: { label: "Welcome Docs Step", color: "bg-purple-50 text-purple-700" },
+  interview_complete: { label: "Interview Complete — Send Welcome Email", color: "bg-amber-50 text-amber-700" },
+  welcome_docs_sent: { label: "Welcome Docs Sent", color: "bg-purple-50 text-purple-700" },
   pending_admin_review_2: { label: "Pending Admin Review", color: "bg-amber-50 text-amber-700" },
   completed: { label: "Onboarding Complete", color: "bg-green-50 text-green-700" },
   assigned_to_training: { label: "Assigned to Training", color: "bg-emerald-50 text-emerald-700" },
@@ -437,10 +438,19 @@ export default function CandidateDetailPage() {
             </div>
           )}
 
-          {/* STEP 2: Welcome Docs */}
-          {candidate.status === "welcome_docs_sent" && (
+          {/* INTERVIEW COMPLETE — manual welcome email trigger */}
+          {candidate.status === "interview_complete" && (
             <div className="space-y-4">
-              <p className="text-sm text-gray-600">Send the welcome email with ACH and W9 form attachments.</p>
+              <div className="rounded-lg bg-amber-50 border border-amber-200 p-4">
+                <div className="flex items-center gap-2 text-sm font-medium text-amber-800 mb-2">
+                  <CheckCircle2 className="h-4 w-4" />
+                  Interview documents completed
+                </div>
+                <p className="text-xs text-amber-700">
+                  {candidate.full_name} has completed their interview documents and is ready for the Welcome Email.
+                  Click the button below to send the ACH and W9 forms when you are ready to move forward.
+                </p>
+              </div>
               <button
                 onClick={handleSendDocs}
                 disabled={sending}
@@ -449,6 +459,19 @@ export default function CandidateDetailPage() {
                 {sending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
                 Send Welcome Email with ACH and W9
               </button>
+            </div>
+          )}
+
+          {/* STEP 2: Welcome Docs (already sent, waiting for completion) */}
+          {candidate.status === "welcome_docs_sent" && (
+            <div className="space-y-4">
+              <div className="rounded-lg bg-purple-50 border border-purple-200 p-4">
+                <div className="flex items-center gap-2 text-sm font-medium text-purple-800 mb-2">
+                  <Clock className="h-4 w-4" />
+                  Welcome email sent — waiting for ACH and W9
+                </div>
+                <p className="text-xs text-purple-700">The welcome email with ACH and W9 forms has been sent to the candidate. Waiting for them to complete and submit.</p>
+              </div>
             </div>
           )}
 

--- a/src/lib/candidateAdvancement.ts
+++ b/src/lib/candidateAdvancement.ts
@@ -111,7 +111,7 @@ export async function checkAndAdvanceCandidate(tokenId: string): Promise<Advance
   let nextStepKey: string | null = null;
 
   if (stepKey === "interview") {
-    newStatus = "welcome_docs_sent";
+    newStatus = "interview_complete";
     nextStepKey = "welcome_docs";
   } else if (stepKey === "welcome_docs") {
     newStatus = "completed";
@@ -160,7 +160,8 @@ export async function checkAndAdvanceCandidate(tokenId: string): Promise<Advance
   let nextTokenUrl: string | null = null;
 
   // If there's a next step with documents, auto-send them
-  if (nextStepKey && candidate.email) {
+  // Skip auto-send when interview completes — admin must manually send welcome docs
+  if (nextStepKey && candidate.email && stepKey !== "interview") {
     try {
       // Check if next step has document assignments or form-enabled templates
       const { data: nextAssignments } = await supabaseAdmin

--- a/src/lib/onboardingNotificationEmail.ts
+++ b/src/lib/onboardingNotificationEmail.ts
@@ -37,7 +37,7 @@ function renderFormDataHtml(docs: CompletedDoc[]): string {
           if (f.type === "checkbox") {
             val = val ? "Yes" : "No";
           } else if (f.type === "sensitive") {
-            val = maskSensitive(String(val));
+            val = String(val);
           } else if (f.type === "signature") {
             val = `<em style="font-family:serif;">${String(val)}</em>`;
           } else {
@@ -102,7 +102,9 @@ export async function sendCompletionNotification(params: NotificationParams): Pr
 
   const isInterviewStep = stepKey === "interview";
 
-  const subject = `${candidateName} — ${isInterviewStep ? "Interview" : "Onboarding"} Documents Completed`;
+  const subject = isInterviewStep
+    ? `Action Required: ${candidateName} — Interview Documents Completed`
+    : `${candidateName} — Onboarding Documents Completed`;
 
   const bodyHtml = `
     <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:600px;margin:0 auto;padding:32px 24px;">
@@ -114,9 +116,14 @@ export async function sendCompletionNotification(params: NotificationParams): Pr
         Candidate <strong>${candidateName}</strong> has completed their <strong>${docNames}</strong>.
       </p>
       ${isInterviewStep ? `
-      <p style="color:#374151;font-size:14px;line-height:1.6;">
-        Please let them know they will need to check their email for the next step, which is signing the <strong>${roleLabel}</strong>.
-      </p>
+      <div style="background:#fef3c7;border:1px solid #f59e0b;border-radius:8px;padding:16px;margin:16px 0;">
+        <p style="color:#92400e;font-size:14px;line-height:1.6;margin:0;font-weight:600;">
+          ${candidateName} is ready for their Welcome Email.
+        </p>
+        <p style="color:#92400e;font-size:14px;line-height:1.6;margin:8px 0 0;">
+          Please login to the CRM and send the candidate their welcome email if they are ready to move forward. The welcome email with ACH and W9 forms will NOT be sent automatically.
+        </p>
+      </div>
       ` : `
       <p style="color:#374151;font-size:14px;line-height:1.6;">
         All onboarding documents have been completed and submitted.


### PR DESCRIPTION
Interview doc submission now sets status to "interview_complete" instead of auto-sending welcome docs. Assigned user + admin receive a notification prompting them to manually send the welcome email from the CRM. Sensitive fields in notification emails are now shown unmasked for internal team.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2