### PR TITLE
Add admin coffee access toggle and require phone/address for all users

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -221,7 +221,7 @@ function UsersManager({ token, onSuccess }: { token: string; onSuccess: (msg: st
   const [search, setSearch] = useState("");
   const [roleFilter, setRoleFilter] = useState("");
   const [editingUser, setEditingUser] = useState<Profile | null>(null);
-  const [editForm, setEditForm] = useState({ role: "", verified: false, featured: false, full_name: "", email: "", company_name: "", phone: "", address: "", city: "", state: "", zip: "" });
+  const [editForm, setEditForm] = useState({ role: "", verified: false, featured: false, coffee_access_enabled: false, full_name: "", email: "", company_name: "", phone: "", address: "", city: "", state: "", zip: "" });
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState("");
   const [deleteTarget, setDeleteTarget] = useState<Profile | null>(null);
@@ -259,6 +259,7 @@ function UsersManager({ token, onSuccess }: { token: string; onSuccess: (msg: st
       role: user.role,
       verified: user.verified,
       featured: user.featured,
+      coffee_access_enabled: !!user.coffee_access_enabled,
       full_name: user.full_name,
       email: user.email,
       company_name: user.company_name || "",
@@ -441,6 +442,7 @@ function UsersManager({ token, onSuccess }: { token: string; onSuccess: (msg: st
                 <th className="px-4 py-3 font-medium text-black-primary/60">Role</th>
                 <th className="px-4 py-3 font-medium text-black-primary/60">Verified</th>
                 <th className="px-4 py-3 font-medium text-black-primary/60">Featured</th>
+                <th className="px-4 py-3 font-medium text-black-primary/60">Coffee</th>
                 <th className="px-4 py-3 font-medium text-black-primary/60">Joined</th>
                 <th className="px-4 py-3 font-medium text-black-primary/60">Actions</th>
               </tr>
@@ -493,6 +495,30 @@ function UsersManager({ token, onSuccess }: { token: string; onSuccess: (msg: st
                       title={user.featured ? "Remove featured status" : "Make featured"}
                     >
                       <Star className={`h-5 w-5 ${user.featured ? "fill-amber-500" : ""}`} />
+                    </button>
+                  </td>
+                  <td className="px-4 py-3">
+                    <button
+                      type="button"
+                      onClick={async () => {
+                        const enabled = !user.coffee_access_enabled;
+                        try {
+                          const res = await fetch(`/api/admin/users/${user.id}`, {
+                            method: "PATCH",
+                            headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+                            body: JSON.stringify({ coffee_access_enabled: enabled }),
+                          });
+                          if (res.ok) fetchUsers();
+                        } catch {}
+                      }}
+                      className={`rounded-lg p-1.5 transition-colors cursor-pointer ${
+                        user.coffee_access_enabled
+                          ? "text-green-600 hover:bg-green-50"
+                          : "text-black-primary/20 hover:bg-gray-50 hover:text-green-400"
+                      }`}
+                      title={user.coffee_access_enabled ? "Disable coffee access" : "Enable coffee access"}
+                    >
+                      <Coffee className="h-5 w-5" />
                     </button>
                   </td>
                   <td className="px-4 py-3 text-black-primary/40 text-xs">
@@ -609,7 +635,7 @@ function UsersManager({ token, onSuccess }: { token: string; onSuccess: (msg: st
                   <option value="admin">Admin</option>
                 </select>
               </div>
-              <div className="flex items-center gap-4">
+              <div className="flex flex-wrap items-center gap-4">
                 <div className="flex items-center gap-2">
                   <input
                     type="checkbox"
@@ -632,6 +658,18 @@ function UsersManager({ token, onSuccess }: { token: string; onSuccess: (msg: st
                   />
                   <label htmlFor="edit_featured" className="text-sm text-black-primary">
                     Featured Operator
+                  </label>
+                </div>
+                <div className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    id="edit_coffee_access"
+                    checked={editForm.coffee_access_enabled}
+                    onChange={(e) => setEditForm((f) => ({ ...f, coffee_access_enabled: e.target.checked }))}
+                    className="h-4 w-4 rounded border-gray-300 text-green-600"
+                  />
+                  <label htmlFor="edit_coffee_access" className="text-sm text-black-primary">
+                    Coffee Access
                   </label>
                 </div>
               </div>

--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -20,7 +20,7 @@ export async function PATCH(
     const allowedFields = [
       "full_name", "email", "role", "company_name", "phone",
       "website", "bio", "address", "city", "state", "zip", "country",
-      "verified", "featured",
+      "verified", "featured", "coffee_access_enabled",
     ];
     const updates: Record<string, unknown> = {};
     for (const field of allowedFields) {

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -118,6 +118,20 @@ function CallbackContent() {
       } else {
         // Clean up any stale signup role from prior flows
         consumeSignupRole();
+
+        // Check if profile is missing required fields — redirect to complete
+        try {
+          const profileRes = await fetch("/api/auth/me", {
+            headers: { Authorization: `Bearer ${session.access_token}` },
+          });
+          if (profileRes.ok) {
+            const profile = await profileRes.json();
+            if (!profile.phone || !profile.address) {
+              window.location.href = "/complete-profile";
+              return;
+            }
+          }
+        } catch {}
       }
 
       const savedRedirect = consumeRedirectAfterLogin();

--- a/src/app/complete-profile/page.tsx
+++ b/src/app/complete-profile/page.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { Loader2 } from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
+import { US_STATES } from "@/lib/types";
+
+export default function CompleteProfilePage() {
+  const router = useRouter();
+  const [token, setToken] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+  const [form, setForm] = useState({
+    phone: "",
+    address: "",
+    city: "",
+    state: "",
+    zip: "",
+  });
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    async function init() {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session?.access_token) {
+        router.push("/login");
+        return;
+      }
+      setToken(session.access_token);
+
+      try {
+        const res = await fetch("/api/auth/me", {
+          headers: { Authorization: `Bearer ${session.access_token}` },
+        });
+        if (res.ok) {
+          const profile = await res.json();
+          if (profile.phone && profile.address) {
+            router.push("/dashboard");
+            return;
+          }
+          setForm({
+            phone: profile.phone || "",
+            address: profile.address || "",
+            city: profile.city || "",
+            state: profile.state || "",
+            zip: profile.zip || "",
+          });
+        }
+      } catch {}
+      setLoading(false);
+    }
+    init();
+  }, [router]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!form.phone.trim()) { setError("Phone number is required"); return; }
+    if (!form.address.trim()) { setError("Address is required"); return; }
+    if (!form.city.trim()) { setError("City is required"); return; }
+    if (!form.state.trim()) { setError("State is required"); return; }
+    if (!form.zip.trim()) { setError("Zip code is required"); return; }
+
+    setSaving(true);
+    setError("");
+
+    try {
+      const res = await fetch("/api/auth/me", {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(form),
+      });
+
+      if (res.ok) {
+        router.push("/dashboard");
+      } else {
+        const data = await res.json();
+        setError(data.error || "Failed to save");
+      }
+    } catch {
+      setError("Failed to save. Please try again.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-green-600" />
+      </div>
+    );
+  }
+
+  const inputClass = "w-full rounded-xl border border-gray-200 px-4 py-3 text-sm focus:border-green-600 focus:outline-none focus:ring-1 focus:ring-green-600/30 transition-colors";
+
+  return (
+    <div className="min-h-[calc(100vh-160px)] flex items-center justify-center px-4 py-12">
+      <div className="w-full max-w-md">
+        <div className="text-center mb-8">
+          <h1 className="text-2xl font-bold text-gray-900">Complete Your Profile</h1>
+          <p className="text-gray-500 mt-2">Please provide your contact information to continue.</p>
+        </div>
+
+        <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 sm:p-8">
+          {error && (
+            <div className="mb-6 p-4 bg-red-50 border border-red-200 rounded-xl text-red-700 text-sm">
+              {error}
+            </div>
+          )}
+
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label className="block text-xs font-medium text-gray-500 mb-1">Phone <span className="text-red-500">*</span></label>
+              <input
+                type="tel"
+                value={form.phone}
+                onChange={(e) => setForm((f) => ({ ...f, phone: e.target.value }))}
+                placeholder="(555) 555-5555"
+                className={inputClass}
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-gray-500 mb-1">Address <span className="text-red-500">*</span></label>
+              <input
+                type="text"
+                value={form.address}
+                onChange={(e) => setForm((f) => ({ ...f, address: e.target.value }))}
+                placeholder="Street address"
+                className={inputClass}
+              />
+            </div>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+              <div>
+                <label className="block text-xs font-medium text-gray-500 mb-1">City <span className="text-red-500">*</span></label>
+                <input
+                  type="text"
+                  value={form.city}
+                  onChange={(e) => setForm((f) => ({ ...f, city: e.target.value }))}
+                  placeholder="City"
+                  className={inputClass}
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-gray-500 mb-1">State <span className="text-red-500">*</span></label>
+                <select
+                  value={form.state}
+                  onChange={(e) => setForm((f) => ({ ...f, state: e.target.value }))}
+                  className={inputClass}
+                >
+                  <option value="">--</option>
+                  {US_STATES.map((s) => (
+                    <option key={s} value={s}>{s}</option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-gray-500 mb-1">Zip <span className="text-red-500">*</span></label>
+                <input
+                  type="text"
+                  value={form.zip}
+                  onChange={(e) => setForm((f) => ({ ...f, zip: e.target.value }))}
+                  placeholder="e.g. 75001"
+                  maxLength={10}
+                  className={inputClass}
+                />
+              </div>
+            </div>
+
+            <button
+              type="submit"
+              disabled={saving}
+              className="w-full py-3 px-4 bg-green-600 hover:bg-green-700 text-white font-semibold rounded-xl transition-colors disabled:opacity-50 cursor-pointer mt-2"
+            >
+              {saving ? (
+                <Loader2 className="h-5 w-5 animate-spin mx-auto" />
+              ) : (
+                "Continue"
+              )}
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
1. Admin can now toggle coffee access per user: a Coffee column with a clickable icon in the users table, plus a checkbox in the edit modal. The admin API now accepts coffee_access_enabled.

2. Users who sign in via OAuth (login page) without phone/address on their profile are redirected to /complete-profile, which requires phone, address, city, state, and zip before they can continue.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2