### PR TITLE
Fix double dollar sign on Locations for Sale listing cards

### DIFF
--- a/src/app/components/RequestCard.tsx
+++ b/src/app/components/RequestCard.tsx
@@ -89,7 +89,7 @@ export default function RequestCard({
         <div className="flex items-center gap-1.5 mt-3">
           <DollarSign className="w-4 h-4 text-green-600" />
           <span className="text-lg font-bold text-green-700">
-            ${request.price.toLocaleString()}
+            {request.price.toLocaleString()}
           </span>
         </div>
       )}


### PR DESCRIPTION
The DollarSign icon already renders a $ visually, so the literal $ in the template string was duplicating it.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2