### PR TITLE
Fix blank home page: render content immediately instead of gating on …

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -238,7 +238,6 @@ function CTACard({
 export default function HomePage() {
   const router = useRouter();
   const [stats, setStats] = useState<PlatformStats | null>(null);
-  const [authChecked, setAuthChecked] = useState(false);
 
   // Scroll reveal refs
   const howItWorksRef = useScrollReveal<HTMLDivElement>();
@@ -257,17 +256,9 @@ export default function HomePage() {
     try {
       const supabase = createBrowserClient();
       supabase.auth.getSession().then(({ data: { session } }) => {
-        if (session) {
-          router.replace("/dashboard");
-        } else {
-          setAuthChecked(true);
-        }
-      }).catch(() => {
-        setAuthChecked(true);
-      });
-    } catch {
-      setAuthChecked(true);
-    }
+        if (session) router.replace("/dashboard");
+      }).catch(() => {});
+    } catch {}
   }, [router]);
 
   useEffect(() => {
@@ -283,10 +274,6 @@ export default function HomePage() {
     { label: "Successful Placements", value: "98+", icon: TrendingUp },
     { label: "States Covered", value: "48", icon: Globe },
   ];
-
-  if (!authChecked) {
-    return <div className="min-h-screen" />;
-  }
 
   return (
     <div className="overflow-hidden grain">


### PR DESCRIPTION
…auth

The page was rendering a blank div during SSR and waiting for client-side getSession() before showing any content. If JS hydration failed for any reason, the page stayed blank. Now the full page renders immediately — logged-in users still get redirected to dashboard in the background.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2