### PR TITLE
Validate sessions server-side to fix stale localStorage hiding login …

### DIFF
--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -57,35 +57,40 @@ export default function Navbar() {
     const supabase = createBrowserClient();
 
     async function checkAuth() {
-      const { data: { session } } = await supabase.auth.getSession();
-      if (session?.access_token) {
-        // Set basic session info immediately so navbar shows logged-in state
-        const meta = session.user?.user_metadata || {};
-        setSessionUser({
-          email: session.user?.email || "",
-          name: meta.full_name || meta.name || meta.custom_claims?.global_name || session.user?.email?.split("@")[0] || "User",
-        });
+      const { data: { user }, error: userError } = await supabase.auth.getUser();
+      if (userError || !user) {
+        await supabase.auth.signOut().catch(() => {});
+        return;
+      }
 
-        try {
-          const [profileRes, adminRes] = await Promise.all([
-            fetch("/api/auth/me", {
-              headers: { Authorization: `Bearer ${session.access_token}` },
-            }),
-            fetch("/api/admin/check", {
-              headers: { Authorization: `Bearer ${session.access_token}` },
-            }),
-          ]);
-          if (profileRes.ok) {
-            const data = await profileRes.json();
-            setProfile(data);
-          }
-          if (adminRes.ok) {
-            const data = await adminRes.json();
-            setIsAdmin(!!data.isAdmin);
-          }
-        } catch {
-          // ignore — sessionUser still shows logged-in state
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session?.access_token) return;
+
+      const meta = user.user_metadata || {};
+      setSessionUser({
+        email: user.email || "",
+        name: meta.full_name || meta.name || meta.custom_claims?.global_name || user.email?.split("@")[0] || "User",
+      });
+
+      try {
+        const [profileRes, adminRes] = await Promise.all([
+          fetch("/api/auth/me", {
+            headers: { Authorization: `Bearer ${session.access_token}` },
+          }),
+          fetch("/api/admin/check", {
+            headers: { Authorization: `Bearer ${session.access_token}` },
+          }),
+        ]);
+        if (profileRes.ok) {
+          const data = await profileRes.json();
+          setProfile(data);
         }
+        if (adminRes.ok) {
+          const data = await adminRes.json();
+          setIsAdmin(!!data.isAdmin);
+        }
+      } catch {
+        // ignore — sessionUser still shows logged-in state
       }
     }
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -14,7 +14,6 @@ function LoginContent() {
   const [checking, setChecking] = useState(true);
 
   useEffect(() => {
-    // If redirected here after an auth failure, show the error and don't auto-redirect
     const authError = searchParams.get("error");
     if (authError) {
       setError(authError);
@@ -23,14 +22,26 @@ function LoginContent() {
     }
 
     const supabase = createBrowserClient();
-    supabase.auth.getSession().then(({ data: { session } }) => {
-      if (session?.user) {
-        const redirect = searchParams.get("redirect") || "/dashboard";
-        window.location.href = redirect;
-      } else {
+
+    async function checkSession() {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session?.user) {
         setChecking(false);
+        return;
       }
-    });
+
+      const { error: userError } = await supabase.auth.getUser();
+      if (userError) {
+        await supabase.auth.signOut();
+        setChecking(false);
+        return;
+      }
+
+      const redirect = searchParams.get("redirect") || "/dashboard";
+      window.location.href = redirect;
+    }
+
+    checkSession();
   }, [searchParams]);
 
   async function handleGoogleLogin() {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -265,8 +265,9 @@ export default function HomePage() {
 
     try {
       const supabase = createBrowserClient();
-      supabase.auth.getSession().then(({ data: { session } }) => {
-        if (session) router.replace("/dashboard");
+      supabase.auth.getUser().then(({ data: { user }, error }) => {
+        if (user && !error) router.replace("/dashboard");
+        else if (error) supabase.auth.signOut().catch(() => {});
       }).catch(() => {});
     } catch {}
   }, [router]);


### PR DESCRIPTION
…buttons

getSession() only reads localStorage and trusts stale/expired sessions. Users with broken sessions were being redirected away from the login page without ever seeing the OAuth buttons. Now getUser() validates with Supabase server first, and stale sessions are cleared automatically.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2