### PR TITLE
Restrict all CRM delete operations to admin/elevated roles only

### DIFF
--- a/src/app/api/sales/accounts/[id]/route.ts
+++ b/src/app/api/sales/accounts/[id]/route.ts
@@ -55,16 +55,8 @@ export async function DELETE(req: NextRequest, { params }: { params: Promise<{ i
   if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   const { id } = await params;
 
-  // Sales reps can only delete accounts they own; admins can delete any.
   if (!isElevatedRole(user.role)) {
-    const { data: acct } = await supabaseAdmin
-      .from("sales_accounts")
-      .select("assigned_to, created_by")
-      .eq("id", id)
-      .single();
-    if (!acct || (acct.assigned_to !== user.id && acct.created_by !== user.id)) {
-      return NextResponse.json({ error: "Not allowed" }, { status: 403 });
-    }
+    return NextResponse.json({ error: "Only admins can delete accounts" }, { status: 403 });
   }
 
   // Detach related records so FK constraints don't block the delete.

--- a/src/app/api/sales/deals/[id]/route.ts
+++ b/src/app/api/sales/deals/[id]/route.ts
@@ -184,14 +184,7 @@ export async function DELETE(req: NextRequest, { params }: { params: Promise<{ i
   const { id } = await params;
 
   if (!isElevatedRole(user.role)) {
-    const { data: deal } = await supabaseAdmin
-      .from("sales_deals")
-      .select("assigned_to")
-      .eq("id", id)
-      .single();
-    if (!deal || deal.assigned_to !== user.id) {
-      return NextResponse.json({ error: "Not allowed" }, { status: 403 });
-    }
+    return NextResponse.json({ error: "Only admins can delete deals" }, { status: 403 });
   }
 
   // Detach orders so the FK doesn't block deletion

--- a/src/app/api/sales/deals/[id]/services/[serviceId]/route.ts
+++ b/src/app/api/sales/deals/[id]/services/[serviceId]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
-import { getSalesUser } from "@/lib/salesAuth";
+import { getSalesUser, isElevatedRole } from "@/lib/salesAuth";
 
 export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string; serviceId: string }> }) {
   const user = await getSalesUser(req);
@@ -38,6 +38,9 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
 export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string; serviceId: string }> }) {
   const user = await getSalesUser(req);
   if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  if (!isElevatedRole(user.role)) {
+    return NextResponse.json({ error: "Only admins can delete deal services" }, { status: 403 });
+  }
   const { id: dealId, serviceId } = await params;
 
   const { error } = await supabaseAdmin

--- a/src/app/api/sales/documents/route.ts
+++ b/src/app/api/sales/documents/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
-import { getSalesUser } from "@/lib/salesAuth";
+import { getSalesUser, isElevatedRole } from "@/lib/salesAuth";
 
 /** POST /api/sales/documents — register a document after uploading to storage */
 export async function POST(req: NextRequest) {
@@ -33,6 +33,9 @@ export async function POST(req: NextRequest) {
 export async function DELETE(req: NextRequest) {
   const user = await getSalesUser(req);
   if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  if (!isElevatedRole(user.role)) {
+    return NextResponse.json({ error: "Only admins can delete documents" }, { status: 403 });
+  }
 
   const id = new URL(req.url).searchParams.get("id");
   if (!id) return NextResponse.json({ error: "id required" }, { status: 400 });

--- a/src/app/api/sales/leads/[id]/route.ts
+++ b/src/app/api/sales/leads/[id]/route.ts
@@ -227,14 +227,7 @@ export async function DELETE(req: NextRequest, { params }: { params: Promise<{ i
   const { id } = await params;
 
   if (!isElevatedRole(user.role)) {
-    const { data: lead } = await supabaseAdmin
-      .from("sales_leads")
-      .select("assigned_to, created_by")
-      .eq("id", id)
-      .single();
-    if (!lead || (lead.assigned_to !== user.id && lead.created_by !== user.id)) {
-      return NextResponse.json({ error: "Not allowed" }, { status: 403 });
-    }
+    return NextResponse.json({ error: "Only admins can delete leads" }, { status: 403 });
   }
 
   // Detach related records so FK constraints don't block deletion.

--- a/src/app/api/sales/orders/[id]/route.ts
+++ b/src/app/api/sales/orders/[id]/route.ts
@@ -46,14 +46,7 @@ export async function DELETE(req: NextRequest, { params }: { params: Promise<{ i
   const { id } = await params;
 
   if (!isElevatedRole(user.role)) {
-    const { data: order } = await supabaseAdmin
-      .from("sales_orders")
-      .select("created_by")
-      .eq("id", id)
-      .single();
-    if (!order || order.created_by !== user.id) {
-      return NextResponse.json({ error: "Not allowed" }, { status: 403 });
-    }
+    return NextResponse.json({ error: "Only admins can delete orders" }, { status: 403 });
   }
 
   // order_items cascade via FK; documents linked to order are removed


### PR DESCRIPTION
Previously sales reps could delete their own accounts, leads, deals, orders, deal services (any), and documents (any). All CRM DELETE handlers now require isElevatedRole (admin, director_of_sales, or market_leader) before proceeding.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2