### PR TITLE
Add confirmation emails for all form submissions and fix route posting

### DIFF
--- a/src/app/api/financing/route.ts
+++ b/src/app/api/financing/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { Resend } from "resend";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { getUserIdFromRequest } from "@/lib/apiAuth";
+import { sendFormConfirmationEmails } from "@/lib/confirmationEmail";
 
 const FROM_EMAIL = process.env.FROM_EMAIL || "onboarding@bytebitevending.com";
 const NOTIFY_EMAIL = process.env.FINANCING_NOTIFY_EMAIL || "james@apexaivending.com";
@@ -156,6 +157,31 @@ export async function POST(req: NextRequest) {
   } catch (emailErr) {
     console.error("[financing] Failed to send notification email:", emailErr);
   }
+
+  // Send confirmation copy to applicant (non-blocking)
+  sendFormConfirmationEmails({
+    formName: "SBA Financing Pre-Qualification",
+    submitterEmail: body.email,
+    submitterName: body.full_name,
+    fields: [
+      { label: "Full Name", value: body.full_name },
+      { label: "Email", value: body.email },
+      { label: "Phone", value: body.phone },
+      { label: "Date of Birth", value: body.date_of_birth },
+      { label: "Citizenship", value: body.citizenship_status },
+      { label: "Credit Score Range", value: body.credit_score_range },
+      { label: "Net Worth Range", value: body.net_worth_range },
+      { label: "Annual Income", value: body.annual_income },
+      { label: "Verifiable Income", value: !!body.has_verifiable_income },
+      { label: "Outstanding Tax Liens", value: !!body.has_tax_liens },
+      { label: "Bankruptcy (Last 7 Years)", value: !!body.has_bankruptcy },
+      { label: "Outstanding Judgments", value: !!body.has_judgments },
+      { label: "Felony Conviction", value: !!body.has_felony },
+      { label: "Current Legal Actions", value: !!body.has_legal_actions },
+      { label: "Delinquent Federal Debt", value: !!body.has_federal_debt },
+    ],
+    adminSubject: `Financing Application Copy: ${body.full_name}`,
+  }).catch((e) => console.error("[financing] confirmation email error", e));
 
   return NextResponse.json({ success: true, applicationId: application.id, crmAccountId, crmLeadId });
 }

--- a/src/app/api/machine-listings/route.ts
+++ b/src/app/api/machine-listings/route.ts
@@ -3,6 +3,7 @@ import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { createMachineListingSchema } from "@/lib/schemas";
 import { getUserIdFromRequest } from "@/lib/apiAuth";
 import { sanitizeSearch } from "@/lib/sanitizeSearch";
+import { sendFormConfirmationEmails } from "@/lib/confirmationEmail";
 
 const PAGE_SIZE = 12;
 
@@ -37,6 +38,46 @@ export async function POST(req: NextRequest) {
     if (error) {
       return NextResponse.json({ error: error.message }, { status: 500 });
     }
+
+    // Send confirmation emails (non-blocking)
+    const d = parsed.data;
+    (async () => {
+      try {
+        const { data: authUser } = await supabaseAdmin.auth.admin.getUserById(userId);
+        const email = authUser?.user?.email ?? d.contact_email ?? null;
+        const { data: profile } = await supabaseAdmin
+          .from("profiles")
+          .select("full_name")
+          .eq("id", userId)
+          .single();
+        await sendFormConfirmationEmails({
+          formName: "Machine for Sale",
+          submitterEmail: email,
+          submitterName: profile?.full_name ?? null,
+          fields: [
+            { label: "Title", value: d.title },
+            { label: "City", value: d.city },
+            { label: "State", value: d.state },
+            { label: "Make", value: d.machine_make },
+            { label: "Model", value: d.machine_model },
+            { label: "Year", value: d.machine_year },
+            { label: "Type", value: d.machine_type },
+            { label: "Condition", value: d.condition },
+            { label: "Quantity", value: d.quantity },
+            { label: "Asking Price", value: d.asking_price ? `$${d.asking_price.toLocaleString()}` : undefined },
+            { label: "Includes Card Reader", value: d.includes_card_reader },
+            { label: "Includes Install", value: d.includes_install },
+            { label: "Includes Delivery", value: d.includes_delivery },
+            { label: "Contact Email", value: d.contact_email },
+            { label: "Contact Phone", value: d.contact_phone },
+            { label: "Description", value: d.description },
+          ],
+          adminSubject: `New Machine Listing: ${d.title} — ${d.city}, ${d.state}`,
+        });
+      } catch (e) {
+        console.error("[machine-listings] confirmation email error", e);
+      }
+    })();
 
     return NextResponse.json({ id: data.id }, { status: 201 });
   } catch (e) {

--- a/src/app/api/requests/route.ts
+++ b/src/app/api/requests/route.ts
@@ -3,6 +3,7 @@ import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { createRequestSchema } from "@/lib/schemas";
 import { getUserIdFromRequest } from "@/lib/apiAuth";
 import { sanitizeSearch } from "@/lib/sanitizeSearch";
+import { sendFormConfirmationEmails } from "@/lib/confirmationEmail";
 
 const PAGE_SIZE = 12;
 
@@ -188,6 +189,41 @@ export async function POST(req: NextRequest) {
     if (error) {
       return NextResponse.json({ error: error.message }, { status: 500 });
     }
+
+    // Send confirmation emails (non-blocking)
+    const d = parsed.data;
+    (async () => {
+      try {
+        const { data: authUser } = await supabaseAdmin.auth.admin.getUserById(userId);
+        const email = authUser?.user?.email ?? null;
+        const { data: profile } = await supabaseAdmin
+          .from("profiles")
+          .select("full_name")
+          .eq("id", userId)
+          .single();
+        await sendFormConfirmationEmails({
+          formName: "Vending Location Request",
+          submitterEmail: email,
+          submitterName: profile?.full_name ?? null,
+          fields: [
+            { label: "Title", value: d.title },
+            { label: "Location Name", value: d.location_name },
+            { label: "City", value: d.city },
+            { label: "State", value: d.state },
+            { label: "ZIP", value: d.zip },
+            { label: "Location Type", value: d.location_type },
+            { label: "Machine Types", value: d.machine_types_wanted?.join(", ") },
+            { label: "Daily Traffic", value: d.estimated_daily_traffic },
+            { label: "Commission Offered", value: d.commission_offered },
+            { label: "Urgency", value: d.urgency },
+            { label: "Description", value: d.description },
+          ],
+          adminSubject: `New Vending Request: ${d.title} — ${d.city}, ${d.state}`,
+        });
+      } catch (e) {
+        console.error("[requests] confirmation email error", e);
+      }
+    })();
 
     return NextResponse.json({ id: data.id }, { status: 201 });
   } catch (e) {

--- a/src/app/api/routes/route.ts
+++ b/src/app/api/routes/route.ts
@@ -3,6 +3,7 @@ import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { createRouteSchema } from "@/lib/schemas";
 import { getUserIdFromRequest } from "@/lib/apiAuth";
 import { sanitizeSearch } from "@/lib/sanitizeSearch";
+import { sendFormConfirmationEmails } from "@/lib/confirmationEmail";
 
 const PAGE_SIZE = 12;
 
@@ -37,6 +38,43 @@ export async function POST(req: NextRequest) {
     if (error) {
       return NextResponse.json({ error: error.message }, { status: 500 });
     }
+
+    // Send confirmation emails (non-blocking)
+    const d = parsed.data;
+    (async () => {
+      try {
+        const { data: authUser } = await supabaseAdmin.auth.admin.getUserById(userId);
+        const email = authUser?.user?.email ?? d.contact_email ?? null;
+        const { data: profile } = await supabaseAdmin
+          .from("profiles")
+          .select("full_name")
+          .eq("id", userId)
+          .single();
+        await sendFormConfirmationEmails({
+          formName: "Route for Sale",
+          submitterEmail: email,
+          submitterName: profile?.full_name ?? null,
+          fields: [
+            { label: "Title", value: d.title },
+            { label: "City", value: d.city },
+            { label: "State", value: d.state },
+            { label: "Machines", value: d.num_machines },
+            { label: "Locations", value: d.num_locations },
+            { label: "Monthly Revenue", value: d.monthly_revenue ? `$${d.monthly_revenue.toLocaleString()}` : undefined },
+            { label: "Asking Price", value: d.asking_price ? `$${d.asking_price.toLocaleString()}` : undefined },
+            { label: "Machine Types", value: d.machine_types?.join(", ") },
+            { label: "Includes Equipment", value: d.includes_equipment },
+            { label: "Includes Contracts", value: d.includes_contracts },
+            { label: "Contact Email", value: d.contact_email },
+            { label: "Contact Phone", value: d.contact_phone },
+            { label: "Description", value: d.description },
+          ],
+          adminSubject: `New Route Listing: ${d.title} — ${d.city}, ${d.state}`,
+        });
+      } catch (e) {
+        console.error("[routes] confirmation email error", e);
+      }
+    })();
 
     return NextResponse.json({ id: data.id }, { status: 201 });
   } catch (e) {

--- a/src/lib/confirmationEmail.ts
+++ b/src/lib/confirmationEmail.ts
@@ -1,0 +1,105 @@
+import { Resend } from "resend";
+
+const FROM_EMAIL = process.env.FROM_EMAIL || "noreply@bytebitevending.com";
+const ADMIN_EMAIL = process.env.ADMIN_NOTIFICATION_EMAIL || "james@apexaivending.com";
+
+function getResend() {
+  return new Resend(process.env.RESEND_API_KEY);
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+interface Field {
+  label: string;
+  value: string | number | boolean | null | undefined;
+}
+
+function buildFieldsTable(fields: Field[]): string {
+  return fields
+    .filter((f) => f.value !== undefined && f.value !== null && f.value !== "")
+    .map((f, i) => {
+      const val =
+        typeof f.value === "boolean"
+          ? f.value
+            ? "Yes"
+            : "No"
+          : escapeHtml(String(f.value));
+      const bg = i % 2 === 1 ? ' style="background:#f9fafb;"' : "";
+      return `<tr${bg}><td style="padding:8px 12px;color:#6b7280;width:40%;font-size:14px;">${escapeHtml(f.label)}</td><td style="padding:8px 12px;color:#111827;font-size:14px;font-weight:500;">${val}</td></tr>`;
+    })
+    .join("");
+}
+
+function wrapEmail(title: string, intro: string, fieldsHtml: string): string {
+  return `
+    <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:600px;margin:0 auto;padding:32px 24px;">
+      <div style="text-align:center;margin-bottom:32px;">
+        <h1 style="color:#16a34a;font-size:24px;margin:0;">VendHub</h1>
+        <p style="color:#6b7280;font-size:14px;margin:4px 0 0;">${escapeHtml(title)}</p>
+      </div>
+      <div style="background:#f0fdf4;border-radius:12px;padding:20px 24px;margin-bottom:24px;">
+        <p style="margin:0;font-size:15px;color:#374151;line-height:1.6;">${intro}</p>
+      </div>
+      <table style="width:100%;border-collapse:collapse;border:1px solid #e5e7eb;border-radius:8px;overflow:hidden;">
+        ${fieldsHtml}
+      </table>
+      <p style="font-size:13px;color:#6b7280;text-align:center;margin-top:24px;">
+        Questions? Reply to this email or visit <a href="${process.env.NEXT_PUBLIC_APP_URL || "https://vendhub.io"}" style="color:#16a34a;">VendHub</a>.
+      </p>
+    </div>
+  `;
+}
+
+interface ConfirmationParams {
+  formName: string;
+  submitterEmail: string | null;
+  submitterName: string | null;
+  fields: Field[];
+  adminSubject: string;
+}
+
+export async function sendFormConfirmationEmails(params: ConfirmationParams) {
+  const { formName, submitterEmail, submitterName, fields, adminSubject } = params;
+  const resend = getResend();
+  const fieldsHtml = buildFieldsTable(fields);
+  const promises: Promise<unknown>[] = [];
+
+  if (submitterEmail) {
+    const name = submitterName || "there";
+    const submitterHtml = wrapEmail(
+      `${formName} — Submission Received`,
+      `Thank you${name !== "there" ? `, ${escapeHtml(name)}` : ""}! We've received your ${formName.toLowerCase()} submission. Our team will review it and follow up shortly.`,
+      fieldsHtml
+    );
+    promises.push(
+      resend.emails.send({
+        from: FROM_EMAIL,
+        to: submitterEmail,
+        subject: `Your ${formName} submission has been received — VendHub`,
+        html: submitterHtml,
+      })
+    );
+  }
+
+  const adminHtml = wrapEmail(
+    `New ${formName} Submission`,
+    `A new ${formName.toLowerCase()} has been submitted${submitterName ? ` by ${escapeHtml(submitterName)}` : ""}${submitterEmail ? ` (${escapeHtml(submitterEmail)})` : ""}.`,
+    fieldsHtml
+  );
+  promises.push(
+    resend.emails.send({
+      from: FROM_EMAIL,
+      to: ADMIN_EMAIL,
+      subject: adminSubject,
+      html: adminHtml,
+    })
+  );
+
+  await Promise.allSettled(promises);
+}

--- a/supabase/migrations/060_route_listings.sql
+++ b/supabase/migrations/060_route_listings.sql
@@ -1,0 +1,63 @@
+-- Create route_listings table (was defined in schema.sql but never had a numbered migration)
+CREATE TABLE IF NOT EXISTS public.route_listings (
+  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  created_by uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  title text NOT NULL,
+  description text,
+  city text NOT NULL,
+  state text NOT NULL,
+  num_machines integer NOT NULL,
+  num_locations integer NOT NULL,
+  monthly_revenue numeric,
+  asking_price numeric,
+  machine_types text[] NOT NULL DEFAULT '{}',
+  location_types text[] NOT NULL DEFAULT '{}',
+  includes_equipment boolean NOT NULL DEFAULT true,
+  includes_contracts boolean NOT NULL DEFAULT true,
+  contact_email text,
+  contact_phone text,
+  status text NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'sold', 'pending')),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.route_listings ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='route_listings' AND policyname='Route listings viewable by everyone') THEN
+    CREATE POLICY "Route listings viewable by everyone"
+      ON public.route_listings FOR SELECT USING (true);
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='route_listings' AND policyname='Authenticated users can create route listings') THEN
+    CREATE POLICY "Authenticated users can create route listings"
+      ON public.route_listings FOR INSERT WITH CHECK (auth.uid() = created_by);
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='route_listings' AND policyname='Owners can update own route listings') THEN
+    CREATE POLICY "Owners can update own route listings"
+      ON public.route_listings FOR UPDATE USING (auth.uid() = created_by);
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='route_listings' AND policyname='Owners can delete own route listings') THEN
+    CREATE POLICY "Owners can delete own route listings"
+      ON public.route_listings FOR DELETE USING (auth.uid() = created_by);
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_route_listings_created_by ON public.route_listings(created_by);
+CREATE INDEX IF NOT EXISTS idx_route_listings_status ON public.route_listings(status);
+
+CREATE OR REPLACE FUNCTION public.set_updated_at()
+RETURNS trigger AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS set_route_listings_updated_at ON public.route_listings;
+CREATE TRIGGER set_route_listings_updated_at
+  BEFORE UPDATE ON public.route_listings
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();


### PR DESCRIPTION
- Create route_listings table migration (060) — table was defined in schema.sql but never had a numbered migration, so users couldn't post routes for sale (insert failed on missing table)
- Add confirmationEmail.ts utility that sends both a submitter copy and an admin copy with all submitted form fields
- Wire confirmation emails into POST /api/requests (vending requests), POST /api/routes (route listings), POST /api/machine-listings, and POST /api/financing (applicant copy was missing)

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2