### PR TITLE
Add interview_complete status to all pipeline UI views

### DIFF
--- a/src/app/api/onboarding/dashboard/route.ts
+++ b/src/app/api/onboarding/dashboard/route.ts
@@ -15,7 +15,7 @@ export async function GET(req: NextRequest) {
   const all = candidates || [];
   const total = all.length;
   const interviewing = all.filter((c) => c.status === "interview").length;
-  const pendingReview = all.filter((c) => c.status === "pending_admin_review_1" || c.status === "pending_admin_review_2").length;
+  const pendingReview = all.filter((c) => c.status === "pending_admin_review_1" || c.status === "pending_admin_review_2" || c.status === "interview_complete").length;
   const welcomeDocs = all.filter((c) => c.status === "welcome_docs_sent").length;
   const completed = all.filter((c) => c.status === "completed").length;
   const assignedToTraining = all.filter((c) => c.status === "assigned_to_training").length;

--- a/src/app/sales/pipelines/onboarding/page.tsx
+++ b/src/app/sales/pipelines/onboarding/page.tsx
@@ -29,6 +29,7 @@ interface Pipeline {
 const STATUS_CONFIG: Record<string, { label: string; color: string }> = {
   interview: { label: "Interview", color: "bg-blue-50 text-blue-700" },
   pending_admin_review_1: { label: "Pending Review", color: "bg-amber-50 text-amber-700" },
+  interview_complete: { label: "Ready for Welcome Email", color: "bg-amber-50 text-amber-700" },
   welcome_docs_sent: { label: "Welcome Docs", color: "bg-purple-50 text-purple-700" },
   pending_admin_review_2: { label: "Pending Review", color: "bg-amber-50 text-amber-700" },
   completed: { label: "Completed", color: "bg-green-50 text-green-700" },
@@ -130,7 +131,7 @@ export default function OnboardingPipelinePage() {
 
   for (const c of candidates) {
     if (c.status === "interview") groupedByStep["interview"].push(c);
-    else if (c.status === "pending_admin_review_1") groupedByStep["pending_review_1"].push(c);
+    else if (c.status === "pending_admin_review_1" || c.status === "interview_complete") groupedByStep["pending_review_1"].push(c);
     else if (c.status === "welcome_docs_sent") groupedByStep["welcome_docs"].push(c);
     else if (c.status === "pending_admin_review_2") groupedByStep["pending_review_2"].push(c);
     else if (c.status === "completed" || c.status === "assigned_to_training") groupedByStep["completed"].push(c);

--- a/src/app/sales/team/page.tsx
+++ b/src/app/sales/team/page.tsx
@@ -28,6 +28,7 @@ interface Candidate {
 const STATUS_CONFIG: Record<string, { label: string; color: string }> = {
   interview: { label: "Interview", color: "bg-blue-50 text-blue-700" },
   pending_admin_review_1: { label: "Pending Review", color: "bg-amber-50 text-amber-700" },
+  interview_complete: { label: "Ready for Welcome Email", color: "bg-amber-50 text-amber-700" },
   welcome_docs_sent: { label: "Welcome Docs", color: "bg-purple-50 text-purple-700" },
   pending_admin_review_2: { label: "Pending Review", color: "bg-amber-50 text-amber-700" },
   completed: { label: "Completed", color: "bg-green-50 text-green-700" },
@@ -39,6 +40,7 @@ const FILTERS = [
   { value: "", label: "All" },
   { value: "interview", label: "Interviewing" },
   { value: "pending_admin_review_1", label: "Pending Review 1" },
+  { value: "interview_complete", label: "Ready for Welcome Email" },
   { value: "welcome_docs_sent", label: "Welcome Docs" },
   { value: "pending_admin_review_2", label: "Pending Review 2" },
   { value: "completed", label: "Completed" },

--- a/src/lib/pipelineTypes.ts
+++ b/src/lib/pipelineTypes.ts
@@ -177,6 +177,7 @@ export type CandidateStatus =
   | "application"
   | "interview"
   | "pending_admin_review_1"
+  | "interview_complete"
   | "welcome_docs_sent"
   | "pending_admin_review_2"
   | "completed"


### PR DESCRIPTION
Candidates with interview_complete status were disappearing from the pipeline Kanban, team list, and dashboard because the new status wasn't recognized. Now shows in Admin Review column with "Ready for Welcome Email" label.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2