### PR TITLE
Fix checkout inserting shipping_cost into coffee_order_items

### DIFF
--- a/src/app/api/coffee/checkout/route.ts
+++ b/src/app/api/coffee/checkout/route.ts
@@ -85,7 +85,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: orderError.message }, { status: 500 });
     }
 
-    const itemsWithOrderId = orderItems.map((item) => ({
+    const itemsWithOrderId = orderItems.map(({ shipping_cost: _, ...item }) => ({
       ...item,
       order_id: order.id,
     }));


### PR DESCRIPTION
The shipping_cost field from the per-product calculation was being spread into the order items insert, but coffee_order_items doesn't have that column. Strip it out before inserting.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2