### PR TITLE
Allow bulk delete of won/lost deals and pipeline items

### DIFF
--- a/src/app/api/pipeline-items/bulk-delete/route.ts
+++ b/src/app/api/pipeline-items/bulk-delete/route.ts
@@ -19,81 +19,54 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Max 500 items per request" }, { status: 400 });
   }
 
-  // Exclude won/lost items to preserve stats
+  // Fetch items to find linked deals
   const { data: items } = await supabaseAdmin
     .from("pipeline_items")
-    .select("id, status, deal_id")
+    .select("id, deal_id")
     .in("id", ids);
 
-  const protectedIds = new Set(
-    (items || []).filter((i) => i.status === "won" || i.status === "lost").map((i) => i.id)
-  );
-  const deletableItems = (items || []).filter((i) => !protectedIds.has(i.id));
-  const deletableIds = deletableItems.map((i) => i.id);
-
-  if (deletableIds.length === 0) {
-    return NextResponse.json({
-      deleted: 0,
-      skipped: protectedIds.size,
-      message: "All selected items are won/lost and were skipped to preserve stats.",
-    });
-  }
-
-  // Also delete linked deals (that aren't won/lost)
-  const linkedDealIds = deletableItems
+  const linkedDealIds = (items || [])
     .map((i) => i.deal_id)
     .filter((id): id is string => !!id);
 
   // Detach/clean up pipeline item FKs
   await Promise.all([
-    supabaseAdmin.from("step_approvals").delete().in("pipeline_item_id", deletableIds),
-    supabaseAdmin.from("pipeline_item_documents").delete().in("pipeline_item_id", deletableIds),
-    supabaseAdmin.from("esign_documents").delete().in("pipeline_item_id", deletableIds),
-    supabaseAdmin.from("pipeline_payments").delete().in("pipeline_item_id", deletableIds),
-    supabaseAdmin.from("agreement_tokens").delete().in("pipeline_item_id", deletableIds),
-    supabaseAdmin.from("sales_deals").update({ pipeline_item_id: null }).in("pipeline_item_id", deletableIds),
+    supabaseAdmin.from("step_approvals").delete().in("pipeline_item_id", ids),
+    supabaseAdmin.from("pipeline_item_documents").delete().in("pipeline_item_id", ids),
+    supabaseAdmin.from("esign_documents").delete().in("pipeline_item_id", ids),
+    supabaseAdmin.from("pipeline_payments").delete().in("pipeline_item_id", ids),
+    supabaseAdmin.from("agreement_tokens").delete().in("pipeline_item_id", ids),
+    supabaseAdmin.from("sales_deals").update({ pipeline_item_id: null }).in("pipeline_item_id", ids),
   ]);
 
   // Delete the pipeline items
   const { error: piErr, count: piCount } = await supabaseAdmin
     .from("pipeline_items")
     .delete({ count: "exact" })
-    .in("id", deletableIds);
+    .in("id", ids);
 
   if (piErr) {
     return NextResponse.json({ error: piErr.message }, { status: 500 });
   }
 
-  // Clean up linked deals (skip won/lost)
+  // Clean up linked deals
   let dealsDeleted = 0;
   if (linkedDealIds.length > 0) {
-    const { data: linkedDeals } = await supabaseAdmin
+    await Promise.all([
+      supabaseAdmin.from("sales_orders").update({ deal_id: null }).in("deal_id", linkedDealIds),
+      supabaseAdmin.from("sales_commissions").delete().in("deal_id", linkedDealIds),
+      supabaseAdmin.from("deal_services").delete().in("deal_id", linkedDealIds),
+    ]);
+
+    const { count } = await supabaseAdmin
       .from("sales_deals")
-      .select("id, stage")
+      .delete({ count: "exact" })
       .in("id", linkedDealIds);
-
-    const deletableDealIds = (linkedDeals || [])
-      .filter((d) => d.stage !== "won" && d.stage !== "lost")
-      .map((d) => d.id);
-
-    if (deletableDealIds.length > 0) {
-      await Promise.all([
-        supabaseAdmin.from("sales_orders").update({ deal_id: null }).in("deal_id", deletableDealIds),
-        supabaseAdmin.from("sales_commissions").delete().in("deal_id", deletableDealIds),
-        supabaseAdmin.from("deal_services").delete().in("deal_id", deletableDealIds),
-      ]);
-
-      const { count } = await supabaseAdmin
-        .from("sales_deals")
-        .delete({ count: "exact" })
-        .in("id", deletableDealIds);
-      dealsDeleted = count || deletableDealIds.length;
-    }
+    dealsDeleted = count || linkedDealIds.length;
   }
 
   return NextResponse.json({
-    deleted: piCount || deletableIds.length,
+    deleted: piCount || ids.length,
     deals_deleted: dealsDeleted,
-    skipped: protectedIds.size,
   });
 }

--- a/src/app/api/sales/deals/bulk-delete/route.ts
+++ b/src/app/api/sales/deals/bulk-delete/route.ts
@@ -19,44 +19,22 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Max 500 deals per request" }, { status: 400 });
   }
 
-  // Exclude won/lost deals to preserve stats
-  const { data: deals } = await supabaseAdmin
-    .from("sales_deals")
-    .select("id, stage")
-    .in("id", ids);
-
-  const protectedIds = new Set(
-    (deals || []).filter((d) => d.stage === "won" || d.stage === "lost").map((d) => d.id)
-  );
-  const deletableIds = ids.filter((id: string) => !protectedIds.has(id));
-
-  if (deletableIds.length === 0) {
-    return NextResponse.json({
-      deleted: 0,
-      skipped: protectedIds.size,
-      message: "All selected deals are won/lost and were skipped to preserve stats.",
-    });
-  }
-
   // Detach FKs before deletion
   await Promise.all([
-    supabaseAdmin.from("sales_orders").update({ deal_id: null }).in("deal_id", deletableIds),
-    supabaseAdmin.from("sales_commissions").delete().in("deal_id", deletableIds),
-    supabaseAdmin.from("deal_services").delete().in("deal_id", deletableIds),
-    supabaseAdmin.from("pipeline_items").update({ deal_id: null }).in("deal_id", deletableIds),
+    supabaseAdmin.from("sales_orders").update({ deal_id: null }).in("deal_id", ids),
+    supabaseAdmin.from("sales_commissions").delete().in("deal_id", ids),
+    supabaseAdmin.from("deal_services").delete().in("deal_id", ids),
+    supabaseAdmin.from("pipeline_items").update({ deal_id: null }).in("deal_id", ids),
   ]);
 
   const { error, count } = await supabaseAdmin
     .from("sales_deals")
     .delete({ count: "exact" })
-    .in("id", deletableIds);
+    .in("id", ids);
 
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 
-  return NextResponse.json({
-    deleted: count || deletableIds.length,
-    skipped: protectedIds.size,
-  });
+  return NextResponse.json({ deleted: count || ids.length });
 }

--- a/src/app/sales/deals/page.tsx
+++ b/src/app/sales/deals/page.tsx
@@ -209,7 +209,7 @@ export default function DealDashboardPage() {
 
   async function handleBulkDelete() {
     if (selected.size === 0) return;
-    if (!confirm(`Delete ${selected.size} selected item${selected.size > 1 ? "s" : ""}? Won/lost items will be skipped to preserve stats. This cannot be undone.`)) return;
+    if (!confirm(`Delete ${selected.size} selected item${selected.size > 1 ? "s" : ""}? This cannot be undone.`)) return;
     setBulkDeleting(true);
     const res = await fetch("/api/pipeline-items/bulk-delete", {
       method: "POST",
@@ -219,11 +219,6 @@ export default function DealDashboardPage() {
     if (!res.ok) {
       const err = await res.json().catch(() => ({}));
       alert(err.error || "Bulk delete failed");
-    } else {
-      const result = await res.json();
-      if (result.skipped > 0) {
-        alert(`Deleted ${result.deleted} item(s). ${result.skipped} won/lost item(s) were skipped.`);
-      }
     }
     setSelected(new Set());
     setBulkDeleting(false);

--- a/src/app/sales/pipelines/[id]/items/page.tsx
+++ b/src/app/sales/pipelines/[id]/items/page.tsx
@@ -129,7 +129,7 @@ export default function PipelineItemsPage() {
 
   async function handleBulkDeleteItems() {
     if (selectedItems.size === 0) return;
-    if (!confirm(`Delete ${selectedItems.size} selected item${selectedItems.size > 1 ? "s" : ""}? Won/lost items will be skipped to preserve stats. This cannot be undone.`)) return;
+    if (!confirm(`Delete ${selectedItems.size} selected item${selectedItems.size > 1 ? "s" : ""}? This cannot be undone.`)) return;
     setBulkDeleting(true);
     const res = await fetch("/api/pipeline-items/bulk-delete", {
       method: "POST",
@@ -139,11 +139,6 @@ export default function PipelineItemsPage() {
     if (!res.ok) {
       const err = await res.json().catch(() => ({}));
       alert(err.error || "Bulk delete failed");
-    } else {
-      const result = await res.json();
-      if (result.skipped > 0) {
-        alert(`Deleted ${result.deleted} item(s). ${result.skipped} won/lost item(s) were skipped.`);
-      }
     }
     setSelectedItems(new Set());
     setBulkDeleting(false);


### PR DESCRIPTION
Removed the won/lost skip protection so admins can delete all items regardless of status.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2