### PR TITLE
Fix signup callback to create profile before patching

### DIFF
--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -44,6 +44,15 @@ function CallbackContent() {
         return;
       }
 
+      // Ensure the profile exists (auto-creates for new users via GET)
+      try {
+        await fetch("/api/auth/me", {
+          headers: { Authorization: `Bearer ${data.session.access_token}` },
+        });
+      } catch {
+        // Best-effort — profile will be created on next page load
+      }
+
       if (isSignup) {
         const signupRole = consumeSignupRole();
         const leadData = consumeSignupLead();
@@ -68,7 +77,7 @@ function CallbackContent() {
               body: JSON.stringify(profileUpdate),
             });
           } catch {
-            // Profile might not exist yet — ignore
+            // Profile update is best-effort
           }
         }
         if (leadData) {


### PR DESCRIPTION
The auth callback was trying to PATCH the profile with signup data (role, business info) before the profile existed for new users. The PATCH silently failed, losing the user's chosen role and business details. Now calls GET /api/auth/me first to ensure the profile is auto-created, then PATCHes it.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2