### PR TITLE
Merge requestor role into location_manager — simplify to two roles

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -296,21 +296,19 @@ function UsersManager({ token }: { token: string }) {
     const colors: Record<string, string> = {
       operator: "bg-blue-50 text-blue-700 ring-blue-200",
       location_manager: "bg-purple-50 text-purple-700 ring-purple-200",
-      requestor: "bg-gray-100 text-gray-700 ring-gray-200",
       admin: "bg-red-50 text-red-700 ring-red-200",
       sales: "bg-amber-50 text-amber-700 ring-amber-200",
     };
     const labels: Record<string, string> = {
       operator: "Operator",
-      location_manager: "Location Mgr",
-      requestor: "Location Requests",
+      location_manager: "Location",
       admin: "Admin",
       sales: "Sales",
     };
     return (
       <span
         className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${
-          colors[role] || colors.requestor
+          colors[role] || "bg-gray-100 text-gray-700 ring-gray-200"
         }`}
       >
         {labels[role] || role}
@@ -341,8 +339,7 @@ function UsersManager({ token }: { token: string }) {
           <option value="admin">Admins</option>
           <option value="sales">Sales Team</option>
           <option value="operator">Operators</option>
-          <option value="location_manager">Location Managers</option>
-          <option value="requestor">Location Requests</option>
+          <option value="location_manager">Locations</option>
         </select>
       </div>
 
@@ -454,8 +451,7 @@ function UsersManager({ token }: { token: string }) {
                   className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:border-green-primary focus:outline-none focus:ring-1 focus:ring-green-primary"
                 >
                   <option value="operator">Operator</option>
-                  <option value="location_manager">Location Manager</option>
-                  <option value="requestor">Location Requests</option>
+                  <option value="location_manager">Location</option>
                   <option value="sales">Sales Team Member</option>
                   <option value="admin">Admin</option>
                 </select>

--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -46,7 +46,7 @@ export async function GET(req: NextRequest) {
       role:
         meta.role && meta.role !== "admin" && meta.role !== "sales"
           ? meta.role
-          : "requestor",
+          : "location_manager",
       country: "US",
       verified: false,
       rating: 0,

--- a/src/app/api/operators/[id]/route.ts
+++ b/src/app/api/operators/[id]/route.ts
@@ -20,7 +20,7 @@ export async function GET(
       .single();
     requesterRole = requesterProfile?.role ?? null;
   }
-  const isLocationAccount = requesterRole === "location_manager" || requesterRole === "requestor";
+  const isLocationAccount = requesterRole === "location_manager";
 
   const { data: profile, error } = await supabaseAdmin
     .from("profiles")

--- a/src/app/api/operators/route.ts
+++ b/src/app/api/operators/route.ts
@@ -53,7 +53,7 @@ export async function GET(req: NextRequest) {
 
   // Determine if requester is a location account
   const requesterRole = await getRequesterRole(req);
-  const isLocationAccount = requesterRole === "location_manager" || requesterRole === "requestor";
+  const isLocationAccount = requesterRole === "location_manager";
 
   if (mode === "profiles") {
     let query = supabaseAdmin

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -80,7 +80,7 @@ function ProfilePageInner() {
           city: data.city || "",
           state: data.state || "",
           zip: data.zip || "",
-          role: data.role || "requestor",
+          role: data.role || "location_manager",
           digest_opt_in: data.digest_opt_in ?? true,
           digest_frequency: data.digest_frequency || "weekly",
         });
@@ -245,8 +245,7 @@ function ProfilePageInner() {
                   className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:border-green-primary focus:outline-none focus:ring-1 focus:ring-green-primary"
                 >
                   <option value="operator">Operator</option>
-                  <option value="location_manager">Location Manager</option>
-                  <option value="requestor">Location Requests</option>
+                  <option value="location_manager">Location</option>
                 </select>
               </div>
 

--- a/src/app/how-it-works/page.tsx
+++ b/src/app/how-it-works/page.tsx
@@ -103,7 +103,7 @@ const FAQ = [
   },
   {
     q: "Can I post multiple requests?",
-    a: "Absolutely. Location managers and requestors can post as many requests as they need.",
+    a: "Absolutely. Location accounts can post as many requests as they need.",
   },
 ];
 

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -6,7 +6,7 @@ import { Truck, Building2, UserPlus, ArrowLeft, Loader2, LogOut } from "lucide-r
 import { signUpWithGoogle, signUpWithMicrosoft, storeSignupRole, storeSignupLead, storeRedirectAfterLogin, ensureSignedOut } from "@/lib/auth";
 import { createBrowserClient } from "@/lib/supabase";
 
-type Role = "operator" | "location_manager" | "requestor";
+type Role = "operator" | "location_manager";
 
 const roles: { value: Role; label: string; icon: typeof Truck; description: string }[] = [
   {
@@ -17,15 +17,9 @@ const roles: { value: Role; label: string; icon: typeof Truck; description: stri
   },
   {
     value: "location_manager",
-    label: "Location Manager",
+    label: "Location",
     icon: Building2,
-    description: "I manage a property and want a vending machine",
-  },
-  {
-    value: "requestor",
-    label: "Location Requests",
-    icon: UserPlus,
-    description: "I want to request a vending machine for a location I frequent",
+    description: "I have a property and want a vending machine placed",
   },
 ];
 

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -4,7 +4,7 @@ export const signupSchema = z.object({
   email: z.string().email("Invalid email"),
   password: z.string().min(6, "Password must be at least 6 characters"),
   full_name: z.string().min(2, "Name is required"),
-  role: z.enum(["operator", "location_manager", "requestor"]),
+  role: z.enum(["operator", "location_manager"]),
 });
 
 export const loginSchema = z.object({

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,4 @@
-export type UserRole = "operator" | "location_manager" | "requestor" | "admin" | "sales" | "director_of_sales" | "market_leader";
+export type UserRole = "operator" | "location_manager" | "admin" | "sales" | "director_of_sales" | "market_leader";
 
 export type LocationType =
   | "office"

--- a/supabase/migrations/062_merge_requestor_role.sql
+++ b/supabase/migrations/062_merge_requestor_role.sql
@@ -1,0 +1,7 @@
+-- Merge requestor role into location_manager
+-- Both roles had identical functionality; simplifying to two customer roles:
+-- "operator" (has machines, wants locations) and "location_manager" (has location, wants machines)
+
+UPDATE public.profiles
+SET role = 'location_manager'
+WHERE role = 'requestor';


### PR DESCRIPTION
Removes the "requestor" role entirely. All users are now either "operator" or "location_manager" (displayed as "Location"). Existing requestor accounts are migrated via migration 062.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2