### PR TITLE
Auto-create CRM sales_documents when agreements/e-signs are completed

### DIFF
--- a/src/app/api/location-agreements/[token]/sign/route.ts
+++ b/src/app/api/location-agreements/[token]/sign/route.ts
@@ -80,6 +80,25 @@ export async function POST(
     }
   }
 
+  // Create a sales_documents record so the signed agreement shows in the CRM account
+  if (agreement.lead_id) {
+    const { data: lead } = await supabaseAdmin
+      .from("sales_leads")
+      .select("account_id")
+      .eq("id", agreement.lead_id)
+      .single();
+
+    if (lead?.account_id) {
+      const appUrl = process.env.NEXT_PUBLIC_APP_URL || "https://vendingconnector.com";
+      await supabaseAdmin.from("sales_documents").insert({
+        account_id: lead.account_id,
+        file_url: `${appUrl}/location-agreement/${token}`,
+        file_name: `Location Agreement — ${business_name?.trim() || "Signed"}`,
+        type: "location_agreement",
+      });
+    }
+  }
+
   // Auto-publish the marketplace listing once the owner signs
   if (agreement.listing_id) {
     await supabaseAdmin

--- a/src/app/api/webhooks/esign/route.ts
+++ b/src/app/api/webhooks/esign/route.ts
@@ -132,6 +132,34 @@ export async function POST(req: NextRequest) {
         // PDF download failure shouldn't block status update
       }
 
+      // Create a sales_documents record so signed e-sign docs appear in the CRM account
+      try {
+        const { data: pipelineItem } = await supabaseAdmin
+          .from("pipeline_items")
+          .select("account_id")
+          .eq("id", esignDoc.pipeline_item_id)
+          .single();
+
+        if (pipelineItem?.account_id) {
+          let fileUrl = `esign://${esignDoc.id}`;
+          if (updates.signed_pdf_url) {
+            const { data: urlData } = supabaseAdmin.storage
+              .from("sales-documents")
+              .getPublicUrl(updates.signed_pdf_url as string);
+            if (urlData?.publicUrl) fileUrl = urlData.publicUrl;
+          }
+
+          await supabaseAdmin.from("sales_documents").insert({
+            account_id: pipelineItem.account_id,
+            file_url: fileUrl,
+            file_name: `${esignDoc.document_name} (signed).pdf`,
+            type: "esign",
+          });
+        }
+      } catch {
+        // Don't block webhook processing
+      }
+
       // Phase 2: If this is a preliminary proposal with PandaDoc+Stripe payment,
       // handle location reveal and full document generation
       const metadata = esignDoc.metadata as Record<string, unknown> | null;

--- a/supabase/migrations/073_sales_documents_type_expansion.sql
+++ b/supabase/migrations/073_sales_documents_type_expansion.sql
@@ -1,0 +1,4 @@
+-- Expand sales_documents type CHECK to include location_agreement and esign types
+ALTER TABLE public.sales_documents DROP CONSTRAINT IF EXISTS sales_documents_type_check;
+ALTER TABLE public.sales_documents ADD CONSTRAINT sales_documents_type_check
+  CHECK (type IN ('order_pdf', 'contract', 'receipt', 'location_agreement', 'esign'));


### PR DESCRIPTION
Location agreements and PandaDoc e-signature documents were not creating sales_documents records, making them invisible in the CRM account documents view. Now both flows create a record on completion.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2