### PR TITLE
Stop using getUser()/signOut() which destroy PKCE code verifier

### DIFF
--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -57,19 +57,13 @@ export default function Navbar() {
     const supabase = createBrowserClient();
 
     async function checkAuth() {
-      const { data: { user }, error: userError } = await supabase.auth.getUser();
-      if (userError || !user) {
-        await supabase.auth.signOut().catch(() => {});
-        return;
-      }
-
       const { data: { session } } = await supabase.auth.getSession();
       if (!session?.access_token) return;
 
-      const meta = user.user_metadata || {};
+      const meta = session.user?.user_metadata || {};
       setSessionUser({
-        email: user.email || "",
-        name: meta.full_name || meta.name || meta.custom_claims?.global_name || user.email?.split("@")[0] || "User",
+        email: session.user?.email || "",
+        name: meta.full_name || meta.name || meta.custom_claims?.global_name || session.user?.email?.split("@")[0] || "User",
       });
 
       try {
@@ -84,6 +78,8 @@ export default function Navbar() {
         if (profileRes.ok) {
           const data = await profileRes.json();
           setProfile(data);
+        } else if (profileRes.status === 401) {
+          setSessionUser(null);
         }
         if (adminRes.ok) {
           const data = await adminRes.json();

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -16,8 +16,6 @@ function LoginContent() {
   useEffect(() => {
     const authError = searchParams.get("error");
     if (authError) {
-      const supabase = createBrowserClient();
-      supabase.auth.signOut().catch(() => {});
       setError(authError);
       setChecking(false);
       return;
@@ -29,14 +27,15 @@ function LoginContent() {
     async function checkSession() {
       try {
         const { data: { session } } = await supabase.auth.getSession();
-        if (!session?.user) {
+        if (!session?.access_token) {
           setChecking(false);
           return;
         }
 
-        const { error: userError } = await supabase.auth.getUser();
-        if (userError) {
-          await supabase.auth.signOut();
+        const res = await fetch("/api/auth/me", {
+          headers: { Authorization: `Bearer ${session.access_token}` },
+        });
+        if (!res.ok) {
           setChecking(false);
           return;
         }
@@ -44,7 +43,6 @@ function LoginContent() {
         const redirect = searchParams.get("redirect") || "/dashboard";
         window.location.href = redirect;
       } catch {
-        await supabase.auth.signOut().catch(() => {});
         setChecking(false);
       }
     }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -265,9 +265,14 @@ export default function HomePage() {
 
     try {
       const supabase = createBrowserClient();
-      supabase.auth.getUser().then(({ data: { user }, error }) => {
-        if (user && !error) router.replace("/dashboard");
-        else if (error) supabase.auth.signOut().catch(() => {});
+      supabase.auth.getSession().then(({ data: { session } }) => {
+        if (session?.access_token) {
+          fetch("/api/auth/me", {
+            headers: { Authorization: `Bearer ${session.access_token}` },
+          }).then((res) => {
+            if (res.ok) router.replace("/dashboard");
+          }).catch(() => {});
+        }
       }).catch(() => {});
     } catch {}
   }, [router]);


### PR DESCRIPTION
getUser() and signOut() in @supabase/auth-js both delete the PKCE code_verifier from localStorage. The Navbar was calling getUser() on every page load, and when it failed (no valid session), it cleared the verifier that signInWithOAuth() had just stored — causing every OAuth login to fail with "code verifier not found."

Now the Navbar, login page, and homepage use getSession() (localStorage only) combined with /api/auth/me API calls to validate sessions. These never touch the code verifier, so PKCE flows complete successfully.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2