### PR TITLE
Add Stripe payment for coffee orders

### DIFF
--- a/src/app/admin/coffee/page.tsx
+++ b/src/app/admin/coffee/page.tsx
@@ -91,6 +91,7 @@ function Toast({ message, type }: { message: string; type: "success" | "error" }
 }
 
 const STATUS_STYLES: Record<string, string> = {
+  awaiting_payment: "bg-orange-100 text-orange-700",
   pending: "bg-yellow-100 text-yellow-700",
   processing: "bg-blue-100 text-blue-700",
   shipped: "bg-purple-100 text-purple-700",
@@ -100,7 +101,7 @@ const STATUS_STYLES: Record<string, string> = {
   rejected: "bg-red-100 text-red-700",
 };
 
-const ORDER_STATUSES = ["pending", "processing", "shipped", "delivered", "cancelled"];
+const ORDER_STATUSES = ["awaiting_payment", "pending", "processing", "shipped", "delivered", "cancelled"];
 
 const inputClass = "w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500";
 

--- a/src/app/api/coffee/checkout/route.ts
+++ b/src/app/api/coffee/checkout/route.ts
@@ -1,0 +1,138 @@
+import { NextRequest, NextResponse } from "next/server";
+import Stripe from "stripe";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getCoffeeUser, forbiddenResponse } from "@/lib/coffeeAuth";
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
+
+export async function POST(req: NextRequest) {
+  try {
+    const user = await getCoffeeUser(req);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    if (!user.coffee_access_enabled) {
+      return forbiddenResponse();
+    }
+
+    const body = await req.json();
+
+    const { data: cartItems, error: cartError } = await supabaseAdmin
+      .from("coffee_cart_items")
+      .select("*, coffee_products(id, name, sku, price, active, stock_status)")
+      .eq("user_id", user.id);
+
+    if (cartError) {
+      return NextResponse.json({ error: cartError.message }, { status: 500 });
+    }
+
+    if (!cartItems || cartItems.length === 0) {
+      return NextResponse.json({ error: "Cart is empty" }, { status: 400 });
+    }
+
+    const validItems = cartItems.filter((item: Record<string, unknown>) => {
+      const product = item.coffee_products as Record<string, unknown>;
+      return product.active === true && product.stock_status !== "out_of_stock";
+    });
+
+    if (validItems.length === 0) {
+      return NextResponse.json({ error: "All items in your cart are unavailable" }, { status: 400 });
+    }
+
+    const orderNumber = `VC-${Date.now()}`;
+
+    const orderItems = validItems.map((item: Record<string, unknown>) => {
+      const product = item.coffee_products as Record<string, unknown>;
+      const unitPrice = Number(product.price);
+      const quantity = Number(item.quantity);
+      return {
+        product_id: product.id as string,
+        product_name: product.name as string,
+        product_sku: product.sku as string,
+        quantity,
+        unit_price: unitPrice,
+        line_total: unitPrice * quantity,
+      };
+    });
+
+    const subtotal = orderItems.reduce((sum, i) => sum + i.line_total, 0);
+    const shippingEstimate = body.shipping_estimate ?? 0;
+    const total = subtotal + shippingEstimate;
+
+    const { data: order, error: orderError } = await supabaseAdmin
+      .from("coffee_orders")
+      .insert({
+        operator_id: user.id,
+        order_number: orderNumber,
+        status: "awaiting_payment",
+        shipping_name: body.shipping_name ?? null,
+        shipping_address: body.shipping_address ?? null,
+        shipping_city: body.shipping_city ?? null,
+        shipping_state: body.shipping_state ?? null,
+        shipping_zip: body.shipping_zip ?? null,
+        shipping_phone: body.shipping_phone ?? null,
+        subtotal,
+        shipping_estimate: shippingEstimate,
+        total,
+        notes: body.notes ?? null,
+      })
+      .select("*")
+      .single();
+
+    if (orderError) {
+      return NextResponse.json({ error: orderError.message }, { status: 500 });
+    }
+
+    const itemsWithOrderId = orderItems.map((item) => ({
+      ...item,
+      order_id: order.id,
+    }));
+
+    const { error: itemsError } = await supabaseAdmin
+      .from("coffee_order_items")
+      .insert(itemsWithOrderId);
+
+    if (itemsError) {
+      return NextResponse.json({ error: itemsError.message }, { status: 500 });
+    }
+
+    const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://vendingconnector.com";
+
+    const lineItems: Stripe.Checkout.SessionCreateParams.LineItem[] = orderItems.map((item) => ({
+      price_data: {
+        currency: "usd",
+        unit_amount: Math.round(item.unit_price * 100),
+        product_data: {
+          name: item.product_name,
+          description: `SKU: ${item.product_sku}`,
+        },
+      },
+      quantity: item.quantity,
+    }));
+
+    const session = await stripe.checkout.sessions.create({
+      mode: "payment",
+      payment_method_types: ["card"],
+      line_items: lineItems,
+      metadata: {
+        type: "coffee_order",
+        order_id: order.id,
+        order_number: orderNumber,
+        user_id: user.id,
+      },
+      customer_email: user.email || undefined,
+      success_url: `${siteUrl}/coffee/orders/${order.id}?paid=true`,
+      cancel_url: `${siteUrl}/coffee/checkout?canceled=true`,
+    });
+
+    await supabaseAdmin
+      .from("coffee_orders")
+      .update({ stripe_checkout_session_id: session.id })
+      .eq("id", order.id);
+
+    return NextResponse.json({ url: session.url });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Unknown error";
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -76,6 +76,12 @@ export async function POST(req: NextRequest) {
   if (event.type === "checkout.session.completed") {
     const session = event.data.object as Stripe.Checkout.Session;
 
+    // Handle coffee order payments
+    if (session.metadata?.type === "coffee_order") {
+      await handleCoffeeOrderPayment(session);
+      return NextResponse.json({ received: true });
+    }
+
     // Handle agreement payments (location placement)
     if (session.metadata?.type === "agreement_payment") {
       await handleAgreementPayment(session);
@@ -268,6 +274,15 @@ export async function POST(req: NextRequest) {
         updated_at: new Date().toISOString(),
       })
       .eq("stripe_checkout_session_id", session.id);
+
+    await supabaseAdmin
+      .from("coffee_orders")
+      .update({
+        status: "cancelled",
+        updated_at: new Date().toISOString(),
+      })
+      .eq("stripe_checkout_session_id", session.id)
+      .eq("status", "awaiting_payment");
   }
 
   // Handle Stripe Connect account updates — mark onboarding complete
@@ -777,5 +792,79 @@ async function handleMarketplacePurchase(session: Stripe.Checkout.Session) {
     } catch (e) {
       console.error("[stripe-webhook] Failed to send marketplace purchase email:", e);
     }
+  }
+}
+
+async function handleCoffeeOrderPayment(session: Stripe.Checkout.Session) {
+  const orderId = session.metadata?.order_id;
+  const userId = session.metadata?.user_id;
+  const paymentIntentId =
+    typeof session.payment_intent === "string"
+      ? session.payment_intent
+      : session.payment_intent?.id ?? null;
+
+  if (!orderId) return;
+
+  const { data: order, error: updateErr } = await supabaseAdmin
+    .from("coffee_orders")
+    .update({
+      status: "pending",
+      stripe_payment_intent_id: paymentIntentId,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", orderId)
+    .select("*, coffee_order_items(*)")
+    .single();
+
+  if (updateErr || !order) {
+    console.error("[stripe-webhook] Failed to update coffee order:", updateErr);
+    return;
+  }
+
+  // Clear cart after successful payment
+  if (userId) {
+    await supabaseAdmin
+      .from("coffee_cart_items")
+      .delete()
+      .eq("user_id", userId);
+  }
+
+  // Send order emails
+  try {
+    const { sendCoffeeOrderNotification, sendCoffeeOrderConfirmation } = await import("@/lib/coffeeEmail");
+
+    const { data: profile } = await supabaseAdmin
+      .from("profiles")
+      .select("full_name, email")
+      .eq("id", order.operator_id)
+      .single();
+
+    const emailParams = {
+      orderNumber: order.order_number,
+      operatorName: profile?.full_name || "Operator",
+      operatorEmail: profile?.email || session.customer_details?.email || "",
+      items: (order.coffee_order_items || []).map((i: Record<string, unknown>) => ({
+        product_name: i.product_name as string,
+        product_sku: i.product_sku as string,
+        quantity: Number(i.quantity),
+        unit_price: Number(i.unit_price),
+        line_total: Number(i.line_total),
+      })),
+      subtotal: Number(order.subtotal),
+      shippingEstimate: Number(order.shipping_estimate),
+      total: Number(order.total),
+      shippingName: order.shipping_name,
+      shippingAddress: order.shipping_address,
+      shippingCity: order.shipping_city,
+      shippingState: order.shipping_state,
+      shippingZip: order.shipping_zip,
+    };
+
+    await Promise.all([
+      sendCoffeeOrderNotification(emailParams),
+      sendCoffeeOrderConfirmation(emailParams),
+    ]);
+  } catch (e) {
+    console.error("[stripe-webhook] Failed to send coffee order emails:", e);
   }
 }

--- a/src/app/coffee/checkout/page.tsx
+++ b/src/app/coffee/checkout/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Suspense } from "react";
 import Link from "next/link";
-import { Loader2, ShoppingCart, ArrowLeft, AlertCircle } from "lucide-react";
+import { Loader2, ShoppingCart, ArrowLeft, AlertCircle, CreditCard } from "lucide-react";
 import { createBrowserClient } from "@/lib/supabase";
 import type { Profile } from "@/lib/types";
 
@@ -24,7 +25,16 @@ interface CartItem {
 }
 
 export default function CoffeeCheckoutPage() {
+  return (
+    <Suspense fallback={<div className="flex min-h-[60vh] items-center justify-center"><Loader2 className="h-8 w-8 animate-spin text-green-600" /></div>}>
+      <CheckoutContent />
+    </Suspense>
+  );
+}
+
+function CheckoutContent() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [token, setToken] = useState("");
   const [profile, setProfile] = useState<Profile | null>(null);
   const [loading, setLoading] = useState(true);
@@ -108,7 +118,7 @@ export default function CoffeeCheckoutPage() {
     setError("");
 
     try {
-      const res = await fetch("/api/coffee/orders", {
+      const res = await fetch("/api/coffee/checkout", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -122,13 +132,17 @@ export default function CoffeeCheckoutPage() {
 
       if (res.ok) {
         const data = await res.json();
-        router.push(`/coffee/orders/${data.order.id}`);
+        if (data.url) {
+          window.location.href = data.url;
+        } else {
+          setError("Failed to create payment session");
+        }
       } else {
         const data = await res.json();
-        setError(data.error || "Failed to submit order");
+        setError(data.error || "Failed to process checkout");
       }
     } catch {
-      setError("Failed to submit order");
+      setError("Failed to process checkout");
     } finally {
       setSubmitting(false);
     }
@@ -171,6 +185,13 @@ export default function CoffeeCheckoutPage() {
       </Link>
 
       <h1 className="text-2xl font-bold text-gray-900 sm:text-3xl">Checkout</h1>
+
+      {searchParams.get("canceled") && (
+        <div className="mt-4 flex items-center gap-2 rounded-xl border border-yellow-200 bg-yellow-50 px-4 py-3 text-sm text-yellow-700">
+          <AlertCircle className="h-4 w-4 flex-shrink-0" />
+          Payment was canceled. You can try again when you&apos;re ready.
+        </div>
+      )}
 
       {error && (
         <div className="mt-4 flex items-center gap-2 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
@@ -300,7 +321,10 @@ export default function CoffeeCheckoutPage() {
               {submitting ? (
                 <Loader2 className="mx-auto h-5 w-5 animate-spin" />
               ) : (
-                "Submit Order"
+                <span className="flex items-center justify-center gap-2">
+                  <CreditCard className="h-4 w-4" />
+                  Pay ${total.toFixed(2)}
+                </span>
               )}
             </button>
           </div>

--- a/src/app/coffee/orders/[id]/page.tsx
+++ b/src/app/coffee/orders/[id]/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { useRouter, useParams } from "next/navigation";
+import { useState, useEffect, Suspense } from "react";
+import { useRouter, useParams, useSearchParams } from "next/navigation";
 import Link from "next/link";
-import { Loader2, ArrowLeft, RotateCcw, Package } from "lucide-react";
+import { Loader2, ArrowLeft, RotateCcw, Package, CheckCircle2 } from "lucide-react";
 import { createBrowserClient } from "@/lib/supabase";
 
 interface OrderItem {
@@ -34,6 +34,7 @@ interface Order {
 }
 
 const STATUS_STYLES: Record<string, string> = {
+  awaiting_payment: "bg-orange-100 text-orange-700",
   pending: "bg-yellow-100 text-yellow-700",
   processing: "bg-blue-100 text-blue-700",
   shipped: "bg-purple-100 text-purple-700",
@@ -42,8 +43,17 @@ const STATUS_STYLES: Record<string, string> = {
 };
 
 export default function CoffeeOrderDetailPage() {
+  return (
+    <Suspense fallback={<div className="flex min-h-[60vh] items-center justify-center"><Loader2 className="h-8 w-8 animate-spin text-green-600" /></div>}>
+      <OrderDetailContent />
+    </Suspense>
+  );
+}
+
+function OrderDetailContent() {
   const router = useRouter();
   const params = useParams();
+  const searchParams = useSearchParams();
   const orderId = params.id as string;
   const [token, setToken] = useState("");
   const [order, setOrder] = useState<Order | null>(null);
@@ -136,6 +146,13 @@ export default function CoffeeOrderDetailPage() {
         <ArrowLeft className="h-4 w-4" />
         Back to Orders
       </Link>
+
+      {searchParams.get("paid") && (
+        <div className="mb-6 flex items-center gap-2 rounded-xl border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700">
+          <CheckCircle2 className="h-4 w-4 flex-shrink-0" />
+          Payment successful! Your order has been placed and is being processed.
+        </div>
+      )}
 
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>

--- a/src/app/coffee/orders/page.tsx
+++ b/src/app/coffee/orders/page.tsx
@@ -20,6 +20,7 @@ interface Order {
 }
 
 const STATUS_STYLES: Record<string, string> = {
+  awaiting_payment: "bg-orange-100 text-orange-700",
   pending: "bg-yellow-100 text-yellow-700",
   processing: "bg-blue-100 text-blue-700",
   shipped: "bg-purple-100 text-purple-700",

--- a/supabase/migrations/20250528_coffee_stripe.sql
+++ b/supabase/migrations/20250528_coffee_stripe.sql
@@ -1,0 +1,8 @@
+-- Add Stripe columns to coffee_orders
+ALTER TABLE coffee_orders ADD COLUMN IF NOT EXISTS stripe_checkout_session_id text;
+ALTER TABLE coffee_orders ADD COLUMN IF NOT EXISTS stripe_payment_intent_id text;
+
+-- Update status check to include awaiting_payment
+ALTER TABLE coffee_orders DROP CONSTRAINT IF EXISTS coffee_orders_status_check;
+ALTER TABLE coffee_orders ADD CONSTRAINT coffee_orders_status_check
+  CHECK (status IN ('awaiting_payment', 'pending', 'processing', 'shipped', 'delivered', 'cancelled'));


### PR DESCRIPTION
- New /api/coffee/checkout route creates Stripe Checkout Session with cart items as line items, creates order with awaiting_payment status, and redirects user to Stripe
- Webhook handler confirms payment, updates order to pending, clears cart, and sends order notification/confirmation emails
- Expired sessions auto-cancel the order
- Checkout page now shows "Pay $X.XX" button and redirects to Stripe
- Order detail shows payment success banner after redirect
- New awaiting_payment status added to all status displays
- Migration adds stripe_checkout_session_id and stripe_payment_intent_id columns to coffee_orders

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2