### PR TITLE
Switch lead dedup from email to business name

### DIFF
--- a/src/app/api/auth/signup-lead/route.ts
+++ b/src/app/api/auth/signup-lead/route.ts
@@ -47,18 +47,15 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  const checkEmail = email || user.email;
-  if (checkEmail) {
-    const { data: existingLead } = await supabaseAdmin
-      .from("sales_leads")
-      .select("id")
-      .eq("email", checkEmail)
-      .limit(1)
-      .maybeSingle();
+  const { data: existingLead } = await supabaseAdmin
+    .from("sales_leads")
+    .select("id")
+    .eq("business_name", business_name)
+    .limit(1)
+    .maybeSingle();
 
-    if (existingLead) {
-      return NextResponse.json({ ok: true, existing: true }, { status: 200 });
-    }
+  if (existingLead) {
+    return NextResponse.json({ ok: true, existing: true }, { status: 200 });
   }
 
   const assigneeId = await getDefaultAssigneeId();

--- a/src/app/api/sales/leads/import/route.ts
+++ b/src/app/api/sales/leads/import/route.ts
@@ -47,19 +47,17 @@ export async function POST(req: NextRequest) {
       continue;
     }
 
-    if (row.email?.trim()) {
-      const { data: existingLead } = await supabaseAdmin
-        .from("sales_leads")
-        .select("id")
-        .eq("email", row.email.trim())
-        .limit(1)
-        .maybeSingle();
+    const { data: existingLead } = await supabaseAdmin
+      .from("sales_leads")
+      .select("id")
+      .eq("business_name", row.business_name.trim())
+      .limit(1)
+      .maybeSingle();
 
-      if (existingLead) {
-        results.skipped++;
-        results.errors.push(`Row ${rowNum} (${row.business_name}): Duplicate email — skipped`);
-        continue;
-      }
+    if (existingLead) {
+      results.skipped++;
+      results.errors.push(`Row ${rowNum} (${row.business_name}): Duplicate business name — skipped`);
+      continue;
     }
 
     const entityType = row.entity_type && VALID_ENTITY_TYPES.includes(row.entity_type)

--- a/src/app/api/sales/leads/route.ts
+++ b/src/app/api/sales/leads/route.ts
@@ -58,17 +58,15 @@ export async function POST(req: NextRequest) {
   if (!business_name)
     return NextResponse.json({ error: "business_name required" }, { status: 400 });
 
-  if (email) {
-    const { data: existingLead } = await supabaseAdmin
-      .from("sales_leads")
-      .select("id")
-      .eq("email", email)
-      .limit(1)
-      .maybeSingle();
+  const { data: existingLead } = await supabaseAdmin
+    .from("sales_leads")
+    .select("id")
+    .eq("business_name", business_name)
+    .limit(1)
+    .maybeSingle();
 
-    if (existingLead) {
-      return NextResponse.json({ error: "A lead with this email already exists" }, { status: 409 });
-    }
+  if (existingLead) {
+    return NextResponse.json({ error: "A lead with this business name already exists" }, { status: 409 });
   }
 
   if (entity_type === "location") {


### PR DESCRIPTION
Same email can now be used across multiple leads. Duplicate detection checks business_name instead, preventing the same location or operator name from being added twice.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2