### PR TITLE
Fix PKCE code verifier loss by using localStorage for OAuth flows

### DIFF
--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { Suspense } from "react";
 import { Loader2 } from "lucide-react";
-import { createBrowserClient } from "@/lib/supabase";
+import { createBrowserClient, createPlainBrowserClient } from "@/lib/supabase";
 import { consumeSignupRole, consumeRedirectAfterLogin, consumeAuthFlow, consumeSignupLead } from "@/lib/auth";
 
 function CallbackContent() {
@@ -15,61 +15,52 @@ function CallbackContent() {
     let cancelled = false;
 
     async function handleCallback() {
-      const supabase = createBrowserClient();
-
       // Determine the flow from URL param (primary) or localStorage fallback.
       const flowParam = searchParams.get("flow");
       const storedFlow = consumeAuthFlow();
       const flow = flowParam || storedFlow || "login";
       const isSignup = flow === "signup";
 
-      // Obtain the session. The client uses implicit flow (session arrives
-      // in the URL hash and is auto-detected by the Supabase client).
-      // We also handle the legacy PKCE flow (code in query string) as a
-      // fallback in case old links or cached redirects still use it.
-      let session: Awaited<ReturnType<typeof supabase.auth.getSession>>["data"]["session"] = null;
-
+      // Exchange the OAuth code for a session using the plain
+      // (localStorage-based) client. The PKCE code verifier was stored in
+      // localStorage by the OAuth initiation functions in auth.ts. The SSR
+      // client (cookie-based) loses the verifier during cross-domain
+      // redirects, so we must use the same storage layer that wrote it.
       const code = searchParams.get("code");
-      if (code) {
-        // PKCE fallback: try to exchange the code for a session
-        const { data, error: exchangeErr } = await supabase.auth.exchangeCodeForSession(code);
-        if (cancelled) return;
-        if (!exchangeErr && data.session) {
-          session = data.session;
-        }
-      }
-
-      if (!session) {
-        // Implicit flow: the Supabase client auto-detects the session
-        // from the URL hash. Give it a moment to process, then read it.
-        if (cancelled) return;
-        const { data: { session: detected } } = await supabase.auth.getSession();
-        session = detected;
-      }
-
-      if (!session) {
-        // Last resort: wait briefly for onAuthStateChange to fire
-        if (cancelled) return;
-        session = await new Promise((resolve) => {
-          const timeout = setTimeout(() => resolve(null), 3000);
-          const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, s) => {
-            if (s) {
-              clearTimeout(timeout);
-              subscription.unsubscribe();
-              resolve(s);
-            }
-          });
-        });
-      }
-
-      if (cancelled) return;
-
-      if (!session) {
-        setError("Failed to complete sign-in. Please try again.");
+      if (!code) {
+        setError("Missing authorization code. Please try again.");
         setTimeout(() => {
-          window.location.href = "/login?error=" + encodeURIComponent("Sign-in failed. Please try again.");
+          window.location.href = "/login?error=" + encodeURIComponent("Missing authorization code. Please try signing in again.");
         }, 2000);
         return;
+      }
+
+      const plainClient = createPlainBrowserClient();
+      const { data, error: exchangeErr } = await plainClient.auth.exchangeCodeForSession(code);
+      if (cancelled) return;
+
+      if (exchangeErr || !data.session) {
+        const msg = exchangeErr?.message || "Failed to complete sign-in.";
+        setError(msg);
+        setTimeout(() => {
+          window.location.href = "/login?error=" + encodeURIComponent("Sign-in failed: " + msg + ". Please try again.");
+        }, 2000);
+        return;
+      }
+
+      const session = data.session;
+
+      // Sync the session to the SSR (cookie-based) client so the rest of
+      // the app can read it via createBrowserClient / getAccessToken.
+      try {
+        const ssrClient = createBrowserClient();
+        await ssrClient.auth.setSession({
+          access_token: session.access_token,
+          refresh_token: session.refresh_token,
+        });
+      } catch {
+        // Best-effort — the plain client session in localStorage is the
+        // primary fallback; cookie sync failing is non-fatal.
       }
 
       // Ensure the profile exists (auto-creates for new users via GET)

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,5 +1,5 @@
 import type { Profile } from "./types";
-import { createBrowserClient } from "./supabase";
+import { createBrowserClient, createPlainBrowserClient } from "./supabase";
 
 const SIGNUP_ROLE_KEY = "vc_signup_role";
 const REDIRECT_KEY = "vc_redirect_after_login";
@@ -65,11 +65,16 @@ export function consumeAuthFlow(): "login" | "signup" | null {
   return flow;
 }
 
-/** Get the current Supabase session access token */
+/** Get the current Supabase session access token (checks both cookie and localStorage) */
 export async function getAccessToken(): Promise<string | null> {
-  const supabase = createBrowserClient();
-  const { data: { session } } = await supabase.auth.getSession();
-  return session?.access_token || null;
+  const ssrClient = createBrowserClient();
+  const { data: { session } } = await ssrClient.auth.getSession();
+  if (session?.access_token) return session.access_token;
+
+  // Fallback: check localStorage-based client (session may not have synced to cookies)
+  const plainClient = createPlainBrowserClient();
+  const { data: { session: plainSession } } = await plainClient.auth.getSession();
+  return plainSession?.access_token || null;
 }
 
 /** Get the base site URL (prefer env var, fall back to window.location.origin) */
@@ -85,19 +90,29 @@ function getSiteUrl(): string {
 
 /**
  * Fully clear any existing Supabase session and verify it's gone.
+ * Clears both cookie-based (SSR) and localStorage-based (plain) sessions.
  * Returns true if session is confirmed cleared.
  */
 export async function ensureSignedOut(): Promise<boolean> {
-  const supabase = createBrowserClient();
-  await supabase.auth.signOut();
-  // Verify the session is actually gone
-  const { data: { session } } = await supabase.auth.getSession();
+  const ssrClient = createBrowserClient();
+  const plainClient = createPlainBrowserClient();
+  await Promise.all([
+    ssrClient.auth.signOut(),
+    plainClient.auth.signOut(),
+  ]);
+  const { data: { session } } = await ssrClient.auth.getSession();
   return session === null;
 }
 
+/**
+ * Use the plain (localStorage-based) client for all OAuth flows.
+ * The SSR client stores the PKCE code verifier in cookies, which get lost
+ * during cross-domain OAuth redirects. localStorage persists reliably.
+ */
+
 /** Sign in with Google OAuth for LOGIN flow */
 export async function signInWithGoogle(): Promise<void> {
-  const supabase = createBrowserClient();
+  const supabase = createPlainBrowserClient();
   storeAuthFlow("login");
   await supabase.auth.signInWithOAuth({
     provider: "google",
@@ -113,7 +128,7 @@ export async function signInWithGoogle(): Promise<void> {
 
 /** Sign in with Google OAuth for SIGNUP flow (forces account selection) */
 export async function signUpWithGoogle(): Promise<void> {
-  const supabase = createBrowserClient();
+  const supabase = createPlainBrowserClient();
   storeAuthFlow("signup");
   await supabase.auth.signInWithOAuth({
     provider: "google",
@@ -129,7 +144,7 @@ export async function signUpWithGoogle(): Promise<void> {
 
 /** Sign in with Microsoft OAuth for LOGIN flow */
 export async function signInWithMicrosoft(): Promise<void> {
-  const supabase = createBrowserClient();
+  const supabase = createPlainBrowserClient();
   storeAuthFlow("login");
   await supabase.auth.signInWithOAuth({
     provider: "azure",
@@ -143,7 +158,7 @@ export async function signInWithMicrosoft(): Promise<void> {
 
 /** Sign in with Microsoft OAuth for SIGNUP flow */
 export async function signUpWithMicrosoft(): Promise<void> {
-  const supabase = createBrowserClient();
+  const supabase = createPlainBrowserClient();
   storeAuthFlow("signup");
   await supabase.auth.signInWithOAuth({
     provider: "azure",

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -4,19 +4,12 @@ import type { Database } from "./types";
 
 /**
  * Browser client that syncs session to cookies (for middleware auth checks).
- * Uses implicit flow to avoid PKCE code verifier cookie issues during OAuth.
  * Use this in client components.
  */
 export function createBrowserClient() {
   return createSSRBrowserClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      auth: {
-        flowType: "implicit",
-        detectSessionInUrl: true,
-      },
-    }
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
   );
 }
 


### PR DESCRIPTION
The @supabase/ssr cookie-based client loses the PKCE code verifier during cross-domain OAuth redirects (especially Microsoft/Azure), causing "PKCE code verifier not found in storage" errors.

Fix: use the plain localStorage-based Supabase client for all OAuth operations (signIn, signUp, exchangeCodeForSession) since localStorage persists reliably across redirects. After exchanging the code, the session is synced to the SSR cookie-based client via setSession() so the rest of the app can read it. getAccessToken() now checks both storage layers as a fallback.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2