### PR TITLE
Rename Marketplace to Sell a Location, fix Stripe redirect fallback URLs

### DIFF
--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -120,7 +120,7 @@ export async function POST(req: NextRequest) {
   }
 
   const amountCents = Math.round(lead.price * 100);
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://vendingconnector.com";
 
   // Check if buyer is exempt from fees (sales team / admin)
   let feesExempt = false;

--- a/src/app/api/connect/onboard/route.ts
+++ b/src/app/api/connect/onboard/route.ts
@@ -33,7 +33,7 @@ export async function POST(req: NextRequest) {
   }
 
   const stripe = new Stripe(process.env.STRIPE_CONNECT_SECRET_KEY!);
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://vendingconnector.com";
 
   let accountId = profile.stripe_account_id;
 

--- a/src/app/api/pipeline-items/[id]/payments/route.ts
+++ b/src/app/api/pipeline-items/[id]/payments/route.ts
@@ -49,7 +49,7 @@ export async function POST(
   }
 
   const siteUrl =
-    process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
+    process.env.NEXT_PUBLIC_SITE_URL || "https://vendingconnector.com";
 
   try {
     let externalOrderId: string | null = null;

--- a/src/app/api/user-listings/[id]/checkout/route.ts
+++ b/src/app/api/user-listings/[id]/checkout/route.ts
@@ -65,7 +65,7 @@ export async function POST(
   }
 
   const stripe = new Stripe(process.env.STRIPE_CONNECT_SECRET_KEY!);
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://vendingconnector.com";
 
   const amountCents = Math.round(Number(listing.price) * 100);
   const platformFeeCents = Math.round(amountCents * PLATFORM_FEE_RATE);

--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -11,7 +11,7 @@ import { TOOLTIP_COPY } from "@/lib/tooltipCopy";
 
 const navLinks = [
   { label: "Locations for Sale", href: "/browse-requests" },
-  { label: "Marketplace", href: "/marketplace" },
+  { label: "Sell a Location", href: "/marketplace" },
   { label: "Machines for Sale", href: "/machines-for-sale" },
   { label: "Routes for Sale", href: "/routes-for-sale" },
   { label: "Browse Operators", href: "/browse-operators" },
@@ -20,7 +20,7 @@ const navLinks = [
 
 const authNavLinks = [
   { label: "Locations for Sale", href: "/browse-requests" },
-  { label: "Marketplace", href: "/marketplace" },
+  { label: "Sell a Location", href: "/marketplace" },
   { label: "Your Leads", href: "/your-leads" },
   { label: "Machines for Sale", href: "/machines-for-sale" },
   { label: "Routes for Sale", href: "/routes-for-sale" },

--- a/src/app/marketplace/[id]/page.tsx
+++ b/src/app/marketplace/[id]/page.tsx
@@ -94,9 +94,13 @@ export default function ListingDetailPage() {
 
     if (res.ok) {
       const { url } = await res.json();
-      window.location.href = url;
+      if (url) {
+        window.location.href = url;
+        return;
+      }
+      setError("Checkout session did not return a redirect URL. Please try again.");
     } else {
-      const data = await res.json();
+      const data = await res.json().catch(() => ({}));
       setError(data.error || "Failed to start checkout");
     }
     setPurchasing(false);


### PR DESCRIPTION
- Changed nav label from "Marketplace" to "Sell a Location" in both authenticated and unauthenticated header nav
- Fixed all Stripe checkout routes using localhost:3000 as fallback when NEXT_PUBLIC_SITE_URL is not set — now defaults to vendingconnector.com
- Added null check for checkout session URL on client side to prevent silent redirect failures

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2