### PR TITLE
Make matched/Near Me filter show leads in operator's state

### DIFF
--- a/src/app/api/requests/route.ts
+++ b/src/app/api/requests/route.ts
@@ -7,16 +7,21 @@ import { sendFormConfirmationEmails } from "@/lib/confirmationEmail";
 
 const PAGE_SIZE = 12;
 
-/** Determine the role of the requesting user (if authenticated) */
-async function getRequesterRole(req: NextRequest): Promise<string | null> {
+/** Determine the role and profile info of the requesting user (if authenticated) */
+async function getRequesterInfo(req: NextRequest): Promise<{
+  id: string;
+  role: string;
+  state: string | null;
+} | null> {
   const userId = await getUserIdFromRequest(req);
   if (!userId) return null;
   const { data } = await supabaseAdmin
     .from("profiles")
-    .select("role")
+    .select("role, state")
     .eq("id", userId)
     .single();
-  return data?.role ?? null;
+  if (!data) return null;
+  return { id: userId, role: data.role, state: data.state ?? null };
 }
 
 /**
@@ -55,9 +60,9 @@ export async function GET(req: NextRequest) {
     const saved = params.get("saved");
     const userId = params.get("user_id");
 
-    // Determine if requester is an operator
-    const requesterRole = await getRequesterRole(req);
-    const isOperator = requesterRole === "operator";
+    // Determine requester info
+    const requester = await getRequesterInfo(req);
+    const isOperator = requester?.role === "operator";
 
     let query = supabaseAdmin
       .from("vending_requests")
@@ -113,7 +118,29 @@ export async function GET(req: NextRequest) {
     if (state) query = query.eq("state", state);
     if (urgency) query = query.eq("urgency", urgency);
     if (commission === "true") query = query.eq("commission_offered", true);
-    if (status && status !== "all") query = query.eq("status", status);
+
+    // "matched" filter: show open leads in the operator's served states
+    if (status === "matched" && requester) {
+      query = query.eq("status", "open");
+      // Get operator's states from profile + operator_listings
+      const operatorStates = new Set<string>();
+      if (requester.state) operatorStates.add(requester.state);
+      const { data: listings } = await supabaseAdmin
+        .from("operator_listings")
+        .select("states_served")
+        .eq("operator_id", requester.id);
+      for (const l of listings || []) {
+        for (const s of l.states_served || []) operatorStates.add(s);
+      }
+      if (operatorStates.size > 0) {
+        query = query.in("state", Array.from(operatorStates));
+      } else {
+        return NextResponse.json({ requests: [], total: 0 });
+      }
+    } else if (status && status !== "all") {
+      query = query.eq("status", status);
+    }
+
     if (machineTypes) {
       const types = machineTypes.split(",");
       query = query.overlaps("machine_types_wanted", types);

--- a/src/app/browse-requests/page.tsx
+++ b/src/app/browse-requests/page.tsx
@@ -36,7 +36,7 @@ const PER_PAGE = 12;
 const STATUS_TABS = [
   { value: "all", label: "All" },
   { value: "open", label: "Open" },
-  { value: "matched", label: "Matched" },
+  { value: "matched", label: "Near Me" },
 ] as const;
 
 // ---------------------------------------------------------------------------
@@ -353,7 +353,9 @@ export default function BrowseRequestsPage() {
         params.set("page", String(pageNum));
         params.set("per_page", String(PER_PAGE));
 
-        const res = await fetch(`/api/requests?${params}`);
+        const headers: HeadersInit = {};
+        if (accessToken) headers["Authorization"] = `Bearer ${accessToken}`;
+        const res = await fetch(`/api/requests?${params}`, { headers });
         if (!res.ok) throw new Error("Failed to fetch");
 
         const data = await res.json();
@@ -388,6 +390,7 @@ export default function BrowseRequestsPage() {
       urgencyFilter,
       commissionFilter,
       statusFilter,
+      accessToken,
     ]
   );
 

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import {
@@ -20,6 +20,14 @@ import { US_STATES } from "@/lib/types";
 import type { Profile } from "@/lib/types";
 
 export default function ProfilePage() {
+  return (
+    <Suspense fallback={<div className="flex min-h-[calc(100vh-160px)] items-center justify-center"><Loader2 className="h-8 w-8 animate-spin text-green-primary" /></div>}>
+      <ProfilePageInner />
+    </Suspense>
+  );
+}
+
+function ProfilePageInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [loading, setLoading] = useState(true);


### PR DESCRIPTION
- Renamed "Matched" tab to "Near Me" on browse-requests page
- When an operator selects "Near Me", the API looks up their state from their profile + operator_listings.states_served and returns open leads in those states
- Browse page now passes auth token on all fetches so the API can identify the operator for personalized filtering

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2