### PR TITLE
Prevent duplicate leads: add conversion guards and email dedup

### DIFF
--- a/src/app/api/auth/signup-lead/route.ts
+++ b/src/app/api/auth/signup-lead/route.ts
@@ -47,6 +47,20 @@ export async function POST(req: NextRequest) {
     );
   }
 
+  const checkEmail = email || user.email;
+  if (checkEmail) {
+    const { data: existingLead } = await supabaseAdmin
+      .from("sales_leads")
+      .select("id")
+      .eq("email", checkEmail)
+      .limit(1)
+      .maybeSingle();
+
+    if (existingLead) {
+      return NextResponse.json({ ok: true, existing: true }, { status: 200 });
+    }
+  }
+
   const assigneeId = await getDefaultAssigneeId();
 
   const { data: account, error: acctErr } = await supabaseAdmin

--- a/src/app/api/sales/leads/[id]/convert/route.ts
+++ b/src/app/api/sales/leads/[id]/convert/route.ts
@@ -20,6 +20,21 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
 
   if (leadErr || !lead) return NextResponse.json({ error: "Lead not found" }, { status: 404 });
 
+  if (lead.status === "qualified") {
+    return NextResponse.json({ error: "Lead has already been converted" }, { status: 400 });
+  }
+
+  const { data: existingItem } = await supabaseAdmin
+    .from("pipeline_items")
+    .select("id")
+    .eq("lead_id", leadId)
+    .limit(1)
+    .maybeSingle();
+
+  if (existingItem) {
+    return NextResponse.json({ error: "Lead is already in a pipeline" }, { status: 400 });
+  }
+
   // Create or find account
   let accountId = lead.account_id;
   if (!accountId) {

--- a/src/app/api/sales/leads/[id]/route.ts
+++ b/src/app/api/sales/leads/[id]/route.ts
@@ -182,42 +182,6 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
     return NextResponse.json({ ok: true });
   }
 
-  if (body.action === "convert") {
-    // Convert lead to deal
-    const { data: lead } = await supabaseAdmin
-      .from("sales_leads")
-      .select("*")
-      .eq("id", id)
-      .single();
-
-    if (!lead) return NextResponse.json({ error: "Lead not found" }, { status: 404 });
-
-    const { data: deal, error } = await supabaseAdmin
-      .from("sales_deals")
-      .insert({
-        lead_id: id,
-        assigned_to: lead.assigned_to || user.id,
-        stage: "new",
-        value: 0,
-        business_name: lead.business_name,
-      })
-      .select("id")
-      .single();
-
-    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-
-    // Mark lead as qualified
-    await supabaseAdmin.from("sales_leads").update({ status: "qualified" }).eq("id", id);
-
-    try {
-      await createAndSendAgreement(id, lead);
-    } catch (err) {
-      console.error("[leads] Failed to send location agreement:", err instanceof Error ? err.message : err);
-    }
-
-    return NextResponse.json({ dealId: deal.id }, { status: 201 });
-  }
-
   return NextResponse.json({ error: "Unknown action" }, { status: 400 });
 }
 

--- a/src/app/api/sales/leads/import/route.ts
+++ b/src/app/api/sales/leads/import/route.ts
@@ -47,6 +47,21 @@ export async function POST(req: NextRequest) {
       continue;
     }
 
+    if (row.email?.trim()) {
+      const { data: existingLead } = await supabaseAdmin
+        .from("sales_leads")
+        .select("id")
+        .eq("email", row.email.trim())
+        .limit(1)
+        .maybeSingle();
+
+      if (existingLead) {
+        results.skipped++;
+        results.errors.push(`Row ${rowNum} (${row.business_name}): Duplicate email — skipped`);
+        continue;
+      }
+    }
+
     const entityType = row.entity_type && VALID_ENTITY_TYPES.includes(row.entity_type)
       ? row.entity_type : null;
     const immediateNeed = row.immediate_need && VALID_IMMEDIATE_NEEDS.includes(row.immediate_need)

--- a/src/app/api/sales/leads/route.ts
+++ b/src/app/api/sales/leads/route.ts
@@ -58,6 +58,19 @@ export async function POST(req: NextRequest) {
   if (!business_name)
     return NextResponse.json({ error: "business_name required" }, { status: 400 });
 
+  if (email) {
+    const { data: existingLead } = await supabaseAdmin
+      .from("sales_leads")
+      .select("id")
+      .eq("email", email)
+      .limit(1)
+      .maybeSingle();
+
+    if (existingLead) {
+      return NextResponse.json({ error: "A lead with this email already exists" }, { status: 409 });
+    }
+  }
+
   if (entity_type === "location") {
     const missing: string[] = [];
     if (!body.location_name) missing.push("location_name");


### PR DESCRIPTION
- Convert route rejects leads already marked qualified or already in a pipeline, preventing double-conversion
- Remove legacy action=convert handler that duplicated the dedicated convert route without pipeline item creation
- Lead creation (manual, signup, CSV import) now checks for existing lead with the same email before inserting

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2