### PR TITLE
Fix call list "All" assignment to use single shared list

### DIFF
--- a/src/app/api/sales/call-lists/[id]/route.ts
+++ b/src/app/api/sales/call-lists/[id]/route.ts
@@ -11,54 +11,10 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
   const { id } = await params;
   const body = await req.json();
 
-  if (body.assigned_to === "all") {
-    const { data: original } = await supabaseAdmin
-      .from("sales_call_lists")
-      .select("*")
-      .eq("id", id)
-      .single();
-
-    if (!original) {
-      return NextResponse.json({ error: "Call list not found" }, { status: 404 });
-    }
-
-    const { data: eligibleUsers } = await supabaseAdmin
-      .from("profiles")
-      .select("id")
-      .in("role", ["admin", "director_of_sales", "market_leader", "sales"]);
-
-    const users = eligibleUsers || [];
-
-    const existingAssignee = original.assigned_to;
-    const otherUsers = users.filter((u) => u.id !== existingAssignee);
-
-    if (existingAssignee) {
-      await supabaseAdmin
-        .from("sales_call_lists")
-        .update({ assigned_to: existingAssignee })
-        .eq("id", id);
-    }
-
-    if (otherUsers.length > 0) {
-      const rows = otherUsers.map((u) => ({
-        title: original.title,
-        description: original.description,
-        category: original.category,
-        sheet_url: original.sheet_url,
-        file_url: original.file_url,
-        file_name: original.file_name,
-        assigned_to: u.id,
-        created_by: user.id,
-      }));
-      await supabaseAdmin.from("sales_call_lists").insert(rows);
-    }
-
-    return NextResponse.json({ ok: true, assigned_count: users.length });
-  }
-
   const allowed = ["title", "description", "category", "sheet_url", "file_url", "file_name", "assigned_to"];
   const updates: Record<string, unknown> = {};
   for (const k of allowed) if (k in body) updates[k] = body[k];
+  if (updates.assigned_to === "all") updates.assigned_to = null;
 
   const { data, error } = await supabaseAdmin
     .from("sales_call_lists")

--- a/src/app/api/sales/call-lists/route.ts
+++ b/src/app/api/sales/call-lists/route.ts
@@ -62,36 +62,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "sheet_url or file_url required" }, { status: 400 });
   }
 
-  if (assigned_to === "all") {
-    const { data: eligibleUsers } = await supabaseAdmin
-      .from("profiles")
-      .select("id")
-      .in("role", ["admin", "director_of_sales", "market_leader", "sales"]);
-
-    const users = eligibleUsers || [];
-    if (users.length === 0) {
-      return NextResponse.json({ error: "No eligible users found" }, { status: 400 });
-    }
-
-    const rows = users.map((u) => ({
-      title,
-      description: description || null,
-      category,
-      sheet_url: sheet_url || null,
-      file_url: file_url || null,
-      file_name: file_name || null,
-      assigned_to: u.id,
-      created_by: user.id,
-    }));
-
-    const { data, error } = await supabaseAdmin
-      .from("sales_call_lists")
-      .insert(rows)
-      .select("*");
-
-    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-    return NextResponse.json(data, { status: 201 });
-  }
+  const resolvedAssignee = assigned_to === "all" ? null : (assigned_to || null);
 
   const { data, error } = await supabaseAdmin
     .from("sales_call_lists")
@@ -102,7 +73,7 @@ export async function POST(req: NextRequest) {
       sheet_url: sheet_url || null,
       file_url: file_url || null,
       file_name: file_name || null,
-      assigned_to: assigned_to || null,
+      assigned_to: resolvedAssignee,
       created_by: user.id,
     })
     .select("*")

--- a/src/app/sales/call-lists/page.tsx
+++ b/src/app/sales/call-lists/page.tsx
@@ -48,7 +48,7 @@ export default function CallListsPage() {
     title: "",
     description: "",
     sheet_url: "",
-    assigned_to: "",
+    assigned_to: "all",
     file: null as File | null,
   });
 
@@ -134,7 +134,7 @@ export default function CallListsPage() {
         alert(err.error || "Failed to save");
         return;
       }
-      setForm({ title: "", description: "", sheet_url: "", assigned_to: "", file: null });
+      setForm({ title: "", description: "", sheet_url: "", assigned_to: "all", file: null });
       setShowAdd(false);
       fetchLists();
     } finally {
@@ -229,7 +229,6 @@ export default function CallListsPage() {
               onChange={(e) => setForm((f) => ({ ...f, assigned_to: e.target.value }))}
               className="rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none"
             >
-              <option value="">Unassigned</option>
               <option value="all">All (DOS, Market Leaders &amp; Sales)</option>
               {salesOnly.map((u) => (
                 <option key={u.id} value={u.id}>
@@ -341,11 +340,10 @@ export default function CallListsPage() {
                   <td className="px-4 py-3 text-xs text-gray-600">
                     {isAdmin ? (
                       <select
-                        value={list.assigned_to || ""}
+                        value={list.assigned_to || "all"}
                         onChange={(e) => handleAssign(list.id, e.target.value)}
                         className="rounded border border-gray-200 px-2 py-1 text-xs cursor-pointer"
                       >
-                        <option value="">Unassigned</option>
                         <option value="all">All (DOS, Market Leaders &amp; Sales)</option>
                         {salesOnly.map((u) => (
                           <option key={u.id} value={u.id}>
@@ -354,7 +352,7 @@ export default function CallListsPage() {
                         ))}
                       </select>
                     ) : (
-                      list.assigned_profile?.full_name || "Unassigned"
+                      list.assigned_profile?.full_name || "All"
                     )}
                   </td>
                   <td className="px-4 py-3 text-xs text-gray-400">


### PR DESCRIPTION
Instead of duplicating the call list for each user, "All" now sets assigned_to to null which makes the single list visible to everyone (the GET filter already shows null-assigned lists to all sales users).

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2