### PR TITLE
Add automated operator location digest email system

### DIFF
--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -94,6 +94,7 @@ export async function PATCH(req: NextRequest) {
     const allowedFields = [
       "full_name", "company_name", "phone", "website", "bio",
       "address", "city", "state", "zip", "role",
+      "digest_opt_in", "digest_frequency",
     ];
     // Privileged roles can ONLY be set by an admin via /api/admin/users.
     // Self-service signup must never grant admin/sales access.

--- a/src/app/api/digest/send/route.ts
+++ b/src/app/api/digest/send/route.ts
@@ -1,0 +1,167 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { sendOperatorDigestEmail } from "@/lib/digestEmail";
+
+const CRON_SECRET = process.env.CRON_SECRET;
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "https://vendingconnector.com";
+const MAX_LEADS_PER_EMAIL = 10;
+
+async function runDigest(frequency: string) {
+  // 1. Get all operators who opted in to digests at this frequency
+  const { data: operators, error: opErr } = await supabaseAdmin
+    .from("profiles")
+    .select("id, full_name, city, state")
+    .eq("role", "operator")
+    .eq("digest_opt_in", true)
+    .eq("digest_frequency", frequency);
+
+  if (opErr) {
+    return { error: opErr.message, status: 500 };
+  }
+
+  if (!operators || operators.length === 0) {
+    return { sent: 0, message: "No eligible operators" };
+  }
+
+  // 2. Also pull operator_listings for states_served (broader coverage)
+  const operatorIds = operators.map((o) => o.id);
+  const { data: listings } = await supabaseAdmin
+    .from("operator_listings")
+    .select("operator_id, states_served")
+    .in("operator_id", operatorIds);
+
+  // Build a map: operator_id -> set of states they serve
+  const statesMap = new Map<string, Set<string>>();
+  for (const op of operators) {
+    const states = new Set<string>();
+    if (op.state) states.add(op.state);
+    statesMap.set(op.id, states);
+  }
+  for (const listing of listings || []) {
+    const existing = statesMap.get(listing.operator_id);
+    if (existing && listing.states_served) {
+      for (const s of listing.states_served) existing.add(s);
+    }
+  }
+
+  // 3. Get all open, public vending requests
+  const { data: openLeads, error: leadErr } = await supabaseAdmin
+    .from("vending_requests")
+    .select("id, title, city, state, location_type, machine_types_wanted, price, urgency, estimated_daily_traffic")
+    .eq("status", "open")
+    .eq("is_public", true)
+    .neq("city", "")
+    .neq("state", "")
+    .not("city", "is", null)
+    .not("state", "is", null)
+    .order("created_at", { ascending: false });
+
+  if (leadErr) {
+    return { error: leadErr.message, status: 500 };
+  }
+
+  if (!openLeads || openLeads.length === 0) {
+    return { sent: 0, message: "No open leads" };
+  }
+
+  // 4. Get operator emails from auth
+  const emailMap = new Map<string, string>();
+  for (const op of operators) {
+    const { data: authUser } = await supabaseAdmin.auth.admin.getUserById(op.id);
+    if (authUser?.user?.email) {
+      emailMap.set(op.id, authUser.user.email);
+    }
+  }
+
+  // 5. For each operator, find leads in their states that haven't been sent before
+  let totalSent = 0;
+  const errors: string[] = [];
+
+  for (const op of operators) {
+    const email = emailMap.get(op.id);
+    if (!email) continue;
+
+    const servedStates = statesMap.get(op.id);
+    if (!servedStates || servedStates.size === 0) continue;
+
+    const stateLeads = openLeads.filter((l) => servedStates.has(l.state));
+    if (stateLeads.length === 0) continue;
+
+    // Exclude leads already sent to this operator
+    const { data: alreadySent } = await supabaseAdmin
+      .from("operator_digest_log")
+      .select("request_id")
+      .eq("operator_id", op.id);
+
+    const sentIds = new Set((alreadySent || []).map((r) => r.request_id));
+    const newLeads = stateLeads.filter((l) => !sentIds.has(l.id));
+    if (newLeads.length === 0) continue;
+
+    const leadsToSend = newLeads.slice(0, MAX_LEADS_PER_EMAIL);
+
+    try {
+      await sendOperatorDigestEmail({
+        to: email,
+        operatorName: op.full_name || "Operator",
+        leads: leadsToSend,
+        unsubscribeUrl: `${APP_URL}/dashboard/profile?digest=off`,
+      });
+
+      // Log sent leads so they aren't repeated
+      const logRows = leadsToSend.map((l) => ({
+        operator_id: op.id,
+        request_id: l.id,
+      }));
+      await supabaseAdmin.from("operator_digest_log").upsert(logRows, {
+        onConflict: "operator_id,request_id",
+      });
+
+      await supabaseAdmin
+        .from("profiles")
+        .update({ digest_last_sent_at: new Date().toISOString() })
+        .eq("id", op.id);
+
+      totalSent++;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "Unknown error";
+      errors.push(`${op.id}: ${msg}`);
+    }
+  }
+
+  return {
+    sent: totalSent,
+    operatorsChecked: operators.length,
+    openLeads: openLeads.length,
+    errors: errors.length > 0 ? errors : undefined,
+  };
+}
+
+/** GET — triggered by Vercel Cron */
+export async function GET(req: NextRequest) {
+  const authHeader = req.headers.get("authorization");
+  const isCron = CRON_SECRET && authHeader === `Bearer ${CRON_SECRET}`;
+
+  if (!isCron) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const frequency = req.nextUrl.searchParams.get("frequency") || "weekly";
+  const result = await runDigest(frequency);
+  const status = "error" in result && result.status ? (result.status as number) : 200;
+  return NextResponse.json(result, { status });
+}
+
+/** POST — triggered manually by admin */
+export async function POST(req: NextRequest) {
+  const { getAdminUserId } = await import("@/lib/adminAuth");
+  const adminId = await getAdminUserId(req);
+  if (!adminId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await req.json().catch(() => ({}));
+  const frequency = body.frequency || "weekly";
+  const result = await runDigest(frequency);
+  const status = "error" in result && result.status ? (result.status as number) : 200;
+  return NextResponse.json(result, { status });
+}

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import {
   ArrowLeft,
@@ -13,6 +13,7 @@ import {
   MapPin,
   Globe,
   Phone,
+  Mail,
 } from "lucide-react";
 import { createBrowserClient } from "@/lib/supabase";
 import { US_STATES } from "@/lib/types";
@@ -20,6 +21,7 @@ import type { Profile } from "@/lib/types";
 
 export default function ProfilePage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [profile, setProfile] = useState<Profile | null>(null);
@@ -36,6 +38,8 @@ export default function ProfilePage() {
     state: "",
     zip: "",
     role: "" as string,
+    digest_opt_in: true,
+    digest_frequency: "weekly" as string,
   });
 
   useEffect(() => {
@@ -69,7 +73,26 @@ export default function ProfilePage() {
           state: data.state || "",
           zip: data.zip || "",
           role: data.role || "requestor",
+          digest_opt_in: data.digest_opt_in ?? true,
+          digest_frequency: data.digest_frequency || "weekly",
         });
+
+        // Handle ?digest=off unsubscribe link
+        if (searchParams.get("digest") === "off" && data.digest_opt_in) {
+          const unsub = await fetch("/api/auth/me", {
+            method: "PATCH",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${session.access_token}`,
+            },
+            body: JSON.stringify({ digest_opt_in: false }),
+          });
+          if (unsub.ok) {
+            setForm((f) => ({ ...f, digest_opt_in: false }));
+            setToast({ message: "You've been unsubscribed from digest emails.", type: "success" });
+            setTimeout(() => setToast(null), 5000);
+          }
+        }
       } catch {
         router.replace("/login?redirect=/dashboard/profile");
       } finally {
@@ -108,6 +131,8 @@ export default function ProfilePage() {
           state: form.state || null,
           zip: form.zip || null,
           role: form.role,
+          digest_opt_in: form.digest_opt_in,
+          digest_frequency: form.digest_frequency,
         }),
       });
 
@@ -328,6 +353,56 @@ export default function ProfilePage() {
               </div>
             </div>
           </div>
+
+          {/* Email Digest Preferences (operators only) */}
+          {(form.role === "operator" || profile.role === "operator") && (
+            <div className="rounded-2xl border border-gray-100 bg-white p-6 shadow-sm">
+              <h2 className="mb-4 flex items-center gap-1.5 text-lg font-semibold text-black-primary">
+                <Mail className="h-5 w-5 text-black-primary/40" />
+                Location Digest Emails
+              </h2>
+              <p className="mb-4 text-sm text-black-primary/60">
+                Get notified when new vending locations open up in your area.
+              </p>
+              <div className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-medium text-black-primary">Receive digest emails</p>
+                    <p className="text-xs text-black-primary/50">We&apos;ll send you new locations matching your state</p>
+                  </div>
+                  <button
+                    type="button"
+                    role="switch"
+                    aria-checked={form.digest_opt_in}
+                    onClick={() => setForm((f) => ({ ...f, digest_opt_in: !f.digest_opt_in }))}
+                    className={`relative inline-flex h-7 w-12 shrink-0 cursor-pointer rounded-full transition-colors ${
+                      form.digest_opt_in ? "bg-green-primary" : "bg-gray-300"
+                    }`}
+                  >
+                    <span className={`pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow-md transform transition-transform mt-1 ${
+                      form.digest_opt_in ? "translate-x-6" : "translate-x-1"
+                    }`} />
+                  </button>
+                </div>
+
+                {form.digest_opt_in && (
+                  <div>
+                    <label className="mb-1.5 block text-sm font-medium text-black-primary">
+                      Frequency
+                    </label>
+                    <select
+                      value={form.digest_frequency}
+                      onChange={(e) => setForm((f) => ({ ...f, digest_frequency: e.target.value }))}
+                      className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:border-green-primary focus:outline-none focus:ring-1 focus:ring-green-primary"
+                    >
+                      <option value="daily">Daily</option>
+                      <option value="weekly">Weekly</option>
+                    </select>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
 
           {/* Save Button */}
           <div className="flex items-center justify-end gap-3">

--- a/src/lib/digestEmail.ts
+++ b/src/lib/digestEmail.ts
@@ -1,0 +1,111 @@
+import { Resend } from "resend";
+
+const FROM_EMAIL = process.env.FROM_EMAIL || "noreply@bytebitevending.com";
+
+function getResend() {
+  return new Resend(process.env.RESEND_API_KEY);
+}
+
+function esc(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+interface DigestLead {
+  id: string;
+  title: string;
+  city: string;
+  state: string;
+  location_type: string | null;
+  machine_types_wanted: string[] | null;
+  price: number | null;
+  urgency: string | null;
+  estimated_daily_traffic: number | null;
+}
+
+interface OperatorDigestParams {
+  to: string;
+  operatorName: string;
+  leads: DigestLead[];
+  unsubscribeUrl: string;
+}
+
+function formatUrgency(u: string | null): string {
+  if (!u) return "";
+  const map: Record<string, string> = {
+    asap: "ASAP",
+    within_2_weeks: "Within 2 Weeks",
+    within_1_month: "Within 1 Month",
+    flexible: "Flexible",
+  };
+  return map[u] || u;
+}
+
+function buildLeadCard(lead: DigestLead, appUrl: string): string {
+  const machineTypes = lead.machine_types_wanted?.join(", ") || "Various";
+  const leadUrl = `${appUrl}/browse-requests`;
+
+  return `
+    <div style="background:#fff;border:1px solid #e5e7eb;border-radius:12px;padding:20px;margin-bottom:16px;">
+      <h3 style="margin:0 0 8px;font-size:16px;color:#111827;">${esc(lead.title)}</h3>
+      <table style="width:100%;border-collapse:collapse;font-size:14px;">
+        <tr>
+          <td style="padding:4px 8px 4px 0;color:#6b7280;width:40%;">Location</td>
+          <td style="padding:4px 0;color:#111827;font-weight:500;">${esc(lead.city)}, ${esc(lead.state)}</td>
+        </tr>
+        ${lead.location_type ? `<tr><td style="padding:4px 8px 4px 0;color:#6b7280;">Type</td><td style="padding:4px 0;color:#111827;">${esc(lead.location_type)}</td></tr>` : ""}
+        <tr>
+          <td style="padding:4px 8px 4px 0;color:#6b7280;">Machine Types</td>
+          <td style="padding:4px 0;color:#111827;">${esc(machineTypes)}</td>
+        </tr>
+        ${lead.estimated_daily_traffic ? `<tr><td style="padding:4px 8px 4px 0;color:#6b7280;">Daily Traffic</td><td style="padding:4px 0;color:#111827;">${lead.estimated_daily_traffic}+</td></tr>` : ""}
+        ${lead.urgency && lead.urgency !== "flexible" ? `<tr><td style="padding:4px 8px 4px 0;color:#6b7280;">Urgency</td><td style="padding:4px 0;color:#dc2626;font-weight:600;">${formatUrgency(lead.urgency)}</td></tr>` : ""}
+      </table>
+      <div style="margin-top:12px;">
+        <a href="${leadUrl}" style="display:inline-block;background:#16a34a;color:#fff;padding:8px 16px;border-radius:8px;text-decoration:none;font-size:13px;font-weight:600;">View Locations</a>
+      </div>
+    </div>
+  `;
+}
+
+export async function sendOperatorDigestEmail(params: OperatorDigestParams) {
+  const { to, operatorName, leads, unsubscribeUrl } = params;
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || "https://vendingconnector.com";
+
+  const leadCards = leads.map((l) => buildLeadCard(l, appUrl)).join("");
+
+  const html = `
+    <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:600px;margin:0 auto;padding:32px 24px;">
+      <div style="text-align:center;margin-bottom:32px;">
+        <h1 style="color:#16a34a;font-size:24px;margin:0;">Vending Connector</h1>
+        <p style="color:#6b7280;font-size:14px;margin:4px 0 0;">Location Digest</p>
+      </div>
+
+      <div style="background:#f0fdf4;border-radius:12px;padding:20px 24px;margin-bottom:24px;">
+        <h2 style="margin:0 0 8px;font-size:18px;color:#166534;">Hi ${esc(operatorName)}!</h2>
+        <p style="margin:0;font-size:15px;color:#374151;line-height:1.6;">
+          We found <strong>${leads.length} new location${leads.length === 1 ? "" : "s"}</strong> in your area that ${leads.length === 1 ? "needs" : "need"} a vending operator. Check ${leads.length === 1 ? "it" : "them"} out below:
+        </p>
+      </div>
+
+      ${leadCards}
+
+      <div style="text-align:center;margin-top:24px;">
+        <a href="${appUrl}/browse-requests" style="display:inline-block;background:#111827;color:#fff;padding:12px 24px;border-radius:10px;text-decoration:none;font-size:14px;font-weight:600;">Browse All Locations</a>
+      </div>
+
+      <div style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e7eb;text-align:center;">
+        <p style="font-size:12px;color:#9ca3af;margin:0;">
+          You're receiving this because you're a registered operator on Vending Connector.
+          <br><a href="${esc(unsubscribeUrl)}" style="color:#6b7280;">Unsubscribe from digest emails</a>
+        </p>
+      </div>
+    </div>
+  `;
+
+  return getResend().emails.send({
+    from: FROM_EMAIL,
+    to,
+    subject: `${leads.length} new vending location${leads.length === 1 ? "" : "s"} near you — Vending Connector`,
+    html,
+  });
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -48,6 +48,9 @@ export interface Profile {
   verified: boolean;
   rating: number;
   review_count: number;
+  digest_opt_in: boolean;
+  digest_frequency: "daily" | "weekly" | "never";
+  digest_last_sent_at: string | null;
   created_at: string;
 }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -19,7 +19,7 @@ const PROTECTED_PATHS = [
   "/financing",
 ];
 
-export async function middleware(req: NextRequest) {
+export async function proxy(req: NextRequest) {
   const { pathname } = req.nextUrl;
 
   // Enforce canonical domain — redirect Vercel preview URLs to vendingconnector.com

--- a/supabase/migrations/061_operator_digest.sql
+++ b/supabase/migrations/061_operator_digest.sql
@@ -1,0 +1,20 @@
+-- Add digest email preferences to operator profiles
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS digest_opt_in boolean NOT NULL DEFAULT true,
+  ADD COLUMN IF NOT EXISTS digest_frequency text NOT NULL DEFAULT 'weekly'
+    CHECK (digest_frequency IN ('daily', 'weekly', 'never')),
+  ADD COLUMN IF NOT EXISTS digest_last_sent_at timestamptz;
+
+-- Track which leads have been sent to which operators so we don't repeat
+CREATE TABLE IF NOT EXISTS public.operator_digest_log (
+  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  operator_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  request_id uuid NOT NULL REFERENCES public.vending_requests(id) ON DELETE CASCADE,
+  sent_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(operator_id, request_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_operator_digest_log_operator
+  ON public.operator_digest_log(operator_id);
+CREATE INDEX IF NOT EXISTS idx_operator_digest_log_sent
+  ON public.operator_digest_log(sent_at);

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/digest/send",
+      "schedule": "0 14 * * 1"
+    }
+  ]
+}


### PR DESCRIPTION
- Migration 061: add digest_opt_in, digest_frequency, digest_last_sent_at to profiles, and operator_digest_log table to track sent leads
- Digest API route (GET for Vercel cron, POST for admin trigger) that matches operators to open leads by state (from profile + operator_listings states_served), sends grouped email via Resend, logs sent leads to avoid repeats
- Vercel cron config: weekly Monday 2pm UTC
- Digest email template with lead cards showing location, type, traffic, urgency, and CTA to browse requests
- Profile page: operators can toggle digest on/off and set frequency (daily/weekly); ?digest=off query param handles email unsubscribe link
- Profile type updated with digest fields

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2