### PR TITLE
Auto-send location agreement form when location lead is created

### DIFF
--- a/src/app/api/sales/leads/[id]/route.ts
+++ b/src/app/api/sales/leads/[id]/route.ts
@@ -2,42 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { getSalesUser, isElevatedRole } from "@/lib/salesAuth";
 import { sendLeadAssignmentEmail } from "@/lib/email";
-import { sendLocationAgreementEmail } from "@/lib/locationAgreementEmail";
-
-const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "https://vendingconnector.com";
-
-async function createAndSendAgreement(leadId: string, lead: { business_name?: string; contact_name?: string; email?: string; phone?: string; address?: string; title_role?: string }) {
-  if (!lead.email) return;
-
-  const existing = await supabaseAdmin
-    .from("location_agreements")
-    .select("id")
-    .eq("lead_id", leadId)
-    .maybeSingle();
-  if (existing.data) return;
-
-  const { data: agreement } = await supabaseAdmin
-    .from("location_agreements")
-    .insert({
-      lead_id: leadId,
-      business_name: lead.business_name || null,
-      contact_name: lead.contact_name || null,
-      email: lead.email,
-      phone: lead.phone || null,
-      address: lead.address || null,
-    })
-    .select("token")
-    .single();
-
-  if (!agreement) return;
-
-  await sendLocationAgreementEmail({
-    to: lead.email,
-    recipientName: lead.contact_name || "Business Owner",
-    businessName: lead.business_name || "your location",
-    agreementUrl: `${APP_URL}/location-agreement/${agreement.token}`,
-  });
-}
+import { createAndSendAgreement } from "@/lib/locationAgreement";
 
 export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const user = await getSalesUser(req);

--- a/src/app/api/sales/leads/route.ts
+++ b/src/app/api/sales/leads/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { getSalesUser } from "@/lib/salesAuth";
+import { createAndSendAgreement } from "@/lib/locationAgreement";
 
 export async function GET(req: NextRequest) {
   const user = await getSalesUser(req);
@@ -137,6 +138,18 @@ export async function POST(req: NextRequest) {
         .from("sales_accounts")
         .update({ entity_type: "location" })
         .eq("id", account.id);
+    }
+
+    try {
+      await createAndSendAgreement(data.id, {
+        business_name: body.location_name || business_name,
+        contact_name: body.decision_maker_name || contact_name,
+        email: body.decision_maker_email || email,
+        phone: phone,
+        address: address,
+      });
+    } catch (err) {
+      console.error("[leads] Failed to send location agreement on create:", err instanceof Error ? err.message : err);
     }
   }
 

--- a/src/lib/locationAgreement.ts
+++ b/src/lib/locationAgreement.ts
@@ -1,0 +1,47 @@
+import { supabaseAdmin } from "./supabaseAdmin";
+import { sendLocationAgreementEmail } from "./locationAgreementEmail";
+
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "https://vendingconnector.com";
+
+export async function createAndSendAgreement(
+  leadId: string,
+  lead: {
+    business_name?: string;
+    contact_name?: string;
+    email?: string;
+    phone?: string;
+    address?: string;
+    title_role?: string;
+  }
+) {
+  if (!lead.email) return;
+
+  const existing = await supabaseAdmin
+    .from("location_agreements")
+    .select("id")
+    .eq("lead_id", leadId)
+    .maybeSingle();
+  if (existing.data) return;
+
+  const { data: agreement } = await supabaseAdmin
+    .from("location_agreements")
+    .insert({
+      lead_id: leadId,
+      business_name: lead.business_name || null,
+      contact_name: lead.contact_name || null,
+      email: lead.email,
+      phone: lead.phone || null,
+      address: lead.address || null,
+    })
+    .select("token")
+    .single();
+
+  if (!agreement) return;
+
+  await sendLocationAgreementEmail({
+    to: lead.email,
+    recipientName: lead.contact_name || "Business Owner",
+    businessName: lead.business_name || "your location",
+    agreementUrl: `${APP_URL}/location-agreement/${agreement.token}`,
+  });
+}


### PR DESCRIPTION
Extract createAndSendAgreement to shared lib and call it from the lead creation POST endpoint. The decision maker receives the placement agreement email immediately, and signed data syncs back to the lead account automatically.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2