### PR TITLE
Auto-create sales lead when sending agreement if none linked

### DIFF
--- a/src/app/api/pipeline-items/[id]/resend-agreement/route.ts
+++ b/src/app/api/pipeline-items/[id]/resend-agreement/route.ts
@@ -108,6 +108,43 @@ export async function POST(
     leadId = item.lead_id;
   }
 
+  // Auto-create a sales lead from location/account data when none exists
+  if (!leadId && (contactEmail || bodyEmail)) {
+    const { data: newLead } = await supabaseAdmin
+      .from("sales_leads")
+      .insert({
+        business_name: businessName || "Unknown",
+        contact_name: contactName || bodyName || null,
+        email: contactEmail || bodyEmail,
+        phone: phone || null,
+        address: address || null,
+        entity_type: "location",
+        status: "qualified",
+        source: "auto-created",
+        created_by: user.id,
+        assigned_to: user.id,
+        account_id: item.account_id || null,
+      })
+      .select("id")
+      .single();
+
+    if (newLead) {
+      leadId = newLead.id;
+      // Link the lead back to the pipeline item and location
+      await supabaseAdmin
+        .from("pipeline_items")
+        .update({ lead_id: newLead.id })
+        .eq("id", itemId);
+      if (item.location_id) {
+        await supabaseAdmin
+          .from("locations")
+          .update({ sales_lead_id: newLead.id })
+          .eq("id", item.location_id);
+      }
+      console.log("[resend-agreement] Auto-created sales lead:", newLead.id);
+    }
+  }
+
   if (!leadId) {
     return NextResponse.json(
       { error: "No sales lead linked — create or link a location first" },


### PR DESCRIPTION
When a location exists on a pipeline item but has no sales_lead_id, the "Send Agreement" button failed with "No sales lead linked." Now auto-creates a sales lead from the location/account data, links it to both the pipeline item and location, then proceeds to send the agreement.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2