### PR TITLE
Fix mobile overlapping text: use animation fill-mode both and fix Too…

### DIFF
--- a/src/app/components/Tooltip.tsx
+++ b/src/app/components/Tooltip.tsx
@@ -38,7 +38,7 @@ export default function Tooltip({
 
   return (
     <span
-      className="relative inline-flex"
+      className="relative inline-flex w-full sm:w-auto"
       onMouseEnter={show}
       onMouseLeave={hide}
       onFocus={show}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -142,8 +142,8 @@ tr:hover td { background: #f0fdf4; }
   50% { border-radius: 30% 60% 70% 40% / 50% 60% 30% 60%; }
 }
 
-.animate-fade-in { animation: fade-in 0.4s ease-out forwards; }
-.animate-slide-up { animation: slide-up 0.5s ease-out forwards; }
+.animate-fade-in { animation: fade-in 0.4s ease-out both; }
+.animate-slide-up { animation: slide-up 0.5s ease-out both; }
 .animate-pulse-dot { animation: pulse-dot 1.5s ease-in-out infinite; }
 .animate-float { animation: float 6s ease-in-out infinite; }
 .animate-float-delayed { animation: float-delayed 7s ease-in-out infinite 1s; }


### PR DESCRIPTION
…ltip width

- Change animate-fade-in/slide-up from 'forwards' to 'both' fill-mode so elements stay at opacity:0 during their animation delay instead of flashing visible at full opacity before the staggered fade-in begins
- Add w-full sm:w-auto to Tooltip wrapper so CTA buttons can be full-width on mobile inside flex-col containers

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2