### PR TITLE
Add 14 new industries to lead generator

### DIFF
--- a/src/app/api/sales/lead-generator/route.ts
+++ b/src/app/api/sales/lead-generator/route.ts
@@ -15,6 +15,20 @@ const INDUSTRIES = [
   "medical offices",
   "private schools",
   "vending operators",
+  "hotels",
+  "apartments",
+  "tire shops",
+  "truck repair shops",
+  "rehabs",
+  "RV parks",
+  "motorcycle dealerships",
+  "motorcycle repair shops",
+  "electrical supply stores",
+  "vocational schools",
+  "universities",
+  "cosmetology schools",
+  "trucking schools",
+  "nursing schools",
 ];
 
 export async function GET(req: NextRequest) {

--- a/src/app/sales/lead-generator/page.tsx
+++ b/src/app/sales/lead-generator/page.tsx
@@ -15,6 +15,20 @@ const INDUSTRIES = [
   "medical offices",
   "private schools",
   "vending operators",
+  "hotels",
+  "apartments",
+  "tire shops",
+  "truck repair shops",
+  "rehabs",
+  "RV parks",
+  "motorcycle dealerships",
+  "motorcycle repair shops",
+  "electrical supply stores",
+  "vocational schools",
+  "universities",
+  "cosmetology schools",
+  "trucking schools",
+  "nursing schools",
 ];
 
 const US_STATES = [


### PR DESCRIPTION
Hotels, apartments, tire shops, truck repair shops, rehabs, RV parks, motorcycle dealerships, motorcycle repair shops, electrical supply stores, vocational schools, universities, cosmetology schools, trucking schools, nursing schools.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2