### PR TITLE
Add admin dedup endpoint and Remove Duplicates button on leads page

### DIFF
--- a/src/app/api/admin/dedup-leads/route.ts
+++ b/src/app/api/admin/dedup-leads/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+
+export async function POST(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  // Find all business_names with more than one lead
+  const { data: allLeads, error } = await supabaseAdmin
+    .from("sales_leads")
+    .select("id, business_name, created_at, status, assigned_to, account_id, email, phone")
+    .order("created_at", { ascending: true });
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  const groups = new Map<string, typeof allLeads>();
+  for (const lead of allLeads || []) {
+    const key = (lead.business_name || "").trim().toLowerCase();
+    if (!key) continue;
+    const group = groups.get(key) || [];
+    group.push(lead);
+    groups.set(key, group);
+  }
+
+  let deleted = 0;
+  let reassigned = 0;
+  const details: string[] = [];
+
+  for (const [name, group] of groups) {
+    if (group.length <= 1) continue;
+
+    // Keep the lead with the most data, preferring qualified status and earliest creation
+    const keep = group.sort((a, b) => {
+      if (a.status === "qualified" && b.status !== "qualified") return -1;
+      if (b.status === "qualified" && a.status !== "qualified") return 1;
+      if (a.account_id && !b.account_id) return -1;
+      if (b.account_id && !a.account_id) return 1;
+      return new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
+    })[0];
+
+    const dupes = group.filter((l) => l.id !== keep.id);
+
+    for (const dupe of dupes) {
+      // Reassign FKs from dupe to the kept lead
+      await supabaseAdmin.from("sales_deals").update({ lead_id: keep.id }).eq("lead_id", dupe.id);
+      await supabaseAdmin.from("pipeline_items").update({ lead_id: keep.id }).eq("lead_id", dupe.id);
+      await supabaseAdmin.from("location_agreements").update({ lead_id: keep.id }).eq("lead_id", dupe.id);
+      await supabaseAdmin.from("non_circumvention_agreements").update({ lead_id: keep.id }).eq("lead_id", dupe.id);
+      await supabaseAdmin.from("locations").update({ sales_lead_id: keep.id }).eq("sales_lead_id", dupe.id);
+
+      // Delete the duplicate (lead_emails and activity_log cascade automatically)
+      const { error: delErr } = await supabaseAdmin.from("sales_leads").delete().eq("id", dupe.id);
+      if (!delErr) {
+        deleted++;
+      } else {
+        details.push(`Failed to delete ${dupe.id} (${name}): ${delErr.message}`);
+      }
+    }
+
+    reassigned++;
+    details.push(`"${name}": kept ${keep.id}, removed ${dupes.length} duplicate(s)`);
+  }
+
+  return NextResponse.json({ deleted, groups_deduped: reassigned, details });
+}

--- a/src/app/sales/leads/page.tsx
+++ b/src/app/sales/leads/page.tsx
@@ -164,6 +164,8 @@ export default function LeadsPage() {
   const [importing, setImporting] = useState(false);
   const [importResult, setImportResult] = useState<{ imported: number; skipped: number; errors: string[] } | null>(null);
 
+  const [deduping, setDeduping] = useState(false);
+
   // Email follow-up state
   const [emailLead, setEmailLead] = useState<SalesLead | null>(null);
   const [emailTemplate, setEmailTemplate] = useState("initial_followup");
@@ -294,6 +296,24 @@ export default function LeadsPage() {
       setConvertError(err.error || `Conversion failed (${res.status})`);
     }
     setConvertSaving(false);
+  }
+
+  async function handleDedup() {
+    if (!confirm("Remove all duplicate leads? This keeps the oldest lead for each business name and deletes the rest.")) return;
+    setDeduping(true);
+    const res = await fetch("/api/admin/dedup-leads", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.ok) {
+      const data = await res.json();
+      alert(`Removed ${data.deleted} duplicate lead${data.deleted !== 1 ? "s" : ""} across ${data.groups_deduped} business name${data.groups_deduped !== 1 ? "s" : ""}.`);
+      fetchLeads();
+    } else {
+      const err = await res.json().catch(() => ({}));
+      alert(err.error || "Failed to remove duplicates");
+    }
+    setDeduping(false);
   }
 
   async function handleDelete(id: string) {
@@ -726,6 +746,16 @@ export default function LeadsPage() {
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-2xl font-bold text-gray-900">Leads</h1>
         <div className="flex gap-2">
+          {userRole === "admin" && (
+            <button
+              onClick={handleDedup}
+              disabled={deduping}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-red-200 bg-white px-4 py-2 text-sm font-medium text-red-600 hover:bg-red-50 transition-colors cursor-pointer disabled:opacity-50"
+            >
+              {deduping ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
+              Remove Duplicates
+            </button>
+          )}
           <button
             onClick={() => { setShowImport(!showImport); setShowAdd(false); }}
             className="inline-flex items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors cursor-pointer"


### PR DESCRIPTION
New POST /api/admin/dedup-leads groups leads by business_name, keeps the best record (qualified status, has account, earliest), reassigns all FK references (deals, pipeline items, agreements, locations) to the kept lead, then deletes duplicates.

Admin users see a "Remove Duplicates" button on the leads page.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2