### PR TITLE
Fix lead deletion blocked by pipeline_items FK constraint

### DIFF
--- a/src/app/api/sales/leads/[id]/route.ts
+++ b/src/app/api/sales/leads/[id]/route.ts
@@ -276,6 +276,7 @@ export async function DELETE(req: NextRequest, { params }: { params: Promise<{ i
   // Activity log rows cascade automatically.
   await supabaseAdmin.from("location_agreements").update({ lead_id: null }).eq("lead_id", id);
   await supabaseAdmin.from("sales_deals").update({ lead_id: null }).eq("lead_id", id);
+  await supabaseAdmin.from("pipeline_items").update({ lead_id: null }).eq("lead_id", id);
 
   const { error } = await supabaseAdmin.from("sales_leads").delete().eq("id", id);
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });


### PR DESCRIPTION
Detach pipeline_items.lead_id before deleting the lead, matching the existing pattern for location_agreements and sales_deals.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2