### PR TITLE
Add Non-Circumvention Agreement signing flow and email template

### DIFF
--- a/src/app/api/non-circumvention/[token]/route.ts
+++ b/src/app/api/non-circumvention/[token]/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ token: string }> }
+) {
+  const { token } = await params;
+
+  const { data, error } = await supabaseAdmin
+    .from("non_circumvention_agreements")
+    .select("*")
+    .eq("token", token)
+    .single();
+
+  if (error || !data) {
+    return NextResponse.json({ error: "Agreement not found" }, { status: 404 });
+  }
+
+  if (data.status === "pending") {
+    await supabaseAdmin
+      .from("non_circumvention_agreements")
+      .update({ status: "viewed", updated_at: new Date().toISOString() })
+      .eq("id", data.id);
+    data.status = "viewed";
+  }
+
+  return NextResponse.json(data);
+}

--- a/src/app/api/non-circumvention/[token]/sign/route.ts
+++ b/src/app/api/non-circumvention/[token]/sign/route.ts
@@ -1,0 +1,123 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { sendSignedCopyToAdmin } from "@/lib/nonCircumvention";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ token: string }> }
+) {
+  const { token } = await params;
+  const body = await req.json();
+  const {
+    signature_name,
+    operator_name,
+    company_name,
+    email,
+    phone,
+    address,
+    confirm_confidential,
+    confirm_no_circumvent,
+    confirm_consequences,
+  } = body;
+
+  if (!signature_name || typeof signature_name !== "string" || signature_name.trim().length < 2) {
+    return NextResponse.json({ error: "Please type your full name to sign" }, { status: 400 });
+  }
+
+  if (!confirm_confidential || !confirm_no_circumvent || !confirm_consequences) {
+    return NextResponse.json({ error: "Please confirm all checkboxes before signing" }, { status: 400 });
+  }
+
+  const { data: agreement } = await supabaseAdmin
+    .from("non_circumvention_agreements")
+    .select("id, status, lead_id")
+    .eq("token", token)
+    .single();
+
+  if (!agreement) {
+    return NextResponse.json({ error: "Agreement not found" }, { status: 404 });
+  }
+
+  if (agreement.status === "signed") {
+    return NextResponse.json({ ok: true, status: "signed" });
+  }
+
+  const ip =
+    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+    req.headers.get("x-real-ip") ||
+    "unknown";
+
+  const signedAt = new Date().toISOString();
+
+  const { error } = await supabaseAdmin
+    .from("non_circumvention_agreements")
+    .update({
+      status: "signed",
+      operator_name: operator_name?.trim() || null,
+      company_name: company_name?.trim() || null,
+      email: email?.trim() || null,
+      phone: phone?.trim() || null,
+      address: address?.trim() || null,
+      signature_name: signature_name.trim(),
+      signature_ip: ip,
+      signed_at: signedAt,
+      confirm_confidential,
+      confirm_no_circumvent,
+      confirm_consequences,
+      updated_at: signedAt,
+    })
+    .eq("id", agreement.id);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  if (agreement.lead_id) {
+    const leadUpdates: Record<string, unknown> = {};
+    if (operator_name?.trim()) leadUpdates.contact_name = operator_name.trim();
+    if (company_name?.trim()) leadUpdates.business_name = company_name.trim();
+    if (email?.trim()) leadUpdates.email = email.trim();
+    if (phone?.trim()) leadUpdates.phone = phone.trim();
+    if (address?.trim()) leadUpdates.address = address.trim();
+    if (Object.keys(leadUpdates).length > 0) {
+      await supabaseAdmin.from("sales_leads").update(leadUpdates).eq("id", agreement.lead_id);
+    }
+
+    const { data: lead } = await supabaseAdmin
+      .from("sales_leads")
+      .select("account_id")
+      .eq("id", agreement.lead_id)
+      .single();
+
+    if (lead?.account_id) {
+      const appUrl = process.env.NEXT_PUBLIC_APP_URL || "https://vendingconnector.com";
+      try {
+        await supabaseAdmin.from("sales_documents").insert({
+          account_id: lead.account_id,
+          file_url: `${appUrl}/non-circumvention/${token}`,
+          file_name: `Non-Circumvention Agreement — ${company_name?.trim() || operator_name?.trim() || "Signed"}`,
+          type: "non_circumvention",
+        });
+      } catch {
+        // Non-critical — document link is optional
+      }
+    }
+  }
+
+  try {
+    await sendSignedCopyToAdmin({
+      operator_name: operator_name?.trim() || null,
+      company_name: company_name?.trim() || null,
+      email: email?.trim() || null,
+      phone: phone?.trim() || null,
+      address: address?.trim() || null,
+      signature_name: signature_name.trim(),
+      signed_at: signedAt,
+      signature_ip: ip,
+    });
+  } catch (err) {
+    console.error("[non-circumvention] Failed to email signed copy to admin:", err);
+  }
+
+  return NextResponse.json({ ok: true, status: "signed" });
+}

--- a/src/app/api/sales/leads/[id]/emails/route.ts
+++ b/src/app/api/sales/leads/[id]/emails/route.ts
@@ -72,6 +72,24 @@ Best regards,
 {{sender_email}}
 Vending Connector`,
   },
+  non_circumvention: {
+    subject: "Non-Circumvention Agreement — Please Sign to Receive Location Details",
+    body: `Hi {{contact_name}},
+
+We completely understand your apprehension — and we want to make sure you feel comfortable before we share any confidential location details.
+
+Please sign our Site Walkthrough Non-Circumvention & Confidentiality Agreement so we can share the location details with you. Once it's signed, we'll send over everything you need right away.
+
+This agreement simply protects both parties and ensures a fair process for everyone involved.
+
+Please reply to this email or contact james@apexaivending.com if you have any questions.
+
+Best regards,
+{{sender_name}}
+{{sender_title}}
+{{sender_email}}
+Vending Connector`,
+  },
   custom: {
     subject: "",
     body: "",

--- a/src/app/api/sales/leads/[id]/non-circumvention/route.ts
+++ b/src/app/api/sales/leads/[id]/non-circumvention/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser } from "@/lib/salesAuth";
+import { createAndSendNonCircumvention } from "@/lib/nonCircumvention";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const user = await getSalesUser(req);
+  if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const { id: leadId } = await params;
+
+  const { data: lead } = await supabaseAdmin
+    .from("sales_leads")
+    .select("*")
+    .eq("id", leadId)
+    .single();
+
+  if (!lead) {
+    return NextResponse.json({ error: "Lead not found" }, { status: 404 });
+  }
+
+  if (!lead.email) {
+    return NextResponse.json({ error: "Lead has no email address" }, { status: 400 });
+  }
+
+  try {
+    await createAndSendNonCircumvention(leadId, {
+      business_name: lead.business_name,
+      contact_name: lead.contact_name,
+      email: lead.email,
+      phone: lead.phone,
+      address: lead.address,
+    });
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/non-circumvention/[token]/page.tsx
+++ b/src/app/non-circumvention/[token]/page.tsx
@@ -1,0 +1,425 @@
+"use client";
+
+import { useState, useEffect, Suspense } from "react";
+import { useParams } from "next/navigation";
+import { Loader2, CheckCircle2, FileText, PenTool, Building2, User, Mail, Phone, MapPin, ShieldCheck } from "lucide-react";
+
+interface NCAgreement {
+  id: string;
+  token: string;
+  operator_name: string | null;
+  company_name: string | null;
+  email: string | null;
+  phone: string | null;
+  address: string | null;
+  status: string;
+  signature_name: string | null;
+  signed_at: string | null;
+  confirm_confidential: boolean;
+  confirm_no_circumvent: boolean;
+  confirm_consequences: boolean;
+  created_at: string;
+}
+
+function NonCircumventionContent() {
+  const { token } = useParams<{ token: string }>();
+  const [agreement, setAgreement] = useState<NCAgreement | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [operatorName, setOperatorName] = useState("");
+  const [companyName, setCompanyName] = useState("");
+  const [email, setEmail] = useState("");
+  const [phoneVal, setPhoneVal] = useState("");
+  const [address, setAddress] = useState("");
+  const [signatureName, setSignatureName] = useState("");
+  const [confirmConfidential, setConfirmConfidential] = useState(false);
+  const [confirmNoCircumvent, setConfirmNoCircumvent] = useState(false);
+  const [confirmConsequences, setConfirmConsequences] = useState(false);
+
+  const [signing, setSigning] = useState(false);
+  const [signError, setSignError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      const res = await fetch(`/api/non-circumvention/${token}`);
+      if (res.ok) {
+        const data: NCAgreement = await res.json();
+        setAgreement(data);
+        setOperatorName(data.operator_name || "");
+        setCompanyName(data.company_name || "");
+        setEmail(data.email || "");
+        setPhoneVal(data.phone || "");
+        setAddress(data.address || "");
+      } else {
+        setError("Agreement not found or has expired.");
+      }
+      setLoading(false);
+    }
+    load();
+  }, [token]);
+
+  async function handleSign() {
+    if (!signatureName.trim() || signatureName.trim().length < 2) {
+      setSignError("Please type your full name to sign");
+      return;
+    }
+    if (!confirmConfidential || !confirmNoCircumvent || !confirmConsequences) {
+      setSignError("Please confirm all checkboxes before signing");
+      return;
+    }
+    setSigning(true);
+    setSignError(null);
+    const res = await fetch(`/api/non-circumvention/${token}/sign`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        signature_name: signatureName,
+        operator_name: operatorName,
+        company_name: companyName,
+        email,
+        phone: phoneVal,
+        address,
+        confirm_confidential: confirmConfidential,
+        confirm_no_circumvent: confirmNoCircumvent,
+        confirm_consequences: confirmConsequences,
+      }),
+    });
+    if (res.ok) {
+      setAgreement((a) =>
+        a
+          ? {
+              ...a,
+              status: "signed",
+              signature_name: signatureName,
+              signed_at: new Date().toISOString(),
+              confirm_confidential: confirmConfidential,
+              confirm_no_circumvent: confirmNoCircumvent,
+              confirm_consequences: confirmConsequences,
+            }
+          : a
+      );
+    } else {
+      const data = await res.json().catch(() => ({}));
+      setSignError(data.error || "Failed to sign agreement");
+    }
+    setSigning(false);
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <Loader2 className="h-8 w-8 animate-spin text-green-600" />
+      </div>
+    );
+  }
+
+  if (error || !agreement) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+        <div className="text-center">
+          <FileText className="mx-auto h-12 w-12 text-gray-300 mb-4" />
+          <h1 className="text-lg font-semibold text-gray-900 mb-2">Agreement Not Found</h1>
+          <p className="text-sm text-gray-500">{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  const isSigned = agreement.status === "signed";
+  const inputClass = "w-full rounded-lg border border-gray-300 px-4 py-2.5 text-sm text-gray-900 focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500 disabled:bg-gray-50 disabled:text-gray-500";
+  const effectiveDate = new Date(agreement.created_at).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-8 px-4">
+      <div className="mx-auto max-w-2xl">
+        {/* Header */}
+        <div className="mb-6 text-center">
+          <h1 className="text-2xl font-bold text-green-600 mb-1">Apex AI Vending / Vending Connector</h1>
+          <p className="text-sm text-gray-500">Site Walkthrough Non-Circumvention &amp; Confidentiality Agreement</p>
+        </div>
+
+        {/* Signed Banner */}
+        {isSigned && (
+          <div className="mb-6 rounded-xl bg-green-50 border border-green-200 p-4 text-center">
+            <CheckCircle2 className="mx-auto h-8 w-8 text-green-600 mb-2" />
+            <p className="font-semibold text-green-800">Agreement Signed</p>
+            <p className="text-sm text-green-600 mt-1">
+              Thank you! A signed copy has been sent to our team. We will share the location details with you shortly.
+            </p>
+            {agreement.signed_at && (
+              <p className="text-xs text-gray-400 mt-2">
+                Signed on {new Date(agreement.signed_at).toLocaleString()}
+              </p>
+            )}
+          </div>
+        )}
+
+        {/* Agreement Card */}
+        <div className="rounded-2xl border border-gray-200 bg-white shadow-sm overflow-hidden">
+          {/* Preamble */}
+          <div className="px-6 py-5 border-b border-gray-100 bg-gray-50/50">
+            <p className="text-sm text-gray-600 leading-relaxed">
+              This Agreement (&quot;Agreement&quot;) is entered into between{" "}
+              <strong>Vending Connector / Apex AI Vending</strong> (&quot;Company&quot;) and the Operator identified below.
+            </p>
+            <p className="text-sm text-gray-500 mt-2">Effective Date: {effectiveDate}</p>
+          </div>
+
+          {/* Section 1: Purpose */}
+          <div className="px-6 py-5 border-b border-gray-100">
+            <p className="text-xs font-medium text-gray-400 uppercase tracking-wider mb-3">1. Purpose</p>
+            <p className="text-sm text-gray-600 leading-relaxed">
+              The purpose of this Agreement is to allow the Operator to participate in a site walkthrough, review,
+              or evaluation of a prospective vending location prior to purchasing or formally securing the location
+              opportunity from the Company.
+            </p>
+          </div>
+
+          {/* Section 2: Confidential Information */}
+          <div className="px-6 py-5 border-b border-gray-100">
+            <p className="text-xs font-medium text-gray-400 uppercase tracking-wider mb-3">2. Confidential Information</p>
+            <p className="text-sm text-gray-600 leading-relaxed">
+              Operator acknowledges that all information provided by the Company related to prospective locations
+              is confidential and proprietary, including business names, addresses, decision maker information,
+              phone numbers, emails, traffic information, employee counts, operational details, photographs,
+              placement opportunities, pricing structures, and negotiation discussions.
+            </p>
+          </div>
+
+          {/* Section 3: Non-Circumvention */}
+          <div className="px-6 py-5 border-b border-gray-100">
+            <p className="text-xs font-medium text-gray-400 uppercase tracking-wider mb-3">3. Non-Circumvention</p>
+            <p className="text-sm text-gray-600 leading-relaxed">
+              Operator agrees they shall not directly or indirectly contact the location independently for placement
+              purposes, attempt to secure the location outside of the Company, circumvent the Company, share details
+              with third parties, or use the disclosed information to compete against the Company.
+            </p>
+          </div>
+
+          {/* Section 4: Term */}
+          <div className="px-6 py-5 border-b border-gray-100">
+            <p className="text-xs font-medium text-gray-400 uppercase tracking-wider mb-3">4. Term</p>
+            <p className="text-sm text-gray-600 leading-relaxed">
+              This non-circumvention obligation shall remain in effect for <strong>24 months</strong> from the
+              date of disclosure of the location information.
+            </p>
+          </div>
+
+          {/* Section 5: Liquidated Damages */}
+          <div className="px-6 py-5 border-b border-gray-100">
+            <p className="text-xs font-medium text-gray-400 uppercase tracking-wider mb-3">5. Liquidated Damages</p>
+            <p className="text-sm text-gray-600 leading-relaxed">
+              In the event of a breach, Operator agrees the Company shall be entitled to injunctive relief,
+              recovery of legal fees and costs, and liquidated damages equal to <strong>$5,000 OR 25%</strong> of
+              estimated placement value, whichever is greater.
+            </p>
+          </div>
+
+          {/* Section 6: No Ownership Transfer */}
+          <div className="px-6 py-5 border-b border-gray-100">
+            <p className="text-xs font-medium text-gray-400 uppercase tracking-wider mb-3">6. No Ownership Transfer</p>
+            <p className="text-sm text-gray-600 leading-relaxed">
+              Disclosure of location information does not grant ownership, exclusivity, or placement rights unless
+              a separate placement agreement and payment are completed.
+            </p>
+          </div>
+
+          {/* Section 7: Good Faith */}
+          <div className="px-6 py-5 border-b border-gray-100">
+            <p className="text-xs font-medium text-gray-400 uppercase tracking-wider mb-3">7. Good Faith</p>
+            <p className="text-sm text-gray-600 leading-relaxed">
+              Both parties agree to act in good faith throughout the evaluation and placement process.
+            </p>
+          </div>
+
+          {/* Section 8: Governing Law */}
+          <div className="px-6 py-5 border-b border-gray-100">
+            <p className="text-xs font-medium text-gray-400 uppercase tracking-wider mb-3">8. Governing Law</p>
+            <p className="text-sm text-gray-600 leading-relaxed">
+              This Agreement shall be governed by the laws of the State of South Carolina.
+            </p>
+          </div>
+
+          {/* Section 9: Acknowledgement */}
+          <div className="px-6 py-5 border-b border-gray-100">
+            <p className="text-xs font-medium text-gray-400 uppercase tracking-wider mb-3">
+              <ShieldCheck className="inline h-3.5 w-3.5 mr-1" />
+              9. Acknowledgement
+            </p>
+            <p className="text-sm text-gray-600 mb-3">By signing, Operator acknowledges that:</p>
+            <ul className="space-y-2 text-sm text-gray-600">
+              <li className="flex items-start gap-2">
+                <span className="text-green-500 mt-0.5">&#9632;</span>
+                They are reviewing confidential business opportunities
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="text-green-500 mt-0.5">&#9632;</span>
+                They understand the Company invested resources sourcing the location
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="text-green-500 mt-0.5">&#9632;</span>
+                They agree not to bypass or circumvent the Company
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="text-green-500 mt-0.5">&#9632;</span>
+                They understand violations may result in legal action
+              </li>
+            </ul>
+          </div>
+
+          {/* Section 10: Operator Details & Signature */}
+          <div className="px-6 py-5">
+            <p className="text-xs font-medium text-gray-400 uppercase tracking-wider mb-3">
+              <PenTool className="inline h-3.5 w-3.5 mr-1" />
+              10. Operator Details &amp; Signature
+            </p>
+
+            {isSigned ? (
+              <div className="rounded-lg bg-green-50 border border-green-200 p-4">
+                <div className="flex items-center gap-2 mb-1">
+                  <CheckCircle2 className="h-4 w-4 text-green-600" />
+                  <span className="text-sm font-medium text-green-800">Signed</span>
+                </div>
+                <p className="text-lg italic text-gray-700 font-serif">{agreement.signature_name}</p>
+                {agreement.signed_at && (
+                  <p className="text-xs text-gray-400 mt-1">
+                    {new Date(agreement.signed_at).toLocaleString()}
+                  </p>
+                )}
+              </div>
+            ) : (
+              <div>
+                <p className="text-sm text-gray-500 mb-4">
+                  Please verify or update your information below, then sign.
+                </p>
+
+                {/* Operator Fields */}
+                <div className="space-y-4 mb-6">
+                  <div>
+                    <label className="flex items-center gap-1.5 text-xs font-medium text-gray-500 mb-1">
+                      <User className="h-3.5 w-3.5" /> Operator Name <span className="text-red-500">*</span>
+                    </label>
+                    <input type="text" value={operatorName} onChange={(e) => setOperatorName(e.target.value)} className={inputClass} placeholder="Your full name" />
+                  </div>
+                  <div>
+                    <label className="flex items-center gap-1.5 text-xs font-medium text-gray-500 mb-1">
+                      <Building2 className="h-3.5 w-3.5" /> Company Name
+                    </label>
+                    <input type="text" value={companyName} onChange={(e) => setCompanyName(e.target.value)} className={inputClass} placeholder="Your company name" />
+                  </div>
+                  <div className="grid grid-cols-2 gap-4">
+                    <div>
+                      <label className="flex items-center gap-1.5 text-xs font-medium text-gray-500 mb-1">
+                        <Mail className="h-3.5 w-3.5" /> Email
+                      </label>
+                      <input type="email" value={email} onChange={(e) => setEmail(e.target.value)} className={inputClass} />
+                    </div>
+                    <div>
+                      <label className="flex items-center gap-1.5 text-xs font-medium text-gray-500 mb-1">
+                        <Phone className="h-3.5 w-3.5" /> Phone
+                      </label>
+                      <input type="tel" value={phoneVal} onChange={(e) => setPhoneVal(e.target.value)} className={inputClass} />
+                    </div>
+                  </div>
+                  <div>
+                    <label className="flex items-center gap-1.5 text-xs font-medium text-gray-500 mb-1">
+                      <MapPin className="h-3.5 w-3.5" /> Address
+                    </label>
+                    <input type="text" value={address} onChange={(e) => setAddress(e.target.value)} className={inputClass} placeholder="Business address" />
+                  </div>
+                </div>
+
+                {/* Confirmation Checkboxes */}
+                <div className="space-y-3 mb-5">
+                  <label className="flex items-start gap-3 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={confirmConfidential}
+                      onChange={(e) => setConfirmConfidential(e.target.checked)}
+                      className="mt-0.5 h-4 w-4 rounded border-gray-300 text-green-600 focus:ring-green-500"
+                    />
+                    <span className="text-sm text-gray-700">
+                      I acknowledge that all location information shared is confidential and proprietary.
+                    </span>
+                  </label>
+                  <label className="flex items-start gap-3 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={confirmNoCircumvent}
+                      onChange={(e) => setConfirmNoCircumvent(e.target.checked)}
+                      className="mt-0.5 h-4 w-4 rounded border-gray-300 text-green-600 focus:ring-green-500"
+                    />
+                    <span className="text-sm text-gray-700">
+                      I agree not to circumvent Vending Connector / Apex AI Vending or contact locations independently.
+                    </span>
+                  </label>
+                  <label className="flex items-start gap-3 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={confirmConsequences}
+                      onChange={(e) => setConfirmConsequences(e.target.checked)}
+                      className="mt-0.5 h-4 w-4 rounded border-gray-300 text-green-600 focus:ring-green-500"
+                    />
+                    <span className="text-sm text-gray-700">
+                      I understand that violations may result in legal action, including liquidated damages of $5,000
+                      or 25% of estimated placement value (whichever is greater).
+                    </span>
+                  </label>
+                </div>
+
+                {/* Signature Input */}
+                <input
+                  type="text"
+                  placeholder="Type your full name to sign"
+                  value={signatureName}
+                  onChange={(e) => setSignatureName(e.target.value)}
+                  className="w-full rounded-lg border border-gray-300 px-4 py-3 text-lg font-serif italic text-gray-700 placeholder:text-gray-300 placeholder:not-italic focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500"
+                />
+                {signError && <p className="mt-2 text-sm text-red-600">{signError}</p>}
+                <button
+                  onClick={handleSign}
+                  disabled={signing || !signatureName.trim() || !confirmConfidential || !confirmNoCircumvent || !confirmConsequences}
+                  className="mt-3 w-full rounded-lg bg-green-600 px-4 py-3 text-sm font-semibold text-white hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors cursor-pointer"
+                >
+                  {signing ? (
+                    <span className="flex items-center justify-center gap-2">
+                      <Loader2 className="h-4 w-4 animate-spin" /> Signing...
+                    </span>
+                  ) : (
+                    <span className="flex items-center justify-center gap-2">
+                      <PenTool className="h-4 w-4" /> Sign Agreement
+                    </span>
+                  )}
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="mt-8 text-center">
+          <p className="text-xs text-gray-400">Apex AI Vending — vendingconnector.com</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function NonCircumventionPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen flex items-center justify-center bg-gray-50">
+          <Loader2 className="h-8 w-8 animate-spin text-green-600" />
+        </div>
+      }
+    >
+      <NonCircumventionContent />
+    </Suspense>
+  );
+}

--- a/src/app/sales/leads/page.tsx
+++ b/src/app/sales/leads/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { createBrowserClient } from "@/lib/supabase";
-import { Plus, Loader2, Search, X, UserPlus, ArrowRight, Trash2, PhoneOff, Phone, Upload, FileSpreadsheet, AlertCircle, CheckCircle2, AlertTriangle, CheckSquare, Pencil, Building2, Mail, Send, Clock } from "lucide-react";
+import { Plus, Loader2, Search, X, UserPlus, ArrowRight, Trash2, PhoneOff, Phone, Upload, FileSpreadsheet, AlertCircle, CheckCircle2, AlertTriangle, CheckSquare, Pencil, Building2, Mail, Send, Clock, ShieldCheck } from "lucide-react";
 import { ENTITY_TYPES, IMMEDIATE_NEEDS, type SalesLead, type EntityType, type ImmediateNeed } from "@/lib/salesTypes";
 
 const LEAD_FIELDS: { key: LeadFieldKey; label: string; required?: boolean }[] = [
@@ -162,6 +162,7 @@ export default function LeadsPage() {
   const [emailSending, setEmailSending] = useState(false);
   const [emailHistory, setEmailHistory] = useState<{ id: string; subject: string; to_email: string; created_at: string; template_name: string }[]>([]);
   const [showEmailHistory, setShowEmailHistory] = useState(false);
+  const [ncaSending, setNcaSending] = useState<string | null>(null);
 
   useEffect(() => {
     const supabase = createBrowserClient();
@@ -571,6 +572,11 @@ export default function LeadsPage() {
       subject: "Oops — We're Missing Your Info!",
       body: "Hi {{contact_name}},\n\nWe recently connected but it looks like we didn't get all of your information — that's on us! We want to make sure we can serve you properly.\n\nCould you reply to this email or send the following details to james@apexaivending.com?\n\n- Full Name\n- Business Name\n- Address\n- Email\n- Phone Number\n- Business Operational Area (cities/regions you serve or operate in)\n\nOnce we have your info, we'll get you set up right away. We appreciate your time and look forward to working with you!\n\nBest regards,\n{{sender_name}}\n{{sender_title}}\n{{sender_email}}\nVending Connector",
     },
+    non_circumvention: {
+      label: "Non-Circumvention Agreement",
+      subject: "Non-Circumvention Agreement — Please Sign to Receive Location Details",
+      body: "Hi {{contact_name}},\n\nWe completely understand your apprehension — and we want to make sure you feel comfortable before we share any confidential location details.\n\nPlease sign our Site Walkthrough Non-Circumvention & Confidentiality Agreement so we can share the location details with you. Once it's signed, we'll send over everything you need right away.\n\nThis agreement simply protects both parties and ensures a fair process for everyone involved.\n\nPlease reply to this email or contact james@apexaivending.com if you have any questions.\n\nBest regards,\n{{sender_name}}\n{{sender_title}}\n{{sender_email}}\nVending Connector",
+    },
     custom: {
       label: "Custom Email",
       subject: "",
@@ -626,6 +632,27 @@ export default function LeadsPage() {
       alert(err.error || "Failed to send email");
     }
     setEmailSending(false);
+  }
+
+  async function handleSendNCA(lead: SalesLead) {
+    if (!lead.email) { alert("This lead has no email address."); return; }
+    setNcaSending(lead.id);
+    try {
+      const res = await fetch(`/api/sales/leads/${lead.id}/non-circumvention`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.ok) {
+        alert(`Non-Circumvention Agreement sent to ${lead.email}`);
+      } else {
+        const data = await res.json().catch(() => ({}));
+        alert(data.error || "Failed to send agreement");
+      }
+    } catch {
+      alert("Network error — please try again");
+    } finally {
+      setNcaSending(null);
+    }
   }
 
   const availableStates = Array.from(
@@ -1172,6 +1199,16 @@ export default function LeadsPage() {
                           className="rounded-lg p-1.5 text-gray-400 hover:bg-purple-50 hover:text-purple-600 cursor-pointer"
                         >
                           <Mail className="h-4 w-4" />
+                        </button>
+                      )}
+                      {lead.email && (
+                        <button
+                          onClick={() => handleSendNCA(lead)}
+                          disabled={ncaSending === lead.id}
+                          title="Send Non-Circumvention Agreement"
+                          className="rounded-lg p-1.5 text-gray-400 hover:bg-emerald-50 hover:text-emerald-600 cursor-pointer disabled:opacity-50"
+                        >
+                          {ncaSending === lead.id ? <Loader2 className="h-4 w-4 animate-spin" /> : <ShieldCheck className="h-4 w-4" />}
                         </button>
                       )}
                       {!lead.assigned_to && (

--- a/src/lib/nonCircumvention.ts
+++ b/src/lib/nonCircumvention.ts
@@ -1,0 +1,161 @@
+import { Resend } from "resend";
+import { supabaseAdmin } from "./supabaseAdmin";
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+const FROM = process.env.FROM_EMAIL || "sales@bytebitevending.com";
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "https://vendingconnector.com";
+const ADMIN_EMAIL = "james@apexaivending.com";
+
+export async function createAndSendNonCircumvention(
+  leadId: string,
+  lead: {
+    business_name?: string;
+    contact_name?: string;
+    email?: string;
+    phone?: string;
+    address?: string;
+  },
+  options?: { force?: boolean }
+) {
+  if (!lead.email) {
+    console.warn(`[non-circumvention] Skipped lead ${leadId}: no email`);
+    return;
+  }
+
+  const existing = await supabaseAdmin
+    .from("non_circumvention_agreements")
+    .select("id, token")
+    .eq("lead_id", leadId)
+    .maybeSingle();
+
+  if (existing.data && !options?.force) {
+    console.log(`[non-circumvention] Skipped lead ${leadId}: agreement exists`);
+    return;
+  }
+
+  const agreementUrl = existing.data
+    ? `${APP_URL}/non-circumvention/${existing.data.token}`
+    : null;
+
+  if (existing.data && options?.force && agreementUrl) {
+    await sendNonCircumventionEmail({
+      to: lead.email,
+      recipientName: lead.contact_name || "Operator",
+      agreementUrl,
+    });
+    return;
+  }
+
+  const { data: agreement } = await supabaseAdmin
+    .from("non_circumvention_agreements")
+    .insert({
+      lead_id: leadId,
+      operator_name: lead.contact_name || null,
+      company_name: lead.business_name || null,
+      email: lead.email,
+      phone: lead.phone || null,
+      address: lead.address || null,
+    })
+    .select("token")
+    .single();
+
+  if (!agreement) {
+    console.error(`[non-circumvention] Failed to create record for lead ${leadId}`);
+    return;
+  }
+
+  await sendNonCircumventionEmail({
+    to: lead.email,
+    recipientName: lead.contact_name || "Operator",
+    agreementUrl: `${APP_URL}/non-circumvention/${agreement.token}`,
+  });
+
+  console.log(`[non-circumvention] Sent to ${lead.email} for lead ${leadId}`);
+}
+
+async function sendNonCircumventionEmail(params: {
+  to: string;
+  recipientName: string;
+  agreementUrl: string;
+}) {
+  const { to, recipientName, agreementUrl } = params;
+
+  await resend.emails.send({
+    from: FROM,
+    to,
+    subject: "Non-Circumvention Agreement — Please Sign to Receive Location Details",
+    html: `
+      <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:560px;margin:0 auto;padding:24px;">
+        <div style="margin-bottom:24px;">
+          <span style="font-size:20px;font-weight:700;color:#16a34a;">Apex AI Vending</span>
+        </div>
+        <p style="color:#111827;font-size:15px;line-height:1.6;">
+          Hi ${recipientName},
+        </p>
+        <p style="color:#374151;font-size:14px;line-height:1.6;">
+          We completely understand your apprehension — and we want to make sure you feel comfortable before we share any confidential location details.
+        </p>
+        <p style="color:#374151;font-size:14px;line-height:1.6;">
+          Please sign our Site Walkthrough Non-Circumvention &amp; Confidentiality Agreement below. Once signed, we'll be able to share the full location information with you right away.
+        </p>
+        <p style="color:#374151;font-size:14px;line-height:1.6;">
+          This agreement simply protects both parties and ensures a fair process for everyone involved.
+        </p>
+        <div style="margin:24px 0;">
+          <a href="${agreementUrl}" style="display:inline-block;background:#16a34a;color:#fff;font-weight:600;font-size:14px;padding:12px 28px;border-radius:8px;text-decoration:none;">
+            Review &amp; Sign Agreement
+          </a>
+        </div>
+        <p style="color:#9ca3af;font-size:12px;">
+          You can also access the agreement at:<br>
+          <a href="${agreementUrl}" style="color:#16a34a;">${agreementUrl}</a>
+        </p>
+        <hr style="border:none;border-top:1px solid #e5e7eb;margin:24px 0;">
+        <p style="color:#9ca3af;font-size:11px;">Apex AI Vending — vendingconnector.com</p>
+      </div>
+    `,
+  });
+}
+
+export async function sendSignedCopyToAdmin(agreement: {
+  operator_name: string | null;
+  company_name: string | null;
+  email: string | null;
+  phone: string | null;
+  address: string | null;
+  signature_name: string;
+  signed_at: string;
+  signature_ip: string;
+}) {
+  const signed = new Date(agreement.signed_at).toLocaleString("en-US", {
+    timeZone: "America/New_York",
+  });
+
+  await resend.emails.send({
+    from: FROM,
+    to: ADMIN_EMAIL,
+    subject: `Non-Circumvention Agreement Signed — ${agreement.company_name || agreement.operator_name || "Unknown"}`,
+    html: `
+      <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:560px;margin:0 auto;padding:24px;">
+        <div style="margin-bottom:24px;">
+          <span style="font-size:20px;font-weight:700;color:#16a34a;">Apex AI Vending</span>
+        </div>
+        <p style="color:#111827;font-size:15px;font-weight:600;">
+          Non-Circumvention Agreement Signed
+        </p>
+        <table style="width:100%;border-collapse:collapse;margin:16px 0;">
+          <tr><td style="padding:8px 0;color:#6b7280;font-size:13px;width:140px;">Operator Name</td><td style="padding:8px 0;color:#111827;font-size:14px;">${agreement.operator_name || "—"}</td></tr>
+          <tr><td style="padding:8px 0;color:#6b7280;font-size:13px;">Company</td><td style="padding:8px 0;color:#111827;font-size:14px;">${agreement.company_name || "—"}</td></tr>
+          <tr><td style="padding:8px 0;color:#6b7280;font-size:13px;">Email</td><td style="padding:8px 0;color:#111827;font-size:14px;">${agreement.email || "—"}</td></tr>
+          <tr><td style="padding:8px 0;color:#6b7280;font-size:13px;">Phone</td><td style="padding:8px 0;color:#111827;font-size:14px;">${agreement.phone || "—"}</td></tr>
+          <tr><td style="padding:8px 0;color:#6b7280;font-size:13px;">Address</td><td style="padding:8px 0;color:#111827;font-size:14px;">${agreement.address || "—"}</td></tr>
+          <tr style="border-top:1px solid #e5e7eb;"><td style="padding:8px 0;color:#6b7280;font-size:13px;">Signature</td><td style="padding:8px 0;color:#111827;font-size:16px;font-style:italic;font-family:serif;">${agreement.signature_name}</td></tr>
+          <tr><td style="padding:8px 0;color:#6b7280;font-size:13px;">Signed At</td><td style="padding:8px 0;color:#111827;font-size:14px;">${signed}</td></tr>
+          <tr><td style="padding:8px 0;color:#6b7280;font-size:13px;">IP Address</td><td style="padding:8px 0;color:#111827;font-size:14px;">${agreement.signature_ip}</td></tr>
+        </table>
+        <hr style="border:none;border-top:1px solid #e5e7eb;margin:24px 0;">
+        <p style="color:#9ca3af;font-size:11px;">Apex AI Vending — vendingconnector.com</p>
+      </div>
+    `,
+  });
+}

--- a/supabase/migrations/077_non_circumvention_agreements.sql
+++ b/supabase/migrations/077_non_circumvention_agreements.sql
@@ -1,0 +1,38 @@
+-- Non-Circumvention Agreements
+-- Sent to operators before sharing confidential location details.
+-- Once signed, a copy is emailed to james@apexaivending.com.
+
+create table if not exists non_circumvention_agreements (
+  id uuid primary key default gen_random_uuid(),
+  token text unique not null default encode(gen_random_bytes(32), 'hex'),
+  lead_id uuid references sales_leads(id),
+  status text not null default 'pending' check (status in ('pending','viewed','signed')),
+
+  -- Operator info (pre-filled from lead, editable by signer)
+  operator_name text,
+  company_name text,
+  email text,
+  phone text,
+  address text,
+
+  -- Signature
+  signature_name text,
+  signature_ip text,
+  signed_at timestamptz,
+
+  -- Confirmations
+  confirm_confidential boolean default false,
+  confirm_no_circumvent boolean default false,
+  confirm_consequences boolean default false,
+
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+-- RLS
+alter table non_circumvention_agreements enable row level security;
+create policy "Service role full access" on non_circumvention_agreements for all using (true) with check (true);
+
+-- Indexes
+create index if not exists idx_nca_token on non_circumvention_agreements(token);
+create index if not exists idx_nca_lead on non_circumvention_agreements(lead_id);


### PR DESCRIPTION
Full agreement signing flow: public page at /non-circumvention/[token] displays the complete 10-section agreement from the PDF. Operator fills in name, company, email, phone, address, confirms 3 checkboxes, and signs. On sign, a copy is auto-emailed to james@apexaivending.com via Resend with all operator details and signature timestamp.

Adds "Non-Circumvention Agreement" email template to leads email system and a ShieldCheck button on each lead row to send the agreement directly.

Migration 077 creates non_circumvention_agreements table with token-based access (same pattern as location_agreements).

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2