### PR TITLE
Fix admin featured toggle: sync both tables, filter dashboard, simpli…

### DIFF
--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -64,6 +64,14 @@ export async function PATCH(
       return NextResponse.json({ error: error.message }, { status: 500 });
     }
 
+    // Keep operator_listings.featured in sync with profiles.featured
+    if ("featured" in updates) {
+      await supabaseAdmin
+        .from("operator_listings")
+        .update({ featured: updates.featured as boolean })
+        .eq("operator_id", id);
+    }
+
     return NextResponse.json(data);
   } catch (e) {
     const msg = e instanceof Error ? e.message : "Unknown error";

--- a/src/app/api/operators/[id]/route.ts
+++ b/src/app/api/operators/[id]/route.ts
@@ -19,7 +19,7 @@ export async function GET(
     return NextResponse.json({ error: "Operator not found" }, { status: 404 });
   }
 
-  const isFeatured = profile.featured === true && !!profile.stripe_subscription_id;
+  const isFeatured = profile.featured === true;
 
   // Never expose Stripe IDs
   const { stripe_subscription_id: _sid, stripe_customer_id: _cid, ...cleanProfile } = profile;

--- a/src/app/api/operators/route.ts
+++ b/src/app/api/operators/route.ts
@@ -4,8 +4,8 @@ import { sanitizeSearch } from "@/lib/sanitizeSearch";
 
 const PAGE_SIZE = 12;
 
-function isPaidFeatured(profile: Record<string, unknown> | null): boolean {
-  return profile?.featured === true && !!profile?.stripe_subscription_id;
+function isFeaturedOperator(profile: Record<string, unknown> | null): boolean {
+  return profile?.featured === true;
 }
 
 /**
@@ -18,7 +18,7 @@ function stripOperatorProfile(
   isFeatured: boolean
 ): Record<string, unknown> | null {
   if (!profile) return null;
-  const { stripe_subscription_id: _sid, stripe_customer_id: _cid, ...clean } = profile;
+  const { stripe_subscription_id: _sid, stripe_customer_id: _cid, ...clean } = profile as Record<string, unknown>;
   if (isFeatured) return { ...clean, featured: true };
   return {
     id: profile.id,
@@ -47,6 +47,7 @@ export async function GET(req: NextRequest) {
   const machineTypes = params.get("machine_types");
   const state = params.get("state");
   const commission = params.get("commission");
+  const featured = params.get("featured");
   const page = Math.max(0, parseInt(params.get("page") || "0"));
   const mine = params.get("mine");
   const userId = params.get("user_id");
@@ -65,6 +66,7 @@ export async function GET(req: NextRequest) {
       }
     }
     if (state) query = query.eq("state", state);
+    if (featured === "true") query = query.eq("featured", true);
 
     const from = page * PAGE_SIZE;
     const { data, error, count } = await query
@@ -75,7 +77,7 @@ export async function GET(req: NextRequest) {
     if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
     const operators = (data || []).map((op: Record<string, unknown>) =>
-      stripOperatorProfile(op, isPaidFeatured(op))
+      stripOperatorProfile(op, isFeaturedOperator(op))
     );
 
     return NextResponse.json({ operators, total: count || 0 });
@@ -84,7 +86,7 @@ export async function GET(req: NextRequest) {
   // Listings mode
   let query = supabaseAdmin
     .from("operator_listings")
-    .select("*, profiles!operator_id(id, full_name, company_name, verified, rating, review_count, address, city, state, zip, featured, stripe_subscription_id)", { count: "exact" });
+    .select("*, profiles!operator_id(id, full_name, company_name, verified, rating, review_count, address, city, state, zip, featured)", { count: "exact" });
 
   if (mine === "true" && userId) {
     query = query.eq("operator_id", userId);
@@ -103,6 +105,9 @@ export async function GET(req: NextRequest) {
   if (commission === "true") {
     query = query.eq("accepts_commission", true);
   }
+  if (featured === "true") {
+    query = query.eq("featured", true);
+  }
 
   const from = page * PAGE_SIZE;
   const { data, error, count } = await query
@@ -114,7 +119,7 @@ export async function GET(req: NextRequest) {
 
   const listings = (data || []).map((listing: Record<string, unknown>) => {
     const profile = listing.profiles as Record<string, unknown> | null;
-    const isFeatured = isPaidFeatured(profile);
+    const isFeatured = isFeaturedOperator(profile);
     return {
       ...listing,
       profiles: stripOperatorProfile(profile, isFeatured),

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -301,7 +301,7 @@ export default function DashboardPage() {
   const fetchOperators = useCallback(async () => {
     setLoadingOperators(true);
     try {
-      const res = await fetch("/api/operators?limit=4");
+      const res = await fetch("/api/operators?limit=4&featured=true");
       const data = await res.json();
       setOperators(data.listings || []);
     } catch {


### PR DESCRIPTION
…fy check

- Sync operator_listings.featured when admin toggles profiles.featured
- Dashboard now fetches only featured=true operators for the Featured section
- Add featured filter param to GET /api/operators
- Simplify isFeaturedOperator to check profiles.featured only (no longer requires stripe_subscription_id, so admin can feature/unfeature freely)

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2