### PR TITLE
Add pre-purchase form for machine Buy Now with full automation

### DIFF
--- a/src/app/api/machine-listings/[id]/checkout/route.ts
+++ b/src/app/api/machine-listings/[id]/checkout/route.ts
@@ -4,6 +4,7 @@ import { supabaseAdmin } from "@/lib/supabaseAdmin";
 
 export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
+  const body = await req.json().catch(() => ({}));
 
   const { data: listing } = await supabaseAdmin
     .from("machine_listings")
@@ -18,6 +19,49 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
   const priceInCents = listing.buy_now_price || (listing.asking_price ? listing.asking_price * 100 : null);
   if (!priceInCents) return NextResponse.json({ error: "No price set for this listing" }, { status: 400 });
 
+  if (!body.full_name || !body.email || !body.phone) {
+    return NextResponse.json({ error: "Full name, email, and phone are required" }, { status: 400 });
+  }
+
+  const { data: purchase, error: purchaseErr } = await supabaseAdmin
+    .from("machine_listing_purchases")
+    .insert({
+      machine_listing_id: listing.id,
+      amount_cents: priceInCents,
+      full_name: body.full_name,
+      email: body.email,
+      phone: body.phone,
+      buyer_type: body.buyer_type || null,
+      business_name: body.business_name || null,
+      llc_status: body.llc_status || null,
+      location_status: body.location_status || null,
+      location_business_name: body.location_business_name || null,
+      location_address: body.location_address || null,
+      location_city: body.location_city || null,
+      location_state: body.location_state || null,
+      location_zip: body.location_zip || null,
+      site_contact_name: body.site_contact_name || null,
+      site_contact_phone: body.site_contact_phone || null,
+      site_contact_email: body.site_contact_email || null,
+      placement_type: body.placement_type || null,
+      preferred_market: body.preferred_market || null,
+      desired_location_type: body.desired_location_type || null,
+      foot_traffic: body.foot_traffic || null,
+      deployment_timeline: body.deployment_timeline || null,
+      has_power_outlet: !!body.has_power_outlet,
+      has_indoor_placement: !!body.has_indoor_placement,
+      has_enough_space: !!body.has_enough_space,
+      has_delivery_access: !!body.has_delivery_access,
+      connectivity: body.connectivity || null,
+      shipping_intent: body.shipping_intent || null,
+    })
+    .select("id")
+    .single();
+
+  if (purchaseErr) {
+    return NextResponse.json({ error: "Failed to create purchase record" }, { status: 500 });
+  }
+
   const stripeKey = process.env.STRIPE_SECRET_KEY;
   if (!stripeKey) return NextResponse.json({ error: "Payment not configured" }, { status: 500 });
 
@@ -26,6 +70,7 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
 
   const session = await stripe.checkout.sessions.create({
     mode: "payment",
+    customer_email: body.email,
     line_items: [
       {
         price_data: {
@@ -41,11 +86,17 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
     ],
     metadata: {
       machine_listing_id: listing.id,
+      purchase_id: purchase.id,
       type: "machine_purchase",
     },
     success_url: `${origin}/machines-for-sale/${listing.id}?purchased=true`,
     cancel_url: `${origin}/machines-for-sale/${listing.id}`,
   });
+
+  await supabaseAdmin
+    .from("machine_listing_purchases")
+    .update({ stripe_checkout_session_id: session.id })
+    .eq("id", purchase.id);
 
   return NextResponse.json({ url: session.url });
 }

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -7,6 +7,7 @@ import {
   sendPurchaseConfirmationEmail,
   isLeadInfoComplete,
 } from "@/lib/email";
+import { sendMachinePurchaseThankYouEmail, sendMachinePurchaseNotificationEmail } from "@/lib/machinePurchaseEmail";
 import { generateSiteDetailsPdf } from "@/lib/pdf/agreementPdf";
 import { sendFullSiteDetailsEmail } from "@/lib/agreementEmail";
 import { PricingResult } from "@/lib/pricing/locationPricing";
@@ -62,6 +63,12 @@ export async function POST(req: NextRequest) {
     // Handle agreement payments (location placement)
     if (session.metadata?.type === "agreement_payment") {
       await handleAgreementPayment(session);
+      return NextResponse.json({ received: true });
+    }
+
+    // Handle machine listing purchases
+    if (session.metadata?.type === "machine_purchase") {
+      await handleMachinePurchase(session);
       return NextResponse.json({ received: true });
     }
 
@@ -197,6 +204,14 @@ export async function POST(req: NextRequest) {
     const session = event.data.object as Stripe.Checkout.Session;
     await supabaseAdmin
       .from("lead_purchases")
+      .update({
+        status: "failed",
+        updated_at: new Date().toISOString(),
+      })
+      .eq("stripe_checkout_session_id", session.id);
+
+    await supabaseAdmin
+      .from("machine_listing_purchases")
       .update({
         status: "failed",
         updated_at: new Date().toISOString(),
@@ -368,5 +383,111 @@ async function handleAgreementPayment(session: Stripe.Checkout.Session) {
     });
   } catch (e) {
     console.error("[stripe-webhook] Failed to send full site details:", e);
+  }
+}
+
+async function handleMachinePurchase(session: Stripe.Checkout.Session) {
+  const purchaseId = session.metadata?.purchase_id;
+  const listingId = session.metadata?.machine_listing_id;
+  const paymentIntentId =
+    typeof session.payment_intent === "string"
+      ? session.payment_intent
+      : session.payment_intent?.id ?? null;
+
+  if (!purchaseId) return;
+
+  const { data: purchase } = await supabaseAdmin
+    .from("machine_listing_purchases")
+    .update({
+      status: "completed",
+      stripe_payment_intent_id: paymentIntentId,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", purchaseId)
+    .select("*")
+    .single();
+
+  if (!purchase) return;
+
+  const { data: listing } = await supabaseAdmin
+    .from("machine_listings")
+    .select("id, title, machine_type, machine_make, machine_model, buy_now_price, asking_price")
+    .eq("id", listingId)
+    .single();
+
+  const machineTitle = listing?.title || "Vending Machine";
+
+  // Auto-create CRM account + lead for the buyer
+  try {
+    const { data: account } = await supabaseAdmin
+      .from("sales_accounts")
+      .insert({
+        business_name: purchase.business_name || purchase.full_name,
+        contact_name: purchase.full_name,
+        phone: purchase.phone,
+        email: purchase.email,
+        address: purchase.location_address || null,
+        entity_type: "operator",
+      })
+      .select("id")
+      .single();
+
+    if (account) {
+      const { data: lead } = await supabaseAdmin
+        .from("sales_leads")
+        .insert({
+          business_name: purchase.business_name || purchase.full_name,
+          contact_name: purchase.full_name,
+          phone: purchase.phone,
+          email: purchase.email,
+          address: purchase.location_address || null,
+          city: purchase.location_city || null,
+          state: purchase.location_state || null,
+          entity_type: "operator",
+          source: "machine_purchase",
+          status: "qualified",
+          account_id: account.id,
+          notes: `Machine purchase: ${machineTitle} — $${(purchase.amount_cents / 100).toFixed(2)}\nBuyer type: ${purchase.buyer_type || "N/A"}\nLocation status: ${purchase.location_status || "N/A"}\nDeployment: ${purchase.deployment_timeline || "N/A"}\nShipping: ${purchase.shipping_intent || "N/A"}`,
+        })
+        .select("id")
+        .single();
+
+      await supabaseAdmin
+        .from("machine_listing_purchases")
+        .update({
+          crm_account_id: account.id,
+          crm_lead_id: lead?.id || null,
+        })
+        .eq("id", purchaseId);
+    }
+  } catch (e) {
+    console.error("[stripe-webhook] Failed to create CRM records for machine purchase:", e);
+  }
+
+  // Send thank-you email to buyer
+  try {
+    await sendMachinePurchaseThankYouEmail({
+      to: purchase.email,
+      buyerName: purchase.full_name,
+      machineTitle,
+      amountCents: purchase.amount_cents,
+      purchaseId: purchase.id,
+      stripePaymentIntentId: paymentIntentId,
+    });
+  } catch (e) {
+    console.error("[stripe-webhook] Failed to send machine purchase thank-you email:", e);
+  }
+
+  // Send notification to james@apexaivending.com
+  try {
+    const notifyEmail = process.env.MACHINE_PURCHASE_NOTIFY_EMAIL || "james@apexaivending.com";
+    await sendMachinePurchaseNotificationEmail({
+      to: notifyEmail,
+      purchase,
+      machineTitle,
+      listing,
+    });
+  } catch (e) {
+    console.error("[stripe-webhook] Failed to send machine purchase notification:", e);
   }
 }

--- a/src/app/machines-for-sale/[id]/checkout/page.tsx
+++ b/src/app/machines-for-sale/[id]/checkout/page.tsx
@@ -1,0 +1,611 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+import {
+  Loader2,
+  ArrowLeft,
+  User,
+  Building2,
+  MapPin,
+  Clock,
+  Wifi,
+  Truck,
+  CheckSquare,
+  ShoppingCart,
+} from "lucide-react";
+
+interface Listing {
+  id: string;
+  title: string;
+  buy_now_enabled: boolean;
+  buy_now_price: number | null;
+  asking_price: number | null;
+  status: string;
+  image_thumb_url: string | null;
+  photos: string[];
+}
+
+const PLACEMENT_TYPES = [
+  "Office",
+  "Gym",
+  "Hotel",
+  "School",
+  "Warehouse",
+  "Apartment",
+  "Hospital",
+  "Retail",
+  "Government",
+  "Other",
+];
+
+function formatCurrency(cents: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(cents / 100);
+}
+
+export default function CheckoutFormPage() {
+  const { id } = useParams<{ id: string }>();
+  const [listing, setListing] = useState<Listing | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Form state
+  const [fullName, setFullName] = useState("");
+  const [email, setEmail] = useState("");
+  const [phone, setPhone] = useState("");
+  const [buyerType, setBuyerType] = useState("");
+  const [businessName, setBusinessName] = useState("");
+  const [llcStatus, setLlcStatus] = useState("");
+  const [locationStatus, setLocationStatus] = useState("");
+
+  // Existing location fields
+  const [locationBusinessName, setLocationBusinessName] = useState("");
+  const [locationAddress, setLocationAddress] = useState("");
+  const [locationCity, setLocationCity] = useState("");
+  const [locationState, setLocationState] = useState("");
+  const [locationZip, setLocationZip] = useState("");
+  const [siteContactName, setSiteContactName] = useState("");
+  const [siteContactPhone, setSiteContactPhone] = useState("");
+  const [siteContactEmail, setSiteContactEmail] = useState("");
+  const [placementType, setPlacementType] = useState("");
+
+  // No location fields
+  const [preferredMarket, setPreferredMarket] = useState("");
+  const [desiredLocationType, setDesiredLocationType] = useState("");
+  const [footTraffic, setFootTraffic] = useState("");
+
+  // Deployment
+  const [deploymentTimeline, setDeploymentTimeline] = useState("");
+
+  // Site readiness
+  const [hasPowerOutlet, setHasPowerOutlet] = useState(false);
+  const [hasIndoorPlacement, setHasIndoorPlacement] = useState(false);
+  const [hasEnoughSpace, setHasEnoughSpace] = useState(false);
+  const [hasDeliveryAccess, setHasDeliveryAccess] = useState(false);
+
+  // Connectivity
+  const [connectivity, setConnectivity] = useState("");
+
+  // Shipping
+  const [shippingIntent, setShippingIntent] = useState("");
+
+  useEffect(() => {
+    async function load() {
+      const res = await fetch(`/api/machine-listings/${id}`);
+      if (res.ok) {
+        const data = await res.json();
+        setListing(data);
+      } else {
+        setError("Listing not found");
+      }
+      setLoading(false);
+    }
+    load();
+  }, [id]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!listing) return;
+
+    if (!fullName.trim() || !email.trim() || !phone.trim()) {
+      setError("Please fill in all required fields (name, email, phone).");
+      return;
+    }
+    if (!buyerType) {
+      setError("Please select your buyer type.");
+      return;
+    }
+    if (!locationStatus) {
+      setError("Please select your location status.");
+      return;
+    }
+    if (!deploymentTimeline) {
+      setError("Please select your deployment timeline.");
+      return;
+    }
+    if (!shippingIntent) {
+      setError("Please select your shipping preference.");
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const res = await fetch(`/api/machine-listings/${listing.id}/checkout`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          full_name: fullName.trim(),
+          email: email.trim(),
+          phone: phone.trim(),
+          buyer_type: buyerType,
+          business_name: businessName.trim() || null,
+          llc_status: llcStatus || null,
+          location_status: locationStatus,
+          location_business_name: locationBusinessName.trim() || null,
+          location_address: locationAddress.trim() || null,
+          location_city: locationCity.trim() || null,
+          location_state: locationState.trim() || null,
+          location_zip: locationZip.trim() || null,
+          site_contact_name: siteContactName.trim() || null,
+          site_contact_phone: siteContactPhone.trim() || null,
+          site_contact_email: siteContactEmail.trim() || null,
+          placement_type: placementType || null,
+          preferred_market: preferredMarket.trim() || null,
+          desired_location_type: desiredLocationType.trim() || null,
+          foot_traffic: footTraffic || null,
+          deployment_timeline: deploymentTimeline,
+          has_power_outlet: hasPowerOutlet,
+          has_indoor_placement: hasIndoorPlacement,
+          has_enough_space: hasEnoughSpace,
+          has_delivery_access: hasDeliveryAccess,
+          connectivity: connectivity || null,
+          shipping_intent: shippingIntent,
+        }),
+      });
+
+      if (res.ok) {
+        const { url } = await res.json();
+        if (url) window.location.href = url;
+      } else {
+        const data = await res.json().catch(() => ({}));
+        setError(data.error || "Failed to start checkout. Please try again.");
+      }
+    } catch {
+      setError("Network error. Please try again.");
+    }
+    setSubmitting(false);
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <Loader2 className="h-8 w-8 animate-spin text-green-600" />
+      </div>
+    );
+  }
+
+  if (!listing) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+        <div className="text-center">
+          <h1 className="text-lg font-semibold text-gray-900 mb-2">Listing Not Found</h1>
+          <Link href="/machines-for-sale" className="text-sm text-green-600 hover:underline">
+            Back to Machines for Sale
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const price = listing.buy_now_price || (listing.asking_price ? listing.asking_price * 100 : null);
+  const showExistingLocation = locationStatus === "confirmed";
+  const showNoLocation = locationStatus === "securing" || locationStatus === "need_help";
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-8 px-4">
+      <div className="mx-auto max-w-2xl">
+        {/* Header */}
+        <Link
+          href={`/machines-for-sale/${listing.id}`}
+          className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-green-600 transition-colors mb-6"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to listing
+        </Link>
+
+        <div className="mb-6">
+          <h1 className="text-2xl font-bold text-gray-900">Complete Your Purchase</h1>
+          <p className="text-sm text-gray-500 mt-1">
+            {listing.title}
+            {price ? ` — ${formatCurrency(price)}` : ""}
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit}>
+          {/* Section 1: Buyer Identity */}
+          <div className="rounded-2xl border border-gray-200 bg-white shadow-sm overflow-hidden mb-4">
+            <div className="px-6 py-4 border-b border-gray-100 bg-gray-50">
+              <div className="flex items-center gap-2">
+                <User className="h-4 w-4 text-green-600" />
+                <h2 className="text-sm font-semibold text-gray-900">Buyer Information</h2>
+              </div>
+            </div>
+            <div className="px-6 py-5 space-y-4">
+              <div>
+                <label className="block text-xs font-medium text-gray-500 mb-1">Full Name *</label>
+                <input type="text" required value={fullName} onChange={(e) => setFullName(e.target.value)} className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500" />
+              </div>
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-xs font-medium text-gray-500 mb-1">Email *</label>
+                  <input type="email" required value={email} onChange={(e) => setEmail(e.target.value)} className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500" />
+                </div>
+                <div>
+                  <label className="block text-xs font-medium text-gray-500 mb-1">Phone *</label>
+                  <input type="tel" required value={phone} onChange={(e) => setPhone(e.target.value)} className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500" />
+                </div>
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-gray-500 mb-1">Buyer Type *</label>
+                <div className="grid grid-cols-3 gap-3">
+                  {[
+                    { value: "individual_operator", label: "Individual Operator" },
+                    { value: "business_owner", label: "Business Owner" },
+                    { value: "investor", label: "Investor (no location yet)" },
+                  ].map((opt) => (
+                    <button
+                      key={opt.value}
+                      type="button"
+                      onClick={() => setBuyerType(opt.value)}
+                      className={`rounded-lg border px-3 py-2.5 text-xs font-medium transition-colors cursor-pointer ${
+                        buyerType === opt.value
+                          ? "border-green-500 bg-green-50 text-green-700"
+                          : "border-gray-200 text-gray-600 hover:border-green-300"
+                      }`}
+                    >
+                      {opt.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Section 2: Business Info */}
+          <div className="rounded-2xl border border-gray-200 bg-white shadow-sm overflow-hidden mb-4">
+            <div className="px-6 py-4 border-b border-gray-100 bg-gray-50">
+              <div className="flex items-center gap-2">
+                <Building2 className="h-4 w-4 text-green-600" />
+                <h2 className="text-sm font-semibold text-gray-900">Business Information</h2>
+              </div>
+            </div>
+            <div className="px-6 py-5 space-y-4">
+              <div>
+                <label className="block text-xs font-medium text-gray-500 mb-1">Business Name</label>
+                <input type="text" value={businessName} onChange={(e) => setBusinessName(e.target.value)} placeholder="Enter business name or TBD" className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm placeholder:text-gray-300 focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500" />
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-gray-500 mb-1">Do you have an LLC formed?</label>
+                <div className="grid grid-cols-3 gap-3">
+                  {[
+                    { value: "yes", label: "Yes" },
+                    { value: "no", label: "No" },
+                    { value: "in_progress", label: "In Progress" },
+                  ].map((opt) => (
+                    <button
+                      key={opt.value}
+                      type="button"
+                      onClick={() => setLlcStatus(opt.value)}
+                      className={`rounded-lg border px-3 py-2.5 text-xs font-medium transition-colors cursor-pointer ${
+                        llcStatus === opt.value
+                          ? "border-green-500 bg-green-50 text-green-700"
+                          : "border-gray-200 text-gray-600 hover:border-green-300"
+                      }`}
+                    >
+                      {opt.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Section 3: Location Status */}
+          <div className="rounded-2xl border border-gray-200 bg-white shadow-sm overflow-hidden mb-4">
+            <div className="px-6 py-4 border-b border-gray-100 bg-gray-50">
+              <div className="flex items-center gap-2">
+                <MapPin className="h-4 w-4 text-green-600" />
+                <h2 className="text-sm font-semibold text-gray-900">Location Status *</h2>
+              </div>
+            </div>
+            <div className="px-6 py-5 space-y-4">
+              <div className="space-y-2">
+                {[
+                  { value: "confirmed", label: "I have a confirmed location" },
+                  { value: "securing", label: "I am actively securing a location" },
+                  { value: "need_help", label: "I need help finding a location" },
+                ].map((opt) => (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    onClick={() => setLocationStatus(opt.value)}
+                    className={`w-full rounded-lg border px-4 py-3 text-sm text-left font-medium transition-colors cursor-pointer ${
+                      locationStatus === opt.value
+                        ? "border-green-500 bg-green-50 text-green-700"
+                        : "border-gray-200 text-gray-600 hover:border-green-300"
+                    }`}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+
+              {/* Existing location fields */}
+              {showExistingLocation && (
+                <div className="mt-4 space-y-4 pt-4 border-t border-gray-100">
+                  <p className="text-xs font-medium text-gray-400 uppercase tracking-wider">Location Details</p>
+                  <div>
+                    <label className="block text-xs font-medium text-gray-500 mb-1">Business Name at Location</label>
+                    <input type="text" value={locationBusinessName} onChange={(e) => setLocationBusinessName(e.target.value)} className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500" />
+                  </div>
+                  <div>
+                    <label className="block text-xs font-medium text-gray-500 mb-1">Address</label>
+                    <input type="text" value={locationAddress} onChange={(e) => setLocationAddress(e.target.value)} className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500" />
+                  </div>
+                  <div className="grid grid-cols-3 gap-3">
+                    <div>
+                      <label className="block text-xs font-medium text-gray-500 mb-1">City</label>
+                      <input type="text" value={locationCity} onChange={(e) => setLocationCity(e.target.value)} className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500" />
+                    </div>
+                    <div>
+                      <label className="block text-xs font-medium text-gray-500 mb-1">State</label>
+                      <input type="text" value={locationState} onChange={(e) => setLocationState(e.target.value)} className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500" />
+                    </div>
+                    <div>
+                      <label className="block text-xs font-medium text-gray-500 mb-1">ZIP</label>
+                      <input type="text" value={locationZip} onChange={(e) => setLocationZip(e.target.value)} className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500" />
+                    </div>
+                  </div>
+                  <p className="text-xs font-medium text-gray-400 uppercase tracking-wider pt-2">Site Contact</p>
+                  <div className="grid grid-cols-3 gap-3">
+                    <div>
+                      <label className="block text-xs font-medium text-gray-500 mb-1">Contact Name</label>
+                      <input type="text" value={siteContactName} onChange={(e) => setSiteContactName(e.target.value)} className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500" />
+                    </div>
+                    <div>
+                      <label className="block text-xs font-medium text-gray-500 mb-1">Contact Phone</label>
+                      <input type="tel" value={siteContactPhone} onChange={(e) => setSiteContactPhone(e.target.value)} className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500" />
+                    </div>
+                    <div>
+                      <label className="block text-xs font-medium text-gray-500 mb-1">Contact Email</label>
+                      <input type="email" value={siteContactEmail} onChange={(e) => setSiteContactEmail(e.target.value)} className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500" />
+                    </div>
+                  </div>
+                  <div>
+                    <label className="block text-xs font-medium text-gray-500 mb-1">Placement Type</label>
+                    <div className="flex flex-wrap gap-2">
+                      {PLACEMENT_TYPES.map((pt) => (
+                        <button
+                          key={pt}
+                          type="button"
+                          onClick={() => setPlacementType(pt)}
+                          className={`rounded-full border px-3 py-1.5 text-xs font-medium transition-colors cursor-pointer ${
+                            placementType === pt
+                              ? "border-green-500 bg-green-50 text-green-700"
+                              : "border-gray-200 text-gray-500 hover:border-green-300"
+                          }`}
+                        >
+                          {pt}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {/* No location fields */}
+              {showNoLocation && (
+                <div className="mt-4 space-y-4 pt-4 border-t border-gray-100">
+                  <p className="text-xs font-medium text-gray-400 uppercase tracking-wider">Target Placement Info</p>
+                  <div>
+                    <label className="block text-xs font-medium text-gray-500 mb-1">Preferred City / Market</label>
+                    <input type="text" value={preferredMarket} onChange={(e) => setPreferredMarket(e.target.value)} placeholder="e.g. Denver, CO" className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm placeholder:text-gray-300 focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500" />
+                  </div>
+                  <div>
+                    <label className="block text-xs font-medium text-gray-500 mb-1">Type of Location Desired</label>
+                    <input type="text" value={desiredLocationType} onChange={(e) => setDesiredLocationType(e.target.value)} placeholder="e.g. Office building, gym" className="w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm placeholder:text-gray-300 focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500" />
+                  </div>
+                  <div>
+                    <label className="block text-xs font-medium text-gray-500 mb-1">Foot Traffic Expectation</label>
+                    <div className="grid grid-cols-3 gap-3">
+                      {[
+                        { value: "low", label: "Low (<50/day)" },
+                        { value: "medium", label: "Medium (50–200/day)" },
+                        { value: "high", label: "High (200+/day)" },
+                      ].map((opt) => (
+                        <button
+                          key={opt.value}
+                          type="button"
+                          onClick={() => setFootTraffic(opt.value)}
+                          className={`rounded-lg border px-3 py-2.5 text-xs font-medium transition-colors cursor-pointer ${
+                            footTraffic === opt.value
+                              ? "border-green-500 bg-green-50 text-green-700"
+                              : "border-gray-200 text-gray-600 hover:border-green-300"
+                          }`}
+                        >
+                          {opt.label}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Section 4: Deployment Timeline */}
+          <div className="rounded-2xl border border-gray-200 bg-white shadow-sm overflow-hidden mb-4">
+            <div className="px-6 py-4 border-b border-gray-100 bg-gray-50">
+              <div className="flex items-center gap-2">
+                <Clock className="h-4 w-4 text-green-600" />
+                <h2 className="text-sm font-semibold text-gray-900">Deployment Timeline *</h2>
+              </div>
+            </div>
+            <div className="px-6 py-5">
+              <div className="grid grid-cols-2 gap-3">
+                {[
+                  { value: "asap", label: "ASAP" },
+                  { value: "30_days", label: "Within 30 Days" },
+                  { value: "60_90_days", label: "60–90 Days" },
+                  { value: "90_plus_days", label: "90+ Days" },
+                ].map((opt) => (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    onClick={() => setDeploymentTimeline(opt.value)}
+                    className={`rounded-lg border px-4 py-3 text-sm font-medium transition-colors cursor-pointer ${
+                      deploymentTimeline === opt.value
+                        ? "border-green-500 bg-green-50 text-green-700"
+                        : "border-gray-200 text-gray-600 hover:border-green-300"
+                    }`}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* Section 5: Site Readiness */}
+          <div className="rounded-2xl border border-gray-200 bg-white shadow-sm overflow-hidden mb-4">
+            <div className="px-6 py-4 border-b border-gray-100 bg-gray-50">
+              <div className="flex items-center gap-2">
+                <CheckSquare className="h-4 w-4 text-green-600" />
+                <h2 className="text-sm font-semibold text-gray-900">Site Readiness</h2>
+              </div>
+            </div>
+            <div className="px-6 py-5 space-y-3">
+              {[
+                { checked: hasPowerOutlet, set: setHasPowerOutlet, label: "Location has standard power outlet (110V)" },
+                { checked: hasIndoorPlacement, set: setHasIndoorPlacement, label: "Indoor placement available" },
+                { checked: hasEnoughSpace, set: setHasEnoughSpace, label: "Enough space (~3 ft x 3 ft)" },
+                { checked: hasDeliveryAccess, set: setHasDeliveryAccess, label: "Delivery access (doorways, no major obstructions)" },
+              ].map((item) => (
+                <label key={item.label} className="flex items-center gap-3 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={item.checked}
+                    onChange={(e) => item.set(e.target.checked)}
+                    className="h-4 w-4 rounded border-gray-300 text-green-600 focus:ring-green-500"
+                  />
+                  <span className="text-sm text-gray-700">{item.label}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+
+          {/* Section 6: Connectivity */}
+          <div className="rounded-2xl border border-gray-200 bg-white shadow-sm overflow-hidden mb-4">
+            <div className="px-6 py-4 border-b border-gray-100 bg-gray-50">
+              <div className="flex items-center gap-2">
+                <Wifi className="h-4 w-4 text-green-600" />
+                <h2 className="text-sm font-semibold text-gray-900">Connectivity</h2>
+              </div>
+            </div>
+            <div className="px-6 py-5">
+              <div className="grid grid-cols-3 gap-3">
+                {[
+                  { value: "wifi", label: "WiFi Available" },
+                  { value: "no_wifi", label: "No WiFi (may need 4G)" },
+                  { value: "not_sure", label: "Not Sure" },
+                ].map((opt) => (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    onClick={() => setConnectivity(opt.value)}
+                    className={`rounded-lg border px-3 py-2.5 text-xs font-medium transition-colors cursor-pointer ${
+                      connectivity === opt.value
+                        ? "border-green-500 bg-green-50 text-green-700"
+                        : "border-gray-200 text-gray-600 hover:border-green-300"
+                    }`}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* Section 7: Shipping */}
+          <div className="rounded-2xl border border-gray-200 bg-white shadow-sm overflow-hidden mb-4">
+            <div className="px-6 py-4 border-b border-gray-100 bg-gray-50">
+              <div className="flex items-center gap-2">
+                <Truck className="h-4 w-4 text-green-600" />
+                <h2 className="text-sm font-semibold text-gray-900">Shipping Preference *</h2>
+              </div>
+            </div>
+            <div className="px-6 py-5">
+              <div className="space-y-2">
+                {[
+                  { value: "ship_immediately", label: "Ship immediately (if ready)" },
+                  { value: "hold_until_secured", label: "Hold until location is secured" },
+                ].map((opt) => (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    onClick={() => setShippingIntent(opt.value)}
+                    className={`w-full rounded-lg border px-4 py-3 text-sm text-left font-medium transition-colors cursor-pointer ${
+                      shippingIntent === opt.value
+                        ? "border-green-500 bg-green-50 text-green-700"
+                        : "border-gray-200 text-gray-600 hover:border-green-300"
+                    }`}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* Error */}
+          {error && (
+            <div className="rounded-lg bg-red-50 border border-red-200 px-4 py-3 mb-4">
+              <p className="text-sm text-red-700">{error}</p>
+            </div>
+          )}
+
+          {/* Submit */}
+          <button
+            type="submit"
+            disabled={submitting}
+            className="w-full rounded-xl bg-green-600 px-6 py-4 text-base font-semibold text-white hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors cursor-pointer flex items-center justify-center gap-2"
+          >
+            {submitting ? (
+              <>
+                <Loader2 className="h-5 w-5 animate-spin" />
+                Processing...
+              </>
+            ) : (
+              <>
+                <ShoppingCart className="h-5 w-5" />
+                Proceed to Payment{price ? ` — ${formatCurrency(price)}` : ""}
+              </>
+            )}
+          </button>
+
+          <p className="text-xs text-gray-400 text-center mt-3">
+            You will be redirected to Stripe for secure payment processing.
+          </p>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/app/machines-for-sale/[id]/page.tsx
+++ b/src/app/machines-for-sale/[id]/page.tsx
@@ -163,7 +163,6 @@ export default function MachineDetailPage() {
   const purchased = searchParams.get("purchased") === "true";
 
   const [listing, setListing] = useState<MachineListing | null>(null);
-  const [checkingOut, setCheckingOut] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [similar, setSimilar] = useState<MachineListing[]>([]);
@@ -194,14 +193,6 @@ export default function MachineDetailPage() {
     fetchListing();
   }, [fetchListing]);
 
-  // Auto-trigger checkout if redirected from Buy Now on listing card
-  useEffect(() => {
-    if (listing && listing.buy_now_enabled && searchParams.get("checkout") === "1" && !checkingOut) {
-      handleBuyNow();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [listing]);
-
   // Fetch similar listings in same state
   useEffect(() => {
     if (!listing) return;
@@ -226,22 +217,9 @@ export default function MachineDetailPage() {
     fetchSimilar();
   }, [listing]);
 
-  async function handleBuyNow() {
+  function handleBuyNow() {
     if (!listing) return;
-    setCheckingOut(true);
-    try {
-      const res = await fetch(`/api/machine-listings/${listing.id}/checkout`, { method: "POST" });
-      if (res.ok) {
-        const { url } = await res.json();
-        if (url) window.location.href = url;
-      } else {
-        const err = await res.json().catch(() => ({}));
-        alert(err.error || "Failed to start checkout");
-      }
-    } catch {
-      alert("Network error. Please try again.");
-    }
-    setCheckingOut(false);
+    window.location.href = `/machines-for-sale/${listing.id}/checkout`;
   }
 
   if (loading) return <DetailSkeleton />;
@@ -564,11 +542,10 @@ export default function MachineDetailPage() {
               {listing.buy_now_enabled && (
                 <button
                   onClick={handleBuyNow}
-                  disabled={checkingOut}
-                  className="mt-5 flex w-full items-center justify-center gap-2 rounded-lg bg-green-primary px-4 py-3 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-green-hover disabled:opacity-50 cursor-pointer"
+                  className="mt-5 flex w-full items-center justify-center gap-2 rounded-lg bg-green-primary px-4 py-3 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-green-hover cursor-pointer"
                 >
-                  {checkingOut ? <Loader2 className="h-4 w-4 animate-spin" /> : <ShoppingCart className="h-4 w-4" />}
-                  {checkingOut ? "Redirecting to checkout..." : "Buy Now"}
+                  <ShoppingCart className="h-4 w-4" />
+                  Buy Now
                 </button>
               )}
 

--- a/src/app/machines-for-sale/page.tsx
+++ b/src/app/machines-for-sale/page.tsx
@@ -187,7 +187,7 @@ function MachineCard({ listing }: { listing: MachineListing }) {
           onClick={(e) => {
             e.preventDefault();
             e.stopPropagation();
-            window.location.href = `/machines-for-sale/${listing.id}?checkout=1`;
+            window.location.href = `/machines-for-sale/${listing.id}/checkout`;
           }}
           className="mt-4 flex w-full items-center justify-center gap-2 rounded-lg bg-green-600 px-4 py-2.5 text-sm font-semibold text-white hover:bg-green-700 transition-colors"
         >

--- a/src/lib/machinePurchaseEmail.ts
+++ b/src/lib/machinePurchaseEmail.ts
@@ -1,0 +1,149 @@
+import { Resend } from "resend";
+
+const FROM_EMAIL = process.env.FROM_EMAIL || "onboarding@bytebitevending.com";
+
+function getResend() {
+  return new Resend(process.env.RESEND_API_KEY);
+}
+
+interface ThankYouParams {
+  to: string;
+  buyerName: string;
+  machineTitle: string;
+  amountCents: number;
+  purchaseId: string;
+  stripePaymentIntentId: string | null;
+}
+
+export async function sendMachinePurchaseThankYouEmail(params: ThankYouParams) {
+  const { to, buyerName, machineTitle, amountCents, purchaseId, stripePaymentIntentId } = params;
+  const amount = `$${(amountCents / 100).toLocaleString("en-US", { minimumFractionDigits: 2 })}`;
+  const date = new Date().toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" });
+
+  await getResend().emails.send({
+    from: FROM_EMAIL,
+    to,
+    subject: `Order Confirmed — ${machineTitle}`,
+    html: `
+      <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:600px;margin:0 auto;padding:32px 24px;">
+        <h1 style="color:#16a34a;font-size:22px;margin:0 0 20px;">Thank You for Your Purchase!</h1>
+        <p style="color:#374151;font-size:14px;line-height:1.6;">
+          Hi ${buyerName},
+        </p>
+        <p style="color:#374151;font-size:14px;line-height:1.6;">
+          Thank you for shopping with <strong>Vending Connector</strong>! Your order has been confirmed and our team is preparing your machine for fulfillment. Keep an eye on your email for next steps.
+        </p>
+
+        <div style="background:#f9fafb;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin:24px 0;">
+          <h2 style="color:#111827;font-size:16px;margin:0 0 16px;">Order Summary</h2>
+          <table style="width:100%;border-collapse:collapse;">
+            <tr>
+              <td style="padding:8px 0;color:#6b7280;font-size:13px;">Item</td>
+              <td style="padding:8px 0;color:#111827;font-size:13px;text-align:right;font-weight:600;">${machineTitle}</td>
+            </tr>
+            <tr>
+              <td style="padding:8px 0;color:#6b7280;font-size:13px;">Amount Paid</td>
+              <td style="padding:8px 0;color:#16a34a;font-size:13px;text-align:right;font-weight:700;">${amount}</td>
+            </tr>
+            <tr>
+              <td style="padding:8px 0;color:#6b7280;font-size:13px;">Date</td>
+              <td style="padding:8px 0;color:#111827;font-size:13px;text-align:right;">${date}</td>
+            </tr>
+            <tr>
+              <td style="padding:8px 0;color:#6b7280;font-size:13px;">Order ID</td>
+              <td style="padding:8px 0;color:#111827;font-size:13px;text-align:right;">${purchaseId.slice(0, 8).toUpperCase()}</td>
+            </tr>
+            ${stripePaymentIntentId ? `
+            <tr>
+              <td style="padding:8px 0;color:#6b7280;font-size:13px;">Payment Reference</td>
+              <td style="padding:8px 0;color:#111827;font-size:13px;text-align:right;">${stripePaymentIntentId}</td>
+            </tr>` : ""}
+          </table>
+        </div>
+
+        <div style="background:#f0fdf4;border:1px solid #bbf7d0;border-radius:12px;padding:16px;margin:24px 0;text-align:center;">
+          <p style="color:#166534;font-size:14px;margin:0;font-weight:600;">What happens next?</p>
+          <p style="color:#374151;font-size:13px;margin:8px 0 0;">
+            Our team will review your order and reach out with shipping details and onboarding instructions.
+          </p>
+        </div>
+
+        <hr style="border:none;border-top:1px solid #e5e7eb;margin:24px 0;" />
+        <p style="color:#9ca3af;font-size:11px;">Vending Connector — vendingconnector.com</p>
+      </div>
+    `,
+  });
+}
+
+interface NotificationParams {
+  to: string;
+  purchase: Record<string, unknown>;
+  machineTitle: string;
+  listing: Record<string, unknown> | null;
+}
+
+export async function sendMachinePurchaseNotificationEmail(params: NotificationParams) {
+  const { to, purchase, machineTitle, listing } = params;
+  const amount = `$${(Number(purchase.amount_cents) / 100).toLocaleString("en-US", { minimumFractionDigits: 2 })}`;
+
+  const locationRows = purchase.location_status === "confirmed"
+    ? `
+      <tr><td style="padding:6px 12px;color:#6b7280;font-size:13px;">Location Business</td><td style="padding:6px 12px;color:#111827;font-size:13px;">${purchase.location_business_name || "—"}</td></tr>
+      <tr><td style="padding:6px 12px;color:#6b7280;font-size:13px;">Location Address</td><td style="padding:6px 12px;color:#111827;font-size:13px;">${purchase.location_address || "—"}, ${purchase.location_city || ""} ${purchase.location_state || ""} ${purchase.location_zip || ""}</td></tr>
+      <tr><td style="padding:6px 12px;color:#6b7280;font-size:13px;">Site Contact</td><td style="padding:6px 12px;color:#111827;font-size:13px;">${purchase.site_contact_name || "—"} — ${purchase.site_contact_phone || ""} — ${purchase.site_contact_email || ""}</td></tr>
+      <tr><td style="padding:6px 12px;color:#6b7280;font-size:13px;">Placement Type</td><td style="padding:6px 12px;color:#111827;font-size:13px;">${purchase.placement_type || "—"}</td></tr>
+    `
+    : `
+      <tr><td style="padding:6px 12px;color:#6b7280;font-size:13px;">Preferred Market</td><td style="padding:6px 12px;color:#111827;font-size:13px;">${purchase.preferred_market || "—"}</td></tr>
+      <tr><td style="padding:6px 12px;color:#6b7280;font-size:13px;">Desired Location Type</td><td style="padding:6px 12px;color:#111827;font-size:13px;">${purchase.desired_location_type || "—"}</td></tr>
+      <tr><td style="padding:6px 12px;color:#6b7280;font-size:13px;">Foot Traffic</td><td style="padding:6px 12px;color:#111827;font-size:13px;">${purchase.foot_traffic || "—"}</td></tr>
+    `;
+
+  const readiness = [
+    purchase.has_power_outlet && "Power outlet",
+    purchase.has_indoor_placement && "Indoor placement",
+    purchase.has_enough_space && "Enough space",
+    purchase.has_delivery_access && "Delivery access",
+  ].filter(Boolean).join(", ") || "None checked";
+
+  await getResend().emails.send({
+    from: FROM_EMAIL,
+    to,
+    subject: `New Machine Purchase: ${String(purchase.full_name)} — ${machineTitle} (${amount})`,
+    html: `
+      <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:600px;margin:0 auto;padding:32px 24px;">
+        <h1 style="color:#111827;font-size:22px;margin:0 0 20px;">New Machine Purchase</h1>
+
+        <div style="background:#f0fdf4;border:1px solid #bbf7d0;border-radius:8px;padding:12px 16px;margin-bottom:20px;">
+          <p style="color:#166534;font-size:14px;margin:0;font-weight:600;">${machineTitle} — ${amount}</p>
+        </div>
+
+        <h3 style="color:#374151;font-size:14px;margin:16px 0 8px;">Buyer Information</h3>
+        <table style="width:100%;border-collapse:collapse;background:#f9fafb;border-radius:8px;overflow:hidden;">
+          <tr><td style="padding:6px 12px;color:#6b7280;font-size:13px;">Name</td><td style="padding:6px 12px;color:#111827;font-size:13px;font-weight:600;">${purchase.full_name}</td></tr>
+          <tr><td style="padding:6px 12px;color:#6b7280;font-size:13px;">Email</td><td style="padding:6px 12px;color:#111827;font-size:13px;">${purchase.email}</td></tr>
+          <tr><td style="padding:6px 12px;color:#6b7280;font-size:13px;">Phone</td><td style="padding:6px 12px;color:#111827;font-size:13px;">${purchase.phone || "—"}</td></tr>
+          <tr><td style="padding:6px 12px;color:#6b7280;font-size:13px;">Buyer Type</td><td style="padding:6px 12px;color:#111827;font-size:13px;">${purchase.buyer_type || "—"}</td></tr>
+          <tr><td style="padding:6px 12px;color:#6b7280;font-size:13px;">Business Name</td><td style="padding:6px 12px;color:#111827;font-size:13px;">${purchase.business_name || "—"}</td></tr>
+          <tr><td style="padding:6px 12px;color:#6b7280;font-size:13px;">LLC Status</td><td style="padding:6px 12px;color:#111827;font-size:13px;">${purchase.llc_status || "—"}</td></tr>
+        </table>
+
+        <h3 style="color:#374151;font-size:14px;margin:16px 0 8px;">Location — ${purchase.location_status || "Unknown"}</h3>
+        <table style="width:100%;border-collapse:collapse;background:#f9fafb;border-radius:8px;overflow:hidden;">
+          ${locationRows}
+        </table>
+
+        <h3 style="color:#374151;font-size:14px;margin:16px 0 8px;">Deployment & Readiness</h3>
+        <table style="width:100%;border-collapse:collapse;background:#f9fafb;border-radius:8px;overflow:hidden;">
+          <tr><td style="padding:6px 12px;color:#6b7280;font-size:13px;">Timeline</td><td style="padding:6px 12px;color:#111827;font-size:13px;">${purchase.deployment_timeline || "—"}</td></tr>
+          <tr><td style="padding:6px 12px;color:#6b7280;font-size:13px;">Site Readiness</td><td style="padding:6px 12px;color:#111827;font-size:13px;">${readiness}</td></tr>
+          <tr><td style="padding:6px 12px;color:#6b7280;font-size:13px;">Connectivity</td><td style="padding:6px 12px;color:#111827;font-size:13px;">${purchase.connectivity || "—"}</td></tr>
+          <tr><td style="padding:6px 12px;color:#6b7280;font-size:13px;">Shipping Intent</td><td style="padding:6px 12px;color:#111827;font-size:13px;">${purchase.shipping_intent || "—"}</td></tr>
+        </table>
+
+        <hr style="border:none;border-top:1px solid #e5e7eb;margin:24px 0;" />
+        <p style="color:#9ca3af;font-size:11px;">Vending Connector — vendingconnector.com</p>
+      </div>
+    `,
+  });
+}

--- a/supabase/migrations/056_machine_listing_purchases.sql
+++ b/supabase/migrations/056_machine_listing_purchases.sql
@@ -1,0 +1,67 @@
+-- Machine listing purchases: tracks buy-now purchases with pre-purchase form data
+CREATE TABLE IF NOT EXISTS public.machine_listing_purchases (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  machine_listing_id uuid REFERENCES public.machine_listings(id),
+  stripe_checkout_session_id text UNIQUE,
+  stripe_payment_intent_id text,
+  amount_cents integer NOT NULL,
+  currency text NOT NULL DEFAULT 'usd',
+  status text NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'completed', 'failed', 'refunded')),
+
+  -- Buyer identity
+  full_name text NOT NULL,
+  email text NOT NULL,
+  phone text,
+
+  -- Buyer type
+  buyer_type text CHECK (buyer_type IN ('individual_operator', 'business_owner', 'investor')),
+
+  -- Business info
+  business_name text,
+  llc_status text CHECK (llc_status IN ('yes', 'no', 'in_progress')),
+
+  -- Location status
+  location_status text CHECK (location_status IN ('confirmed', 'securing', 'need_help')),
+
+  -- Existing location fields
+  location_business_name text,
+  location_address text,
+  location_city text,
+  location_state text,
+  location_zip text,
+  site_contact_name text,
+  site_contact_phone text,
+  site_contact_email text,
+  placement_type text,
+
+  -- No location fields
+  preferred_market text,
+  desired_location_type text,
+  foot_traffic text CHECK (foot_traffic IN ('low', 'medium', 'high')),
+
+  -- Deployment
+  deployment_timeline text CHECK (deployment_timeline IN ('asap', '30_days', '60_90_days', '90_plus_days')),
+
+  -- Site readiness (checkboxes)
+  has_power_outlet boolean DEFAULT false,
+  has_indoor_placement boolean DEFAULT false,
+  has_enough_space boolean DEFAULT false,
+  has_delivery_access boolean DEFAULT false,
+
+  -- Connectivity
+  connectivity text CHECK (connectivity IN ('wifi', 'no_wifi', 'not_sure')),
+
+  -- Shipping
+  shipping_intent text CHECK (shipping_intent IN ('ship_immediately', 'hold_until_secured')),
+
+  -- CRM references
+  crm_account_id uuid,
+  crm_lead_id uuid,
+
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_mlp_listing ON machine_listing_purchases(machine_listing_id);
+CREATE INDEX idx_mlp_email ON machine_listing_purchases(email);
+CREATE INDEX idx_mlp_stripe ON machine_listing_purchases(stripe_checkout_session_id);


### PR DESCRIPTION
- New checkout form at /machines-for-sale/[id]/checkout collects: buyer identity, buyer type, business/LLC info, location status (with conditional fields), deployment timeline, site readiness, connectivity, and shipping preference
- Migration 056: machine_listing_purchases table stores all form data plus Stripe session/payment references
- Checkout API creates purchase record before Stripe session
- Stripe webhook handler for machine_purchase:
  - Marks purchase completed
  - Auto-creates CRM sales_account + sales_lead (as operator)
  - Sends thank-you email to buyer with order summary/receipt
  - Sends notification with all form data to james@apexaivending.com
- Buy Now buttons on listing cards and detail page now route through the pre-purchase form

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2