### PR TITLE
Use details_submitted to detect Stripe onboarding completion

### DIFF
--- a/src/app/api/connect/status/route.ts
+++ b/src/app/api/connect/status/route.ts
@@ -35,7 +35,10 @@ export async function GET(req: NextRequest) {
   const stripe = new Stripe(process.env.STRIPE_CONNECT_SECRET_KEY!);
 
   const account = await stripe.accounts.retrieve(profile.stripe_account_id);
-  const onboardingComplete = account.charges_enabled && account.payouts_enabled;
+  // details_submitted is true once the user finishes the onboarding form.
+  // charges_enabled/payouts_enabled may lag behind while Stripe verifies.
+  const onboardingComplete =
+    account.details_submitted || (account.charges_enabled && account.payouts_enabled);
 
   if (onboardingComplete && !profile.stripe_onboarding_complete) {
     await supabaseAdmin
@@ -47,7 +50,8 @@ export async function GET(req: NextRequest) {
   return NextResponse.json({
     connected: true,
     onboarding_complete: onboardingComplete,
-    charges_enabled: account.charges_enabled,
-    payouts_enabled: account.payouts_enabled,
+    charges_enabled: account.charges_enabled ?? false,
+    payouts_enabled: account.payouts_enabled ?? false,
+    details_submitted: account.details_submitted ?? false,
   });
 }

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -273,7 +273,7 @@ export async function POST(req: NextRequest) {
   // Handle Stripe Connect account updates — mark onboarding complete
   if (event.type === "account.updated") {
     const account = event.data.object as Stripe.Account;
-    if (account.charges_enabled && account.payouts_enabled) {
+    if (account.details_submitted || (account.charges_enabled && account.payouts_enabled)) {
       await supabaseAdmin
         .from("profiles")
         .update({ stripe_onboarding_complete: true })


### PR DESCRIPTION
charges_enabled and payouts_enabled can remain false while Stripe verifies the account, even after the user finishes the onboarding form. details_submitted is true immediately when the user completes onboarding, which is the correct signal to unblock the UI.

Updated both the /api/connect/status endpoint and the account.updated webhook handler to accept details_submitted as sufficient.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2