### PR TITLE
Fix dashboard auth bounce by separating initial load from event handling

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -243,42 +243,81 @@ export default function DashboardPage() {
 
   useEffect(() => {
     const supabase = createBrowserClient();
+    let mounted = true;
 
-    const {
-      data: { subscription },
-    } = supabase.auth.onAuthStateChange(async (event, session) => {
-      if (
-        event === "INITIAL_SESSION" ||
-        event === "SIGNED_IN" ||
-        event === "TOKEN_REFRESHED"
-      ) {
-        if (!session) {
+    async function initAuth() {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!mounted) return;
+
+      if (!session?.access_token) {
+        setNotLoggedIn(true);
+        setAuthLoading(false);
+        return;
+      }
+
+      try {
+        const res = await fetch("/api/auth/me", {
+          headers: { Authorization: `Bearer ${session.access_token}` },
+        });
+        if (!mounted) return;
+        if (!res.ok) {
           setNotLoggedIn(true);
           setAuthLoading(false);
           return;
         }
+        const data = await res.json();
+        setProfile(data);
+        setToken(session.access_token);
+      } catch {
+        if (mounted) setNotLoggedIn(true);
+      } finally {
+        if (mounted) setAuthLoading(false);
+      }
+    }
 
+    initAuth();
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange(async (event, session) => {
+      if (!mounted) return;
+
+      if (event === "TOKEN_REFRESHED" && session?.access_token) {
+        setToken(session.access_token);
+        return;
+      }
+
+      if (event === "SIGNED_IN" && session?.access_token) {
         try {
           const res = await fetch("/api/auth/me", {
             headers: { Authorization: `Bearer ${session.access_token}` },
           });
-          if (!res.ok) {
-            setNotLoggedIn(true);
+          if (!mounted) return;
+          if (res.ok) {
+            const data = await res.json();
+            setProfile(data);
+            setToken(session.access_token);
+            setNotLoggedIn(false);
             setAuthLoading(false);
-            return;
           }
-          const data = await res.json();
-          setProfile(data);
-          setToken(session.access_token);
         } catch {
-          setNotLoggedIn(true);
-        } finally {
-          setAuthLoading(false);
+          // keep existing state
         }
+        return;
+      }
+
+      if (event === "SIGNED_OUT") {
+        setProfile(null);
+        setToken("");
+        setNotLoggedIn(true);
+        setAuthLoading(false);
       }
     });
 
-    return () => subscription.unsubscribe();
+    return () => {
+      mounted = false;
+      subscription.unsubscribe();
+    };
   }, []);
 
   /* ============================================================== */


### PR DESCRIPTION
The dashboard's onAuthStateChange handled INITIAL_SESSION, SIGNED_IN, and TOKEN_REFRESHED identically — each re-fetching the profile. When the initial token was expired, INITIAL_SESSION set notLoggedIn=true, then TOKEN_REFRESHED immediately corrected it, causing a visible flicker between logged-out and logged-in states.

Now uses getSession() for the initial auth check (synchronous from localStorage) and only listens for TOKEN_REFRESHED (to update the token silently), SIGNED_IN (to load profile on fresh login), and SIGNED_OUT (to clear state).

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2