### PR TITLE
Fix awaiting_payment showing after Stripe payment and ensure order em…

### DIFF
--- a/src/app/api/coffee/orders/[id]/confirm/route.ts
+++ b/src/app/api/coffee/orders/[id]/confirm/route.ts
@@ -1,0 +1,120 @@
+import { NextRequest, NextResponse } from "next/server";
+import Stripe from "stripe";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getCoffeeUser } from "@/lib/coffeeAuth";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const user = await getCoffeeUser(req);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { id } = await params;
+
+    const { data: order, error } = await supabaseAdmin
+      .from("coffee_orders")
+      .select("*, coffee_order_items(*)")
+      .eq("id", id)
+      .eq("operator_id", user.id)
+      .single();
+
+    if (error || !order) {
+      return NextResponse.json({ error: "Order not found" }, { status: 404 });
+    }
+
+    if (order.status !== "awaiting_payment") {
+      return NextResponse.json({ order });
+    }
+
+    if (!order.stripe_checkout_session_id) {
+      return NextResponse.json({ order });
+    }
+
+    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
+    const session = await stripe.checkout.sessions.retrieve(order.stripe_checkout_session_id);
+
+    if (session.payment_status !== "paid") {
+      return NextResponse.json({ order });
+    }
+
+    const paymentIntentId =
+      typeof session.payment_intent === "string"
+        ? session.payment_intent
+        : session.payment_intent?.id ?? null;
+
+    const { data: updated } = await supabaseAdmin
+      .from("coffee_orders")
+      .update({
+        status: "pending",
+        stripe_payment_intent_id: paymentIntentId,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", id)
+      .eq("status", "awaiting_payment")
+      .select("*, coffee_order_items(*)")
+      .single();
+
+    if (!updated) {
+      const { data: current } = await supabaseAdmin
+        .from("coffee_orders")
+        .select("*, coffee_order_items(*)")
+        .eq("id", id)
+        .single();
+      return NextResponse.json({ order: current });
+    }
+
+    if (user.id) {
+      await supabaseAdmin
+        .from("coffee_cart_items")
+        .delete()
+        .eq("user_id", user.id);
+    }
+
+    try {
+      const { sendCoffeeOrderNotification, sendCoffeeOrderConfirmation } = await import("@/lib/coffeeEmail");
+
+      const { data: profile } = await supabaseAdmin
+        .from("profiles")
+        .select("full_name, email")
+        .eq("id", updated.operator_id)
+        .single();
+
+      const emailParams = {
+        orderNumber: updated.order_number,
+        operatorName: profile?.full_name || "Operator",
+        operatorEmail: profile?.email || user.email || "",
+        items: (updated.coffee_order_items || []).map((i: Record<string, unknown>) => ({
+          product_name: i.product_name as string,
+          product_sku: i.product_sku as string,
+          quantity: Number(i.quantity),
+          unit_price: Number(i.unit_price),
+          line_total: Number(i.line_total),
+        })),
+        subtotal: Number(updated.subtotal),
+        shippingEstimate: Number(updated.shipping_estimate),
+        total: Number(updated.total),
+        shippingName: updated.shipping_name,
+        shippingAddress: updated.shipping_address,
+        shippingCity: updated.shipping_city,
+        shippingState: updated.shipping_state,
+        shippingZip: updated.shipping_zip,
+      };
+
+      await Promise.all([
+        sendCoffeeOrderNotification(emailParams),
+        sendCoffeeOrderConfirmation(emailParams),
+      ]);
+    } catch (e) {
+      console.error("[confirm] Failed to send coffee order emails:", e);
+    }
+
+    return NextResponse.json({ order: updated });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Unknown error";
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/coffee/orders/[id]/page.tsx
+++ b/src/app/coffee/orders/[id]/page.tsx
@@ -82,27 +82,24 @@ function OrderDetailContent() {
         });
         if (res.ok) {
           const data = await res.json();
-          setOrder(data.order);
+          let orderData = data.order;
 
-          if (searchParams.get("paid") && data.order?.status === "awaiting_payment") {
-            let attempts = 0;
-            const poll = setInterval(async () => {
-              attempts++;
-              try {
-                const r = await fetch(`/api/coffee/orders/${orderId}`, {
-                  headers: { Authorization: `Bearer ${session.access_token}` },
-                });
-                if (r.ok) {
-                  const d = await r.json();
-                  if (d.order?.status !== "awaiting_payment") {
-                    setOrder(d.order);
-                    clearInterval(poll);
-                  }
+          if (searchParams.get("paid") && orderData?.status === "awaiting_payment") {
+            try {
+              const confirmRes = await fetch(`/api/coffee/orders/${orderId}/confirm`, {
+                method: "POST",
+                headers: { Authorization: `Bearer ${session.access_token}` },
+              });
+              if (confirmRes.ok) {
+                const confirmData = await confirmRes.json();
+                if (confirmData.order) {
+                  orderData = confirmData.order;
                 }
-              } catch {}
-              if (attempts >= 10) clearInterval(poll);
-            }, 2000);
+              }
+            } catch {}
           }
+
+          setOrder(orderData);
         } else {
           router.push("/coffee/orders");
         }
@@ -187,7 +184,7 @@ function OrderDetailContent() {
         </div>
         <div className="flex items-center gap-3">
           <span className={`inline-block rounded-full px-3 py-1 text-sm font-medium capitalize ${STATUS_STYLES[order.status] || "bg-gray-100 text-gray-600"}`}>
-            {order.status}
+            {order.status === "awaiting_payment" ? "pending" : order.status}
           </span>
           <button
             type="button"

--- a/src/app/coffee/orders/page.tsx
+++ b/src/app/coffee/orders/page.tsx
@@ -153,7 +153,7 @@ export default function CoffeeOrdersPage() {
                       <td className="px-5 py-4 font-medium text-gray-900">${Number(order.total).toFixed(2)}</td>
                       <td className="px-5 py-4">
                         <span className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium capitalize ${STATUS_STYLES[order.status] || "bg-gray-100 text-gray-600"}`}>
-                          {order.status}
+                          {order.status === "awaiting_payment" ? "pending" : order.status}
                         </span>
                       </td>
                       <td className="px-5 py-4">


### PR DESCRIPTION
…ails send

The Stripe webhook wasn't reliably updating order status or triggering emails. Added a /confirm endpoint that the order page calls after Stripe redirect — it verifies payment directly with Stripe, updates status to pending, clears the cart, and sends both the admin notification email (james@apexaivending.com) and customer confirmation email. Also maps awaiting_payment to display as "pending" on customer-facing pages.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2