### PR TITLE
Fix admin detection in marketplace API to use email-based auth

### DIFF
--- a/src/app/api/user-listings/[id]/route.ts
+++ b/src/app/api/user-listings/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { getUserIdFromRequest } from "@/lib/apiAuth";
+import { getAdminUserId } from "@/lib/adminAuth";
 
 export async function GET(
   req: NextRequest,
@@ -56,13 +57,7 @@ export async function PATCH(
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const { data: profile } = await supabaseAdmin
-    .from("profiles")
-    .select("role")
-    .eq("id", userId)
-    .single();
-
-  const isAdmin = profile?.role === "admin";
+  const isAdmin = !!(await getAdminUserId(req));
 
   const { data: listing } = await supabaseAdmin
     .from("user_listings")
@@ -118,13 +113,7 @@ export async function DELETE(
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const { data: profile } = await supabaseAdmin
-    .from("profiles")
-    .select("role")
-    .eq("id", userId)
-    .single();
-
-  const isAdmin = profile?.role === "admin";
+  const isAdmin = !!(await getAdminUserId(req));
 
   let query = supabaseAdmin
     .from("user_listings")

--- a/src/app/api/user-listings/route.ts
+++ b/src/app/api/user-listings/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { getUserIdFromRequest } from "@/lib/apiAuth";
+import { getAdminUserId } from "@/lib/adminAuth";
 import { sendLocationAgreementEmail } from "@/lib/locationAgreementEmail";
 
 const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "https://vendingconnector.com";
@@ -32,17 +33,9 @@ export async function GET(req: NextRequest) {
     .order("created_at", { ascending: false })
     .range((page - 1) * perPage, page * perPage - 1);
 
-  // Check if requester is admin
-  const requesterId = await getUserIdFromRequest(req);
-  let isAdmin = false;
-  if (requesterId) {
-    const { data: reqProfile } = await supabaseAdmin
-      .from("profiles")
-      .select("role")
-      .eq("id", requesterId)
-      .single();
-    isAdmin = reqProfile?.role === "admin";
-  }
+  // Check if requester is admin (email-based)
+  const adminId = await getAdminUserId(req);
+  const isAdmin = !!adminId;
 
   if (resolvedSellerId && sellerIdParam === "me") {
     query = query.eq("seller_id", resolvedSellerId).neq("status", "removed");


### PR DESCRIPTION
The admin check was using profile.role === "admin" but this app uses an email-based ADMIN_EMAILS list via getAdminUserId(). This caused the admin panel to not see pending listings and blocked approve/reject.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2