### PR TITLE
Security: remove overly permissive RLS policies on user_listings tables

### DIFF
--- a/supabase/migrations/066_stripe_connect_marketplace.sql
+++ b/supabase/migrations/066_stripe_connect_marketplace.sql
@@ -74,12 +74,3 @@ CREATE POLICY "Users can update own listings"
 CREATE POLICY "Users can read own purchases"
   ON user_listing_purchases FOR SELECT
   USING (buyer_id = auth.uid() OR seller_id = auth.uid());
-
--- Service role bypass (for webhook updates)
-CREATE POLICY "Service role full access to user_listings"
-  ON user_listings FOR ALL
-  USING (true) WITH CHECK (true);
-
-CREATE POLICY "Service role full access to user_listing_purchases"
-  ON user_listing_purchases FOR ALL
-  USING (true) WITH CHECK (true);

--- a/supabase/migrations/067_fix_user_listings_rls.sql
+++ b/supabase/migrations/067_fix_user_listings_rls.sql
@@ -1,0 +1,8 @@
+-- Fix: Remove overly permissive RLS policies from migration 066.
+-- These policies used FOR ALL / USING (true) without a TO service_role
+-- restriction, meaning ANY authenticated user could update/delete any
+-- listing or purchase record. The supabase service role key bypasses
+-- RLS by design, so these policies were both unnecessary and dangerous.
+
+DROP POLICY IF EXISTS "Service role full access to user_listings" ON user_listings;
+DROP POLICY IF EXISTS "Service role full access to user_listing_purchases" ON user_listing_purchases;


### PR DESCRIPTION
Migration 066 included two "Service role full access" RLS policies on user_listings and user_listing_purchases that used FOR ALL / USING (true) WITHOUT a TO service_role restriction. This meant any authenticated user could update, delete, or read any record in those tables — completely bypassing the user-scoped policies.

Fix:
- Remove the bad policies from 066 (for fresh deployments)
- Add migration 067 to DROP the policies (for environments that already ran 066)

The supabase service role key (used by all server-side API routes via supabaseAdmin) bypasses RLS by design, so these policies were never needed. All 7 affected API routes already use supabaseAdmin.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2