### PR TITLE
Fix interview completion flow: stop all auto-send paths for welcome docs

### DIFF
--- a/src/app/api/onboarding/candidates/[id]/approve/route.ts
+++ b/src/app/api/onboarding/candidates/[id]/approve/route.ts
@@ -31,74 +31,13 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
     await supabaseAdmin
       .from("candidates")
       .update({
-        status: "welcome_docs_sent",
+        status: "interview_complete",
         current_step_id: nextStep?.id || candidate.current_step_id,
         updated_at: new Date().toISOString(),
       })
       .eq("id", id);
 
-    // Auto-send welcome docs with portal link if candidate has email
-    let portalUrl: string | null = null;
-    if (candidate.email) {
-      try {
-        const nextStepKey = "welcome_docs";
-        const { data: assignments } = await supabaseAdmin
-          .from("step_document_assignments")
-          .select("id, required, document_templates(id, active)")
-          .eq("pipeline_id", candidate.current_pipeline_id)
-          .eq("step_key", nextStepKey);
-
-        let requiredCount = (assignments || []).filter(
-          (a: Record<string, unknown>) => {
-            const tmpl = a.document_templates as Record<string, unknown> | null;
-            return a.required && tmpl && tmpl.active && tmpl.form_enabled;
-          }
-        ).length;
-
-        // Fallback: count form-enabled templates if no assignments
-        if (requiredCount === 0) {
-          const { count } = await supabaseAdmin
-            .from("document_templates")
-            .select("id", { count: "exact", head: true })
-            .eq("step_key", nextStepKey)
-            .eq("form_enabled", true)
-            .eq("active", true);
-          requiredCount = count || 0;
-        }
-
-        if (requiredCount > 0) {
-          const { data: tokenRecord } = await supabaseAdmin
-            .from("candidate_tokens")
-            .insert({
-              candidate_id: id,
-              step_key: nextStepKey,
-              pipeline_id: candidate.current_pipeline_id,
-              required_doc_count: requiredCount,
-            })
-            .select("token")
-            .single();
-
-          if (tokenRecord) {
-            const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "https://vendingconnector.com";
-            portalUrl = `${baseUrl}/onboarding/${tokenRecord.token}`;
-          }
-
-          await sendOnboardingDocsEmail({
-            candidateId: id,
-            candidateEmail: candidate.email,
-            candidateName: candidate.full_name,
-            stepKey: nextStepKey,
-            pipelineId: candidate.current_pipeline_id,
-            roleType: candidate.onboarding_pipelines?.role_type || candidate.role_type,
-            portalUrl,
-          });
-        }
-      } catch {
-        // Don't block approval if email fails
-      }
-    }
-
-    return NextResponse.json({ success: true, new_status: "welcome_docs_sent", portal_url: portalUrl });
+    return NextResponse.json({ success: true, new_status: "interview_complete" });
   }
 
   if (currentStatus === "pending_admin_review_2") {

--- a/src/app/api/onboarding/candidates/[id]/send-docs/route.ts
+++ b/src/app/api/onboarding/candidates/[id]/send-docs/route.ts
@@ -52,7 +52,7 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
     // Count required documents for this step
     const { data: assignments } = await supabaseAdmin
       .from("step_document_assignments")
-      .select("id, required, document_templates(id, active)")
+      .select("id, required, document_templates(id, active, form_enabled)")
       .eq("pipeline_id", candidate.current_pipeline_id)
       .eq("step_key", stepKey);
 

--- a/src/app/onboarding/[token]/page.tsx
+++ b/src/app/onboarding/[token]/page.tsx
@@ -152,7 +152,7 @@ function PortalContent() {
             <p className="text-sm text-gray-600">
               Thank you, {data.candidate_name}! All required documents have been signed and submitted.
               {data.step_key === "interview"
-                ? " You'll receive your next set of onboarding documents shortly."
+                ? " Your assigned representative will review your documents and send you the next steps when ready."
                 : " Your onboarding is now complete."}
             </p>
           </div>


### PR DESCRIPTION
- Approve endpoint: no longer auto-sends welcome docs on admin review 1 approval, sets status to interview_complete instead
- Send-docs endpoint: fix missing form_enabled in select query that caused required_doc_count to always be 0
- Portal: update completion message since welcome docs are no longer sent automatically

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2