### PR TITLE
Add manual send/resend location details after payment

### DIFF
--- a/src/app/api/pipeline-items/[id]/send-details/route.ts
+++ b/src/app/api/pipeline-items/[id]/send-details/route.ts
@@ -1,0 +1,140 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser } from "@/lib/salesAuth";
+import { generateSiteDetailsPdf } from "@/lib/pdf/agreementPdf";
+import { sendFullSiteDetailsEmail } from "@/lib/agreementEmail";
+import { PricingResult } from "@/lib/pricing/locationPricing";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const user = await getSalesUser(req);
+  if (!user) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  const { id: itemId } = await params;
+
+  let emailOverride: string | null = null;
+  try {
+    const body = await req.json();
+    emailOverride = body.email || null;
+  } catch {
+    // No body
+  }
+
+  const { data: item } = await supabaseAdmin
+    .from("pipeline_items")
+    .select("id, location_id, proposal_status, sales_accounts(id, business_name, contact_name, email)")
+    .eq("id", itemId)
+    .single();
+
+  if (!item) {
+    return NextResponse.json({ error: "Pipeline item not found" }, { status: 404 });
+  }
+
+  if (!item.location_id) {
+    return NextResponse.json({ error: "No location linked to this pipeline item" }, { status: 400 });
+  }
+
+  const account = item.sales_accounts as unknown as { id: string; business_name: string; contact_name: string; email: string } | null;
+  const recipientEmail = emailOverride || account?.email;
+  if (!recipientEmail) {
+    return NextResponse.json({ error: "No email found — provide one in the request body" }, { status: 400 });
+  }
+
+  const { data: agreement } = await supabaseAdmin
+    .from("agreement_tokens")
+    .select("id, pricing_score, pricing_tier, pricing_price, recipient_name")
+    .eq("pipeline_item_id", itemId)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  const { data: location } = await supabaseAdmin
+    .from("locations")
+    .select("*")
+    .eq("id", item.location_id)
+    .single();
+
+  if (!location) {
+    return NextResponse.json({ error: "Location not found" }, { status: 404 });
+  }
+
+  let locationAgreement: {
+    signature_name: string | null;
+    signed_at: string | null;
+    contact_name: string | null;
+    email: string | null;
+    phone: string | null;
+    title_role: string | null;
+  } | null = null;
+
+  if (location.sales_lead_id) {
+    const { data: la } = await supabaseAdmin
+      .from("location_agreements")
+      .select("signature_name, signed_at, contact_name, email, phone, title_role")
+      .eq("lead_id", location.sales_lead_id)
+      .eq("status", "signed")
+      .maybeSingle();
+    locationAgreement = la;
+  }
+
+  const pricing: PricingResult = {
+    total_score: agreement?.pricing_score ?? 0,
+    traffic_score: 0,
+    hours_score: 0,
+    machine_score: 0,
+    tier: (agreement?.pricing_tier as 1 | 2 | 3 | 4 | 5) ?? 3,
+    tier_label: `Tier ${agreement?.pricing_tier ?? 3}`,
+    price: Number(agreement?.pricing_price ?? 0),
+  };
+
+  const pdfBytes = await generateSiteDetailsPdf({
+    businessName: account?.business_name || agreement?.recipient_name || "",
+    contactName: account?.contact_name || agreement?.recipient_name || "",
+    locationName: location.location_name || "",
+    address: location.address || "",
+    phone: location.phone || "",
+    decisionMakerName: location.decision_maker_name || "",
+    decisionMakerEmail: location.decision_maker_email || "",
+    industry: location.industry || "",
+    zip: location.zip || "",
+    employeeCount: location.employee_count || 0,
+    trafficCount: location.traffic_count || 0,
+    machineType: location.machine_type || "",
+    machinesRequested: location.machines_requested || 1,
+    businessHours: location.business_hours || "",
+    pricing,
+    generatedAt: new Date().toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" }),
+    locationAgreement: locationAgreement
+      ? {
+          signatureName: locationAgreement.signature_name || "",
+          signedAt: locationAgreement.signed_at || "",
+          contactName: locationAgreement.contact_name || "",
+          titleRole: locationAgreement.title_role || "",
+          email: locationAgreement.email || "",
+          phone: locationAgreement.phone || "",
+        }
+      : undefined,
+  });
+
+  await sendFullSiteDetailsEmail({
+    to: recipientEmail,
+    recipientName: account?.contact_name || agreement?.recipient_name || "",
+    businessName: account?.business_name || "",
+    locationName: location.location_name || "Location",
+    pdfBuffer: pdfBytes,
+    locationAgreement: locationAgreement
+      ? {
+          signatureName: locationAgreement.signature_name || "",
+          signedAt: locationAgreement.signed_at || "",
+          contactName: locationAgreement.contact_name || "",
+          email: locationAgreement.email || "",
+          phone: locationAgreement.phone || "",
+        }
+      : undefined,
+  });
+
+  return NextResponse.json({ ok: true, sent_to: recipientEmail });
+}

--- a/src/app/sales/pipelines/[id]/items/[itemId]/page.tsx
+++ b/src/app/sales/pipelines/[id]/items/[itemId]/page.tsx
@@ -178,6 +178,8 @@ export default function PipelineItemDetailPage() {
   const [esignForm, setEsignForm] = useState({ document_name: "", recipient_email: "", template_id: "" });
   const [sendingProposal, setSendingProposal] = useState(false);
   const [proposalError, setProposalError] = useState<string | null>(null);
+  const [sendingDetails, setSendingDetails] = useState(false);
+  const [detailsResult, setDetailsResult] = useState<string | null>(null);
   const [resendingAgreement, setResendingAgreement] = useState(false);
   const [resendResult, setResendResult] = useState<string | null>(null);
   const [manualAgreementEmail, setManualAgreementEmail] = useState("");
@@ -731,6 +733,32 @@ export default function PipelineItemDetailPage() {
       setProposalError(err instanceof Error ? err.message : "Network error");
     } finally {
       setSendingProposal(false);
+    }
+  }
+
+  async function handleSendDetails(emailOverride?: string) {
+    setSendingDetails(true);
+    setDetailsResult(null);
+    try {
+      const fetchOptions: RequestInit = {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+      };
+      if (emailOverride) {
+        (fetchOptions.headers as Record<string, string>)["Content-Type"] = "application/json";
+        fetchOptions.body = JSON.stringify({ email: emailOverride });
+      }
+      const res = await fetch(`/api/pipeline-items/${itemId}/send-details`, fetchOptions);
+      const data = await res.json();
+      if (res.ok) {
+        setDetailsResult(`Location details sent to ${data.sent_to}`);
+      } else {
+        setDetailsResult(`Error: ${data.error}`);
+      }
+    } catch {
+      setDetailsResult("Network error");
+    } finally {
+      setSendingDetails(false);
     }
   }
 
@@ -1462,10 +1490,25 @@ export default function PipelineItemDetailPage() {
             </div>
           )}
           {item.proposal_status === "paid" ? (
-            <p className="text-sm text-green-600 flex items-center gap-1.5">
-              <CheckCircle2 className="h-3.5 w-3.5" />
-              Payment received — full location details sent to customer
-            </p>
+            <div className="space-y-3">
+              <p className="text-sm text-green-600 flex items-center gap-1.5">
+                <CheckCircle2 className="h-3.5 w-3.5" />
+                Payment received — full location details sent to customer
+              </p>
+              <button
+                onClick={() => handleSendDetails()}
+                disabled={sendingDetails}
+                className="inline-flex items-center gap-1.5 rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-50 disabled:opacity-50 cursor-pointer"
+              >
+                {sendingDetails ? <Loader2 className="h-3 w-3 animate-spin" /> : <RefreshCw className="h-3 w-3" />}
+                Resend Location Details
+              </button>
+              {detailsResult && (
+                <p className={`text-xs ${detailsResult.startsWith("Error") ? "text-red-600" : "text-green-600"}`}>
+                  {detailsResult}
+                </p>
+              )}
+            </div>
           ) : item.proposal_status === "proposal_sent" ? (
             <div className="space-y-3">
               <p className="text-sm text-blue-600 flex items-center gap-1.5">


### PR DESCRIPTION
- New API endpoint POST /api/pipeline-items/[id]/send-details that regenerates the full site details PDF and emails it to the operator
- Resend Location Details button shown on pipeline item detail page when proposal_status is "paid"
- Supports optional email override in request body

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2