### PR TITLE
Add Buy Now button to machine listing cards on browse page

### DIFF
--- a/src/app/machines-for-sale/[id]/page.tsx
+++ b/src/app/machines-for-sale/[id]/page.tsx
@@ -194,6 +194,14 @@ export default function MachineDetailPage() {
     fetchListing();
   }, [fetchListing]);
 
+  // Auto-trigger checkout if redirected from Buy Now on listing card
+  useEffect(() => {
+    if (listing && listing.buy_now_enabled && searchParams.get("checkout") === "1" && !checkingOut) {
+      handleBuyNow();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [listing]);
+
   // Fetch similar listings in same state
   useEffect(() => {
     if (!listing) return;

--- a/src/app/machines-for-sale/page.tsx
+++ b/src/app/machines-for-sale/page.tsx
@@ -10,6 +10,7 @@ import {
   MapPin,
   Plus,
   Package,
+  ShoppingCart,
 } from "lucide-react";
 import type { MachineListing } from "@/lib/types";
 import { US_STATES, US_STATE_NAMES } from "@/lib/types";
@@ -179,6 +180,21 @@ function MachineCard({ listing }: { listing: MachineListing }) {
           </span>
         )}
       </div>
+
+      {/* Buy Now button */}
+      {listing.buy_now_enabled && (
+        <button
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            window.location.href = `/machines-for-sale/${listing.id}?checkout=1`;
+          }}
+          className="mt-4 flex w-full items-center justify-center gap-2 rounded-lg bg-green-600 px-4 py-2.5 text-sm font-semibold text-white hover:bg-green-700 transition-colors"
+        >
+          <ShoppingCart className="h-4 w-4" />
+          Buy Now{listing.buy_now_price ? ` — ${formatCurrency(listing.buy_now_price / 100)}` : ""}
+        </button>
+      )}
     </Link>
   );
 }


### PR DESCRIPTION
Shows a green Buy Now button with price on cards where buy_now is enabled. Clicking it navigates to the detail page with ?checkout=1 which auto-triggers the Stripe checkout flow.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2