### PR TITLE
Allow all sales members to see and use Get Leads

### DIFF
--- a/src/app/api/sales/lead-generator/route.ts
+++ b/src/app/api/sales/lead-generator/route.ts
@@ -24,8 +24,8 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   const user = await getSalesUser(req);
-  if (!user || !isElevatedRole(user.role)) {
-    return NextResponse.json({ error: "Only admins/DOS/market leaders can generate leads" }, { status: 403 });
+  if (!user) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
   const body = await req.json();

--- a/src/app/sales/layout.tsx
+++ b/src/app/sales/layout.tsx
@@ -41,7 +41,7 @@ const NAV_ITEMS = [
   { href: "/sales/team", label: "Team", icon: UserCog, minLevel: 3 as const },
   { href: "/sales/commissions", label: "Commissions", icon: DollarSign, minLevel: 4 as const },
   { href: "/sales/call-lists", label: "Call Lists", icon: PhoneCall, minLevel: 4 as const },
-  { href: "/sales/lead-generator", label: "Get Leads", icon: Zap, minLevel: 3 as const },
+  { href: "/sales/lead-generator", label: "Get Leads", icon: Zap, minLevel: 4 as const },
   { href: "/sales/time-clock", label: "Time Clock", icon: Timer, minLevel: 4 as const },
   { href: "/sales/resources", label: "Resources", icon: FolderOpen, minLevel: 4 as const },
   { href: "/sales/candidates", label: "Candidates", icon: UserPlus, minLevel: 4 as const },


### PR DESCRIPTION
Changed nav minLevel from 3 to 4 (all sales roles) and removed elevated-role restriction on the API route.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2