### PR TITLE
Fix home page not rendering pre sign-in

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -254,14 +254,20 @@ export default function HomePage() {
   const ctaRef = useScrollReveal<HTMLDivElement>();
 
   useEffect(() => {
-    const supabase = createBrowserClient();
-    supabase.auth.getSession().then(({ data: { session } }) => {
-      if (session) {
-        router.replace("/dashboard");
-      } else {
+    try {
+      const supabase = createBrowserClient();
+      supabase.auth.getSession().then(({ data: { session } }) => {
+        if (session) {
+          router.replace("/dashboard");
+        } else {
+          setAuthChecked(true);
+        }
+      }).catch(() => {
         setAuthChecked(true);
-      }
-    });
+      });
+    } catch {
+      setAuthChecked(true);
+    }
   }, [router]);
 
   useEffect(() => {


### PR DESCRIPTION
getSession() had no error handling — if it threw or rejected, authChecked stayed false and the page rendered a blank div forever. Now catches both sync and async errors to always show the page.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2