### PR TITLE
Fix time clock: handle missing role column, add error display

### DIFF
--- a/src/app/api/time-entries/route.ts
+++ b/src/app/api/time-entries/route.ts
@@ -88,17 +88,31 @@ export async function POST(req: NextRequest) {
 
   const body = await req.json().catch(() => ({}));
 
+  const insertData: Record<string, unknown> = {
+    user_id: userId,
+    notes: body.notes || null,
+  };
+  if (role) insertData.role = role;
+
   const { data, error } = await supabaseAdmin
     .from("time_entries")
-    .insert({
-      user_id: userId,
-      role: role,
-      notes: body.notes || null,
-    })
+    .insert(insertData)
     .select("*")
     .single();
 
   if (error) {
+    // If role column doesn't exist, retry without it
+    if (error.message.includes("role")) {
+      const { data: retryData, error: retryError } = await supabaseAdmin
+        .from("time_entries")
+        .insert({ user_id: userId, notes: body.notes || null })
+        .select("*")
+        .single();
+      if (retryError) {
+        return NextResponse.json({ error: retryError.message }, { status: 500 });
+      }
+      return NextResponse.json({ entry: retryData }, { status: 201 });
+    }
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 

--- a/src/app/sales/time-clock/page.tsx
+++ b/src/app/sales/time-clock/page.tsx
@@ -42,6 +42,7 @@ export default function TimeClockPage() {
   const [loading, setLoading] = useState(true);
   const [acting, setActing] = useState(false);
   const [elapsed, setElapsed] = useState("");
+  const [error, setError] = useState<string | null>(null);
   const [view, setView] = useState<"today" | "week">("today");
 
   useEffect(() => {
@@ -102,6 +103,7 @@ export default function TimeClockPage() {
 
   async function clockIn() {
     setActing(true);
+    setError(null);
     try {
       const res = await fetch("/api/time-entries", {
         method: "POST",
@@ -112,13 +114,19 @@ export default function TimeClockPage() {
         const data = await res.json();
         setActiveEntry(data.entry);
         fetchEntries();
+      } else {
+        const data = await res.json();
+        setError(data.error || "Failed to clock in");
       }
+    } catch {
+      setError("Network error — please try again");
     } finally { setActing(false); }
   }
 
   async function clockOut() {
     if (!activeEntry) return;
     setActing(true);
+    setError(null);
     try {
       const res = await fetch("/api/time-entries", {
         method: "PATCH",
@@ -128,7 +136,12 @@ export default function TimeClockPage() {
       if (res.ok) {
         setActiveEntry(null);
         fetchEntries();
+      } else {
+        const data = await res.json();
+        setError(data.error || "Failed to clock out");
       }
+    } catch {
+      setError("Network error — please try again");
     } finally { setActing(false); }
   }
 
@@ -215,6 +228,12 @@ export default function TimeClockPage() {
           )}
         </div>
       </div>
+
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
 
       {/* Summary Cards */}
       <div className="grid grid-cols-2 gap-4">


### PR DESCRIPTION
The clock-in was failing silently because migration 065 (which adds the role column) hadn't been applied. Now the API retries without the role column if the first insert fails, and the frontend shows error messages so issues are visible.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2