### PR TITLE
Fix location manager emails: logging, resend, deal-close, and matched…

### DIFF
--- a/src/app/api/pipeline-items/[id]/resend-agreement/route.ts
+++ b/src/app/api/pipeline-items/[id]/resend-agreement/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser } from "@/lib/salesAuth";
+import { createAndSendAgreement } from "@/lib/locationAgreement";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const user = await getSalesUser(req);
+  if (!user) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  const { id: itemId } = await params;
+
+  const { data: item } = await supabaseAdmin
+    .from("pipeline_items")
+    .select("*, locations(sales_lead_id, location_name, decision_maker_name, decision_maker_email, phone, address)")
+    .eq("id", itemId)
+    .single();
+
+  if (!item) {
+    return NextResponse.json({ error: "Pipeline item not found" }, { status: 404 });
+  }
+
+  if (!item.location_id || !item.locations) {
+    return NextResponse.json({ error: "No location linked" }, { status: 422 });
+  }
+
+  const loc = item.locations;
+  if (!loc.sales_lead_id) {
+    return NextResponse.json({ error: "Location has no linked lead" }, { status: 422 });
+  }
+
+  if (!loc.decision_maker_email) {
+    return NextResponse.json({ error: "Location has no decision maker email" }, { status: 422 });
+  }
+
+  try {
+    await createAndSendAgreement(
+      loc.sales_lead_id,
+      {
+        business_name: loc.location_name || item.name,
+        contact_name: loc.decision_maker_name || undefined,
+        email: loc.decision_maker_email,
+        phone: loc.phone || undefined,
+        address: loc.address || undefined,
+      },
+      { force: true }
+    );
+
+    return NextResponse.json({ ok: true, sent_to: loc.decision_maker_email });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/api/pipeline-items/[id]/send-proposal/route.ts
+++ b/src/app/api/pipeline-items/[id]/send-proposal/route.ts
@@ -9,6 +9,7 @@ import {
 } from "@/lib/pricing/locationPricing";
 import { generateAgreementPdf } from "@/lib/pdf/agreementPdf";
 import { sendAgreementEmail } from "@/lib/agreementEmail";
+import { sendLocationMatchedEmail } from "@/lib/locationAgreementEmail";
 
 function getSiteUrl(): string {
   return process.env.NEXT_PUBLIC_SITE_URL || "https://vendingconnector.com";
@@ -211,6 +212,22 @@ export async function POST(
       .from("pipeline_items")
       .update({ proposal_status: "proposal_sent", updated_at: new Date().toISOString() })
       .eq("id", itemId);
+
+    // Notify location manager that an operator is interested
+    try {
+      const locEmail = location.decision_maker_email;
+      if (locEmail) {
+        await sendLocationMatchedEmail({
+          to: locEmail,
+          recipientName: location.decision_maker_name || "Business Owner",
+          businessName: item.sales_accounts?.business_name || item.name,
+          locationName: location.location_name || "your location",
+        });
+        console.log(`[send-proposal] Notified location manager ${locEmail} of operator interest`);
+      }
+    } catch (notifyErr) {
+      console.error("[send-proposal] Failed to notify location manager:", notifyErr);
+    }
 
     return NextResponse.json({
       ok: true,

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -10,6 +10,7 @@ import {
 import { sendMachinePurchaseThankYouEmail, sendMachinePurchaseNotificationEmail } from "@/lib/machinePurchaseEmail";
 import { generateSiteDetailsPdf } from "@/lib/pdf/agreementPdf";
 import { sendFullSiteDetailsEmail } from "@/lib/agreementEmail";
+import { sendLocationDealClosedEmail } from "@/lib/locationAgreementEmail";
 import { PricingResult } from "@/lib/pricing/locationPricing";
 
 function getStripeClient(): Stripe {
@@ -381,6 +382,33 @@ async function handleAgreementPayment(session: Stripe.Checkout.Session) {
         phone: locationAgreement.phone || "",
       } : undefined,
     });
+
+    // Notify location manager that the deal is closed
+    if (locationAgreement?.email) {
+      try {
+        await sendLocationDealClosedEmail({
+          to: locationAgreement.email,
+          recipientName: locationAgreement.contact_name || "Business Owner",
+          businessName: locationAgreement.business_name || location.location_name || "",
+          locationName: location.location_name || "your location",
+        });
+        console.log(`[stripe-webhook] Sent deal-closed email to location manager: ${locationAgreement.email}`);
+      } catch (locErr) {
+        console.error("[stripe-webhook] Failed to send location deal-closed email:", locErr);
+      }
+    } else if (location.decision_maker_email) {
+      try {
+        await sendLocationDealClosedEmail({
+          to: location.decision_maker_email,
+          recipientName: location.decision_maker_name || "Business Owner",
+          businessName: location.location_name || "",
+          locationName: location.location_name || "your location",
+        });
+        console.log(`[stripe-webhook] Sent deal-closed email to decision maker: ${location.decision_maker_email}`);
+      } catch (locErr) {
+        console.error("[stripe-webhook] Failed to send location deal-closed email:", locErr);
+      }
+    }
   } catch (e) {
     console.error("[stripe-webhook] Failed to send full site details:", e);
   }

--- a/src/app/sales/pipelines/[id]/items/[itemId]/page.tsx
+++ b/src/app/sales/pipelines/[id]/items/[itemId]/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { createBrowserClient } from "@/lib/supabase";
-import { ArrowLeft, Loader2, ChevronRight, Upload, CheckCircle2, Circle, AlertTriangle, FileText, Lock, Building2, Search, X, Link2, Unlink, Send, DollarSign, ShieldCheck, PenTool, CreditCard, Clock, ExternalLink, MapPin, Calculator, Plus, ClipboardList } from "lucide-react";
+import { ArrowLeft, Loader2, ChevronRight, Upload, CheckCircle2, Circle, AlertTriangle, FileText, Lock, Building2, Search, X, Link2, Unlink, Send, DollarSign, ShieldCheck, PenTool, CreditCard, Clock, ExternalLink, MapPin, Calculator, Plus, ClipboardList, RefreshCw } from "lucide-react";
 
 interface StepDoc {
   id: string;
@@ -173,6 +173,8 @@ export default function PipelineItemDetailPage() {
   const [esignForm, setEsignForm] = useState({ document_name: "", recipient_email: "", template_id: "" });
   const [sendingProposal, setSendingProposal] = useState(false);
   const [proposalError, setProposalError] = useState<string | null>(null);
+  const [resendingAgreement, setResendingAgreement] = useState(false);
+  const [resendResult, setResendResult] = useState<string | null>(null);
   const [pricingData, setPricingData] = useState<PricingData | null>(null);
   const [pricingInputs, setPricingInputs] = useState({ employees: 0, foot_traffic: 0, business_hours: "low" as string, machines_requested: 1 });
   const [calculatingPricing, setCalculatingPricing] = useState(false);
@@ -494,6 +496,27 @@ export default function PipelineItemDetailPage() {
       setProposalError(err instanceof Error ? err.message : "Network error");
     } finally {
       setSendingProposal(false);
+    }
+  }
+
+  async function handleResendAgreement() {
+    setResendingAgreement(true);
+    setResendResult(null);
+    try {
+      const res = await fetch(`/api/pipeline-items/${itemId}/resend-agreement`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setResendResult(`Agreement resent to ${data.sent_to}`);
+      } else {
+        setResendResult(`Error: ${data.error}`);
+      }
+    } catch {
+      setResendResult("Network error");
+    } finally {
+      setResendingAgreement(false);
     }
   }
 
@@ -837,14 +860,61 @@ export default function PipelineItemDetailPage() {
               </div>
             </div>
           ) : (
-            <div className="flex items-center gap-2 text-sm text-gray-500">
-              <Clock className="h-4 w-4 text-gray-400" />
-              <span>
-                Agreement sent {new Date(item.location_agreement.created_at).toLocaleDateString()}
-                {item.location_agreement.email && <> to {item.location_agreement.email}</>}
-                {" — waiting for location partner to sign"}
-              </span>
+            <div className="space-y-3">
+              <div className="flex items-center gap-2 text-sm text-gray-500">
+                <Clock className="h-4 w-4 text-gray-400" />
+                <span>
+                  Agreement sent {new Date(item.location_agreement.created_at).toLocaleDateString()}
+                  {item.location_agreement.email && <> to {item.location_agreement.email}</>}
+                  {" — waiting for location partner to sign"}
+                </span>
+              </div>
+              <button
+                type="button"
+                onClick={handleResendAgreement}
+                disabled={resendingAgreement}
+                className="inline-flex items-center gap-1.5 rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-50 disabled:opacity-50 cursor-pointer"
+              >
+                {resendingAgreement ? <Loader2 className="h-3 w-3 animate-spin" /> : <RefreshCw className="h-3 w-3" />}
+                Resend Agreement Email
+              </button>
+              {resendResult && (
+                <p className={`text-xs ${resendResult.startsWith("Error") ? "text-red-600" : "text-green-600"}`}>
+                  {resendResult}
+                </p>
+              )}
             </div>
+          )}
+        </div>
+      )}
+
+      {/* Send Location Agreement (when none exists yet) */}
+      {!item.location_agreement && item.location_id && (
+        <div className="rounded-xl border border-yellow-200 bg-yellow-50 p-6 mb-6">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-sm font-semibold text-gray-900 flex items-center gap-2">
+                <FileText className="h-4 w-4 text-yellow-600" />
+                Location Agreement Not Sent
+              </h2>
+              <p className="mt-1 text-xs text-gray-500">
+                No agreement has been sent to the location manager yet.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={handleResendAgreement}
+              disabled={resendingAgreement}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-yellow-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-yellow-700 disabled:opacity-50 cursor-pointer"
+            >
+              {resendingAgreement ? <Loader2 className="h-3 w-3 animate-spin" /> : <Send className="h-3 w-3" />}
+              Send Agreement to Location
+            </button>
+          </div>
+          {resendResult && (
+            <p className={`mt-2 text-xs ${resendResult.startsWith("Error") ? "text-red-600" : "text-green-600"}`}>
+              {resendResult}
+            </p>
           )}
         </div>
       )}

--- a/src/lib/locationAgreement.ts
+++ b/src/lib/locationAgreement.ts
@@ -12,16 +12,36 @@ export async function createAndSendAgreement(
     phone?: string;
     address?: string;
     title_role?: string;
-  }
+  },
+  options?: { force?: boolean }
 ) {
-  if (!lead.email) return;
+  if (!lead.email) {
+    console.warn(`[location-agreement] Skipped lead ${leadId}: no email provided`);
+    return;
+  }
 
   const existing = await supabaseAdmin
     .from("location_agreements")
-    .select("id")
+    .select("id, token")
     .eq("lead_id", leadId)
     .maybeSingle();
-  if (existing.data) return;
+
+  if (existing.data && !options?.force) {
+    console.log(`[location-agreement] Skipped lead ${leadId}: agreement already exists (${existing.data.id}). Use force=true to resend.`);
+    return;
+  }
+
+  if (existing.data && options?.force) {
+    console.log(`[location-agreement] Force resending agreement for lead ${leadId}`);
+    await sendLocationAgreementEmail({
+      to: lead.email,
+      recipientName: lead.contact_name || "Business Owner",
+      businessName: lead.business_name || "your location",
+      agreementUrl: `${APP_URL}/location-agreement/${existing.data.token}`,
+    });
+    console.log(`[location-agreement] Resent agreement email to ${lead.email} for lead ${leadId}`);
+    return;
+  }
 
   const { data: agreement } = await supabaseAdmin
     .from("location_agreements")
@@ -36,7 +56,10 @@ export async function createAndSendAgreement(
     .select("token")
     .single();
 
-  if (!agreement) return;
+  if (!agreement) {
+    console.error(`[location-agreement] Failed to create agreement record for lead ${leadId}`);
+    return;
+  }
 
   await sendLocationAgreementEmail({
     to: lead.email,
@@ -44,4 +67,6 @@ export async function createAndSendAgreement(
     businessName: lead.business_name || "your location",
     agreementUrl: `${APP_URL}/location-agreement/${agreement.token}`,
   });
+
+  console.log(`[location-agreement] Sent agreement email to ${lead.email} for lead ${leadId}`);
 }

--- a/src/lib/locationAgreementEmail.ts
+++ b/src/lib/locationAgreementEmail.ts
@@ -2,6 +2,7 @@ import { Resend } from "resend";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 const FROM = process.env.FROM_EMAIL || "sales@bytebitevending.com";
+const PHONE = "(888) 851-1462";
 
 export async function sendLocationAgreementEmail(params: {
   to: string;
@@ -40,6 +41,84 @@ export async function sendLocationAgreementEmail(params: {
           You can also access the agreement at:<br>
           <a href="${agreementUrl}" style="color:#16a34a;">${agreementUrl}</a>
         </p>
+        <hr style="border:none;border-top:1px solid #e5e7eb;margin:24px 0;">
+        <p style="color:#9ca3af;font-size:11px;">Apex AI Vending — vendingconnector.com</p>
+      </div>
+    `,
+  });
+}
+
+export async function sendLocationMatchedEmail(params: {
+  to: string;
+  recipientName: string;
+  businessName: string;
+  locationName: string;
+}) {
+  const { to, recipientName, businessName, locationName } = params;
+
+  await resend.emails.send({
+    from: FROM,
+    to,
+    subject: `Great news — an operator is interested in ${locationName}`,
+    html: `
+      <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:560px;margin:0 auto;padding:24px;">
+        <div style="margin-bottom:24px;">
+          <span style="font-size:20px;font-weight:700;color:#16a34a;">Apex AI Vending</span>
+        </div>
+        <p style="color:#111827;font-size:15px;line-height:1.6;">
+          Hi ${recipientName},
+        </p>
+        <p style="color:#374151;font-size:14px;line-height:1.6;">
+          We have a vending operator interested in placing machines at <strong>${locationName}</strong>
+          (${businessName}). We're currently working to finalize the placement details.
+        </p>
+        <p style="color:#374151;font-size:14px;line-height:1.6;">
+          No action is needed from you right now — we'll keep you updated as things progress.
+          If you have any questions, feel free to call us at <strong>${PHONE}</strong>.
+        </p>
+        <hr style="border:none;border-top:1px solid #e5e7eb;margin:24px 0;">
+        <p style="color:#9ca3af;font-size:11px;">Apex AI Vending — vendingconnector.com</p>
+      </div>
+    `,
+  });
+}
+
+export async function sendLocationDealClosedEmail(params: {
+  to: string;
+  recipientName: string;
+  businessName: string;
+  locationName: string;
+}) {
+  const { to, recipientName, businessName, locationName } = params;
+
+  await resend.emails.send({
+    from: FROM,
+    to,
+    subject: `Placement confirmed — ${locationName}`,
+    html: `
+      <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:560px;margin:0 auto;padding:24px;">
+        <div style="margin-bottom:24px;">
+          <span style="font-size:20px;font-weight:700;color:#16a34a;">Apex AI Vending</span>
+        </div>
+        <p style="color:#111827;font-size:15px;line-height:1.6;">
+          Hi ${recipientName},
+        </p>
+        <p style="color:#374151;font-size:14px;line-height:1.6;">
+          Great news! A vending operator has confirmed placement at <strong>${locationName}</strong>
+          (${businessName}). The deal is finalized and your location will be receiving a vending machine.
+        </p>
+        <p style="color:#374151;font-size:14px;line-height:1.6;">
+          Our team will be in touch to coordinate the installation timeline and next steps.
+          If you have any questions, call us at <strong>${PHONE}</strong>.
+        </p>
+        <div style="margin:24px 0;padding:16px;background:#f0fdf4;border:1px solid #bbf7d0;border-radius:8px;">
+          <p style="color:#166534;font-size:14px;font-weight:600;margin:0;">What happens next?</p>
+          <ul style="color:#374151;font-size:13px;margin:8px 0 0 0;padding-left:20px;">
+            <li>Our team will schedule the machine installation</li>
+            <li>The operator will reach out to confirm details</li>
+            <li>You'll start generating revenue from your vending machine</li>
+          </ul>
+        </div>
         <hr style="border:none;border-top:1px solid #e5e7eb;margin:24px 0;">
         <p style="color:#9ca3af;font-size:11px;">Apex AI Vending — vendingconnector.com</p>
       </div>


### PR DESCRIPTION
… notifications

- Add logging to createAndSendAgreement so silent failures are visible
- Add force resend option that bypasses idempotency check
- Add /api/pipeline-items/[id]/resend-agreement endpoint
- Add "Resend Agreement" button in pipeline item UI (also shows "Send Agreement" when no agreement exists yet)
- Send deal-closure email to location manager when operator pays (via Stripe webhook)
- Send "operator interested" notification to location manager when a proposal is sent to an operator

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2