### PR TITLE
Add location owner verification for marketplace listings

### DIFF
--- a/src/app/api/cron/verification-reminders/route.ts
+++ b/src/app/api/cron/verification-reminders/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { sendLocationAgreementEmail } from "@/lib/locationAgreementEmail";
+
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "https://vendingconnector.com";
+const CRON_SECRET = process.env.CRON_SECRET;
+
+export async function GET(req: NextRequest) {
+  if (CRON_SECRET && req.headers.get("authorization") !== `Bearer ${CRON_SECRET}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const now = new Date();
+  let reminded = 0;
+  let expired = 0;
+
+  // 1. Expire unsigned agreements older than 7 days
+  const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString();
+  const { data: expiredAgreements } = await supabaseAdmin
+    .from("location_agreements")
+    .select("id, listing_id")
+    .in("status", ["pending", "viewed"])
+    .not("listing_id", "is", null)
+    .lt("created_at", sevenDaysAgo);
+
+  if (expiredAgreements && expiredAgreements.length > 0) {
+    const agreementIds = expiredAgreements.map((a) => a.id);
+    const listingIds = expiredAgreements.map((a) => a.listing_id).filter(Boolean) as string[];
+
+    await supabaseAdmin
+      .from("location_agreements")
+      .update({ status: "expired", updated_at: now.toISOString() })
+      .in("id", agreementIds);
+
+    if (listingIds.length > 0) {
+      await supabaseAdmin
+        .from("user_listings")
+        .update({ status: "expired", is_public: false, updated_at: now.toISOString() })
+        .in("id", listingIds)
+        .eq("status", "pending_verification");
+    }
+
+    expired = expiredAgreements.length;
+  }
+
+  // 2. Send 24h reminder (created 24-25h ago, no reminder yet)
+  const twentyFiveHoursAgo = new Date(now.getTime() - 25 * 60 * 60 * 1000).toISOString();
+  const twentyFourHoursAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString();
+  const { data: reminders24 } = await supabaseAdmin
+    .from("location_agreements")
+    .select("id, token, email, contact_name, business_name")
+    .in("status", ["pending", "viewed"])
+    .not("listing_id", "is", null)
+    .is("reminder_sent_at", null)
+    .lt("created_at", twentyFourHoursAgo)
+    .gt("created_at", twentyFiveHoursAgo);
+
+  // 3. Send 72h reminder (created 72-73h ago, already got 24h reminder)
+  const seventyThreeHoursAgo = new Date(now.getTime() - 73 * 60 * 60 * 1000).toISOString();
+  const seventyTwoHoursAgo = new Date(now.getTime() - 72 * 60 * 60 * 1000).toISOString();
+  const { data: reminders72 } = await supabaseAdmin
+    .from("location_agreements")
+    .select("id, token, email, contact_name, business_name")
+    .in("status", ["pending", "viewed"])
+    .not("listing_id", "is", null)
+    .not("reminder_sent_at", "is", null)
+    .lt("created_at", seventyTwoHoursAgo)
+    .gt("created_at", seventyThreeHoursAgo);
+
+  const allReminders = [...(reminders24 || []), ...(reminders72 || [])];
+
+  for (const agreement of allReminders) {
+    if (!agreement.email) continue;
+    try {
+      await sendLocationAgreementEmail({
+        to: agreement.email,
+        recipientName: agreement.contact_name || "Business Owner",
+        businessName: agreement.business_name || "your location",
+        agreementUrl: `${APP_URL}/location-agreement/${agreement.token}`,
+      });
+      await supabaseAdmin
+        .from("location_agreements")
+        .update({ reminder_sent_at: now.toISOString(), updated_at: now.toISOString() })
+        .eq("id", agreement.id);
+      reminded++;
+    } catch (err) {
+      console.error(`[cron] Failed to send reminder for agreement ${agreement.id}:`, err);
+    }
+  }
+
+  return NextResponse.json({ ok: true, reminded, expired });
+}

--- a/src/app/api/location-agreements/[token]/sign/route.ts
+++ b/src/app/api/location-agreements/[token]/sign/route.ts
@@ -30,7 +30,7 @@ export async function POST(
 
   const { data: agreement } = await supabaseAdmin
     .from("location_agreements")
-    .select("id, status, lead_id")
+    .select("id, status, lead_id, listing_id")
     .eq("token", token)
     .single();
 
@@ -78,6 +78,19 @@ export async function POST(
     if (Object.keys(leadUpdates).length > 0) {
       await supabaseAdmin.from("sales_leads").update(leadUpdates).eq("id", agreement.lead_id);
     }
+  }
+
+  // Auto-publish the marketplace listing once the owner signs
+  if (agreement.listing_id) {
+    await supabaseAdmin
+      .from("user_listings")
+      .update({
+        status: "active",
+        is_public: true,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", agreement.listing_id)
+      .eq("status", "pending_verification");
   }
 
   return NextResponse.json({ ok: true, status: "signed" });

--- a/src/app/api/user-listings/route.ts
+++ b/src/app/api/user-listings/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { getUserIdFromRequest } from "@/lib/apiAuth";
+import { sendLocationAgreementEmail } from "@/lib/locationAgreementEmail";
+
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "https://vendingconnector.com";
 
 const ALLOWED_SELLER_ROLES = ["operator", "location_manager"];
 const MIN_PRICE = 100;
@@ -92,6 +95,8 @@ export async function POST(req: NextRequest) {
     contact_name,
     contact_phone,
     contact_email,
+    owner_name,
+    owner_email,
   } = body;
 
   if (!title?.trim()) {
@@ -108,6 +113,12 @@ export async function POST(req: NextRequest) {
   }
   if (!state?.trim()) {
     return NextResponse.json({ error: "State is required" }, { status: 400 });
+  }
+  if (!owner_name?.trim() || !owner_email?.trim()) {
+    return NextResponse.json(
+      { error: "Location owner name and email are required for verification" },
+      { status: 400 }
+    );
   }
 
   const { data, error } = await supabaseAdmin
@@ -128,12 +139,42 @@ export async function POST(req: NextRequest) {
       contact_name: contact_name?.trim() || null,
       contact_phone: contact_phone?.trim() || null,
       contact_email: contact_email?.trim() || null,
+      owner_name: owner_name.trim(),
+      owner_email: owner_email.trim().toLowerCase(),
+      status: "pending_verification",
+      is_public: false,
     })
     .select("*")
     .single();
 
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  // Create location agreement and send verification email to the location owner
+  try {
+    const { data: agreement } = await supabaseAdmin
+      .from("location_agreements")
+      .insert({
+        listing_id: data.id,
+        business_name: title.trim(),
+        contact_name: owner_name.trim(),
+        email: owner_email.trim().toLowerCase(),
+        address: [city?.trim(), state.trim(), zip?.trim()].filter(Boolean).join(", ") || null,
+      })
+      .select("token")
+      .single();
+
+    if (agreement) {
+      await sendLocationAgreementEmail({
+        to: owner_email.trim().toLowerCase(),
+        recipientName: owner_name.trim(),
+        businessName: title.trim(),
+        agreementUrl: `${APP_URL}/location-agreement/${agreement.token}`,
+      });
+    }
+  } catch (emailErr) {
+    console.error("[user-listings] Failed to send verification email:", emailErr);
   }
 
   return NextResponse.json(data, { status: 201 });

--- a/src/app/my-listings/page.tsx
+++ b/src/app/my-listings/page.tsx
@@ -89,6 +89,8 @@ export default function MyListingsPage() {
     contact_name: "",
     contact_phone: "",
     contact_email: "",
+    owner_name: "",
+    owner_email: "",
   });
 
   const fetchData = useCallback(async () => {
@@ -119,7 +121,7 @@ export default function MyListingsPage() {
 
   useEffect(() => {
     if (toast) {
-      const t = setTimeout(() => setToast(null), 3000);
+      const t = setTimeout(() => setToast(null), 6000);
       return () => clearTimeout(t);
     }
   }, [toast]);
@@ -173,6 +175,8 @@ export default function MyListingsPage() {
       return;
     }
     if (!form.state) { setError("State is required"); return; }
+    if (!form.owner_name.trim()) { setError("Location owner name is required"); return; }
+    if (!form.owner_email.trim()) { setError("Location owner email is required"); return; }
 
     setCreating(true);
     const token = await getAccessToken();
@@ -183,7 +187,10 @@ export default function MyListingsPage() {
     });
 
     if (res.ok) {
-      router.push("/your-leads");
+      setShowCreate(false);
+      setToast("Verification email sent to the location owner. Your listing will go live once they sign.");
+      setForm({ title: "", description: "", listing_type: "lead", price: "", city: "", state: "", zip: "", entity_type: "", business_type: "", foot_traffic: "", square_footage: "", contact_name: "", contact_phone: "", contact_email: "", owner_name: "", owner_email: "" });
+      fetchData();
     } else {
       const data = await res.json();
       setError(data.error || "Failed to create listing");
@@ -358,6 +365,15 @@ export default function MyListingsPage() {
               </div>
 
               <div className="border-t pt-4">
+                <p className="text-xs font-medium text-gray-500 mb-1">Location Owner Verification <span className="text-red-500">*</span></p>
+                <p className="text-xs text-gray-400 mb-3">An agreement will be emailed to the location owner. Your listing goes live once they sign.</p>
+                <div className="space-y-3">
+                  <input value={form.owner_name} onChange={(e) => setForm(f => ({ ...f, owner_name: e.target.value }))} placeholder="Owner full name" className={inputClass} />
+                  <input type="email" value={form.owner_email} onChange={(e) => setForm(f => ({ ...f, owner_email: e.target.value }))} placeholder="Owner email address" className={inputClass} />
+                </div>
+              </div>
+
+              <div className="border-t pt-4">
                 <p className="text-xs font-medium text-gray-500 mb-3">Contact Info (shared with buyer after purchase)</p>
                 <div className="space-y-3">
                   <input value={form.contact_name} onChange={(e) => setForm(f => ({ ...f, contact_name: e.target.value }))} placeholder="Contact name" className={inputClass} />
@@ -375,7 +391,7 @@ export default function MyListingsPage() {
               </button>
               <button onClick={handleCreate} disabled={creating} className="flex-1 bg-green-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-green-700 disabled:opacity-50 flex items-center justify-center gap-2">
                 {creating && <Loader2 className="h-4 w-4 animate-spin" />}
-                Post Listing
+                Submit for Verification
               </button>
             </div>
           </div>
@@ -401,9 +417,10 @@ export default function MyListingsPage() {
                 <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${
                   l.status === "active" ? "bg-green-100 text-green-700" :
                   l.status === "sold" ? "bg-blue-100 text-blue-700" :
+                  l.status === "pending_verification" ? "bg-amber-100 text-amber-700" :
                   "bg-gray-100 text-gray-600"
                 }`}>
-                  {l.status === "active" ? "Active" : l.status === "sold" ? "Sold" : l.status}
+                  {l.status === "active" ? "Active" : l.status === "sold" ? "Sold" : l.status === "pending_verification" ? "Pending Verification" : l.status}
                 </span>
                 <span className="text-xs text-gray-400">{daysAgo(l.created_at)}</span>
               </div>

--- a/src/app/your-leads/page.tsx
+++ b/src/app/your-leads/page.tsx
@@ -380,6 +380,7 @@ function ListingCard({ listing, onRemove }: { listing: UserListing; onRemove?: (
     active: "bg-green-50 text-green-700",
     sold: "bg-blue-50 text-blue-700",
     expired: "bg-gray-100 text-gray-600",
+    pending_verification: "bg-amber-50 text-amber-700",
   };
 
   return (
@@ -390,7 +391,7 @@ function ListingCard({ listing, onRemove }: { listing: UserListing; onRemove?: (
             {listing.title}
           </h3>
           <span className={`shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${statusColors[listing.status] || "bg-gray-100 text-gray-600"}`}>
-            {listing.status}
+            {listing.status === "pending_verification" ? "Pending Verification" : listing.status}
           </span>
         </div>
 
@@ -645,7 +646,7 @@ export default function YourLeadsPage() {
                             </td>
                             <td className="px-4 py-3">
                               <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${statusColors[listing.status] || "bg-gray-100 text-gray-600"}`}>
-                                {listing.status}
+                                {listing.status === "pending_verification" ? "Pending Verification" : listing.status}
                               </span>
                             </td>
                             <td className="px-4 py-3 text-black-primary/40 text-xs whitespace-nowrap">

--- a/supabase/migrations/070_listing_owner_verification.sql
+++ b/supabase/migrations/070_listing_owner_verification.sql
@@ -1,0 +1,37 @@
+-- Migration 070: Location owner verification for marketplace listings
+--
+-- When a user posts a lead for sale, an agreement is sent to the location owner.
+-- The listing stays in "pending_verification" until the owner signs.
+-- On signature the listing auto-publishes.
+
+-- 1. Add listing_id to location_agreements so we can link to user_listings
+ALTER TABLE public.location_agreements
+  ADD COLUMN IF NOT EXISTS listing_id UUID REFERENCES public.user_listings(id) ON DELETE CASCADE;
+
+CREATE INDEX IF NOT EXISTS idx_location_agreements_listing
+  ON public.location_agreements(listing_id);
+
+-- 2. Add pending_verification + expired to the user_listings status check
+ALTER TABLE public.user_listings
+  DROP CONSTRAINT IF EXISTS user_listings_status_check;
+
+ALTER TABLE public.user_listings
+  ADD CONSTRAINT user_listings_status_check
+  CHECK (status IN ('active', 'sold', 'expired', 'removed', 'pending_verification'));
+
+-- 3. Add owner contact fields to user_listings for reference
+ALTER TABLE public.user_listings
+  ADD COLUMN IF NOT EXISTS owner_name TEXT,
+  ADD COLUMN IF NOT EXISTS owner_email TEXT;
+
+-- 4. Add reminder_sent_at to location_agreements for cron reminders
+ALTER TABLE public.location_agreements
+  ADD COLUMN IF NOT EXISTS reminder_sent_at TIMESTAMPTZ;
+
+-- 5. Expand location_agreements status to include 'expired'
+ALTER TABLE public.location_agreements
+  DROP CONSTRAINT IF EXISTS location_agreements_status_check;
+
+ALTER TABLE public.location_agreements
+  ADD CONSTRAINT location_agreements_status_check
+  CHECK (status IN ('pending', 'viewed', 'signed', 'expired'));

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,10 @@
     {
       "path": "/api/digest/send",
       "schedule": "0 14 * * 1"
+    },
+    {
+      "path": "/api/cron/verification-reminders",
+      "schedule": "0 * * * *"
     }
   ]
 }


### PR DESCRIPTION
Listings now require location owner sign-off before going public. When a seller creates a listing, an agreement email is sent to the location owner. The listing stays in pending_verification status until the owner signs via the existing /location-agreement/[token] page, which then auto-publishes it.

- Add owner_name and owner_email fields to listing form and API
- Insert listings as pending_verification with is_public=false
- Auto-send agreement email on listing creation via Resend
- Auto-publish listing when location owner signs the agreement
- Add pending_verification status badge to my-listings and your-leads
- Add hourly Vercel cron for 24h/72h reminders and 7-day expiration
- Migration 070: listing_id on location_agreements, new status values

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2