### PR TITLE
Fix auth: prevent double PKCE code exchange that broke all login

### DIFF
--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -21,6 +21,15 @@ function CallbackContent() {
       const flow = flowParam || storedFlow || "login";
       const isSignup = flow === "signup";
 
+      const urlError = searchParams.get("error_description") || searchParams.get("error");
+      if (urlError) {
+        setError(urlError);
+        setTimeout(() => {
+          window.location.href = "/login?error=" + encodeURIComponent(urlError);
+        }, 2000);
+        return;
+      }
+
       const code = searchParams.get("code");
       if (!code) {
         setError("Missing authorization code. Please try again.");
@@ -35,10 +44,13 @@ function CallbackContent() {
       if (cancelled) return;
 
       if (exchangeErr || !data.session) {
-        const msg = exchangeErr?.message || "Failed to complete sign-in.";
+        const raw = exchangeErr?.message || "Failed to complete sign-in.";
+        const msg = raw.includes("code verifier")
+          ? "Session expired. Please try signing in again."
+          : raw;
         setError(msg);
         setTimeout(() => {
-          window.location.href = "/login?error=" + encodeURIComponent("Sign-in failed: " + msg + ". Please try again.");
+          window.location.href = "/login?error=" + encodeURIComponent(msg);
         }, 2000);
         return;
       }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -98,7 +98,7 @@ export async function ensureSignedOut(): Promise<boolean> {
 export async function signInWithGoogle(): Promise<void> {
   const supabase = createBrowserClient();
   storeAuthFlow("login");
-  await supabase.auth.signInWithOAuth({
+  const { error } = await supabase.auth.signInWithOAuth({
     provider: "google",
     options: {
       redirectTo: `${getSiteUrl()}/auth/callback?flow=login`,
@@ -108,13 +108,14 @@ export async function signInWithGoogle(): Promise<void> {
       },
     },
   });
+  if (error) throw error;
 }
 
 /** Sign in with Google OAuth for SIGNUP flow (forces account selection) */
 export async function signUpWithGoogle(): Promise<void> {
   const supabase = createBrowserClient();
   storeAuthFlow("signup");
-  await supabase.auth.signInWithOAuth({
+  const { error } = await supabase.auth.signInWithOAuth({
     provider: "google",
     options: {
       redirectTo: `${getSiteUrl()}/auth/callback?flow=signup`,
@@ -124,13 +125,14 @@ export async function signUpWithGoogle(): Promise<void> {
       },
     },
   });
+  if (error) throw error;
 }
 
 /** Sign in with Microsoft OAuth for LOGIN flow */
 export async function signInWithMicrosoft(): Promise<void> {
   const supabase = createBrowserClient();
   storeAuthFlow("login");
-  await supabase.auth.signInWithOAuth({
+  const { error } = await supabase.auth.signInWithOAuth({
     provider: "azure",
     options: {
       redirectTo: `${getSiteUrl()}/auth/callback?flow=login`,
@@ -138,13 +140,14 @@ export async function signInWithMicrosoft(): Promise<void> {
       scopes: "email",
     },
   });
+  if (error) throw error;
 }
 
 /** Sign in with Microsoft OAuth for SIGNUP flow */
 export async function signUpWithMicrosoft(): Promise<void> {
   const supabase = createBrowserClient();
   storeAuthFlow("signup");
-  await supabase.auth.signInWithOAuth({
+  const { error } = await supabase.auth.signInWithOAuth({
     provider: "azure",
     options: {
       redirectTo: `${getSiteUrl()}/auth/callback?flow=signup`,
@@ -152,6 +155,7 @@ export async function signUpWithMicrosoft(): Promise<void> {
       scopes: "email",
     },
   });
+  if (error) throw error;
 }
 
 /** Sign out */

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -10,7 +10,13 @@ export function createBrowserClient() {
   if (!browserClient) {
     browserClient = createClient<Database>(
       process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      {
+        auth: {
+          detectSessionInUrl: false,
+          flowType: "pkce",
+        },
+      }
     );
   }
   return browserClient;


### PR DESCRIPTION
Root cause: Supabase client v2.103.3 auto-detects ?code= in the URL and exchanges it during client initialization (detectSessionInUrl=true by default). The callback page then tried to exchange the same code again, which failed because it was already consumed server-side. This made every login attempt appear to fail even though the session was actually established.

Fix:
- Set detectSessionInUrl:false so only the callback page exchanges codes
- Set flowType:'pkce' explicitly for clarity
- OAuth functions now throw on error instead of silently failing
- Callback handles Supabase error redirects (?error= params)
- User-friendly message for PKCE code verifier errors

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2