### PR TITLE
Wire goals, results, and commissions together in CRM

### DIFF
--- a/src/app/api/sales/goals/route.ts
+++ b/src/app/api/sales/goals/route.ts
@@ -33,7 +33,7 @@ export async function POST(req: NextRequest) {
   }
 
   const body = await req.json();
-  const { user_id, period, target_revenue, target_deals, target_leads } = body;
+  const { user_id, period, target_revenue, target_deals, target_leads, target_commission } = body;
   if (!user_id || !period) {
     return NextResponse.json({ error: "user_id and period required" }, { status: 400 });
   }
@@ -47,6 +47,7 @@ export async function POST(req: NextRequest) {
         target_revenue: Number(target_revenue) || 0,
         target_deals: Number(target_deals) || 0,
         target_leads: Number(target_leads) || 0,
+        target_commission: Number(target_commission) || 0,
         created_by: user.id,
         updated_at: new Date().toISOString(),
       },

--- a/src/app/api/sales/results/route.ts
+++ b/src/app/api/sales/results/route.ts
@@ -170,6 +170,21 @@ export async function GET(req: NextRequest) {
 
   const { data: orders } = await ordersQuery;
 
+  // --- Commissions ---
+  let commissionsQuery = supabaseAdmin
+    .from("sales_commissions")
+    .select("id, commission_amount, status, created_at")
+    .gte("created_at", since);
+  if (until) commissionsQuery = commissionsQuery.lte("created_at", until);
+
+  if (targetUserId) {
+    commissionsQuery = commissionsQuery.eq("user_id", targetUserId);
+  } else if (allowedUserIds) {
+    commissionsQuery = commissionsQuery.in("user_id", allowedUserIds);
+  }
+
+  const { data: commissions } = await commissionsQuery;
+
   // --- Goal ---
   const goalPeriod = period === "ytd" ? "yearly" : period === "custom" ? "yearly" : period;
   const goalUserId = filterUserId || user.id;
@@ -215,6 +230,19 @@ export async function GET(req: NextRequest) {
   const totalDeals = (allDeals || []).length;
   const closeRate = totalDeals > 0 ? wonCount / totalDeals : 0;
 
+  // Commission metrics
+  let commissionTotal = 0;
+  let commissionPending = 0;
+  let commissionApproved = 0;
+  let commissionPaid = 0;
+  for (const c of commissions || []) {
+    const amt = Number(c.commission_amount || 0);
+    commissionTotal += amt;
+    if (c.status === "pending") commissionPending += amt;
+    else if (c.status === "approved") commissionApproved += amt;
+    else if (c.status === "paid") commissionPaid += amt;
+  }
+
   return NextResponse.json({
     period,
     user_id: filterUserId || (elevated || user.role === "market_leader" ? "all" : user.id),
@@ -233,6 +261,10 @@ export async function GET(req: NextRequest) {
       orders_completed: completedOrders,
       order_revenue: orderRevenue,
       conversion_rate: closeRate,
+      commission_total: commissionTotal,
+      commission_pending: commissionPending,
+      commission_approved: commissionApproved,
+      commission_paid: commissionPaid,
     },
     goal: goal || null,
   });

--- a/src/app/sales/page.tsx
+++ b/src/app/sales/page.tsx
@@ -34,12 +34,17 @@ interface ResultsResponse {
     orders_completed: number;
     order_revenue: number;
     conversion_rate: number;
+    commission_total: number;
+    commission_pending: number;
+    commission_approved: number;
+    commission_paid: number;
   };
   goal: {
     period: string;
     target_revenue: number;
     target_deals: number;
     target_leads: number;
+    target_commission: number;
   } | null;
 }
 
@@ -333,6 +338,22 @@ export default function SalesDashboard() {
                     <p className="text-xs text-gray-500">Completed Orders</p>
                     <p className="text-xl font-bold text-gray-900">{results.metrics.orders_completed}</p>
                   </div>
+                  <div className="rounded-lg bg-green-50 p-4">
+                    <p className="text-xs text-gray-500">Commission Earned</p>
+                    <p className="text-xl font-bold text-green-600">{fmt(results.metrics.commission_total)}</p>
+                  </div>
+                  <div className="rounded-lg bg-amber-50 p-4">
+                    <p className="text-xs text-gray-500">Commission Pending</p>
+                    <p className="text-xl font-bold text-amber-600">{fmt(results.metrics.commission_pending)}</p>
+                  </div>
+                  <div className="rounded-lg bg-blue-50 p-4">
+                    <p className="text-xs text-gray-500">Commission Approved</p>
+                    <p className="text-xl font-bold text-blue-600">{fmt(results.metrics.commission_approved)}</p>
+                  </div>
+                  <div className="rounded-lg bg-green-50 p-4">
+                    <p className="text-xs text-gray-500">Commission Paid</p>
+                    <p className="text-xl font-bold text-green-700">{fmt(results.metrics.commission_paid)}</p>
+                  </div>
                 </div>
 
                 {/* Lead status breakdown */}
@@ -369,6 +390,22 @@ export default function SalesDashboard() {
                     </div>
                     <ProgressBar value={results.metrics.deals_won} target={results.goal.target_deals} label="Deals Won" />
                     <ProgressBar value={results.metrics.leads_total} target={results.goal.target_leads} label="Leads" />
+                    {results.goal.target_commission > 0 && (
+                      <div>
+                        <div className="flex justify-between text-xs text-gray-500 mb-1">
+                          <span className="flex items-center gap-1"><DollarSign className="h-3 w-3" /> Commission</span>
+                          <span>{fmt(results.metrics.commission_total)} / {fmt(results.goal.target_commission)}</span>
+                        </div>
+                        <div className="h-2 w-full rounded-full bg-gray-100">
+                          <div
+                            className="h-2 rounded-full bg-green-500"
+                            style={{
+                              width: `${Math.min(100, (results.metrics.commission_total / results.goal.target_commission) * 100)}%`,
+                            }}
+                          />
+                        </div>
+                      </div>
+                    )}
                   </div>
                 ) : (
                   <p className="text-sm text-gray-400">

--- a/src/app/sales/results/page.tsx
+++ b/src/app/sales/results/page.tsx
@@ -26,6 +26,10 @@ interface ResultsMetrics {
   orders_completed: number;
   order_revenue: number;
   conversion_rate: number;
+  commission_total: number;
+  commission_pending: number;
+  commission_approved: number;
+  commission_paid: number;
 }
 
 interface ResultsResponse {
@@ -38,6 +42,7 @@ interface ResultsResponse {
     target_revenue: number;
     target_deals: number;
     target_leads: number;
+    target_commission: number;
   } | null;
 }
 
@@ -102,7 +107,7 @@ export default function SalesResultsPage() {
   const [loading, setLoading] = useState(true);
 
   // Goal setting state
-  const [goalForm, setGoalForm] = useState({ target_revenue: "", target_deals: "", target_leads: "" });
+  const [goalForm, setGoalForm] = useState({ target_revenue: "", target_deals: "", target_leads: "", target_commission: "" });
   const [savingGoal, setSavingGoal] = useState(false);
 
   const isElevated = userRole === "admin" || userRole === "director_of_sales" || userRole === "market_leader";
@@ -159,9 +164,10 @@ export default function SalesResultsPage() {
           target_revenue: String(data.goal.target_revenue),
           target_deals: String(data.goal.target_deals),
           target_leads: String(data.goal.target_leads),
+          target_commission: String(data.goal.target_commission || 0),
         });
       } else {
-        setGoalForm({ target_revenue: "", target_deals: "", target_leads: "" });
+        setGoalForm({ target_revenue: "", target_deals: "", target_leads: "", target_commission: "" });
       }
     }
     setLoading(false);
@@ -182,6 +188,7 @@ export default function SalesResultsPage() {
         target_revenue: Number(goalForm.target_revenue) || 0,
         target_deals: Number(goalForm.target_deals) || 0,
         target_leads: Number(goalForm.target_leads) || 0,
+        target_commission: Number(goalForm.target_commission) || 0,
       }),
     });
     setSavingGoal(false);
@@ -328,6 +335,22 @@ export default function SalesResultsPage() {
               <p className="text-xs text-gray-500">Completed Orders</p>
               <p className="text-2xl font-bold text-gray-900">{results.metrics.orders_completed}</p>
             </div>
+            <div className="rounded-xl border border-green-200 bg-green-50/50 p-5">
+              <p className="text-xs text-gray-500">Commission Earned</p>
+              <p className="text-2xl font-bold text-green-600">{fmt(results.metrics.commission_total)}</p>
+            </div>
+            <div className="rounded-xl border border-amber-200 bg-amber-50/50 p-5">
+              <p className="text-xs text-gray-500">Commission Pending</p>
+              <p className="text-2xl font-bold text-amber-600">{fmt(results.metrics.commission_pending)}</p>
+            </div>
+            <div className="rounded-xl border border-blue-200 bg-blue-50/50 p-5">
+              <p className="text-xs text-gray-500">Commission Approved</p>
+              <p className="text-2xl font-bold text-blue-600">{fmt(results.metrics.commission_approved)}</p>
+            </div>
+            <div className="rounded-xl border border-green-200 bg-green-50/50 p-5">
+              <p className="text-xs text-gray-500">Commission Paid</p>
+              <p className="text-2xl font-bold text-green-700">{fmt(results.metrics.commission_paid)}</p>
+            </div>
           </div>
 
           {/* Lead status breakdown */}
@@ -378,6 +401,22 @@ export default function SalesResultsPage() {
                 </div>
                 <ProgressBar value={results.metrics.deals_won} target={results.goal.target_deals} label="Deals Won" />
                 <ProgressBar value={results.metrics.leads_total} target={results.goal.target_leads} label="Leads" />
+                {results.goal.target_commission > 0 && (
+                  <div>
+                    <div className="flex justify-between text-xs text-gray-500 mb-1">
+                      <span className="flex items-center gap-1"><DollarSign className="h-3 w-3" /> Commission</span>
+                      <span>{fmt(results.metrics.commission_total)} / {fmt(results.goal.target_commission)}</span>
+                    </div>
+                    <div className="h-2 w-full rounded-full bg-gray-100">
+                      <div
+                        className="h-2 rounded-full bg-green-500"
+                        style={{
+                          width: `${Math.min(100, (results.metrics.commission_total / results.goal.target_commission) * 100)}%`,
+                        }}
+                      />
+                    </div>
+                  </div>
+                )}
               </div>
             ) : (
               <p className="text-sm text-gray-400">
@@ -394,7 +433,7 @@ export default function SalesResultsPage() {
                 {" for "}
                 {salesUsers.find((u) => u.id === filterUserId)?.full_name || "Rep"}
               </h3>
-              <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
                 <div>
                   <label className="text-xs text-gray-500">Revenue Target ($)</label>
                   <input
@@ -419,6 +458,15 @@ export default function SalesResultsPage() {
                     type="number"
                     value={goalForm.target_leads}
                     onChange={(e) => setGoalForm((f) => ({ ...f, target_leads: e.target.value }))}
+                    className="mt-1 w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm focus:border-green-500 focus:outline-none"
+                  />
+                </div>
+                <div>
+                  <label className="text-xs text-gray-500">Commission Target ($)</label>
+                  <input
+                    type="number"
+                    value={goalForm.target_commission}
+                    onChange={(e) => setGoalForm((f) => ({ ...f, target_commission: e.target.value }))}
                     className="mt-1 w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm focus:border-green-500 focus:outline-none"
                   />
                 </div>

--- a/supabase/migrations/075_goals_target_commission.sql
+++ b/supabase/migrations/075_goals_target_commission.sql
@@ -1,0 +1,3 @@
+-- Add commission target to sales_goals so goals can track commission payout targets
+ALTER TABLE public.sales_goals
+  ADD COLUMN IF NOT EXISTS target_commission NUMERIC(12,2) DEFAULT 0;


### PR DESCRIPTION
- Results API now queries sales_commissions for the period and returns commission_total, commission_pending, commission_approved, commission_paid
- Goals support target_commission field (migration 075 adds column)
- Sales dashboard shows commission metrics alongside other results
- Goal progress shows commission progress bar when target is set
- Results page goal-setting form includes commission target field

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2