### PR TITLE
Make mobile nav drawer full-screen for better usability

### DIFF
--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -373,15 +373,15 @@ export default function Navbar() {
 
       {/* Mobile Slide-out Drawer */}
       <div
-        className={`fixed right-0 top-0 z-50 flex h-full w-[90vw] max-w-80 flex-col bg-green-primary shadow-2xl transition-transform duration-300 ease-in-out lg:hidden ${
+        className={`fixed inset-0 z-50 flex flex-col bg-green-primary shadow-2xl transition-transform duration-300 ease-in-out lg:hidden ${
           mobileOpen ? "translate-x-0" : "translate-x-full"
         }`}
       >
         {/* Drawer Header */}
-        <div className="flex items-center justify-between border-b border-white/20 px-4 py-4">
+        <div className="flex items-center justify-between border-b border-white/20 px-5 py-5">
           <div className="flex items-center gap-2">
-            <Zap className="h-5 w-5 text-white" />
-            <span className="text-base font-bold text-white">Vending Connector</span>
+            <Zap className="h-6 w-6 text-white" />
+            <span className="text-lg font-bold text-white">Vending Connector</span>
           </div>
           <button
             type="button"
@@ -394,7 +394,7 @@ export default function Navbar() {
         </div>
 
         {/* Drawer Navigation Links */}
-        <div className="flex-1 overflow-y-auto px-3 py-4">
+        <div className="flex-1 overflow-y-auto px-5 py-6">
           {/* User info if logged in */}
           {isLoggedIn && (
             <div className="mb-4 flex items-center gap-3 rounded-xl bg-white/15 px-3 py-3">
@@ -412,13 +412,13 @@ export default function Navbar() {
             </div>
           )}
 
-          <ul className="space-y-2">
+          <ul className="space-y-3">
             {(isLoggedIn ? authNavLinks : navLinks).map((link) => (
               <li key={link.href}>
                 <Link
                   href={link.href}
                   onClick={() => setMobileOpen(false)}
-                  className="flex items-center justify-between rounded-lg px-4 py-3.5 text-base font-medium text-white transition-colors hover:bg-white/15"
+                  className="flex items-center justify-between rounded-lg px-4 py-4 text-lg font-medium text-white transition-colors hover:bg-white/15"
                   aria-label={TOOLTIP_COPY[link.label] ?? undefined}
                 >
                   {link.label}
@@ -432,7 +432,7 @@ export default function Navbar() {
                 <Link
                   href={link.href}
                   onClick={() => setMobileOpen(false)}
-                  className="flex items-center justify-between rounded-lg px-4 py-3.5 text-base font-medium text-white transition-colors hover:bg-white/15"
+                  className="flex items-center justify-between rounded-lg px-4 py-4 text-lg font-medium text-white transition-colors hover:bg-white/15"
                 >
                   {link.label}
                   <ChevronRight className="h-5 w-5 text-white/40" />
@@ -446,7 +446,7 @@ export default function Navbar() {
                   <Link
                     href="/dashboard"
                     onClick={() => setMobileOpen(false)}
-                    className="flex items-center justify-between rounded-lg px-4 py-3.5 text-base font-medium text-white transition-colors hover:bg-white/15"
+                    className="flex items-center justify-between rounded-lg px-4 py-4 text-lg font-medium text-white transition-colors hover:bg-white/15"
                     aria-label={TOOLTIP_COPY["Dashboard"]}
                   >
                     <span className="flex items-center gap-2">
@@ -460,7 +460,7 @@ export default function Navbar() {
                   <Link
                     href="/your-leads"
                     onClick={() => setMobileOpen(false)}
-                    className="flex items-center justify-between rounded-lg px-4 py-3.5 text-base font-medium text-white transition-colors hover:bg-white/15"
+                    className="flex items-center justify-between rounded-lg px-4 py-4 text-lg font-medium text-white transition-colors hover:bg-white/15"
                     aria-label={TOOLTIP_COPY["Your Leads"]}
                   >
                     <span className="flex items-center gap-2">
@@ -474,7 +474,7 @@ export default function Navbar() {
                   <Link
                     href="/saved-requests"
                     onClick={() => setMobileOpen(false)}
-                    className="flex items-center justify-between rounded-lg px-4 py-3.5 text-base font-medium text-white transition-colors hover:bg-white/15"
+                    className="flex items-center justify-between rounded-lg px-4 py-4 text-lg font-medium text-white transition-colors hover:bg-white/15"
                     aria-label="View your saved requests"
                   >
                     <span className="flex items-center gap-2">
@@ -488,7 +488,7 @@ export default function Navbar() {
                   <Link
                     href="/routes-for-sale"
                     onClick={() => setMobileOpen(false)}
-                    className="flex items-center justify-between rounded-lg px-4 py-3.5 text-base font-medium text-white transition-colors hover:bg-white/15"
+                    className="flex items-center justify-between rounded-lg px-4 py-4 text-lg font-medium text-white transition-colors hover:bg-white/15"
                     aria-label={TOOLTIP_COPY["Routes for Sale"]}
                   >
                     <span className="flex items-center gap-2">
@@ -502,7 +502,7 @@ export default function Navbar() {
                   <Link
                     href="/account/agreements"
                     onClick={() => setMobileOpen(false)}
-                    className="flex items-center justify-between rounded-lg px-4 py-3.5 text-base font-medium text-white transition-colors hover:bg-white/15"
+                    className="flex items-center justify-between rounded-lg px-4 py-4 text-lg font-medium text-white transition-colors hover:bg-white/15"
                     aria-label="View and download your signed agreements"
                   >
                     <span className="flex items-center gap-2">
@@ -517,7 +517,7 @@ export default function Navbar() {
                     <Link
                       href="/sales"
                       onClick={() => setMobileOpen(false)}
-                      className="flex items-center justify-between rounded-lg px-4 py-3.5 text-base font-medium text-white transition-colors hover:bg-white/15"
+                      className="flex items-center justify-between rounded-lg px-4 py-4 text-lg font-medium text-white transition-colors hover:bg-white/15"
                     >
                       <span className="flex items-center gap-2">
                         <Briefcase className="h-5 w-5" />
@@ -532,7 +532,7 @@ export default function Navbar() {
                     <Link
                       href="/admin"
                       onClick={() => setMobileOpen(false)}
-                      className="flex items-center justify-between rounded-lg px-4 py-3.5 text-base font-medium text-white transition-colors hover:bg-white/15"
+                      className="flex items-center justify-between rounded-lg px-4 py-4 text-lg font-medium text-white transition-colors hover:bg-white/15"
                     >
                       <span className="flex items-center gap-2">
                         <Shield className="h-5 w-5" />
@@ -548,7 +548,7 @@ export default function Navbar() {
         </div>
 
         {/* Drawer Auth Buttons */}
-        <div className="border-t border-white/20 px-4 py-4 space-y-3">
+        <div className="border-t border-white/20 px-5 py-5 space-y-3">
           {isLoggedIn ? (
             <button
               type="button"
@@ -556,7 +556,7 @@ export default function Navbar() {
                 setMobileOpen(false);
                 handleLogout();
               }}
-              className="flex w-full items-center justify-center gap-2 rounded-lg border border-white/30 bg-white/10 px-4 py-3.5 text-base font-medium text-white transition-colors hover:bg-white/20 cursor-pointer"
+              className="flex w-full items-center justify-center gap-2 rounded-xl border border-white/30 bg-white/10 px-4 py-4 text-lg font-medium text-white transition-colors hover:bg-white/20 cursor-pointer"
             >
               <LogOut className="h-4 w-4" />
               Sign Out
@@ -566,7 +566,7 @@ export default function Navbar() {
               <Link
                 href="/login"
                 onClick={() => setMobileOpen(false)}
-                className="block w-full rounded-lg border border-white/30 bg-white/10 px-4 py-3.5 text-center text-base font-medium text-white transition-colors hover:bg-white/20"
+                className="block w-full rounded-xl border border-white/30 bg-white/10 px-4 py-4 text-center text-lg font-medium text-white transition-colors hover:bg-white/20"
                 aria-label={TOOLTIP_COPY["Login"]}
               >
                 Login
@@ -574,7 +574,7 @@ export default function Navbar() {
               <Link
                 href="/signup"
                 onClick={() => setMobileOpen(false)}
-                className="block w-full rounded-lg bg-white px-4 py-3.5 text-center text-base font-semibold text-green-primary shadow-sm transition-colors hover:bg-white/90"
+                className="block w-full rounded-xl bg-white px-4 py-4 text-center text-lg font-semibold text-green-primary shadow-sm transition-colors hover:bg-white/90"
                 aria-label={TOOLTIP_COPY["Get Started"]}
               >
                 Get Started


### PR DESCRIPTION
The drawer now covers the entire viewport (fixed inset-0) instead of a narrow side panel, with larger text (text-lg), increased padding, and more spacing between items so every link is easy to see and tap on mobile.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2