### PR TITLE
Instantly swap Clock In/Out button without waiting for refetch

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -3967,7 +3967,10 @@ function AdminClockWidget({ token }: { token: string }) {
         headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
         body: JSON.stringify({}),
       });
-      if (res.ok) await fetchStatus();
+      if (res.ok) {
+        const data = await res.json();
+        setActiveEntry(data.entry);
+      }
     } finally { setActing(false); }
   }
 
@@ -3980,7 +3983,10 @@ function AdminClockWidget({ token }: { token: string }) {
         headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
         body: JSON.stringify({ entry_id: activeEntry.id, clock_out: new Date().toISOString() }),
       });
-      if (res.ok) await fetchStatus();
+      if (res.ok) {
+        setActiveEntry(null);
+        fetchStatus();
+      }
     } finally { setActing(false); }
   }
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -293,7 +293,10 @@ function ClockWidget({ token }: { token: string }) {
         },
         body: JSON.stringify({}),
       });
-      if (res.ok) await fetchStatus();
+      if (res.ok) {
+        const data = await res.json();
+        setActiveEntry(data.entry);
+      }
     } finally {
       setActing(false);
     }
@@ -314,7 +317,10 @@ function ClockWidget({ token }: { token: string }) {
           clock_out: new Date().toISOString(),
         }),
       });
-      if (res.ok) await fetchStatus();
+      if (res.ok) {
+        setActiveEntry(null);
+        fetchStatus();
+      }
     } finally {
       setActing(false);
     }


### PR DESCRIPTION
Use the API response to set activeEntry immediately on clock-in, and clear it immediately on clock-out, so the button toggles without a visible delay.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2