### PR TITLE
Add AI Machine to machine type options across all forms

### DIFF
--- a/src/app/machines-for-sale/page.tsx
+++ b/src/app/machines-for-sale/page.tsx
@@ -15,6 +15,7 @@ import type { MachineListing } from "@/lib/types";
 import { US_STATES, US_STATE_NAMES } from "@/lib/types";
 
 const MACHINE_TYPE_OPTIONS = [
+  "AI Machine",
   "Snack",
   "Beverage",
   "Combo",

--- a/src/app/post-machine/page.tsx
+++ b/src/app/post-machine/page.tsx
@@ -24,6 +24,7 @@ const MACHINE_TYPE_OPTIONS = [
   "Cold Food",
   "Frozen",
   "Healthy",
+  "AI Machine",
   "Specialty",
   "Other",
 ];

--- a/src/app/sales/leads/page.tsx
+++ b/src/app/sales/leads/page.tsx
@@ -729,6 +729,7 @@ export default function LeadsPage() {
                 <input placeholder="Phone *" value={addForm.phone || ""} onChange={(e) => setAddForm((f) => ({ ...f, phone: e.target.value }))} className="rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none" />
                 <select value={addForm.machine_type} onChange={(e) => setAddForm((f) => ({ ...f, machine_type: e.target.value }))} className="rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none cursor-pointer">
                   <option value="">Machine Type *</option>
+                  <option value="ai">AI Machine</option>
                   <option value="snack">Snack</option>
                   <option value="beverage">Beverage</option>
                   <option value="combo">Combo</option>


### PR DESCRIPTION
Added to post-machine, machines-for-sale filter, and leads page machine type dropdown.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2