### PR TITLE
Fix timezone bug in time entries date filters

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -3597,12 +3597,8 @@ function TimeTrackingManager({ token }: { token: string }) {
     try {
       const params = new URLSearchParams();
       if (filterUser) params.set("user_id", filterUser);
-      if (filterFrom) params.set("from", new Date(filterFrom).toISOString());
-      if (filterTo) {
-        const to = new Date(filterTo);
-        to.setHours(23, 59, 59, 999);
-        params.set("to", to.toISOString());
-      }
+      if (filterFrom) params.set("from", `${filterFrom}T00:00:00.000Z`);
+      if (filterTo) params.set("to", `${filterTo}T23:59:59.999Z`);
       const res = await fetch(`/api/time-entries?${params}`, {
         headers: { Authorization: `Bearer ${token}` },
       });

--- a/src/app/sales/time-clock/page.tsx
+++ b/src/app/sales/time-clock/page.tsx
@@ -68,17 +68,17 @@ export default function TimeClockPage() {
     if (!token || !userId) return;
     setLoading(true);
     try {
-      const today = new Date();
-      today.setHours(0, 0, 0, 0);
-
-      const weekStart = new Date(today);
+      const now = new Date();
+      const todayStr = now.toISOString().split("T")[0];
+      const weekStart = new Date(now);
       weekStart.setDate(weekStart.getDate() - weekStart.getDay());
+      const weekStartStr = weekStart.toISOString().split("T")[0];
 
       const headers = { Authorization: `Bearer ${token}` };
 
       const [todayRes, weekRes, activeRes] = await Promise.all([
-        fetch(`/api/time-entries?from=${today.toISOString()}&user_id=${userId}`, { headers }),
-        fetch(`/api/time-entries?from=${weekStart.toISOString()}&user_id=${userId}`, { headers }),
+        fetch(`/api/time-entries?from=${todayStr}T00:00:00.000Z&user_id=${userId}`, { headers }),
+        fetch(`/api/time-entries?from=${weekStartStr}T00:00:00.000Z&user_id=${userId}`, { headers }),
         fetch(`/api/time-entries?user_id=${userId}&status=active`, { headers }),
       ]);
 


### PR DESCRIPTION
The date filters used new Date(dateString).setHours() which mixes UTC-parsed dates with local-time setHours, cutting off most of the day in US timezones. Now constructs ISO strings directly with explicit UTC boundaries (T00:00:00.000Z to T23:59:59.999Z).

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2