### PR TITLE
Add contracted lead type with inquiry-only UI and 170+ new location l…

### DIFF
--- a/scripts/generate-locations-sql.js
+++ b/scripts/generate-locations-sql.js
@@ -1,0 +1,288 @@
+// Script to generate SQL INSERT statements for location listings
+// Run: node scripts/generate-locations-sql.js > supabase/seed-locations.sql
+
+const STATE_ABBR = {
+  'Alabama': 'AL', 'Alaska': 'AK', 'Arizona': 'AZ', 'Arkansas': 'AR',
+  'California': 'CA', 'Colorado': 'CO', 'Connecticut': 'CT', 'Delaware': 'DE',
+  'District of Columbia': 'DC', 'Florida': 'FL', 'Georgia': 'GA', 'Hawaii': 'HI',
+  'Idaho': 'ID', 'Illinois': 'IL', 'Indiana': 'IN', 'Iowa': 'IA',
+  'Kansas': 'KS', 'Kentucky': 'KY', 'Louisiana': 'LA', 'Maine': 'ME',
+  'Maryland': 'MD', 'Massachusetts': 'MA', 'Michigan': 'MI', 'Minnesota': 'MN',
+  'Mississippi': 'MS', 'Missouri': 'MO', 'Montana': 'MT', 'Nebraska': 'NE',
+  'Nevada': 'NV', 'New Hampshire': 'NH', 'New Jersey': 'NJ', 'New Mexico': 'NM',
+  'New York': 'NY', 'North Carolina': 'NC', 'North Dakota': 'ND', 'Ohio': 'OH',
+  'Oklahoma': 'OK', 'Oregon': 'OR', 'Pennsylvania': 'PA', 'Portland': 'OR',
+  'Rhode Island': 'RI', 'South Carolina': 'SC', 'South Dakota': 'SD',
+  'Tennessee': 'TN', 'Texas': 'TX', 'Utah': 'UT', 'Vermont': 'VT',
+  'Virginia': 'VA', 'Washington': 'WA', 'West Virginia': 'WV',
+  'Wisconsin': 'WI', 'Wyoming': 'WY',
+};
+
+const TYPE_MAP = {
+  'Apartment Building': 'apartment',
+  'Apartment Complex': 'apartment',
+  'Office': 'office',
+  'Office Complex': 'office',
+  'Manufacturing Facility': 'warehouse',
+  'Facility': 'other',
+  'Car Wash': 'other',
+  'Retail Establishment': 'retail',
+  'Community Clubhouse': 'other',
+  'Warehouse': 'warehouse',
+  'Hotel / Motel': 'hotel',
+  'Hotel / motel': 'hotel',
+  'Distribution Center': 'warehouse',
+  'Assisted Living Facility': 'hospital',
+  'Production Facility': 'warehouse',
+  'Automotive Location': 'other',
+  'Sports Facility': 'gym',
+  'Medical Facility': 'hospital',
+  'School': 'school',
+  'Nursing Home': 'hospital',
+  'Transportation Facility': 'other',
+  'Car Dealer': 'other',
+  'Gym': 'gym',
+  'Outdoor Facility': 'other',
+  'Seasonal Living Facility': 'other',
+};
+
+const rows = `05/01/2026	Apartment Building	Louisville/Kentucky/40272	APARTMENT BUILDING/COMPLEX OPPURTUNITY!	$1,100	$1,210
+05/01/2026	Apartment Building	Prattville/Alabama/36066	APARTMENT BUILDING/COMPLEX OPPURTUNITY!	$900	$990
+05/01/2026	Apartment Building	Springfield/Illinois/62704	APARTMENT BUILDING/COMPLEX OPPURTUNITY!	$860	$946
+05/01/2026	Office	Waterloo/Iowa/50701	OFFICE 50 EMPS!(COFFEE)	$740	$814
+05/01/2026	Apartment Building	Independence/Missouri/64057	APARTMENT BUILDING/COMPLEX OPPURTUNITY!	$680	$748
+05/01/2026	Apartment Building	Madison/Wisconsin/53719	APARTMENT BUILDING/COMPLEX OPPURTUNITY!	$780	$858
+05/01/2026	Apartment Building	Gurnee/Illinois/60031	APARTMENT BUILDING/COMPLEX OPPURTUNITY!	$1,400	$1,540
+05/01/2026	Office	Houston/Texas/77021	OFFICE 10 EMPS 12 CUSTOMERS!	$420	$462
+05/01/2026	Apartment Building	Port Huron/Michigan/48060	APARTMENT BUILDING/COMPLEX OPPURTUNITY!	$820	$902
+05/01/2026	Apartment Building	Richmond/Virginia/23231	APARTMENT BUILDING/COMPLEX OPPURTUNITY!	$820	$902
+05/01/2026	Apartment Building	Battle Creek/Michigan/49014	APARTMENT BUILDING/COMPLEX OPPURTUNITY!	$940	$1,034
+05/01/2026	Manufacturing Facility	River Falls/Wisconsin/54022	MANUFACTURING 30 EMPS CARD ALLOWANCE!	$620	$682
+05/01/2026	Apartment Building	Jackson/Mississippi/39211	APARTMENT BUILDING/COMPLEX OPPURTUNITY!	$1,000	$1,100
+05/01/2026	Apartment Building	Augusta/Georgia/30906	APARTMENT BUILDING/COMPLEX OPPURTUNITY!	$880	$968
+05/01/2026	Apartment Building	Macon/Georgia/31220	APARTMENT BUILDING/COMPLEX OPPURTUNITY!	$800	$880
+05/01/2026	Apartment Building	Evansville/Indiana/47715	2 APARTMENT BUILDING/COMPLEX OPPURTUNITY!	$900	$990
+05/01/2026	Apartment Building	Saint Joseph/Missouri/64506	APARTMENT BUILDING/COMPLEX 4EMPS 385+RES!	$880	$968
+05/01/2026	Apartment Building	Lexington/Kentucky/40517	APARTMENT BUILDING/COMPLEX 4EMPS 208+RES!	$880	$968
+05/01/2026	Apartment Building	Lincoln/Nebraska/68504	APARTMENT BUILDING/COMPLEX 4EMPS 246+RES!	$680	$748
+05/01/2026	Apartment Building	Columbia/Michigan/48187	APARTMENT BUILDING/COMPLEX 4EMPS 192+RES!	$840	$924
+05/01/2026	Apartment Building	Auburn/Alabama/36830	APARTMENT BUILDING/COMPLEX 4EMPS 112+RES!	$560	$616
+05/01/2026	Apartment Building	Swartz Creek/Michigan/48473	APARTMENT BUILDING/COMPLEX 4EMPS 112+RES!	$840	$924
+05/01/2026	Apartment Building	Tallahassee/Florida/32304	2 APARTMENT BUILDING/COMPLEX OPPURTUNITY!	$920	$1,012
+05/01/2026	Apartment Building	Mobile/Alabama/36609	3 APARTMENT BUILDING/COMPLEX OPPURTUNITY!	$980	$1,078
+05/01/2026	Apartment Building	Prattville/Alabama/36066	APARTMENT BUILDING/COMPLEX 4EMPS 80+RES!	$740	$814
+05/01/2026	Apartment Complex	Harker Heights/Texas/76548	APARTMENT COMPLEX 6 EMPS 300 RESIDENTS!	$840	$924
+05/01/2026	Office	Fort Walton Beach/Florida/32548	GROWING OFFICE!	$500	$550
+05/01/2026	Facility	Palm Desert/California/92211	SEASONAL LIVING FACILITY 14-300+RES!	$800	$880
+05/01/2026	Car Wash	Cumming/Georgia/30041	CAR DEALER 35 EMPS!	$480	$528
+05/01/2026	Facility	Brooksville/Florida/34604	FACILITY 100+EMPS!	$1,400	$1,540
+05/01/2026	Retail Establishment	Braceville/Illinois/60407	RETAIL ESTABLISHMENT 2 EMPS 15 CUSTOMERS!	$480	$528
+05/01/2026	Community Clubhouse	Indian Trail/North Carolina/28079	COMMUNITY CLUBHOUSE 800+ RES!	$1,200	$1,320
+05/01/2026	Office	Glen Allen/Virginia/23060	OFFICE 30 EMPS!	$580	$638
+05/01/2026	Apartment Building	Muskegon/Michigan/49442	APARTMENT BUILDING/COMPLEX 4EMPS 112+RES!	$780	$858
+05/01/2026	Office	Waterloo/Iowa/50701	OFFICE 50 EMPS!	$820	$902
+04/30/2026	Apartment Building	Knoxville/Tennessee/37920	2 APTS 600 RES! ( COFFEE SERVICE)	$580	$638
+04/30/2026	Facility	Easley/South Carolina/29640	FACILITY 8 EMPS 11 CUSTOMERS!	$380	$418
+04/30/2026	Warehouse	Laramie/Wyoming/82070	WAREHOUSE 40EMPS!	$580	$638
+04/30/2026	Office	Chicago/Illinois/60606	OFFICE 10 EMPS/COFFEE SERVICE!	$380	$418
+04/30/2026	Production Facility	Steele/Alabama/35987	PRODUCTION 75 EMPS!	$780	$858
+04/30/2026	Assisted Living Facility	Moorhead/Minnesota/56560	ASSISTED LIVING FACILITY 8+EMPS 18+RES!	$380	$418
+04/30/2026	Manufacturing Facility	Griffin/Georgia/30224	MANUFACTURING 30EMPS!	$880	$968
+04/30/2026	Facility	Miami/Texas/79059	FACILITY 3000 EMPS!	$2,000	$2,200
+04/30/2026	Facility	Bay City/Michigan/48706	FACILITY 50EMPS!	$480	$528
+04/30/2026	Facility	Bloomington/Indiana/47406	LIVING FACILITY 100 RES!	$480	$528
+04/30/2026	Warehouse	Denver/Colorado/80229	WAREHOUSE 70 EMPS!	$980	$1,078
+04/30/2026	Office	North Haven/Connecticut/06473	OFFICE 25 HUNGRY EMPS!	$580	$638
+04/30/2026	Hotel / Motel	Springhill/Louisiana/71075	HOTEL 50-60 GUESTS!	$540	$594
+04/30/2026	Outdoor Facility	South Haven/Michigan/	OUTDOOR FACILITY 72 GUESTS 6 EMPS!	$780	$858
+04/30/2026	Office	Washington/District of Columbia/20037	OFFICE COMPLEX 100 EMPS, 40 VIS!	$1,200	$1,320
+04/30/2026	Office	Black Hawk/Colorado/80422	3 OFFICE LOCATION OPPURTUNITY! (COFFEE)	$1,800	$1,980
+04/30/2026	Facility	Hubbard/Texas/76648	FACILITY 700 EMPS!	$1,200	$1,320
+04/30/2026	Office	San Tan Valley/Arizona/85140	OFFICE 50+EMPS!	$880	$968
+04/30/2026	Facility	Beverly/Massachusetts/01915	FACILITY 10EMPS 100+STUDENTS!	$1,000	$1,100
+04/30/2026	Assisted Living Facility	Venice/Florida/34285	AST.LIVING 75 EMPS, 30 VIS!	$980	$1,078
+04/30/2026	Distribution Center	Charlotte/North Carolina/28269	DISTRIBUTION CENTER 45 EMPS, 10 VIS!	$980	$1,078
+04/30/2026	Office	Black Hawk/Colorado/80422	3 OFFICE LOCATION OPPURTUNITY!	$1,400	$1,540
+04/29/2026	Automotive Location	Libertyville/Illinois/60048	AUTOMOTIVE LOCATION 35 EMPS 40 CUSTOMERS!	$980	$1,078
+04/29/2026	Office	Cynthiana/Kentucky/41031	OFFICE 1EMP 10VIS!	$380	$418
+04/29/2026	Facility	Chicago/Illinois/60622	FACILITY 50 VIS!	$580	$638
+04/29/2026	Manufacturing Facility	Memphis/Tennessee/38106	GROWING MANUFACTURING 15-20 EMPS!	$480	$528
+04/29/2026	Office	Shrewsbury/Massachusetts/01545	OFFICE 19EMPS 30VIS!	$660	$726
+04/29/2026	Office	Oshkosh/Wisconsin/54904	OFFICE 15 EMPS/ COFFEE SERVICE!	$380	$418
+04/29/2026	Office	Baltimore/Maryland/21202	OFFICE 180EMPS!	$1,200	$1,320
+04/29/2026	Facility	Lester/Pennsylvania/19029	FACILITY 40 EMPS 10+VIS!	$800	$880
+04/29/2026	Manufacturing Facility	Raymond/Wisconsin/53126	MANUFACTURING FACILITY 40 EMPS!	$800	$880
+04/29/2026	Warehouse	Tucker/Georgia/30084	WAREHOUSE 10 EMPS, 10-20 VIS!	$620	$682
+04/29/2026	Office	Fremont/California/94538	OFFICE 45EMPS 5VIS!	$680	$748
+04/29/2026	Office	Brentwood/Tennessee/37027	OFFICE 15-20 EMPS/COFFEE SERVICE!	$480	$528
+04/29/2026	Apartment Building	Marathon/Florida/33050	APARTMENT BUILDING 180RES 2EMPS!	$780	$858
+04/29/2026	Facility	Sun Prairie/Wisconsin/53590	FACILITY 6-30 EMPS!	$480	$528
+04/28/2026	Sports Facility	Boca Raton/Florida/33487	INDOOR SPORTS FACILITY 3EMPS 50+VIS!	$760	$836
+04/28/2026	Automotive Location	Fort Pierce/Florida/34945	GROWING AUTOMOTIVE LOCATION !	$800	$880
+04/28/2026	Office	Monterey/California/93940	OFFICE 35+EMPS!	$540	$594
+04/28/2026	Office Complex	Grand Rapids/Michigan/49505	OFFICE COMPLEX 100 EMPS!	$840	$924
+04/28/2026	Facility	Salem/Oregon/97301	FACILITY 2 EMPS 300+ VISITORS!	$980	$1,078
+04/28/2026	Facility	Bristol/Connecticut/06010	FACILITY 20+EMPS!	$620	$682
+04/28/2026	Hotel / Motel	Orlando/Florida/32819	HOTEL/MOTEL 6 EMPS 300 GUESTS! ( COFFEE VENDING)	$800	$880
+04/28/2026	Assisted Living Facility	Pittsburgh/Pennsylvania/15202	SENIOR LIVING FACILITY 6EMPS 101RES!	$840	$924
+04/28/2026	Office	Lisle/Illinois/60532	OFFICE 20 EMPS 2 VISITORS!( COFFEE SERVICE)	$900	$990
+04/28/2026	Facility	Marshall/Arkansas/72650	FACILITY 100EMPS 3 VIS!	$780	$858
+04/28/2026	Facility	Spokane/Washington/99205	FACILITY 12 EMPS 30 VIS (COFFEE SERVICE)	$480	$528
+04/28/2026	Facility	Winston-Salem/North Carolina/27101	2 BUILDING PUBLIC FACILITY 200 EMPS, 75 VIS!	$780	$858
+04/28/2026	Office Complex	Las Cruces/New Mexico/88005	OFFICE 75 EMPS!	$700	$770
+04/28/2026	Manufacturing Facility	Lewes/Delaware/19958	MANUFACTURING 50 EMPS! ( HAS EQUIPMENT!)	$700	$770
+04/28/2026	Facility	Toledo/Ohio/43623	PUBLIC FACILITY 25-50 VIS!	$780	$858
+04/28/2026	Office	Alexander City/Alabama/35010	OFFICE 20 STUDENTS, 7 EMPS!	$480	$528
+04/28/2026	Apartment Building	Grand Rapids/Minnesota/55744	APT 130 RES!	$700	$770
+04/28/2026	School	Parachute/Colorado/81635	UPDATE 4/28 SCHOOL 300 STUDENTS 40 EMPS!	$680	$748
+04/28/2026	Community Clubhouse	Bonita Springs/Florida/34135	COMMUNITY CLUBHOUSE 463 RES!	$980	$1,078
+04/27/2026	Automotive Location	San Jose/California/95122	AUTOMOTIVE LOCATION 14-25+EMPS! (GROWING)	$380	$418
+04/27/2026	Facility	Everett/Washington/98201	Facility 2 EMPS 50 CUSTOMERS!	$580	$638
+04/27/2026	School	Milwaukee/Wisconsin/53204	SCHOOL 50 STAFF 400+ STUDENTS!	$1,400	$1,540
+04/27/2026	Facility	Murfreesboro/Tennessee/37129	FACILITY 25 EMPS!	$580	$638
+04/27/2026	School	Philadelphia/Pennsylvania/19146	SCHOOL 100+EMPS!	$1,200	$1,320
+04/27/2026	Warehouse	Philadelphia/Pennsylvania/19120	WAREHOUSE 15 EMPS!	$380	$418
+04/27/2026	Office	Rochester/New York/14623	OFFICE 75 EMPS!	$680	$748
+04/27/2026	Apartment Complex	Pine Ridge/Florida/	APT. COMPLEX 150 RES!	$820	$902
+04/27/2026	Retail Establishment	Davidsonville/Maryland/21035	RETAIL 80 EMPS!	$880	$968
+04/27/2026	Manufacturing Facility	Montgomeryville/Pennsylvania/18936	MANUFACTURING 70 EMPS !	$980	$1,078
+04/27/2026	Manufacturing Facility	Hammond/Louisiana/70401	MANUFACTURING 6 EMPS BUT GROWING!	$380	$418
+04/24/2026	Retail Establishment	Richmond Heights/Missouri/63117	RETAIL ESTABLISHMENT 40EMPS!	$580	$638
+04/24/2026	Apartment Complex	Washington/Pennsylvania/15301	APARTMENT COMPLEX 4EMPS 180+RES!	$980	$1,078
+04/24/2026	Office	Sioux Falls/South Dakota/57108	OFFICE 8EMPS ( COFFEE SERVICE)	$480	$528
+04/24/2026	Apartment Building	Bozeman/Montana/59718	APARTMENT BUILDING 400 RES 4 EMPS HAS EQUIPMENT!	$780	$858
+04/24/2026	Office	Fremont/California/94538	OFFICE 55 EMPS!	$780	$858
+04/24/2026	Production Facility	Loris/South Carolina/29569	PRODUCTION FACILITY 25 EMPS !	$500	$550
+04/24/2026	Warehouse	Linden/New Jersey/07036	WAREHOUSE 300 EMPS!	$2,600	$2,860
+04/24/2026	Office	Wixom/Michigan/48393	OFFICE 40 EMPS 5VIS!	$880	$968
+04/24/2026	Office	Columbia/Missouri/65201	OFFICE 134 EMPS!	$940	$1,034
+04/24/2026	Warehouse	Milford/Michigan/48381	WAREHOUSE 12 EMPS GROWING TO 50!	$580	$638
+04/24/2026	Office	Chicago/Illinois/60606	OFFICE 60 EMPS!	$980	$1,078
+04/24/2026	Office	New York/New York/10011	OFFICE 0-25 EMPS/COFFEE SERVICE!	$480	$528
+04/24/2026	Hotel / motel	Guernsey/Wyoming/82214	HOTEL/MOTEL 8 EMPS 50+VIS!	$580	$638
+04/24/2026	Transportation Facility	Winter Garden/Florida/34787	TRANSPORTATION FACILITY 40+EMPS 10VIS!	$860	$946
+04/24/2026	Nursing Home	Topeka/Kansas/66615	NURSING HOME 80EMPS!	$780	$858
+04/24/2026	Office Complex	Denver/Colorado/80204	6 BUILDING OFFICE COMPLEX OPPURTUNITY (600+EMPS)!	$2,200	$2,420
+04/24/2026	Facility	Denver/Colorado/80207	FACILITY 200 CUSTOMERS!	$2,000	$2,200
+04/24/2026	Office	Bee Cave/Texas/78738	OFFICE 50 EMPS!	$780	$858
+04/23/2026	Manufacturing Facility	Tualatin/Oregon/	MANUFACTURING FACILITY 65EMPS!	$880	$968
+04/23/2026	Facility	Baltimore/Maryland/21216	PUBLIC FACILITY 200-250 VIS!	$980	$1,078
+04/23/2026	Medical Facility	Tulsa/Oklahoma/74116	MEDICAL FACILITY 34+EMPS 10+VIS!	$420	$462
+04/23/2026	Facility	Charleston/West Virginia/25314	FACILITY 10 EMPS 40 VIS!	$420	$462
+04/23/2026	Facility	Austin/Texas/78704	FACILITY 130+EMPS!	$1,400	$1,540
+04/23/2026	Assisted Living Facility	Greendale/Wisconsin/53129	ASSITED LIVING 20 EMPS 80 RES!	$880	$968
+04/23/2026	Manufacturing Facility	Clackamas/Portland/97015	MANUFACTURING 50EMPS 2VIS!	$660	$726
+04/23/2026	Manufacturing Facility	Marlow/Oklahoma/73055	MANUFACTURING 60 EMPS!	$540	$594
+04/23/2026	Hotel / Motel	Montgomery/Alabama/36104	HOTEL/MOTEL 100 EMPS!	$700	$770
+04/23/2026	Retail Establishment	Tulsa/Oklahoma/74136	RETAIL ESTABLISHMENT 2 EMPS 100 CUSTOMERS!	$440	$484
+04/23/2026	Office	Kenansville/North Carolina/28349	OFFICE 20 EMPS 30 VISITORS!	$500	$550
+04/23/2026	Retail Establishment	Greencastle/Indiana/46135	RETAIL 15 EMPS, 20 CUSTOMERS!	$500	$550
+04/23/2026	Manufacturing Facility	Rainbow City/Alabama/35906	MANUFACTURING 15-30 EMPS!	$500	$550
+04/23/2026	Apartment Complex	Corvallis/Oregon/97330	APT.COMPLEX 230 RES!	$680	$748
+04/23/2026	Facility	Harrisonburg/Virginia/22802	UPDATE 5/1 FACILITY 4 EMPS 100 VISITORS!	$280	$308
+04/23/2026	Assisted Living Facility	South Bend/Indiana/	UPDATE 4/23 ASSISTED LIVING 220 RES 6 EMPS!	$580	$638
+04/22/2026	Office	Cleveland/Ohio/44110	OFFICE 30+EMPS!	$500	$550
+04/22/2026	Assisted Living Facility	Sellersburg/Indiana/47172	ASSITED LIVING 50 EMPS 50 RES!	$780	$858
+04/22/2026	Manufacturing Facility	Milwaukee/Wisconsin/53223	UPDATE 4/29/26- MANUFACTURING 10 EMPS!	$380	$418
+04/22/2026	Manufacturing Facility	Burlington/North Carolina/27215	MANUFATURING 30+EMPS! (GROWING)	$460	$506
+04/22/2026	Warehouse	Richmond/Virginia/23230	WAREHOUSE 25 EMPS!	$580	$638
+04/22/2026	Facility	Kalispell/Montana/59901	FACILITY 20+ EMPS, 100 VIS!	$520	$572
+04/22/2026	Manufacturing Facility	Brighton/Colorado/80603	MANUFACTURING 50EMPS 10VIS!	$580	$638
+04/22/2026	Apartment Complex	Lakeland/Florida/33809	APARTMENT COMPLEX 20EMPS 850+RES!	$1,600	$1,760
+04/22/2026	Apartment Complex	Charlotte/North Carolina/28262	APARTMENT COMPLEX 3 EMPS 150 RESIDENTS!	$880	$968
+04/22/2026	Medical Facility	Abilene/Texas/79602	3 BUILDING MEDICAL 80 EMPS, 80 VIS PER BUILDING!	$1,200	$1,320
+04/22/2026	Facility	Evansville/Indiana/47720	FACILITY 12 EMPS 5 DRIVERS!	$480	$528
+04/22/2026	Hotel / Motel	Savannah/Georgia/31401	HOTEL/MOTEL 100 EMPS 250 EMPS!	$1,200	$1,320
+04/22/2026	School	Danville/Virginia/24541	SCHOOL 40 EMPS!	$580	$638
+04/22/2026	Warehouse	Kentwood/Michigan/49512	WAREHOUSE 30 EMPS!	$580	$638
+04/22/2026	Manufacturing Facility	Horsham/Pennsylvania/19044	MANUFACTURING 50+ EMPS!	$760	$836
+04/22/2026	Office	Bothell/Washington/98011	OFFICE 50EMPS!	$580	$638
+04/22/2026	Warehouse	Montgomeryville/Pennsylvania/18936	4/29/26-WAREHOUSE 14 EMPS!	$300	$330
+04/21/2026	School	Milford/New Hampshire/03055	SCHOOL 45+EMPS!	$680	$748
+04/21/2026	Apartment Building	Wyomissing/Pennsylvania/19610	APT 90+ RES!(COFFEE SERVICE)	$380	$418
+04/21/2026	Retail Establishment	Dayton/Ohio/45403	RETAIL 100-200 CUSTOMERS/ COFFEE SERVICE!	$480	$528
+04/21/2026	Car Dealer	Charleston/West Virginia/25387	CAR DEALER 96 EMPS 50 CUSTOMERS!	$780	$858
+04/21/2026	Manufacturing Facility	Decatur/Illinois/62526	MANUFACTURING 30 EMPS!	$540	$594
+04/21/2026	Facility	Moncks Corner/South Carolina/29461	FACILITY 40EMPS!	$640	$704
+04/21/2026	Community Clubhouse	Davenport/Florida/33896	COMMUNITY CLUBHOUSE 1000+ RES!	$1,600	$1,760
+04/21/2026	Distribution Center	Hebron/Ohio/43025	DISTRIBUTION CENTER 20EMPS 3VIS!	$540	$594
+04/21/2026	Facility	Dubuque/Iowa/52003	FACILITY 2 LOCATIONS!	$480	$528
+04/21/2026	Production Facility	Bay St. Louis/Mississippi/39520	PRODUCTION 80 EMPS!	$620	$682
+04/21/2026	Manufacturing Facility	Goodman/Missouri/64843	MANUFACTURING 300 EMPS!	$1,200	$1,320
+04/21/2026	Car Dealer	Charleston/West Virginia/25315	CAR DEALER 54 EMPS 30 CUSTOMERS!	$640	$704
+04/21/2026	Apartment Complex	Kingsville/Texas/78363	APT 300 RES!	$480	$528
+04/21/2026	Automotive Location	Greensboro/North Carolina/27409	AUTOMOTIVE LOCATION 15 EMPS 50 DRIVERS!	$980	$1,078
+04/21/2026	Automotive Location	Brooksville/Florida/34601	AUTOMOTIVE LOCATION 15 EMPS!	$480	$528
+04/21/2026	Manufacturing Facility	Birmingham/Alabama/35217	MANUFACTURING FACILITY 50 EMPS!	$700	$770
+04/21/2026	Apartment Complex	Sarasota/Florida/34239	APT COMPLEX 500 RES!	$880	$968
+04/21/2026	Transportation Facility	Harrisburg/Pennsylvania/17104	TRANSPORTATION 35 EMPS, 125 DRIVERS!	$1,200	$1,320
+04/21/2026	Office	Bronx/New York/10469	OFFICE/CHURCH 10EMPS 100VIS!	$780	$858
+04/21/2026	Apartment Building	Cedar Rapids/Iowa/52404	APARTMENT BUILDING 200 RESIDENTS 10 VISITORS!	$740	$814
+04/21/2026	Gym	Mishawaka/Indiana/46545	GYM 4 EMPS 200 VISITORS!	$600	$660
+04/21/2026	Warehouse	Florence/Kentucky/41042	WAREHOUSE 10 EMPS 10 DRIVERS!	$440	$484
+04/20/2026	Office	Tucson/Arizona/85741	OFFICE 50 EMPS (COFFEE SERVICE)	$480	$528
+04/20/2026	Office	Milwaukee/Wisconsin/53212	OFFICE 60 EMPS!	$900	$990
+04/20/2026	Community Clubhouse	Holden Beach/North Carolina/28462	COMMUNITY CLUBHOUSE 900 RES!	$880	$968
+04/20/2026	Office Complex	Portland/Oregon/97266	OFFICE OPPORTUNITY 46 EMPS!	$880	$968
+04/20/2026	Assisted Living Facility	Moultrie/Georgia/31768	ASSISTED LIVING FACILITY 50EMPS!	$700	$770
+04/20/2026	Hotel / Motel	Big Sky/Montana/59716	HOTEL 400 EMPS!	$900	$990
+04/20/2026	Hotel / motel	Charlotte/North Carolina/28202	HOTEL 300 EMPS!	$880	$968
+04/20/2026	Retail Establishment	Vancouver/Washington/98663	RETAIL 200 CUSTOMERS, 7 EMPS!	$960	$1,056
+04/20/2026	Medical Facility	Leesville/Louisiana/71446	MEDICAL FACILITY 10+EMPS!	$500	$550
+04/20/2026	Office	Scottsdale/Arizona/85258	OFFICE 40 EMPS AND GROWING! ( COFFEE SERVICE)	$480	$528
+04/20/2026	Office	Elizabethtown/Kentucky/42701	UPDATE 4/20 OFFICE 15 EMPS 150 VIS!	$780	$858
+04/20/2026	Manufacturing Facility	New York/New York/10001	MANUFACTURING FACILITY 50 EMPS!	$900	$990`.split('\n');
+
+function parsePrice(s) {
+  return parseFloat(s.replace(/[$,]/g, ''));
+}
+
+function esc(s) {
+  return s.replace(/'/g, "''");
+}
+
+function parseDate(s) {
+  const [m, d, y] = s.split('/');
+  return `${y}-${m.padStart(2, '0')}-${d.padStart(2, '0')}T12:00:00Z`;
+}
+
+const lines = [];
+lines.push("-- Generated location listings data");
+lines.push("-- Run migration 059_lead_type.sql FIRST, then run this script");
+lines.push("");
+lines.push("-- Delete all existing vending_requests except York PA");
+lines.push("DELETE FROM vending_requests WHERE NOT (city = 'York' AND state = 'PA');");
+lines.push("");
+lines.push("-- Insert new contracted location listings");
+lines.push("-- Uses the first admin user as the creator");
+lines.push("DO $$");
+lines.push("DECLARE admin_id uuid;");
+lines.push("BEGIN");
+lines.push("  SELECT id INTO admin_id FROM auth.users WHERE email = 'james@apexaivending.com' LIMIT 1;");
+lines.push("  IF admin_id IS NULL THEN");
+lines.push("    SELECT id INTO admin_id FROM profiles LIMIT 1;");
+lines.push("  END IF;");
+lines.push("");
+
+for (const row of rows) {
+  const parts = row.split('\t');
+  if (parts.length < 6) continue;
+
+  const [dateStr, locType, location, desc, , finalPrice] = parts;
+  const locParts = location.split('/');
+  const city = locParts[0] || '';
+  const stateFull = locParts[1] || '';
+  const zip = locParts[2] || '';
+  const stateAbbr = STATE_ABBR[stateFull] || stateFull;
+  const dbLocType = TYPE_MAP[locType] || 'other';
+  const price = parsePrice(finalPrice);
+  const createdAt = parseDate(dateStr);
+
+  lines.push(`  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)`);
+  lines.push(`  VALUES (admin_id, '${esc(desc)}', '${esc(locType)} in ${esc(city)}, ${stateAbbr}', '${esc(locType)}', '${esc(city)}', '${stateAbbr}', ${zip ? `'${zip}'` : 'NULL'}, '${dbLocType}', '{}', ${price}, 'open', 'email', true, 'contracted', 'flexible', false, '${createdAt}', now(), 'Vending Connector');`);
+  lines.push("");
+}
+
+lines.push("END $$;");
+
+console.log(lines.join('\n'));

--- a/src/app/components/RequestCard.tsx
+++ b/src/app/components/RequestCard.tsx
@@ -10,6 +10,8 @@ import {
   ArrowRight,
   HandCoins,
   DollarSign,
+  Phone,
+  Mail,
 } from "lucide-react";
 import MachineTypeBadge from "./MachineTypeBadge";
 import UrgencyBadge from "./UrgencyBadge";
@@ -122,9 +124,34 @@ export default function RequestCard({
         </div>
       </div>
 
+      {/* Contracted inquiry buttons */}
+      {request.lead_type === "contracted" && (
+        <div className="flex items-center gap-2 mt-4">
+          <a
+            href="tel:+18888511462"
+            className="flex-1 inline-flex items-center justify-center gap-1.5 rounded-lg border border-green-200 bg-green-50 px-3 py-2 text-xs font-semibold text-green-700 hover:bg-green-100 transition-colors"
+          >
+            <Phone className="w-3.5 h-3.5" />
+            Call to Inquire
+          </a>
+          <a
+            href={`mailto:james@apexaivending.com?subject=Location%20Inquiry%20—%20${encodeURIComponent(request.title)}&body=I%20am%20interested%20in%20the%20location%20lead%20in%20${encodeURIComponent(request.city)}%2C%20${encodeURIComponent(request.state)}.`}
+            className="flex-1 inline-flex items-center justify-center gap-1.5 rounded-lg border border-green-200 bg-green-50 px-3 py-2 text-xs font-semibold text-green-700 hover:bg-green-100 transition-colors"
+          >
+            <Mail className="w-3.5 h-3.5" />
+            Email to Inquire
+          </a>
+        </div>
+      )}
+
       {/* Footer */}
       <div className="flex items-center justify-between mt-4 pt-3 border-t border-gray-100">
         <div className="flex items-center gap-3">
+          {request.lead_type === "contracted" && (
+            <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-bold uppercase tracking-wider bg-amber-50 text-amber-700 ring-1 ring-inset ring-amber-200">
+              Contracted
+            </span>
+          )}
           <UrgencyBadge urgency={request.urgency} />
           <span className="flex items-center gap-1 text-xs text-gray-400">
             <Clock className="w-3 h-3" />

--- a/src/app/requests/[id]/page.tsx
+++ b/src/app/requests/[id]/page.tsx
@@ -948,6 +948,34 @@ export default function RequestDetailPage() {
                     Browse Other Leads
                   </Link>
                 </>
+              ) : request.lead_type === "contracted" ? (
+                <>
+                  <h3 className="text-lg font-bold text-black-primary">
+                    Interested in this location?
+                  </h3>
+                  <p className="mt-1 text-sm text-gray-500">
+                    This is a contracted lead. Call or email to inquire about this location opportunity.
+                  </p>
+                  {request.price != null && (
+                    <p className="mt-2 text-xl font-bold text-green-700">
+                      ${request.price.toLocaleString()}
+                    </p>
+                  )}
+                  <a
+                    href="tel:+18888511462"
+                    className="mt-5 flex w-full items-center justify-center gap-2 rounded-lg bg-green-primary px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-green-hover"
+                  >
+                    <Phone className="h-4 w-4" />
+                    Call to Inquire — (888) 851-1462
+                  </a>
+                  <a
+                    href={`mailto:james@apexaivending.com?subject=Location%20Inquiry%20—%20${encodeURIComponent(request.title)}&body=I%20am%20interested%20in%20the%20location%20lead%20in%20${encodeURIComponent(request.city)}%2C%20${encodeURIComponent(request.state)}.%0A%0ARequest%20ID:%20${id}`}
+                    className="mt-2 flex w-full items-center justify-center gap-2 rounded-lg border border-gray-200 px-4 py-2.5 text-sm font-semibold text-black-primary transition-colors hover:border-green-primary/40 hover:bg-green-50"
+                  >
+                    <Mail className="h-4 w-4" />
+                    Email to Inquire
+                  </a>
+                </>
               ) : (
                 <>
                   <h3 className="text-lg font-bold text-black-primary">

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -76,6 +76,7 @@ export interface VendingRequest {
   is_public: boolean;
   views: number;
   seller_name: string | null;
+  lead_type: "standard" | "contracted";
   created_at: string;
   updated_at: string;
   // Joined

--- a/supabase/migrations/059_lead_type.sql
+++ b/supabase/migrations/059_lead_type.sql
@@ -1,0 +1,4 @@
+-- Add lead_type to distinguish contracted (inquiry only) vs standard (buy now) leads
+ALTER TABLE vending_requests
+  ADD COLUMN IF NOT EXISTS lead_type text NOT NULL DEFAULT 'standard'
+  CHECK (lead_type IN ('standard', 'contracted'));

--- a/supabase/seed-locations.sql
+++ b/supabase/seed-locations.sql
@@ -1,0 +1,575 @@
+-- Generated location listings data
+-- Run migration 059_lead_type.sql FIRST, then run this script
+
+-- Delete all existing vending_requests except York PA
+DELETE FROM vending_requests WHERE NOT (city = 'York' AND state = 'PA');
+
+-- Insert new contracted location listings
+-- Uses the first admin user as the creator
+DO $$
+DECLARE admin_id uuid;
+BEGIN
+  SELECT id INTO admin_id FROM auth.users WHERE email = 'james@apexaivending.com' LIMIT 1;
+  IF admin_id IS NULL THEN
+    SELECT id INTO admin_id FROM profiles LIMIT 1;
+  END IF;
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'APARTMENT BUILDING/COMPLEX OPPURTUNITY!', 'Apartment Building in Louisville, KY', 'Apartment Building', 'Louisville', 'KY', '40272', 'apartment', '{}', 1210, 'open', 'email', true, 'contracted', 'flexible', false, '2026-05-01T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'APARTMENT BUILDING/COMPLEX OPPURTUNITY!', 'Apartment Building in Prattville, AL', 'Apartment Building', 'Prattville', 'AL', '36066', 'apartment', '{}', 990, 'open', 'email', true, 'contracted', 'flexible', false, '2026-05-01T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'APARTMENT BUILDING/COMPLEX OPPURTUNITY!', 'Apartment Building in Springfield, IL', 'Apartment Building', 'Springfield', 'IL', '62704', 'apartment', '{}', 946, 'open', 'email', true, 'contracted', 'flexible', false, '2026-05-01T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'OFFICE 50 EMPS!(COFFEE)', 'Office in Waterloo, IA', 'Office', 'Waterloo', 'IA', '50701', 'office', '{}', 814, 'open', 'email', true, 'contracted', 'flexible', false, '2026-05-01T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'APARTMENT BUILDING/COMPLEX OPPURTUNITY!', 'Apartment Building in Independence, MO', 'Apartment Building', 'Independence', 'MO', '64057', 'apartment', '{}', 748, 'open', 'email', true, 'contracted', 'flexible', false, '2026-05-01T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'APARTMENT BUILDING/COMPLEX OPPURTUNITY!', 'Apartment Building in Madison, WI', 'Apartment Building', 'Madison', 'WI', '53719', 'apartment', '{}', 858, 'open', 'email', true, 'contracted', 'flexible', false, '2026-05-01T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'APARTMENT BUILDING/COMPLEX OPPURTUNITY!', 'Apartment Building in Gurnee, IL', 'Apartment Building', 'Gurnee', 'IL', '60031', 'apartment', '{}', 1540, 'open', 'email', true, 'contracted', 'flexible', false, '2026-05-01T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'OFFICE 10 EMPS 12 CUSTOMERS!', 'Office in Houston, TX', 'Office', 'Houston', 'TX', '77021', 'office', '{}', 462, 'open', 'email', true, 'contracted', 'flexible', false, '2026-05-01T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'APARTMENT BUILDING/COMPLEX OPPURTUNITY!', 'Apartment Building in Port Huron, MI', 'Apartment Building', 'Port Huron', 'MI', '48060', 'apartment', '{}', 902, 'open', 'email', true, 'contracted', 'flexible', false, '2026-05-01T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'APARTMENT BUILDING/COMPLEX OPPURTUNITY!', 'Apartment Building in Richmond, VA', 'Apartment Building', 'Richmond', 'VA', '23231', 'apartment', '{}', 902, 'open', 'email', true, 'contracted', 'flexible', false, '2026-05-01T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'APARTMENT BUILDING/COMPLEX OPPURTUNITY!', 'Apartment Building in Battle Creek, MI', 'Apartment Building', 'Battle Creek', 'MI', '49014', 'apartment', '{}', 1034, 'open', 'email', true, 'contracted', 'flexible', false, '2026-05-01T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'MANUFACTURING 30 EMPS CARD ALLOWANCE!', 'Manufacturing Facility in River Falls, WI', 'Manufacturing Facility', 'River Falls', 'WI', '54022', 'warehouse', '{}', 682, 'open', 'email', true, 'contracted', 'flexible', false, '2026-05-01T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'APARTMENT BUILDING/COMPLEX OPPURTUNITY!', 'Apartment Building in Jackson, MS', 'Apartment Building', 'Jackson', 'MS', '39211', 'apartment', '{}', 1100, 'open', 'email', true, 'contracted', 'flexible', false, '2026-05-01T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'APARTMENT BUILDING/COMPLEX OPPURTUNITY!', 'Apartment Building in Augusta, GA', 'Apartment Building', 'Augusta', 'GA', '30906', 'apartment', '{}', 968, 'open', 'email', true, 'contracted', 'flexible', false, '2026-05-01T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'APARTMENT BUILDING/COMPLEX OPPURTUNITY!', 'Apartment Building in Macon, GA', 'Apartment Building', 'Macon', 'GA', '31220', 'apartment', '{}', 880, 'open', 'email', true, 'contracted', 'flexible', false, '2026-05-01T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, '2 APARTMENT BUILDING/COMPLEX OPPURTUNITY!', 'Apartment Building in Evansville, IN', 'Apartment Building', 'Evansville', 'IN', '47715', 'apartment', '{}', 990, 'open', 'email', true, 'contracted', 'flexible', false, '2026-05-01T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'APARTMENT BUILDING/COMPLEX 4EMPS 385+RES!', 'Apartment Building in Saint Joseph, MO', 'Apartment Building', 'Saint Joseph', 'MO', '64506', 'apartment', '{}', 968, 'open', 'email', true, 'contracted', 'flexible', false, '2026-05-01T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'APARTMENT BUILDING/COMPLEX 4EMPS 208+RES!', 'Apartment Building in Lexington, KY', 'Apartment Building', 'Lexington', 'KY', '40517', 'apartment', '{}', 968, 'open', 'email', true, 'contracted', 'flexible', false, '2026-05-01T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'APARTMENT BUILDING/COMPLEX 4EMPS 246+RES!', 'Apartment Building in Lincoln, NE', 'Apartment Building', 'Lincoln', 'NE', '68504', 'apartment', '{}', 748, 'open', 'email', true, 'contracted', 'flexible', false, '2026-05-01T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'APARTMENT BUILDING/COMPLEX 4EMPS 192+RES!', 'Apartment Building in Columbia, MI', 'Apartment Building', 'Columbia', 'MI', '48187', 'apartment', '{}', 924, 'open', 'email', true, 'contracted', 'flexible', false, '2026-05-01T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'APARTMENT BUILDING/COMPLEX 4EMPS 112+RES!', 'Apartment Building in Auburn, AL', 'Apartment Building', 'Auburn', 'AL', '36830', 'apartment', '{}', 616, 'open', 'email', true, 'contracted', 'flexible', false, '2026-05-01T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'APARTMENT BUILDING/COMPLEX 4EMPS 112+RES!', 'Apartment Building in Swartz Creek, MI', 'Apartment Building', 'Swartz Creek', 'MI', '48473', 'apartment', '{}', 924, 'open', 'email', true, 'contracted', 'flexible', false, '2026-05-01T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, '2 APARTMENT BUILDING/COMPLEX OPPURTUNITY!', 'Apartment Building in Tallahassee, FL', 'Apartment Building', 'Tallahassee', 'FL', '32304', 'apartment', '{}', 1012, 'open', 'email', true, 'contracted', 'flexible', false, '2026-05-01T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, '3 APARTMENT BUILDING/COMPLEX OPPURTUNITY!', 'Apartment Building in Mobile, AL', 'Apartment Building', 'Mobile', 'AL', '36609', 'apartment', '{}', 1078, 'open', 'email', true, 'contracted', 'flexible', false, '2026-05-01T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'APARTMENT BUILDING/COMPLEX 4EMPS 80+RES!', 'Apartment Building in Prattville, AL', 'Apartment Building', 'Prattville', 'AL', '36066', 'apartment', '{}', 814, 'open', 'email', true, 'contracted', 'flexible', false, '2026-05-01T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'APARTMENT COMPLEX 6 EMPS 300 RESIDENTS!', 'Apartment Complex in Harker Heights, TX', 'Apartment Complex', 'Harker Heights', 'TX', '76548', 'apartment', '{}', 924, 'open', 'email', true, 'contracted', 'flexible', false, '2026-05-01T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'GROWING OFFICE!', 'Office in Fort Walton Beach, FL', 'Office', 'Fort Walton Beach', 'FL', '32548', 'office', '{}', 550, 'open', 'email', true, 'contracted', 'flexible', false, '2026-05-01T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'SEASONAL LIVING FACILITY 14-300+RES!', 'Facility in Palm Desert, CA', 'Facility', 'Palm Desert', 'CA', '92211', 'other', '{}', 880, 'open', 'email', true, 'contracted', 'flexible', false, '2026-05-01T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'CAR DEALER 35 EMPS!', 'Car Wash in Cumming, GA', 'Car Wash', 'Cumming', 'GA', '30041', 'other', '{}', 528, 'open', 'email', true, 'contracted', 'flexible', false, '2026-05-01T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'FACILITY 100+EMPS!', 'Facility in Brooksville, FL', 'Facility', 'Brooksville', 'FL', '34604', 'other', '{}', 1540, 'open', 'email', true, 'contracted', 'flexible', false, '2026-05-01T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'RETAIL ESTABLISHMENT 2 EMPS 15 CUSTOMERS!', 'Retail Establishment in Braceville, IL', 'Retail Establishment', 'Braceville', 'IL', '60407', 'retail', '{}', 528, 'open', 'email', true, 'contracted', 'flexible', false, '2026-05-01T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'COMMUNITY CLUBHOUSE 800+ RES!', 'Community Clubhouse in Indian Trail, NC', 'Community Clubhouse', 'Indian Trail', 'NC', '28079', 'other', '{}', 1320, 'open', 'email', true, 'contracted', 'flexible', false, '2026-05-01T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'OFFICE 30 EMPS!', 'Office in Glen Allen, VA', 'Office', 'Glen Allen', 'VA', '23060', 'office', '{}', 638, 'open', 'email', true, 'contracted', 'flexible', false, '2026-05-01T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'APARTMENT BUILDING/COMPLEX 4EMPS 112+RES!', 'Apartment Building in Muskegon, MI', 'Apartment Building', 'Muskegon', 'MI', '49442', 'apartment', '{}', 858, 'open', 'email', true, 'contracted', 'flexible', false, '2026-05-01T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'OFFICE 50 EMPS!', 'Office in Waterloo, IA', 'Office', 'Waterloo', 'IA', '50701', 'office', '{}', 902, 'open', 'email', true, 'contracted', 'flexible', false, '2026-05-01T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, '2 APTS 600 RES! ( COFFEE SERVICE)', 'Apartment Building in Knoxville, TN', 'Apartment Building', 'Knoxville', 'TN', '37920', 'apartment', '{}', 638, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-30T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'FACILITY 8 EMPS 11 CUSTOMERS!', 'Facility in Easley, SC', 'Facility', 'Easley', 'SC', '29640', 'other', '{}', 418, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-30T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'WAREHOUSE 40EMPS!', 'Warehouse in Laramie, WY', 'Warehouse', 'Laramie', 'WY', '82070', 'warehouse', '{}', 638, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-30T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'OFFICE 10 EMPS/COFFEE SERVICE!', 'Office in Chicago, IL', 'Office', 'Chicago', 'IL', '60606', 'office', '{}', 418, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-30T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'PRODUCTION 75 EMPS!', 'Production Facility in Steele, AL', 'Production Facility', 'Steele', 'AL', '35987', 'warehouse', '{}', 858, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-30T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'ASSISTED LIVING FACILITY 8+EMPS 18+RES!', 'Assisted Living Facility in Moorhead, MN', 'Assisted Living Facility', 'Moorhead', 'MN', '56560', 'hospital', '{}', 418, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-30T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'MANUFACTURING 30EMPS!', 'Manufacturing Facility in Griffin, GA', 'Manufacturing Facility', 'Griffin', 'GA', '30224', 'warehouse', '{}', 968, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-30T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'FACILITY 3000 EMPS!', 'Facility in Miami, TX', 'Facility', 'Miami', 'TX', '79059', 'other', '{}', 2200, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-30T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'FACILITY 50EMPS!', 'Facility in Bay City, MI', 'Facility', 'Bay City', 'MI', '48706', 'other', '{}', 528, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-30T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'LIVING FACILITY 100 RES!', 'Facility in Bloomington, IN', 'Facility', 'Bloomington', 'IN', '47406', 'other', '{}', 528, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-30T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'WAREHOUSE 70 EMPS!', 'Warehouse in Denver, CO', 'Warehouse', 'Denver', 'CO', '80229', 'warehouse', '{}', 1078, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-30T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'OFFICE 25 HUNGRY EMPS!', 'Office in North Haven, CT', 'Office', 'North Haven', 'CT', '06473', 'office', '{}', 638, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-30T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'HOTEL 50-60 GUESTS!', 'Hotel / Motel in Springhill, LA', 'Hotel / Motel', 'Springhill', 'LA', '71075', 'hotel', '{}', 594, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-30T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'OUTDOOR FACILITY 72 GUESTS 6 EMPS!', 'Outdoor Facility in South Haven, MI', 'Outdoor Facility', 'South Haven', 'MI', NULL, 'other', '{}', 858, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-30T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'OFFICE COMPLEX 100 EMPS, 40 VIS!', 'Office in Washington, DC', 'Office', 'Washington', 'DC', '20037', 'office', '{}', 1320, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-30T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, '3 OFFICE LOCATION OPPURTUNITY! (COFFEE)', 'Office in Black Hawk, CO', 'Office', 'Black Hawk', 'CO', '80422', 'office', '{}', 1980, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-30T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'FACILITY 700 EMPS!', 'Facility in Hubbard, TX', 'Facility', 'Hubbard', 'TX', '76648', 'other', '{}', 1320, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-30T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'OFFICE 50+EMPS!', 'Office in San Tan Valley, AZ', 'Office', 'San Tan Valley', 'AZ', '85140', 'office', '{}', 968, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-30T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'FACILITY 10EMPS 100+STUDENTS!', 'Facility in Beverly, MA', 'Facility', 'Beverly', 'MA', '01915', 'other', '{}', 1100, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-30T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'AST.LIVING 75 EMPS, 30 VIS!', 'Assisted Living Facility in Venice, FL', 'Assisted Living Facility', 'Venice', 'FL', '34285', 'hospital', '{}', 1078, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-30T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'DISTRIBUTION CENTER 45 EMPS, 10 VIS!', 'Distribution Center in Charlotte, NC', 'Distribution Center', 'Charlotte', 'NC', '28269', 'warehouse', '{}', 1078, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-30T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, '3 OFFICE LOCATION OPPURTUNITY!', 'Office in Black Hawk, CO', 'Office', 'Black Hawk', 'CO', '80422', 'office', '{}', 1540, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-30T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'AUTOMOTIVE LOCATION 35 EMPS 40 CUSTOMERS!', 'Automotive Location in Libertyville, IL', 'Automotive Location', 'Libertyville', 'IL', '60048', 'other', '{}', 1078, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-29T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'OFFICE 1EMP 10VIS!', 'Office in Cynthiana, KY', 'Office', 'Cynthiana', 'KY', '41031', 'office', '{}', 418, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-29T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'FACILITY 50 VIS!', 'Facility in Chicago, IL', 'Facility', 'Chicago', 'IL', '60622', 'other', '{}', 638, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-29T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'GROWING MANUFACTURING 15-20 EMPS!', 'Manufacturing Facility in Memphis, TN', 'Manufacturing Facility', 'Memphis', 'TN', '38106', 'warehouse', '{}', 528, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-29T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'OFFICE 19EMPS 30VIS!', 'Office in Shrewsbury, MA', 'Office', 'Shrewsbury', 'MA', '01545', 'office', '{}', 726, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-29T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'OFFICE 15 EMPS/ COFFEE SERVICE!', 'Office in Oshkosh, WI', 'Office', 'Oshkosh', 'WI', '54904', 'office', '{}', 418, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-29T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'OFFICE 180EMPS!', 'Office in Baltimore, MD', 'Office', 'Baltimore', 'MD', '21202', 'office', '{}', 1320, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-29T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'FACILITY 40 EMPS 10+VIS!', 'Facility in Lester, PA', 'Facility', 'Lester', 'PA', '19029', 'other', '{}', 880, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-29T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'MANUFACTURING FACILITY 40 EMPS!', 'Manufacturing Facility in Raymond, WI', 'Manufacturing Facility', 'Raymond', 'WI', '53126', 'warehouse', '{}', 880, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-29T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'WAREHOUSE 10 EMPS, 10-20 VIS!', 'Warehouse in Tucker, GA', 'Warehouse', 'Tucker', 'GA', '30084', 'warehouse', '{}', 682, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-29T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'OFFICE 45EMPS 5VIS!', 'Office in Fremont, CA', 'Office', 'Fremont', 'CA', '94538', 'office', '{}', 748, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-29T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'OFFICE 15-20 EMPS/COFFEE SERVICE!', 'Office in Brentwood, TN', 'Office', 'Brentwood', 'TN', '37027', 'office', '{}', 528, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-29T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'APARTMENT BUILDING 180RES 2EMPS!', 'Apartment Building in Marathon, FL', 'Apartment Building', 'Marathon', 'FL', '33050', 'apartment', '{}', 858, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-29T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'FACILITY 6-30 EMPS!', 'Facility in Sun Prairie, WI', 'Facility', 'Sun Prairie', 'WI', '53590', 'other', '{}', 528, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-29T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'INDOOR SPORTS FACILITY 3EMPS 50+VIS!', 'Sports Facility in Boca Raton, FL', 'Sports Facility', 'Boca Raton', 'FL', '33487', 'gym', '{}', 836, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-28T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'GROWING AUTOMOTIVE LOCATION !', 'Automotive Location in Fort Pierce, FL', 'Automotive Location', 'Fort Pierce', 'FL', '34945', 'other', '{}', 880, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-28T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'OFFICE 35+EMPS!', 'Office in Monterey, CA', 'Office', 'Monterey', 'CA', '93940', 'office', '{}', 594, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-28T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'OFFICE COMPLEX 100 EMPS!', 'Office Complex in Grand Rapids, MI', 'Office Complex', 'Grand Rapids', 'MI', '49505', 'office', '{}', 924, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-28T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'FACILITY 2 EMPS 300+ VISITORS!', 'Facility in Salem, OR', 'Facility', 'Salem', 'OR', '97301', 'other', '{}', 1078, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-28T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'FACILITY 20+EMPS!', 'Facility in Bristol, CT', 'Facility', 'Bristol', 'CT', '06010', 'other', '{}', 682, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-28T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'HOTEL/MOTEL 6 EMPS 300 GUESTS! ( COFFEE VENDING)', 'Hotel / Motel in Orlando, FL', 'Hotel / Motel', 'Orlando', 'FL', '32819', 'hotel', '{}', 880, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-28T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'SENIOR LIVING FACILITY 6EMPS 101RES!', 'Assisted Living Facility in Pittsburgh, PA', 'Assisted Living Facility', 'Pittsburgh', 'PA', '15202', 'hospital', '{}', 924, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-28T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'OFFICE 20 EMPS 2 VISITORS!( COFFEE SERVICE)', 'Office in Lisle, IL', 'Office', 'Lisle', 'IL', '60532', 'office', '{}', 990, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-28T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'FACILITY 100EMPS 3 VIS!', 'Facility in Marshall, AR', 'Facility', 'Marshall', 'AR', '72650', 'other', '{}', 858, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-28T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'FACILITY 12 EMPS 30 VIS (COFFEE SERVICE)', 'Facility in Spokane, WA', 'Facility', 'Spokane', 'WA', '99205', 'other', '{}', 528, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-28T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, '2 BUILDING PUBLIC FACILITY 200 EMPS, 75 VIS!', 'Facility in Winston-Salem, NC', 'Facility', 'Winston-Salem', 'NC', '27101', 'other', '{}', 858, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-28T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'OFFICE 75 EMPS!', 'Office Complex in Las Cruces, NM', 'Office Complex', 'Las Cruces', 'NM', '88005', 'office', '{}', 770, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-28T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'MANUFACTURING 50 EMPS! ( HAS EQUIPMENT!)', 'Manufacturing Facility in Lewes, DE', 'Manufacturing Facility', 'Lewes', 'DE', '19958', 'warehouse', '{}', 770, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-28T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'PUBLIC FACILITY 25-50 VIS!', 'Facility in Toledo, OH', 'Facility', 'Toledo', 'OH', '43623', 'other', '{}', 858, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-28T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'OFFICE 20 STUDENTS, 7 EMPS!', 'Office in Alexander City, AL', 'Office', 'Alexander City', 'AL', '35010', 'office', '{}', 528, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-28T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'APT 130 RES!', 'Apartment Building in Grand Rapids, MN', 'Apartment Building', 'Grand Rapids', 'MN', '55744', 'apartment', '{}', 770, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-28T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'UPDATE 4/28 SCHOOL 300 STUDENTS 40 EMPS!', 'School in Parachute, CO', 'School', 'Parachute', 'CO', '81635', 'school', '{}', 748, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-28T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'COMMUNITY CLUBHOUSE 463 RES!', 'Community Clubhouse in Bonita Springs, FL', 'Community Clubhouse', 'Bonita Springs', 'FL', '34135', 'other', '{}', 1078, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-28T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'AUTOMOTIVE LOCATION 14-25+EMPS! (GROWING)', 'Automotive Location in San Jose, CA', 'Automotive Location', 'San Jose', 'CA', '95122', 'other', '{}', 418, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-27T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'Facility 2 EMPS 50 CUSTOMERS!', 'Facility in Everett, WA', 'Facility', 'Everett', 'WA', '98201', 'other', '{}', 638, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-27T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'SCHOOL 50 STAFF 400+ STUDENTS!', 'School in Milwaukee, WI', 'School', 'Milwaukee', 'WI', '53204', 'school', '{}', 1540, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-27T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'FACILITY 25 EMPS!', 'Facility in Murfreesboro, TN', 'Facility', 'Murfreesboro', 'TN', '37129', 'other', '{}', 638, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-27T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'SCHOOL 100+EMPS!', 'School in Philadelphia, PA', 'School', 'Philadelphia', 'PA', '19146', 'school', '{}', 1320, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-27T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'WAREHOUSE 15 EMPS!', 'Warehouse in Philadelphia, PA', 'Warehouse', 'Philadelphia', 'PA', '19120', 'warehouse', '{}', 418, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-27T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'OFFICE 75 EMPS!', 'Office in Rochester, NY', 'Office', 'Rochester', 'NY', '14623', 'office', '{}', 748, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-27T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'APT. COMPLEX 150 RES!', 'Apartment Complex in Pine Ridge, FL', 'Apartment Complex', 'Pine Ridge', 'FL', NULL, 'apartment', '{}', 902, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-27T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'RETAIL 80 EMPS!', 'Retail Establishment in Davidsonville, MD', 'Retail Establishment', 'Davidsonville', 'MD', '21035', 'retail', '{}', 968, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-27T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'MANUFACTURING 70 EMPS !', 'Manufacturing Facility in Montgomeryville, PA', 'Manufacturing Facility', 'Montgomeryville', 'PA', '18936', 'warehouse', '{}', 1078, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-27T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'MANUFACTURING 6 EMPS BUT GROWING!', 'Manufacturing Facility in Hammond, LA', 'Manufacturing Facility', 'Hammond', 'LA', '70401', 'warehouse', '{}', 418, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-27T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'RETAIL ESTABLISHMENT 40EMPS!', 'Retail Establishment in Richmond Heights, MO', 'Retail Establishment', 'Richmond Heights', 'MO', '63117', 'retail', '{}', 638, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-24T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'APARTMENT COMPLEX 4EMPS 180+RES!', 'Apartment Complex in Washington, PA', 'Apartment Complex', 'Washington', 'PA', '15301', 'apartment', '{}', 1078, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-24T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'OFFICE 8EMPS ( COFFEE SERVICE)', 'Office in Sioux Falls, SD', 'Office', 'Sioux Falls', 'SD', '57108', 'office', '{}', 528, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-24T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'APARTMENT BUILDING 400 RES 4 EMPS HAS EQUIPMENT!', 'Apartment Building in Bozeman, MT', 'Apartment Building', 'Bozeman', 'MT', '59718', 'apartment', '{}', 858, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-24T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'OFFICE 55 EMPS!', 'Office in Fremont, CA', 'Office', 'Fremont', 'CA', '94538', 'office', '{}', 858, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-24T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'PRODUCTION FACILITY 25 EMPS !', 'Production Facility in Loris, SC', 'Production Facility', 'Loris', 'SC', '29569', 'warehouse', '{}', 550, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-24T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'WAREHOUSE 300 EMPS!', 'Warehouse in Linden, NJ', 'Warehouse', 'Linden', 'NJ', '07036', 'warehouse', '{}', 2860, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-24T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'OFFICE 40 EMPS 5VIS!', 'Office in Wixom, MI', 'Office', 'Wixom', 'MI', '48393', 'office', '{}', 968, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-24T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'OFFICE 134 EMPS!', 'Office in Columbia, MO', 'Office', 'Columbia', 'MO', '65201', 'office', '{}', 1034, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-24T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'WAREHOUSE 12 EMPS GROWING TO 50!', 'Warehouse in Milford, MI', 'Warehouse', 'Milford', 'MI', '48381', 'warehouse', '{}', 638, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-24T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'OFFICE 60 EMPS!', 'Office in Chicago, IL', 'Office', 'Chicago', 'IL', '60606', 'office', '{}', 1078, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-24T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'OFFICE 0-25 EMPS/COFFEE SERVICE!', 'Office in New York, NY', 'Office', 'New York', 'NY', '10011', 'office', '{}', 528, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-24T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'HOTEL/MOTEL 8 EMPS 50+VIS!', 'Hotel / motel in Guernsey, WY', 'Hotel / motel', 'Guernsey', 'WY', '82214', 'hotel', '{}', 638, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-24T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'TRANSPORTATION FACILITY 40+EMPS 10VIS!', 'Transportation Facility in Winter Garden, FL', 'Transportation Facility', 'Winter Garden', 'FL', '34787', 'other', '{}', 946, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-24T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'NURSING HOME 80EMPS!', 'Nursing Home in Topeka, KS', 'Nursing Home', 'Topeka', 'KS', '66615', 'hospital', '{}', 858, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-24T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, '6 BUILDING OFFICE COMPLEX OPPURTUNITY (600+EMPS)!', 'Office Complex in Denver, CO', 'Office Complex', 'Denver', 'CO', '80204', 'office', '{}', 2420, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-24T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'FACILITY 200 CUSTOMERS!', 'Facility in Denver, CO', 'Facility', 'Denver', 'CO', '80207', 'other', '{}', 2200, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-24T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'OFFICE 50 EMPS!', 'Office in Bee Cave, TX', 'Office', 'Bee Cave', 'TX', '78738', 'office', '{}', 858, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-24T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'MANUFACTURING FACILITY 65EMPS!', 'Manufacturing Facility in Tualatin, OR', 'Manufacturing Facility', 'Tualatin', 'OR', NULL, 'warehouse', '{}', 968, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-23T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'PUBLIC FACILITY 200-250 VIS!', 'Facility in Baltimore, MD', 'Facility', 'Baltimore', 'MD', '21216', 'other', '{}', 1078, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-23T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'MEDICAL FACILITY 34+EMPS 10+VIS!', 'Medical Facility in Tulsa, OK', 'Medical Facility', 'Tulsa', 'OK', '74116', 'hospital', '{}', 462, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-23T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'FACILITY 10 EMPS 40 VIS!', 'Facility in Charleston, WV', 'Facility', 'Charleston', 'WV', '25314', 'other', '{}', 462, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-23T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'FACILITY 130+EMPS!', 'Facility in Austin, TX', 'Facility', 'Austin', 'TX', '78704', 'other', '{}', 1540, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-23T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'ASSITED LIVING 20 EMPS 80 RES!', 'Assisted Living Facility in Greendale, WI', 'Assisted Living Facility', 'Greendale', 'WI', '53129', 'hospital', '{}', 968, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-23T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'MANUFACTURING 50EMPS 2VIS!', 'Manufacturing Facility in Clackamas, OR', 'Manufacturing Facility', 'Clackamas', 'OR', '97015', 'warehouse', '{}', 726, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-23T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'MANUFACTURING 60 EMPS!', 'Manufacturing Facility in Marlow, OK', 'Manufacturing Facility', 'Marlow', 'OK', '73055', 'warehouse', '{}', 594, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-23T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'HOTEL/MOTEL 100 EMPS!', 'Hotel / Motel in Montgomery, AL', 'Hotel / Motel', 'Montgomery', 'AL', '36104', 'hotel', '{}', 770, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-23T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'RETAIL ESTABLISHMENT 2 EMPS 100 CUSTOMERS!', 'Retail Establishment in Tulsa, OK', 'Retail Establishment', 'Tulsa', 'OK', '74136', 'retail', '{}', 484, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-23T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'OFFICE 20 EMPS 30 VISITORS!', 'Office in Kenansville, NC', 'Office', 'Kenansville', 'NC', '28349', 'office', '{}', 550, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-23T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'RETAIL 15 EMPS, 20 CUSTOMERS!', 'Retail Establishment in Greencastle, IN', 'Retail Establishment', 'Greencastle', 'IN', '46135', 'retail', '{}', 550, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-23T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'MANUFACTURING 15-30 EMPS!', 'Manufacturing Facility in Rainbow City, AL', 'Manufacturing Facility', 'Rainbow City', 'AL', '35906', 'warehouse', '{}', 550, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-23T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'APT.COMPLEX 230 RES!', 'Apartment Complex in Corvallis, OR', 'Apartment Complex', 'Corvallis', 'OR', '97330', 'apartment', '{}', 748, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-23T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'UPDATE 5/1 FACILITY 4 EMPS 100 VISITORS!', 'Facility in Harrisonburg, VA', 'Facility', 'Harrisonburg', 'VA', '22802', 'other', '{}', 308, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-23T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'UPDATE 4/23 ASSISTED LIVING 220 RES 6 EMPS!', 'Assisted Living Facility in South Bend, IN', 'Assisted Living Facility', 'South Bend', 'IN', NULL, 'hospital', '{}', 638, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-23T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'OFFICE 30+EMPS!', 'Office in Cleveland, OH', 'Office', 'Cleveland', 'OH', '44110', 'office', '{}', 550, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-22T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'ASSITED LIVING 50 EMPS 50 RES!', 'Assisted Living Facility in Sellersburg, IN', 'Assisted Living Facility', 'Sellersburg', 'IN', '47172', 'hospital', '{}', 858, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-22T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'UPDATE 4/29/26- MANUFACTURING 10 EMPS!', 'Manufacturing Facility in Milwaukee, WI', 'Manufacturing Facility', 'Milwaukee', 'WI', '53223', 'warehouse', '{}', 418, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-22T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'MANUFATURING 30+EMPS! (GROWING)', 'Manufacturing Facility in Burlington, NC', 'Manufacturing Facility', 'Burlington', 'NC', '27215', 'warehouse', '{}', 506, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-22T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'WAREHOUSE 25 EMPS!', 'Warehouse in Richmond, VA', 'Warehouse', 'Richmond', 'VA', '23230', 'warehouse', '{}', 638, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-22T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'FACILITY 20+ EMPS, 100 VIS!', 'Facility in Kalispell, MT', 'Facility', 'Kalispell', 'MT', '59901', 'other', '{}', 572, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-22T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'MANUFACTURING 50EMPS 10VIS!', 'Manufacturing Facility in Brighton, CO', 'Manufacturing Facility', 'Brighton', 'CO', '80603', 'warehouse', '{}', 638, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-22T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'APARTMENT COMPLEX 20EMPS 850+RES!', 'Apartment Complex in Lakeland, FL', 'Apartment Complex', 'Lakeland', 'FL', '33809', 'apartment', '{}', 1760, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-22T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'APARTMENT COMPLEX 3 EMPS 150 RESIDENTS!', 'Apartment Complex in Charlotte, NC', 'Apartment Complex', 'Charlotte', 'NC', '28262', 'apartment', '{}', 968, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-22T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, '3 BUILDING MEDICAL 80 EMPS, 80 VIS PER BUILDING!', 'Medical Facility in Abilene, TX', 'Medical Facility', 'Abilene', 'TX', '79602', 'hospital', '{}', 1320, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-22T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'FACILITY 12 EMPS 5 DRIVERS!', 'Facility in Evansville, IN', 'Facility', 'Evansville', 'IN', '47720', 'other', '{}', 528, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-22T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'HOTEL/MOTEL 100 EMPS 250 EMPS!', 'Hotel / Motel in Savannah, GA', 'Hotel / Motel', 'Savannah', 'GA', '31401', 'hotel', '{}', 1320, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-22T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'SCHOOL 40 EMPS!', 'School in Danville, VA', 'School', 'Danville', 'VA', '24541', 'school', '{}', 638, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-22T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'WAREHOUSE 30 EMPS!', 'Warehouse in Kentwood, MI', 'Warehouse', 'Kentwood', 'MI', '49512', 'warehouse', '{}', 638, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-22T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'MANUFACTURING 50+ EMPS!', 'Manufacturing Facility in Horsham, PA', 'Manufacturing Facility', 'Horsham', 'PA', '19044', 'warehouse', '{}', 836, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-22T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'OFFICE 50EMPS!', 'Office in Bothell, WA', 'Office', 'Bothell', 'WA', '98011', 'office', '{}', 638, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-22T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, '4/29/26-WAREHOUSE 14 EMPS!', 'Warehouse in Montgomeryville, PA', 'Warehouse', 'Montgomeryville', 'PA', '18936', 'warehouse', '{}', 330, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-22T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'SCHOOL 45+EMPS!', 'School in Milford, NH', 'School', 'Milford', 'NH', '03055', 'school', '{}', 748, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-21T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'APT 90+ RES!(COFFEE SERVICE)', 'Apartment Building in Wyomissing, PA', 'Apartment Building', 'Wyomissing', 'PA', '19610', 'apartment', '{}', 418, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-21T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'RETAIL 100-200 CUSTOMERS/ COFFEE SERVICE!', 'Retail Establishment in Dayton, OH', 'Retail Establishment', 'Dayton', 'OH', '45403', 'retail', '{}', 528, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-21T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'CAR DEALER 96 EMPS 50 CUSTOMERS!', 'Car Dealer in Charleston, WV', 'Car Dealer', 'Charleston', 'WV', '25387', 'other', '{}', 858, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-21T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'MANUFACTURING 30 EMPS!', 'Manufacturing Facility in Decatur, IL', 'Manufacturing Facility', 'Decatur', 'IL', '62526', 'warehouse', '{}', 594, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-21T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'FACILITY 40EMPS!', 'Facility in Moncks Corner, SC', 'Facility', 'Moncks Corner', 'SC', '29461', 'other', '{}', 704, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-21T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'COMMUNITY CLUBHOUSE 1000+ RES!', 'Community Clubhouse in Davenport, FL', 'Community Clubhouse', 'Davenport', 'FL', '33896', 'other', '{}', 1760, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-21T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'DISTRIBUTION CENTER 20EMPS 3VIS!', 'Distribution Center in Hebron, OH', 'Distribution Center', 'Hebron', 'OH', '43025', 'warehouse', '{}', 594, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-21T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'FACILITY 2 LOCATIONS!', 'Facility in Dubuque, IA', 'Facility', 'Dubuque', 'IA', '52003', 'other', '{}', 528, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-21T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'PRODUCTION 80 EMPS!', 'Production Facility in Bay St. Louis, MS', 'Production Facility', 'Bay St. Louis', 'MS', '39520', 'warehouse', '{}', 682, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-21T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'MANUFACTURING 300 EMPS!', 'Manufacturing Facility in Goodman, MO', 'Manufacturing Facility', 'Goodman', 'MO', '64843', 'warehouse', '{}', 1320, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-21T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'CAR DEALER 54 EMPS 30 CUSTOMERS!', 'Car Dealer in Charleston, WV', 'Car Dealer', 'Charleston', 'WV', '25315', 'other', '{}', 704, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-21T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'APT 300 RES!', 'Apartment Complex in Kingsville, TX', 'Apartment Complex', 'Kingsville', 'TX', '78363', 'apartment', '{}', 528, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-21T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'AUTOMOTIVE LOCATION 15 EMPS 50 DRIVERS!', 'Automotive Location in Greensboro, NC', 'Automotive Location', 'Greensboro', 'NC', '27409', 'other', '{}', 1078, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-21T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'AUTOMOTIVE LOCATION 15 EMPS!', 'Automotive Location in Brooksville, FL', 'Automotive Location', 'Brooksville', 'FL', '34601', 'other', '{}', 528, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-21T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'MANUFACTURING FACILITY 50 EMPS!', 'Manufacturing Facility in Birmingham, AL', 'Manufacturing Facility', 'Birmingham', 'AL', '35217', 'warehouse', '{}', 770, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-21T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'APT COMPLEX 500 RES!', 'Apartment Complex in Sarasota, FL', 'Apartment Complex', 'Sarasota', 'FL', '34239', 'apartment', '{}', 968, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-21T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'TRANSPORTATION 35 EMPS, 125 DRIVERS!', 'Transportation Facility in Harrisburg, PA', 'Transportation Facility', 'Harrisburg', 'PA', '17104', 'other', '{}', 1320, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-21T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'OFFICE/CHURCH 10EMPS 100VIS!', 'Office in Bronx, NY', 'Office', 'Bronx', 'NY', '10469', 'office', '{}', 858, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-21T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'APARTMENT BUILDING 200 RESIDENTS 10 VISITORS!', 'Apartment Building in Cedar Rapids, IA', 'Apartment Building', 'Cedar Rapids', 'IA', '52404', 'apartment', '{}', 814, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-21T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'GYM 4 EMPS 200 VISITORS!', 'Gym in Mishawaka, IN', 'Gym', 'Mishawaka', 'IN', '46545', 'gym', '{}', 660, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-21T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'WAREHOUSE 10 EMPS 10 DRIVERS!', 'Warehouse in Florence, KY', 'Warehouse', 'Florence', 'KY', '41042', 'warehouse', '{}', 484, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-21T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'OFFICE 50 EMPS (COFFEE SERVICE)', 'Office in Tucson, AZ', 'Office', 'Tucson', 'AZ', '85741', 'office', '{}', 528, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-20T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'OFFICE 60 EMPS!', 'Office in Milwaukee, WI', 'Office', 'Milwaukee', 'WI', '53212', 'office', '{}', 990, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-20T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'COMMUNITY CLUBHOUSE 900 RES!', 'Community Clubhouse in Holden Beach, NC', 'Community Clubhouse', 'Holden Beach', 'NC', '28462', 'other', '{}', 968, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-20T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'OFFICE OPPORTUNITY 46 EMPS!', 'Office Complex in Portland, OR', 'Office Complex', 'Portland', 'OR', '97266', 'office', '{}', 968, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-20T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'ASSISTED LIVING FACILITY 50EMPS!', 'Assisted Living Facility in Moultrie, GA', 'Assisted Living Facility', 'Moultrie', 'GA', '31768', 'hospital', '{}', 770, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-20T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'HOTEL 400 EMPS!', 'Hotel / Motel in Big Sky, MT', 'Hotel / Motel', 'Big Sky', 'MT', '59716', 'hotel', '{}', 990, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-20T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'HOTEL 300 EMPS!', 'Hotel / motel in Charlotte, NC', 'Hotel / motel', 'Charlotte', 'NC', '28202', 'hotel', '{}', 968, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-20T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'RETAIL 200 CUSTOMERS, 7 EMPS!', 'Retail Establishment in Vancouver, WA', 'Retail Establishment', 'Vancouver', 'WA', '98663', 'retail', '{}', 1056, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-20T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'MEDICAL FACILITY 10+EMPS!', 'Medical Facility in Leesville, LA', 'Medical Facility', 'Leesville', 'LA', '71446', 'hospital', '{}', 550, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-20T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'OFFICE 40 EMPS AND GROWING! ( COFFEE SERVICE)', 'Office in Scottsdale, AZ', 'Office', 'Scottsdale', 'AZ', '85258', 'office', '{}', 528, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-20T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'UPDATE 4/20 OFFICE 15 EMPS 150 VIS!', 'Office in Elizabethtown, KY', 'Office', 'Elizabethtown', 'KY', '42701', 'office', '{}', 858, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-20T12:00:00Z', now(), 'Vending Connector');
+
+  INSERT INTO vending_requests (created_by, title, description, location_name, city, state, zip, location_type, machine_types_wanted, price, status, contact_preference, is_public, lead_type, urgency, commission_offered, created_at, updated_at, seller_name)
+  VALUES (admin_id, 'MANUFACTURING FACILITY 50 EMPS!', 'Manufacturing Facility in New York, NY', 'Manufacturing Facility', 'New York', 'NY', '10001', 'warehouse', '{}', 990, 'open', 'email', true, 'contracted', 'flexible', false, '2026-04-20T12:00:00Z', now(), 'Vending Connector');
+
+END $$;


### PR DESCRIPTION
…istings

- Migration 059: adds lead_type column (standard/contracted) to vending_requests
- seed-locations.sql: deletes old listings (preserves York PA), inserts 170+ new contracted location leads with Final Price as listing price
- RequestCard: shows "Contracted" badge and call/email inquiry buttons for contracted leads (no buy button)
- Request detail page: shows call/email CTA instead of purchase button for contracted leads
- Types updated with lead_type field

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2