### PR TITLE
Switch browser client from cookie-based SSR to localStorage

### DIFF
--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { Suspense } from "react";
 import { Loader2 } from "lucide-react";
-import { createBrowserClient, createPlainBrowserClient } from "@/lib/supabase";
+import { createBrowserClient } from "@/lib/supabase";
 import { consumeSignupRole, consumeRedirectAfterLogin, consumeAuthFlow, consumeSignupLead } from "@/lib/auth";
 
 function CallbackContent() {
@@ -21,11 +21,6 @@ function CallbackContent() {
       const flow = flowParam || storedFlow || "login";
       const isSignup = flow === "signup";
 
-      // Exchange the OAuth code for a session using the plain
-      // (localStorage-based) client. The PKCE code verifier was stored in
-      // localStorage by the OAuth initiation functions in auth.ts. The SSR
-      // client (cookie-based) loses the verifier during cross-domain
-      // redirects, so we must use the same storage layer that wrote it.
       const code = searchParams.get("code");
       if (!code) {
         setError("Missing authorization code. Please try again.");
@@ -35,8 +30,8 @@ function CallbackContent() {
         return;
       }
 
-      const plainClient = createPlainBrowserClient();
-      const { data, error: exchangeErr } = await plainClient.auth.exchangeCodeForSession(code);
+      const supabase = createBrowserClient();
+      const { data, error: exchangeErr } = await supabase.auth.exchangeCodeForSession(code);
       if (cancelled) return;
 
       if (exchangeErr || !data.session) {
@@ -49,19 +44,6 @@ function CallbackContent() {
       }
 
       const session = data.session;
-
-      // Sync the session to the SSR (cookie-based) client so the rest of
-      // the app can read it via createBrowserClient / getAccessToken.
-      try {
-        const ssrClient = createBrowserClient();
-        await ssrClient.auth.setSession({
-          access_token: session.access_token,
-          refresh_token: session.refresh_token,
-        });
-      } catch {
-        // Best-effort — the plain client session in localStorage is the
-        // primary fallback; cookie sync failing is non-fatal.
-      }
 
       // Ensure the profile exists (auto-creates for new users via GET)
       try {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,5 +1,5 @@
 import type { Profile } from "./types";
-import { createBrowserClient, createPlainBrowserClient } from "./supabase";
+import { createBrowserClient } from "./supabase";
 
 const SIGNUP_ROLE_KEY = "vc_signup_role";
 const REDIRECT_KEY = "vc_redirect_after_login";
@@ -65,16 +65,11 @@ export function consumeAuthFlow(): "login" | "signup" | null {
   return flow;
 }
 
-/** Get the current Supabase session access token (checks both cookie and localStorage) */
+/** Get the current Supabase session access token */
 export async function getAccessToken(): Promise<string | null> {
-  const ssrClient = createBrowserClient();
-  const { data: { session } } = await ssrClient.auth.getSession();
-  if (session?.access_token) return session.access_token;
-
-  // Fallback: check localStorage-based client (session may not have synced to cookies)
-  const plainClient = createPlainBrowserClient();
-  const { data: { session: plainSession } } = await plainClient.auth.getSession();
-  return plainSession?.access_token || null;
+  const supabase = createBrowserClient();
+  const { data: { session } } = await supabase.auth.getSession();
+  return session?.access_token || null;
 }
 
 /** Get the base site URL (prefer env var, fall back to window.location.origin) */
@@ -90,29 +85,18 @@ function getSiteUrl(): string {
 
 /**
  * Fully clear any existing Supabase session and verify it's gone.
- * Clears both cookie-based (SSR) and localStorage-based (plain) sessions.
  * Returns true if session is confirmed cleared.
  */
 export async function ensureSignedOut(): Promise<boolean> {
-  const ssrClient = createBrowserClient();
-  const plainClient = createPlainBrowserClient();
-  await Promise.all([
-    ssrClient.auth.signOut(),
-    plainClient.auth.signOut(),
-  ]);
-  const { data: { session } } = await ssrClient.auth.getSession();
+  const supabase = createBrowserClient();
+  await supabase.auth.signOut();
+  const { data: { session } } = await supabase.auth.getSession();
   return session === null;
 }
 
-/**
- * Use the plain (localStorage-based) client for all OAuth flows.
- * The SSR client stores the PKCE code verifier in cookies, which get lost
- * during cross-domain OAuth redirects. localStorage persists reliably.
- */
-
 /** Sign in with Google OAuth for LOGIN flow */
 export async function signInWithGoogle(): Promise<void> {
-  const supabase = createPlainBrowserClient();
+  const supabase = createBrowserClient();
   storeAuthFlow("login");
   await supabase.auth.signInWithOAuth({
     provider: "google",
@@ -128,7 +112,7 @@ export async function signInWithGoogle(): Promise<void> {
 
 /** Sign in with Google OAuth for SIGNUP flow (forces account selection) */
 export async function signUpWithGoogle(): Promise<void> {
-  const supabase = createPlainBrowserClient();
+  const supabase = createBrowserClient();
   storeAuthFlow("signup");
   await supabase.auth.signInWithOAuth({
     provider: "google",
@@ -144,7 +128,7 @@ export async function signUpWithGoogle(): Promise<void> {
 
 /** Sign in with Microsoft OAuth for LOGIN flow */
 export async function signInWithMicrosoft(): Promise<void> {
-  const supabase = createPlainBrowserClient();
+  const supabase = createBrowserClient();
   storeAuthFlow("login");
   await supabase.auth.signInWithOAuth({
     provider: "azure",
@@ -158,7 +142,7 @@ export async function signInWithMicrosoft(): Promise<void> {
 
 /** Sign in with Microsoft OAuth for SIGNUP flow */
 export async function signUpWithMicrosoft(): Promise<void> {
-  const supabase = createPlainBrowserClient();
+  const supabase = createBrowserClient();
   storeAuthFlow("signup");
   await supabase.auth.signInWithOAuth({
     provider: "azure",

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,25 +1,20 @@
-import { createBrowserClient as createSSRBrowserClient } from "@supabase/ssr";
 import { createClient } from "@supabase/supabase-js";
 import type { Database } from "./types";
 
 /**
- * Browser client that syncs session to cookies (for middleware auth checks).
- * Use this in client components.
+ * Browser client using localStorage for session and PKCE storage.
+ * localStorage persists reliably across OAuth redirects, unlike the
+ * cookie-based SSR client which loses the PKCE code verifier during
+ * cross-domain redirects.
  */
 export function createBrowserClient() {
-  return createSSRBrowserClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-  );
-}
-
-/**
- * Plain browser client without cookie sync.
- * Only needed if you explicitly want localStorage-only behavior.
- */
-export function createPlainBrowserClient() {
   return createClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
   );
 }
+
+/**
+ * Alias kept for call-sites that reference it explicitly.
+ */
+export const createPlainBrowserClient = createBrowserClient;


### PR DESCRIPTION
The @supabase/ssr cookie-based browser client was losing the PKCE code verifier during OAuth redirects, breaking login entirely. Since this app has no Next.js middleware that reads session cookies, switched to the standard @supabase/supabase-js createClient which uses localStorage. localStorage reliably persists the PKCE verifier across cross-domain OAuth redirects. All auth flows now use a single consistent client.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2