### PR TITLE
Add admin-only bulk delete for deals and pipeline items

### DIFF
--- a/src/app/api/pipeline-items/bulk-delete/route.ts
+++ b/src/app/api/pipeline-items/bulk-delete/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser, isElevatedRole } from "@/lib/salesAuth";
+
+export async function POST(req: NextRequest) {
+  const user = await getSalesUser(req);
+  if (!user || !isElevatedRole(user.role)) {
+    return NextResponse.json({ error: "Admin only" }, { status: 403 });
+  }
+
+  const body = await req.json();
+  const { ids } = body;
+
+  if (!Array.isArray(ids) || ids.length === 0) {
+    return NextResponse.json({ error: "ids array required" }, { status: 400 });
+  }
+
+  if (ids.length > 500) {
+    return NextResponse.json({ error: "Max 500 items per request" }, { status: 400 });
+  }
+
+  // Exclude won/lost items to preserve stats
+  const { data: items } = await supabaseAdmin
+    .from("pipeline_items")
+    .select("id, status, deal_id")
+    .in("id", ids);
+
+  const protectedIds = new Set(
+    (items || []).filter((i) => i.status === "won" || i.status === "lost").map((i) => i.id)
+  );
+  const deletableItems = (items || []).filter((i) => !protectedIds.has(i.id));
+  const deletableIds = deletableItems.map((i) => i.id);
+
+  if (deletableIds.length === 0) {
+    return NextResponse.json({
+      deleted: 0,
+      skipped: protectedIds.size,
+      message: "All selected items are won/lost and were skipped to preserve stats.",
+    });
+  }
+
+  // Also delete linked deals (that aren't won/lost)
+  const linkedDealIds = deletableItems
+    .map((i) => i.deal_id)
+    .filter((id): id is string => !!id);
+
+  // Detach/clean up pipeline item FKs
+  await Promise.all([
+    supabaseAdmin.from("step_approvals").delete().in("pipeline_item_id", deletableIds),
+    supabaseAdmin.from("pipeline_item_documents").delete().in("pipeline_item_id", deletableIds),
+    supabaseAdmin.from("esign_documents").delete().in("pipeline_item_id", deletableIds),
+    supabaseAdmin.from("pipeline_payments").delete().in("pipeline_item_id", deletableIds),
+    supabaseAdmin.from("agreement_tokens").delete().in("pipeline_item_id", deletableIds),
+    supabaseAdmin.from("sales_deals").update({ pipeline_item_id: null }).in("pipeline_item_id", deletableIds),
+  ]);
+
+  // Delete the pipeline items
+  const { error: piErr, count: piCount } = await supabaseAdmin
+    .from("pipeline_items")
+    .delete({ count: "exact" })
+    .in("id", deletableIds);
+
+  if (piErr) {
+    return NextResponse.json({ error: piErr.message }, { status: 500 });
+  }
+
+  // Clean up linked deals (skip won/lost)
+  let dealsDeleted = 0;
+  if (linkedDealIds.length > 0) {
+    const { data: linkedDeals } = await supabaseAdmin
+      .from("sales_deals")
+      .select("id, stage")
+      .in("id", linkedDealIds);
+
+    const deletableDealIds = (linkedDeals || [])
+      .filter((d) => d.stage !== "won" && d.stage !== "lost")
+      .map((d) => d.id);
+
+    if (deletableDealIds.length > 0) {
+      await Promise.all([
+        supabaseAdmin.from("sales_orders").update({ deal_id: null }).in("deal_id", deletableDealIds),
+        supabaseAdmin.from("sales_commissions").delete().in("deal_id", deletableDealIds),
+        supabaseAdmin.from("deal_services").delete().in("deal_id", deletableDealIds),
+      ]);
+
+      const { count } = await supabaseAdmin
+        .from("sales_deals")
+        .delete({ count: "exact" })
+        .in("id", deletableDealIds);
+      dealsDeleted = count || deletableDealIds.length;
+    }
+  }
+
+  return NextResponse.json({
+    deleted: piCount || deletableIds.length,
+    deals_deleted: dealsDeleted,
+    skipped: protectedIds.size,
+  });
+}

--- a/src/app/api/sales/deals/bulk-delete/route.ts
+++ b/src/app/api/sales/deals/bulk-delete/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser, isElevatedRole } from "@/lib/salesAuth";
+
+export async function POST(req: NextRequest) {
+  const user = await getSalesUser(req);
+  if (!user || !isElevatedRole(user.role)) {
+    return NextResponse.json({ error: "Admin only" }, { status: 403 });
+  }
+
+  const body = await req.json();
+  const { ids } = body;
+
+  if (!Array.isArray(ids) || ids.length === 0) {
+    return NextResponse.json({ error: "ids array required" }, { status: 400 });
+  }
+
+  if (ids.length > 500) {
+    return NextResponse.json({ error: "Max 500 deals per request" }, { status: 400 });
+  }
+
+  // Exclude won/lost deals to preserve stats
+  const { data: deals } = await supabaseAdmin
+    .from("sales_deals")
+    .select("id, stage")
+    .in("id", ids);
+
+  const protectedIds = new Set(
+    (deals || []).filter((d) => d.stage === "won" || d.stage === "lost").map((d) => d.id)
+  );
+  const deletableIds = ids.filter((id: string) => !protectedIds.has(id));
+
+  if (deletableIds.length === 0) {
+    return NextResponse.json({
+      deleted: 0,
+      skipped: protectedIds.size,
+      message: "All selected deals are won/lost and were skipped to preserve stats.",
+    });
+  }
+
+  // Detach FKs before deletion
+  await Promise.all([
+    supabaseAdmin.from("sales_orders").update({ deal_id: null }).in("deal_id", deletableIds),
+    supabaseAdmin.from("sales_commissions").delete().in("deal_id", deletableIds),
+    supabaseAdmin.from("deal_services").delete().in("deal_id", deletableIds),
+    supabaseAdmin.from("pipeline_items").update({ deal_id: null }).in("deal_id", deletableIds),
+  ]);
+
+  const { error, count } = await supabaseAdmin
+    .from("sales_deals")
+    .delete({ count: "exact" })
+    .in("id", deletableIds);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    deleted: count || deletableIds.length,
+    skipped: protectedIds.size,
+  });
+}

--- a/src/app/sales/deals/page.tsx
+++ b/src/app/sales/deals/page.tsx
@@ -15,6 +15,7 @@ import {
   X,
   TrendingUp,
   ChevronRight,
+  CheckSquare,
 } from "lucide-react";
 import type { SalesDeal } from "@/lib/salesTypes";
 
@@ -71,21 +72,31 @@ export default function DealDashboardPage() {
   const [selectedAccount, setSelectedAccount] = useState<Account | null>(null);
   const [showAccountDropdown, setShowAccountDropdown] = useState(false);
 
+  const [userRole, setUserRole] = useState<"admin" | "sales">("sales");
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [bulkDeleting, setBulkDeleting] = useState(false);
+
   useEffect(() => {
     const supabase = createBrowserClient();
     async function init() {
       const { data: { session } } = await supabase.auth.getSession();
       if (!session?.access_token) return;
       setToken(session.access_token);
-      const [pRes, aRes] = await Promise.all([
+      const [pRes, aRes, uRes] = await Promise.all([
         fetch("/api/pipelines?type=sales", { headers: { Authorization: `Bearer ${session.access_token}` } }),
         fetch("/api/sales/accounts", { headers: { Authorization: `Bearer ${session.access_token}` } }),
+        fetch("/api/sales/users", { headers: { Authorization: `Bearer ${session.access_token}` } }),
       ]);
       if (pRes.ok) {
         const data = await pRes.json();
         setPipelines(data);
       }
       if (aRes.ok) setAccounts(await aRes.json());
+      if (uRes.ok) {
+        const users = await uRes.json();
+        const me = users.find((u: { id: string }) => u.id === session.user.id);
+        if (me?.role === "admin" || me?.role === "director_of_sales" || me?.role === "market_leader") setUserRole("admin");
+      }
     }
     init();
   }, []);
@@ -179,6 +190,46 @@ export default function DealDashboardPage() {
         (a.email || "").toLowerCase().includes(accountSearch.toLowerCase())
       ).slice(0, 8)
     : [];
+
+  function toggleSelect(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  }
+
+  function toggleSelectAll() {
+    if (selected.size === salesItems.length) {
+      setSelected(new Set());
+    } else {
+      setSelected(new Set(salesItems.map((i) => i.id)));
+    }
+  }
+
+  async function handleBulkDelete() {
+    if (selected.size === 0) return;
+    if (!confirm(`Delete ${selected.size} selected item${selected.size > 1 ? "s" : ""}? Won/lost items will be skipped to preserve stats. This cannot be undone.`)) return;
+    setBulkDeleting(true);
+    const res = await fetch("/api/pipeline-items/bulk-delete", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ ids: Array.from(selected) }),
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      alert(err.error || "Bulk delete failed");
+    } else {
+      const result = await res.json();
+      if (result.skipped > 0) {
+        alert(`Deleted ${result.deleted} item(s). ${result.skipped} won/lost item(s) were skipped.`);
+      }
+    }
+    setSelected(new Set());
+    setBulkDeleting(false);
+    fetchDeals();
+    if (activeTab !== "all") fetchPipelineItems(activeTab);
+  }
 
   const statusColor = (s: string) => {
     if (s === "won") return "bg-green-50 text-green-700";
@@ -344,12 +395,41 @@ export default function DealDashboardPage() {
         </div>
       )}
 
+      {/* Bulk selection banner */}
+      {selected.size > 0 && userRole === "admin" && (
+        <div className="mb-4 flex items-center gap-3 rounded-lg border border-red-200 bg-red-50 px-4 py-2.5">
+          <CheckSquare className="h-4 w-4 text-red-600 shrink-0" />
+          <span className="text-sm font-medium text-red-800">{selected.size} item{selected.size > 1 ? "s" : ""} selected</span>
+          <button
+            onClick={handleBulkDelete}
+            disabled={bulkDeleting}
+            className="ml-auto inline-flex items-center gap-1.5 rounded-lg bg-red-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-700 disabled:opacity-50 cursor-pointer"
+          >
+            {bulkDeleting ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Trash2 className="h-3.5 w-3.5" />}
+            Delete Selected
+          </button>
+          <button onClick={() => setSelected(new Set())} className="text-red-400 hover:text-red-600 cursor-pointer">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      )}
+
       {/* ============ ALL DEALS VIEW ============ */}
       {activeTab === "all" && (
         <div className="rounded-xl border border-gray-200 bg-white overflow-hidden">
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-gray-100 bg-gray-50/60">
+                {userRole === "admin" && (
+                  <th className="w-10 px-3 py-3">
+                    <input
+                      type="checkbox"
+                      checked={salesItems.length > 0 && selected.size === salesItems.length}
+                      onChange={toggleSelectAll}
+                      className="h-4 w-4 rounded border-gray-300 text-green-600 cursor-pointer"
+                    />
+                  </th>
+                )}
                 <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Name</th>
                 <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Pipeline</th>
                 <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500">Current Step</th>
@@ -359,7 +439,7 @@ export default function DealDashboardPage() {
             </thead>
             <tbody>
               {salesItems.length === 0 && (
-                <tr><td colSpan={5} className="px-4 py-8 text-center text-gray-400">No deals found</td></tr>
+                <tr><td colSpan={userRole === "admin" ? 6 : 5} className="px-4 py-8 text-center text-gray-400">No deals found</td></tr>
               )}
               {salesItems.map((item) => (
                 <tr
@@ -367,6 +447,16 @@ export default function DealDashboardPage() {
                   onClick={() => router.push(`/sales/pipelines/${item.pipeline_id}/items/${item.id}`)}
                   className="border-b border-gray-50 hover:bg-gray-50 cursor-pointer transition-colors"
                 >
+                  {userRole === "admin" && (
+                    <td className="w-10 px-3 py-3" onClick={(e) => e.stopPropagation()}>
+                      <input
+                        type="checkbox"
+                        checked={selected.has(item.id)}
+                        onChange={() => toggleSelect(item.id)}
+                        className="h-4 w-4 rounded border-gray-300 text-green-600 cursor-pointer"
+                      />
+                    </td>
+                  )}
                   <td className="px-4 py-3 font-medium text-gray-900">{item.name}</td>
                   <td className="px-4 py-3">
                     {item.pipelines ? (

--- a/src/app/sales/pipelines/[id]/items/page.tsx
+++ b/src/app/sales/pipelines/[id]/items/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
 import { createBrowserClient } from "@/lib/supabase";
-import { Loader2, Plus, ChevronRight, Search, Building2, X } from "lucide-react";
+import { Loader2, Plus, ChevronRight, Search, Building2, X, Trash2, CheckSquare } from "lucide-react";
 
 interface Account {
   id: string;
@@ -42,10 +42,21 @@ export default function PipelineItemsPage() {
   const [selectedAccount, setSelectedAccount] = useState<Account | null>(null);
   const [showAccountList, setShowAccountList] = useState(false);
 
+  const [userRole, setUserRole] = useState<"admin" | "sales">("sales");
+  const [selectedItems, setSelectedItems] = useState<Set<string>>(new Set());
+  const [bulkDeleting, setBulkDeleting] = useState(false);
+
   useEffect(() => {
     const supabase = createBrowserClient();
-    supabase.auth.getSession().then(({ data: { session } }) => {
-      if (session?.access_token) setToken(session.access_token);
+    supabase.auth.getSession().then(async ({ data: { session } }) => {
+      if (!session?.access_token) return;
+      setToken(session.access_token);
+      const res = await fetch("/api/sales/users", { headers: { Authorization: `Bearer ${session.access_token}` } });
+      if (res.ok) {
+        const users = await res.json();
+        const me = users.find((u: { id: string }) => u.id === session.user.id);
+        if (me?.role === "admin" || me?.role === "director_of_sales" || me?.role === "market_leader") setUserRole("admin");
+      }
     });
   }, []);
 
@@ -100,6 +111,45 @@ export default function PipelineItemsPage() {
       )
     : accounts;
 
+  function toggleSelectItem(id: string) {
+    setSelectedItems((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  }
+
+  function toggleSelectAllItems() {
+    if (selectedItems.size === items.length) {
+      setSelectedItems(new Set());
+    } else {
+      setSelectedItems(new Set(items.map((i) => i.id)));
+    }
+  }
+
+  async function handleBulkDeleteItems() {
+    if (selectedItems.size === 0) return;
+    if (!confirm(`Delete ${selectedItems.size} selected item${selectedItems.size > 1 ? "s" : ""}? Won/lost items will be skipped to preserve stats. This cannot be undone.`)) return;
+    setBulkDeleting(true);
+    const res = await fetch("/api/pipeline-items/bulk-delete", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ ids: Array.from(selectedItems) }),
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      alert(err.error || "Bulk delete failed");
+    } else {
+      const result = await res.json();
+      if (result.skipped > 0) {
+        alert(`Deleted ${result.deleted} item(s). ${result.skipped} won/lost item(s) were skipped.`);
+      }
+    }
+    setSelectedItems(new Set());
+    setBulkDeleting(false);
+    load();
+  }
+
   const statusColor = (s: string) => {
     if (s === "won") return "bg-green-50 text-green-700";
     if (s === "lost") return "bg-red-50 text-red-600";
@@ -122,6 +172,38 @@ export default function PipelineItemsPage() {
           <Plus className="h-4 w-4" /> Add Item
         </button>
       </div>
+
+      {/* Bulk selection banner */}
+      {selectedItems.size > 0 && userRole === "admin" && (
+        <div className="mb-4 flex items-center gap-3 rounded-lg border border-red-200 bg-red-50 px-4 py-2.5">
+          <CheckSquare className="h-4 w-4 text-red-600 shrink-0" />
+          <span className="text-sm font-medium text-red-800">{selectedItems.size} item{selectedItems.size > 1 ? "s" : ""} selected</span>
+          <button
+            onClick={handleBulkDeleteItems}
+            disabled={bulkDeleting}
+            className="ml-auto inline-flex items-center gap-1.5 rounded-lg bg-red-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-700 disabled:opacity-50 cursor-pointer"
+          >
+            {bulkDeleting ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Trash2 className="h-3.5 w-3.5" />}
+            Delete Selected
+          </button>
+          <button onClick={() => setSelectedItems(new Set())} className="text-red-400 hover:text-red-600 cursor-pointer">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      )}
+
+      {/* Admin select-all toggle */}
+      {userRole === "admin" && items.length > 0 && (
+        <div className="mb-3 flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={items.length > 0 && selectedItems.size === items.length}
+            onChange={toggleSelectAllItems}
+            className="h-4 w-4 rounded border-gray-300 text-green-600 cursor-pointer"
+          />
+          <span className="text-xs text-gray-500">Select all ({items.length})</span>
+        </div>
+      )}
 
       {showAdd && (
         <div className="mb-6 rounded-xl border border-gray-200 bg-white p-5">
@@ -217,18 +299,29 @@ export default function PipelineItemsPage() {
               </div>
               <div className="space-y-2">
                 {stepItems.map((item) => (
-                  <Link
-                    key={item.id}
-                    href={`/sales/pipelines/${pipelineId}/items/${item.id}`}
-                    className="block rounded-lg border border-gray-200 bg-white p-3 hover:border-green-200 transition-colors"
-                  >
-                    <p className="text-sm font-medium text-gray-900">{item.name}</p>
-                    {item.sales_accounts && <p className="text-xs text-gray-400">{item.sales_accounts.business_name}</p>}
-                    <div className="flex items-center justify-between mt-2">
-                      {item.value > 0 && <span className="text-xs font-medium text-green-600">${Number(item.value).toLocaleString()}</span>}
-                      <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${statusColor(item.status)}`}>{item.status}</span>
-                    </div>
-                  </Link>
+                  <div key={item.id} className="relative">
+                    {userRole === "admin" && (
+                      <div className="absolute top-2 right-2 z-10" onClick={(e) => e.preventDefault()}>
+                        <input
+                          type="checkbox"
+                          checked={selectedItems.has(item.id)}
+                          onChange={() => toggleSelectItem(item.id)}
+                          className="h-4 w-4 rounded border-gray-300 text-green-600 cursor-pointer"
+                        />
+                      </div>
+                    )}
+                    <Link
+                      href={`/sales/pipelines/${pipelineId}/items/${item.id}`}
+                      className={`block rounded-lg border bg-white p-3 hover:border-green-200 transition-colors ${selectedItems.has(item.id) ? "border-red-300 bg-red-50/30" : "border-gray-200"}`}
+                    >
+                      <p className="text-sm font-medium text-gray-900 pr-6">{item.name}</p>
+                      {item.sales_accounts && <p className="text-xs text-gray-400">{item.sales_accounts.business_name}</p>}
+                      <div className="flex items-center justify-between mt-2">
+                        {item.value > 0 && <span className="text-xs font-medium text-green-600">${Number(item.value).toLocaleString()}</span>}
+                        <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${statusColor(item.status)}`}>{item.status}</span>
+                      </div>
+                    </Link>
+                  </div>
                 ))}
                 {stepItems.length === 0 && <p className="text-xs text-gray-300 text-center py-4">Empty</p>}
               </div>


### PR DESCRIPTION
Adds bulk delete endpoints and UI that skip won/lost items to preserve sales stats. Admin/director/market_leader roles only.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2