### PR TITLE
Add 'Entire United States' option to machine listing location

### DIFF
--- a/src/app/machines-for-sale/[id]/page.tsx
+++ b/src/app/machines-for-sale/[id]/page.tsx
@@ -124,7 +124,7 @@ function SimilarMachineCard({ listing }: { listing: MachineListing }) {
         <div className="flex items-center gap-1 mt-0.5 text-xs text-gray-500">
           <MapPin className="w-3 h-3 shrink-0" />
           <span className="truncate">
-            {listing.city}, {listing.state}
+            {listing.state === "US" ? "Entire United States" : `${listing.city}, ${listing.state}`}
           </span>
         </div>
       )}
@@ -412,7 +412,7 @@ export default function MachineDetailPage() {
                         Location
                       </p>
                       <p className="text-sm font-medium text-black-primary mt-0.5">
-                        {listing.city}, {listing.state}
+                        {listing.state === "US" ? "Entire United States" : `${listing.city}, ${listing.state}`}
                       </p>
                     </div>
                   )}
@@ -555,7 +555,7 @@ export default function MachineDetailPage() {
                 href={`mailto:james@apexaivending.com?subject=${encodeURIComponent(
                   `Machine Inquiry: ${listing.title}`
                 )}&body=${encodeURIComponent(
-                  `Hi,\n\nI'm interested in the machine listing "${listing.title}" in ${listing.city}, ${listing.state}.\n\nListing ID: ${listing.id}\n\nPlease share more details.\n\nThank you`
+                  `Hi,\n\nI'm interested in the machine listing "${listing.title}" in ${listing.state === "US" ? "the United States" : `${listing.city}, ${listing.state}`}.\n\nListing ID: ${listing.id}\n\nPlease share more details.\n\nThank you`
                 )}`}
                 className={`${listing.buy_now_enabled ? "mt-2" : "mt-5"} flex w-full items-center justify-center gap-2 rounded-lg ${listing.buy_now_enabled ? "border border-gray-200 text-black-primary hover:border-green-primary/40 hover:bg-green-50" : "bg-green-primary text-white hover:bg-green-hover shadow-sm"} px-4 py-2.5 text-sm font-semibold transition-colors`}
               >

--- a/src/app/machines-for-sale/page.tsx
+++ b/src/app/machines-for-sale/page.tsx
@@ -106,7 +106,7 @@ function MachineCard({ listing }: { listing: MachineListing }) {
         <div className="flex items-center gap-1 mt-1.5 text-sm text-gray-500">
           <MapPin className="w-3.5 h-3.5 shrink-0" />
           <span>
-            {listing.city}, {listing.state}
+            {listing.state === "US" ? "Entire United States" : `${listing.city}, ${listing.state}`}
           </span>
         </div>
       )}

--- a/src/app/post-machine/page.tsx
+++ b/src/app/post-machine/page.tsx
@@ -543,6 +543,7 @@ export default function PostMachinePage() {
 
           {/* City & State */}
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            {state !== "US" && (
             <div>
               <label
                 htmlFor="city"
@@ -560,6 +561,7 @@ export default function PostMachinePage() {
                 className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-black-primary focus:border-green-primary focus:ring-2 focus:ring-green-primary/20"
               />
             </div>
+            )}
             <div>
               <label
                 htmlFor="state"
@@ -570,10 +572,15 @@ export default function PostMachinePage() {
               <select
                 id="state"
                 value={state}
-                onChange={(e) => setState(e.target.value)}
+                onChange={(e) => {
+                  setState(e.target.value);
+                  if (e.target.value === "US") setCity("Nationwide");
+                  else if (city === "Nationwide") setCity("");
+                }}
                 className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-black-primary focus:border-green-primary focus:ring-2 focus:ring-green-primary/20"
               >
                 <option value="">Select state</option>
+                <option value="US">Entire United States</option>
                 {US_STATES.map((s) => (
                   <option key={s} value={s}>
                     {s} - {US_STATE_NAMES[s] ?? s}


### PR DESCRIPTION
When selected, city field is hidden and auto-set to 'Nationwide'. Display pages show 'Entire United States' instead of city/state.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2