### PR TITLE
Add per-product shipping cost field to coffee marketplace

### DIFF
--- a/src/app/admin/coffee/page.tsx
+++ b/src/app/admin/coffee/page.tsx
@@ -35,6 +35,7 @@ interface Product {
   sku: string;
   description: string | null;
   price: number;
+  shipping_cost: number;
   image_url: string | null;
   stock_status: string;
   unit: string;
@@ -124,6 +125,7 @@ export default function AdminCoffeePage() {
     sku: "",
     description: "",
     price: "",
+    shipping_cost: "0",
     image_url: "",
     stock_status: "in_stock",
     unit: "each",
@@ -239,6 +241,7 @@ export default function AdminCoffeePage() {
       sku: "",
       description: "",
       price: "",
+      shipping_cost: "0",
       image_url: "",
       stock_status: "in_stock",
       unit: "each",
@@ -257,6 +260,7 @@ export default function AdminCoffeePage() {
       sku: product.sku,
       description: product.description || "",
       price: String(product.price),
+      shipping_cost: String(product.shipping_cost || 0),
       image_url: product.image_url || "",
       stock_status: product.stock_status,
       unit: product.unit,
@@ -310,6 +314,7 @@ export default function AdminCoffeePage() {
         sku: productForm.sku,
         description: productForm.description || null,
         price: parseFloat(productForm.price),
+        shipping_cost: parseFloat(productForm.shipping_cost) || 0,
         image_url: productForm.image_url || null,
         stock_status: productForm.stock_status,
         unit: productForm.unit,
@@ -560,6 +565,17 @@ export default function AdminCoffeePage() {
                   />
                 </div>
                 <div>
+                  <label className="mb-1.5 block text-sm font-medium text-gray-700">Shipping Cost</label>
+                  <input
+                    type="number"
+                    step="0.01"
+                    min="0"
+                    value={productForm.shipping_cost}
+                    onChange={(e) => setProductForm((p) => ({ ...p, shipping_cost: e.target.value }))}
+                    className={inputClass}
+                  />
+                </div>
+                <div>
                   <label className="mb-1.5 block text-sm font-medium text-gray-700">Stock Status</label>
                   <select
                     value={productForm.stock_status}
@@ -701,6 +717,7 @@ export default function AdminCoffeePage() {
                     <th className="px-5 py-3 text-left font-semibold text-gray-600">SKU</th>
                     <th className="px-5 py-3 text-left font-semibold text-gray-600">Category</th>
                     <th className="px-5 py-3 text-right font-semibold text-gray-600">Price</th>
+                    <th className="px-5 py-3 text-right font-semibold text-gray-600">Shipping</th>
                     <th className="px-5 py-3 text-left font-semibold text-gray-600">Stock</th>
                     <th className="px-5 py-3 text-center font-semibold text-gray-600">Active</th>
                     <th className="px-5 py-3 text-right font-semibold text-gray-600">Actions</th>
@@ -709,7 +726,7 @@ export default function AdminCoffeePage() {
                 <tbody>
                   {products.length === 0 ? (
                     <tr>
-                      <td colSpan={7} className="px-5 py-12 text-center text-gray-500">No products yet</td>
+                      <td colSpan={8} className="px-5 py-12 text-center text-gray-500">No products yet</td>
                     </tr>
                   ) : (
                     products.map((product) => (
@@ -718,6 +735,7 @@ export default function AdminCoffeePage() {
                         <td className="px-5 py-3 text-gray-600">{product.sku}</td>
                         <td className="px-5 py-3 text-gray-600">{product.coffee_categories?.name || "—"}</td>
                         <td className="px-5 py-3 text-right font-medium text-gray-900">${Number(product.price).toFixed(2)}</td>
+                        <td className="px-5 py-3 text-right text-gray-600">{Number(product.shipping_cost) > 0 ? `$${Number(product.shipping_cost).toFixed(2)}` : "Free"}</td>
                         <td className="px-5 py-3">
                           <span className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${
                             product.stock_status === "in_stock" ? "bg-green-100 text-green-700" :

--- a/src/app/api/admin/coffee/products/route.ts
+++ b/src/app/api/admin/coffee/products/route.ts
@@ -42,6 +42,7 @@ export async function POST(req: NextRequest) {
         sku: body.sku,
         description: body.description ?? null,
         price: body.price,
+        shipping_cost: body.shipping_cost ?? 0,
         image_url: body.image_url ?? null,
         stock_status: body.stock_status ?? "in_stock",
         unit: body.unit ?? "each",
@@ -78,7 +79,7 @@ export async function PATCH(req: NextRequest) {
     }
 
     const allowedFields = [
-      "category_id", "name", "sku", "description", "price", "image_url",
+      "category_id", "name", "sku", "description", "price", "shipping_cost", "image_url",
       "stock_status", "unit", "min_order_qty", "active", "sort_order",
     ];
     const updates: Record<string, unknown> = { updated_at: new Date().toISOString() };

--- a/src/app/api/coffee/cart/route.ts
+++ b/src/app/api/coffee/cart/route.ts
@@ -11,7 +11,7 @@ export async function GET(req: NextRequest) {
 
     const { data, error } = await supabaseAdmin
       .from("coffee_cart_items")
-      .select("*, coffee_products(id, name, sku, price, image_url, stock_status, unit, min_order_qty, active)")
+      .select("*, coffee_products(id, name, sku, price, shipping_cost, image_url, stock_status, unit, min_order_qty, active)")
       .eq("user_id", user.id)
       .order("created_at", { ascending: true });
 

--- a/src/app/api/coffee/checkout/route.ts
+++ b/src/app/api/coffee/checkout/route.ts
@@ -19,7 +19,7 @@ export async function POST(req: NextRequest) {
 
     const { data: cartItems, error: cartError } = await supabaseAdmin
       .from("coffee_cart_items")
-      .select("*, coffee_products(id, name, sku, price, active, stock_status)")
+      .select("*, coffee_products(id, name, sku, price, shipping_cost, active, stock_status)")
       .eq("user_id", user.id);
 
     if (cartError) {
@@ -44,6 +44,7 @@ export async function POST(req: NextRequest) {
     const orderItems = validItems.map((item: Record<string, unknown>) => {
       const product = item.coffee_products as Record<string, unknown>;
       const unitPrice = Number(product.price);
+      const shippingCost = Number(product.shipping_cost || 0);
       const quantity = Number(item.quantity);
       return {
         product_id: product.id as string,
@@ -51,13 +52,14 @@ export async function POST(req: NextRequest) {
         product_sku: product.sku as string,
         quantity,
         unit_price: unitPrice,
-        line_total: unitPrice * quantity,
+        shipping_cost: shippingCost,
+        line_total: (unitPrice + shippingCost) * quantity,
       };
     });
 
-    const subtotal = orderItems.reduce((sum, i) => sum + i.line_total, 0);
-    const shippingEstimate = body.shipping_estimate ?? 0;
-    const total = subtotal + shippingEstimate;
+    const subtotal = orderItems.reduce((sum, i) => sum + i.unit_price * i.quantity, 0);
+    const shippingTotal = orderItems.reduce((sum, i) => sum + i.shipping_cost * i.quantity, 0);
+    const total = subtotal + shippingTotal;
 
     const { data: order, error: orderError } = await supabaseAdmin
       .from("coffee_orders")
@@ -72,7 +74,7 @@ export async function POST(req: NextRequest) {
         shipping_zip: body.shipping_zip ?? null,
         shipping_phone: body.shipping_phone ?? null,
         subtotal,
-        shipping_estimate: shippingEstimate,
+        shipping_estimate: shippingTotal,
         total,
         notes: body.notes ?? null,
       })
@@ -109,6 +111,19 @@ export async function POST(req: NextRequest) {
       },
       quantity: item.quantity,
     }));
+
+    if (shippingTotal > 0) {
+      lineItems.push({
+        price_data: {
+          currency: "usd",
+          unit_amount: Math.round(shippingTotal * 100),
+          product_data: {
+            name: "Shipping",
+          },
+        },
+        quantity: 1,
+      });
+    }
 
     const session = await stripe.checkout.sessions.create({
       mode: "payment",

--- a/src/app/coffee/checkout/page.tsx
+++ b/src/app/coffee/checkout/page.tsx
@@ -13,6 +13,7 @@ interface CartProduct {
   name: string;
   sku: string;
   price: number;
+  shipping_cost: number;
   image_url: string | null;
   unit: string;
 }
@@ -104,7 +105,9 @@ function CheckoutContent() {
     return sum + Number(item.coffee_products?.price || 0) * item.quantity;
   }, 0);
 
-  const shipping = 0;
+  const shipping = items.reduce((sum, item) => {
+    return sum + Number(item.coffee_products?.shipping_cost || 0) * item.quantity;
+  }, 0);
   const total = subtotal + shipping;
 
   function updateForm(field: string, value: string) {
@@ -305,7 +308,7 @@ function CheckoutContent() {
               </div>
               <div className="flex justify-between">
                 <span className="text-gray-500">Shipping</span>
-                <span className="font-medium text-green-600">Free</span>
+                <span className="font-medium text-gray-900">{shipping > 0 ? `$${shipping.toFixed(2)}` : "Free"}</span>
               </div>
             </div>
             <hr className="border-gray-100 my-4" />

--- a/src/app/coffee/page.tsx
+++ b/src/app/coffee/page.tsx
@@ -20,6 +20,7 @@ interface Product {
   sku: string;
   description: string | null;
   price: number;
+  shipping_cost: number;
   image_url: string | null;
   stock_status: string;
   unit: string;
@@ -319,6 +320,9 @@ export default function CoffeeMarketplacePage() {
                       ${Number(product.price).toFixed(2)}
                       <span className="text-xs font-normal text-gray-400 ml-1">/ {product.unit || "each"}</span>
                     </p>
+                    {Number(product.shipping_cost) > 0 && (
+                      <p className="text-xs text-gray-500">+ ${Number(product.shipping_cost).toFixed(2)} shipping</p>
+                    )}
                     <div className="mt-auto pt-4 flex items-center gap-2">
                       <input
                         type="number"

--- a/src/app/components/CoffeeCartDrawer.tsx
+++ b/src/app/components/CoffeeCartDrawer.tsx
@@ -9,6 +9,7 @@ interface CartProduct {
   name: string;
   sku: string;
   price: number;
+  shipping_cost: number;
   image_url: string | null;
   stock_status: string;
   unit: string;
@@ -109,7 +110,8 @@ export default function CoffeeCartDrawer({ open, onClose, token }: CoffeeCartDra
 
   const subtotal = items.reduce((sum, item) => {
     const price = Number(item.coffee_products?.price || 0);
-    return sum + price * item.quantity;
+    const shipping = Number(item.coffee_products?.shipping_cost || 0);
+    return sum + (price + shipping) * item.quantity;
   }, 0);
 
   return (
@@ -158,7 +160,8 @@ export default function CoffeeCartDrawer({ open, onClose, token }: CoffeeCartDra
               {items.map((item) => {
                 const product = item.coffee_products;
                 const price = Number(product?.price || 0);
-                const lineTotal = price * item.quantity;
+                const itemShipping = Number(product?.shipping_cost || 0);
+                const lineTotal = (price + itemShipping) * item.quantity;
                 const isUpdating = updating === item.product_id;
 
                 return (
@@ -172,7 +175,7 @@ export default function CoffeeCartDrawer({ open, onClose, token }: CoffeeCartDra
                     </div>
                     <div className="flex-1 min-w-0">
                       <p className="text-sm font-semibold text-gray-900 truncate">{product?.name}</p>
-                      <p className="text-xs text-gray-500">${price.toFixed(2)} / {product?.unit || "each"}</p>
+                      <p className="text-xs text-gray-500">${price.toFixed(2)} / {product?.unit || "each"}{itemShipping > 0 ? ` + $${itemShipping.toFixed(2)} ship` : ""}</p>
                       <div className="mt-2 flex items-center gap-2">
                         <button
                           type="button"

--- a/supabase/migrations/20250529_coffee_shipping_cost.sql
+++ b/supabase/migrations/20250529_coffee_shipping_cost.sql
@@ -1,0 +1,2 @@
+-- Add per-product shipping cost to coffee products
+ALTER TABLE coffee_products ADD COLUMN IF NOT EXISTS shipping_cost numeric DEFAULT 0;


### PR DESCRIPTION
Adds a shipping_cost column to coffee_products so admins can set a per-item shipping charge. The cost flows through the full stack: admin form, product API, cart display, checkout totals, and Stripe line items.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2