### PR TITLE
Require city and state during operator signup

### DIFF
--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -46,22 +46,30 @@ function CallbackContent() {
 
       if (isSignup) {
         const signupRole = consumeSignupRole();
+        const leadData = consumeSignupLead();
+
         if (signupRole) {
           try {
+            const profileUpdate: Record<string, string> = { role: signupRole };
+            if (leadData?.city) profileUpdate.city = leadData.city;
+            if (leadData?.state) profileUpdate.state = leadData.state;
+            if (leadData?.address) profileUpdate.address = leadData.address;
+            if (leadData?.business_name) profileUpdate.company_name = leadData.business_name;
+            if (leadData?.contact_name) profileUpdate.full_name = leadData.contact_name;
+            if (leadData?.phone) profileUpdate.phone = leadData.phone;
+
             await fetch("/api/auth/me", {
               method: "PATCH",
               headers: {
                 "Content-Type": "application/json",
                 Authorization: `Bearer ${data.session.access_token}`,
               },
-              body: JSON.stringify({ role: signupRole }),
+              body: JSON.stringify(profileUpdate),
             });
           } catch {
             // Profile might not exist yet — ignore
           }
         }
-
-        const leadData = consumeSignupLead();
         if (leadData) {
           try {
             await fetch("/api/auth/signup-lead", {

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -111,6 +111,16 @@ export default function SignupPage() {
       setError("Phone number is required");
       return;
     }
+    if (role === "operator") {
+      if (!leadForm.city.trim()) {
+        setError("City is required for operators");
+        return;
+      }
+      if (!leadForm.state.trim()) {
+        setError("State is required for operators");
+        return;
+      }
+    }
     setError(null);
     setStep(3);
   }
@@ -315,12 +325,12 @@ export default function SignupPage() {
                 </div>
                 <div className="grid grid-cols-2 gap-3">
                   <div>
-                    <label className="block text-xs font-medium text-gray-500 mb-1">City</label>
+                    <label className="block text-xs font-medium text-gray-500 mb-1">City {role === "operator" && <span className="text-red-500">*</span>}</label>
                     <input value={leadForm.city} onChange={(e) => setLeadForm((f) => ({ ...f, city: e.target.value }))} placeholder="City" className={inputClass} />
                   </div>
                   <div>
-                    <label className="block text-xs font-medium text-gray-500 mb-1">State</label>
-                    <input value={leadForm.state} onChange={(e) => setLeadForm((f) => ({ ...f, state: e.target.value }))} placeholder="State" className={inputClass} />
+                    <label className="block text-xs font-medium text-gray-500 mb-1">State {role === "operator" && <span className="text-red-500">*</span>}</label>
+                    <input value={leadForm.state} onChange={(e) => setLeadForm((f) => ({ ...f, state: e.target.value.toUpperCase() }))} placeholder="e.g. TX" maxLength={2} className={inputClass} />
                   </div>
                 </div>
                 <div className="grid grid-cols-2 gap-3">


### PR DESCRIPTION
- City and state are now required fields for operators in the signup form
- State input auto-uppercases and is limited to 2 characters
- Auth callback now saves city/state/address/company/name/phone to the profile directly, so operators have location info immediately and the OperatorOnboarding step is skipped when data is complete

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2