### PR TITLE
Fix Microsoft OAuth redirect loop preventing account creation

### DIFF
--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -32,15 +32,20 @@ function CallbackContent() {
       const code = searchParams.get("code");
       if (!code) {
         setError("Missing authorization code. Please try again.");
-        setTimeout(() => { window.location.href = "/login"; }, 2000);
+        setTimeout(() => {
+          window.location.href = "/login?error=" + encodeURIComponent("Missing authorization code. Please try signing in again.");
+        }, 2000);
         return;
       }
 
       const { data, error: exchangeErr } = await supabase.auth.exchangeCodeForSession(code);
       if (cancelled) return;
       if (exchangeErr || !data.session) {
-        setError(exchangeErr?.message || "Failed to complete sign-in.");
-        setTimeout(() => { window.location.href = "/login"; }, 2000);
+        const msg = exchangeErr?.message || "Failed to complete sign-in.";
+        setError(msg);
+        setTimeout(() => {
+          window.location.href = "/login?error=" + encodeURIComponent("Sign-in failed: " + msg + ". Please try again.");
+        }, 2000);
         return;
       }
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -14,6 +14,14 @@ function LoginContent() {
   const [checking, setChecking] = useState(true);
 
   useEffect(() => {
+    // If redirected here after an auth failure, show the error and don't auto-redirect
+    const authError = searchParams.get("error");
+    if (authError) {
+      setError(authError);
+      setChecking(false);
+      return;
+    }
+
     const supabase = createBrowserClient();
     supabase.auth.getSession().then(({ data: { session } }) => {
       if (session?.user) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -253,6 +253,16 @@ export default function HomePage() {
   const ctaRef = useScrollReveal<HTMLDivElement>();
 
   useEffect(() => {
+    // If Supabase redirected here with an OAuth code (misconfigured redirect URL),
+    // forward to the auth callback so the code can be exchanged for a session.
+    if (typeof window !== "undefined") {
+      const params = new URLSearchParams(window.location.search);
+      if (params.get("code")) {
+        window.location.href = `/auth/callback${window.location.search}`;
+        return;
+      }
+    }
+
     try {
       const supabase = createBrowserClient();
       supabase.auth.getSession().then(({ data: { session } }) => {


### PR DESCRIPTION
Three fixes:
1. Homepage now catches stray ?code= params (from Supabase redirect URL misconfiguration) and forwards them to /auth/callback so the OAuth code gets properly exchanged for a session.
2. Login page no longer auto-redirects when it receives an ?error= param, breaking the loop between failed callback → login → auto-redirect.
3. Auth callback passes descriptive error messages to the login page instead of a bare redirect.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2