### PR TITLE
Hide operator company names, show city/state, add 888 call CTA

### DIFF
--- a/src/app/api/operators/[id]/route.ts
+++ b/src/app/api/operators/[id]/route.ts
@@ -20,7 +20,7 @@ export async function GET(
       .single();
     requesterRole = requesterProfile?.role ?? null;
   }
-  const isLocationAccount = requesterRole === "location_manager";
+  const isOperator = requesterRole === "operator";
 
   const { data: profile, error } = await supabaseAdmin
     .from("profiles")
@@ -33,9 +33,9 @@ export async function GET(
     return NextResponse.json({ error: "Operator not found" }, { status: 404 });
   }
 
-  // Strip sensitive operator data for location accounts (only show zip code)
+  // Strip company name and contact info for non-operator viewers; keep city/state
   let safeProfile = profile;
-  if (isLocationAccount) {
+  if (!isOperator) {
     safeProfile = {
       ...profile,
       full_name: "Operator",
@@ -44,8 +44,7 @@ export async function GET(
       phone: null,
       website: null,
       bio: null,
-      city: null,
-      // Keep: id, zip, state, verified, rating, review_count, role, created_at
+      // Keep: id, city, state, zip, address, verified, rating, review_count, role, created_at
     };
   }
 

--- a/src/app/api/operators/route.ts
+++ b/src/app/api/operators/route.ts
@@ -64,10 +64,10 @@ export async function GET(req: NextRequest) {
     if (search) {
       const s = sanitizeSearch(search);
       if (s) {
-        if (isLocationAccount) {
-          query = query.or(`state.ilike.%${s}%,zip.ilike.%${s}%`);
-        } else {
+        if (requesterRole === "operator") {
           query = query.or(`full_name.ilike.%${s}%,company_name.ilike.%${s}%,city.ilike.%${s}%,state.ilike.%${s}%`);
+        } else {
+          query = query.or(`city.ilike.%${s}%,state.ilike.%${s}%,zip.ilike.%${s}%`);
         }
       }
     }
@@ -80,9 +80,10 @@ export async function GET(req: NextRequest) {
 
     if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
-    // Strip sensitive data for location accounts
+    // Strip company name and contact info for all non-operator viewers
     let operators = data || [];
-    if (isLocationAccount) {
+    const isOperator = requesterRole === "operator";
+    if (!isOperator) {
       operators = operators.map((op: Record<string, unknown>) => ({
         ...op,
         full_name: "Operator",
@@ -129,9 +130,10 @@ export async function GET(req: NextRequest) {
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
-  // Strip operator profile data for location accounts
+  // Strip operator profile data for non-operator viewers
   let listings = data || [];
-  if (isLocationAccount) {
+  const isOp = requesterRole === "operator";
+  if (!isOp) {
     listings = listings.map((listing: Record<string, unknown>) => ({
       ...listing,
       profiles: stripOperatorProfileForLocations(listing.profiles as Record<string, unknown> | null),

--- a/src/app/browse-operators/page.tsx
+++ b/src/app/browse-operators/page.tsx
@@ -16,6 +16,7 @@ import {
   BadgeCheck,
   Monitor,
   UserPlus,
+  Phone,
 } from "lucide-react";
 import type { Profile, MachineType, OperatorListing } from "@/lib/types";
 import { MACHINE_TYPES, US_STATES, US_STATE_NAMES } from "@/lib/types";
@@ -382,15 +383,18 @@ function OperatorCard({ operator, onViewProfile }: { operator: OperatorWithListi
         <OperatorAvatar name={operator.full_name} />
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-1.5">
-            <h3 className="font-semibold text-black-primary text-base leading-snug truncate select-none blur-sm">
-              {operator.full_name}
+            <h3 className="font-semibold text-black-primary text-base leading-snug truncate">
+              Verified Operator
             </h3>
             {operator.verified && (
               <BadgeCheck className="h-4.5 w-4.5 shrink-0 text-green-primary" />
             )}
           </div>
-          {operator.company_name && (
-            <p className="text-sm text-gray-500 truncate">{operator.company_name}</p>
+          {/* City/State always visible */}
+          {(operator.city || operator.state) && (
+            <p className="text-sm text-gray-500 truncate">
+              {[operator.city, operator.state].filter(Boolean).join(", ")}
+            </p>
           )}
         </div>
         <StatusBadge status={status} />
@@ -439,6 +443,13 @@ function OperatorCard({ operator, onViewProfile }: { operator: OperatorWithListi
         {!operator.accepts_commission && <span />}
 
         <div className="flex items-center gap-2">
+          <a
+            href="tel:+18888511462"
+            className="inline-flex items-center gap-1 rounded-lg bg-green-primary px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-green-hover"
+          >
+            <Phone className="h-3 w-3" />
+            Call to Connect
+          </a>
           <Link
             href={`/operators/${operator.id}`}
             className="inline-flex items-center gap-1 rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-semibold text-black-primary transition-colors hover:border-green-primary/40 hover:bg-green-50 hover:text-green-primary"
@@ -668,7 +679,7 @@ export default function BrowseOperatorsPage() {
                 type="text"
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
-                placeholder="Search operators by name, city, state..."
+                placeholder="Search operators by city, state..."
                 className="w-full rounded-xl border border-gray-200 bg-white py-3 pl-10 pr-10 text-sm shadow-sm placeholder:text-gray-400 focus:border-green-primary focus:ring-2 focus:ring-green-primary/20"
               />
               {search && (

--- a/src/app/operators/[id]/page.tsx
+++ b/src/app/operators/[id]/page.tsx
@@ -422,21 +422,12 @@ export default function OperatorProfilePage() {
                 <div className="text-center sm:text-left min-w-0 flex-1">
                   <div className="flex items-center justify-center gap-2 sm:justify-start">
                     <h1 className="text-xl font-bold text-black-primary sm:text-2xl">
-                      <BlurredText isPurchased={isPurchased} placeholder="Operator Name">
-                        {profile.full_name}
-                      </BlurredText>
+                      Verified Operator
                     </h1>
                     {profile.verified && (
                       <BadgeCheck className="h-5 w-5 shrink-0 text-green-primary" />
                     )}
                   </div>
-                  {profile.company_name && (
-                    <p className="mt-0.5 text-sm text-gray-500">
-                      <BlurredText isPurchased={isPurchased} placeholder="Company Name">
-                        {profile.company_name}
-                      </BlurredText>
-                    </p>
-                  )}
                   {/* Full address always visible */}
                   {(profile.address || profile.city || profile.state || profile.zip) && (
                     <p className="mt-1 flex items-center justify-center gap-1 text-sm text-gray-500 sm:justify-start">
@@ -451,14 +442,15 @@ export default function OperatorProfilePage() {
                     </p>
                   )}
 
-                  {/* Contact links - all blurred until purchased */}
+                  {/* Call to connect CTA */}
                   <div className="mt-3 flex flex-wrap items-center justify-center gap-3 sm:justify-start">
-                    <span className="inline-flex items-center gap-1 text-xs text-gray-500">
-                      <Mail className="h-3 w-3" />
-                      <BlurredText isPurchased={isPurchased} placeholder="user@email.com">
-                        {profile.email}
-                      </BlurredText>
-                    </span>
+                    <a
+                      href="tel:+18888511462"
+                      className="inline-flex items-center gap-1.5 rounded-lg bg-green-primary px-4 py-2 text-xs font-semibold text-white transition-colors hover:bg-green-hover"
+                    >
+                      <Phone className="h-3 w-3" />
+                      Call (888) 851-1462 to Connect
+                    </a>
                   </div>
 
                   <p className="mt-1 text-xs text-gray-400">


### PR DESCRIPTION
Company names and contact info are now hidden for all non-operator viewers. City and state remain visible so locations can find nearby operators. Browse and detail pages show a "Call to Connect" button linking to the 888 number for brokered connections.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2