### PR TITLE
Add How-to Guides tab to coffee admin panel

### DIFF
--- a/src/app/admin/coffee/page.tsx
+++ b/src/app/admin/coffee/page.tsx
@@ -9,6 +9,7 @@ import {
   Package,
   ShoppingCart,
   FileText,
+  BookOpen,
   Plus,
   Pencil,
   Trash2,
@@ -21,7 +22,7 @@ import {
 } from "lucide-react";
 import { createBrowserClient } from "@/lib/supabase";
 
-type Tab = "products" | "orders" | "applications";
+type Tab = "products" | "orders" | "applications" | "guides";
 
 interface Category {
   id: string;
@@ -78,6 +79,20 @@ interface Application {
   profiles: { id: string; full_name: string; email: string } | null;
 }
 
+interface Guide {
+  id: string;
+  title: string;
+  slug: string;
+  summary: string | null;
+  content: string;
+  image_url: string | null;
+  category_id: string | null;
+  sort_order: number;
+  active: boolean;
+  created_at: string;
+  coffee_categories: Category | null;
+}
+
 function Toast({ message, type }: { message: string; type: "success" | "error" }) {
   return (
     <div
@@ -118,6 +133,8 @@ export default function AdminCoffeePage() {
   const [orders, setOrders] = useState<Order[]>([]);
   const [applications, setApplications] = useState<Application[]>([]);
 
+  const [guides, setGuides] = useState<Guide[]>([]);
+
   const [showProductForm, setShowProductForm] = useState(false);
   const [editingProduct, setEditingProduct] = useState<Product | null>(null);
   const [productForm, setProductForm] = useState({
@@ -140,6 +157,21 @@ export default function AdminCoffeePage() {
   const [expandedOrder, setExpandedOrder] = useState<string | null>(null);
   const [updatingOrder, setUpdatingOrder] = useState<string | null>(null);
   const [processingApp, setProcessingApp] = useState<string | null>(null);
+
+  const [showGuideForm, setShowGuideForm] = useState(false);
+  const [editingGuide, setEditingGuide] = useState<Guide | null>(null);
+  const [guideForm, setGuideForm] = useState({
+    title: "",
+    summary: "",
+    content: "",
+    image_url: "",
+    category_id: "",
+    sort_order: "0",
+    active: true,
+  });
+  const [savingGuide, setSavingGuide] = useState(false);
+  const [deletingGuide, setDeletingGuide] = useState<string | null>(null);
+  const [uploadingGuideImage, setUploadingGuideImage] = useState(false);
 
   function showToast(message: string, type: "success" | "error") {
     setToast({ message, type });
@@ -227,13 +259,27 @@ export default function AdminCoffeePage() {
     } catch {}
   }, [token]);
 
+  const fetchGuides = useCallback(async () => {
+    if (!token) return;
+    try {
+      const res = await fetch("/api/admin/coffee/guides", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setGuides(data.guides || []);
+      }
+    } catch {}
+  }, [token]);
+
   useEffect(() => {
     if (!token) return;
     fetchProducts();
     fetchCategories();
     fetchOrders();
     fetchApplications();
-  }, [token, fetchProducts, fetchCategories, fetchOrders, fetchApplications]);
+    fetchGuides();
+  }, [token, fetchProducts, fetchCategories, fetchOrders, fetchApplications, fetchGuides]);
 
   function resetProductForm() {
     setProductForm({
@@ -441,6 +487,149 @@ export default function AdminCoffeePage() {
     }
   }
 
+  function resetGuideForm() {
+    setGuideForm({
+      title: "",
+      summary: "",
+      content: "",
+      image_url: "",
+      category_id: "",
+      sort_order: "0",
+      active: true,
+    });
+    setEditingGuide(null);
+    setShowGuideForm(false);
+  }
+
+  function startEditGuide(guide: Guide) {
+    setGuideForm({
+      title: guide.title,
+      summary: guide.summary || "",
+      content: guide.content,
+      image_url: guide.image_url || "",
+      category_id: guide.category_id || "",
+      sort_order: String(guide.sort_order),
+      active: guide.active,
+    });
+    setEditingGuide(guide);
+    setShowGuideForm(true);
+  }
+
+  async function handleGuideImageUpload(file: File) {
+    if (!token) return;
+    if (!file.type.startsWith("image/")) {
+      showToast("Please select an image file", "error");
+      return;
+    }
+    if (file.size > 5 * 1024 * 1024) {
+      showToast("Image must be under 5MB", "error");
+      return;
+    }
+    setUploadingGuideImage(true);
+    try {
+      const supabase = createBrowserClient();
+      const ext = file.name.split(".").pop()?.toLowerCase() || "jpg";
+      const path = `coffee-guides/${Date.now()}-${Math.random().toString(36).slice(2, 8)}.${ext}`;
+      const { error: uploadErr } = await supabase.storage
+        .from("documents")
+        .upload(path, file, { upsert: false, contentType: file.type });
+      if (uploadErr) {
+        showToast(`Upload failed: ${uploadErr.message}`, "error");
+        return;
+      }
+      const { data: urlData } = supabase.storage.from("documents").getPublicUrl(path);
+      setGuideForm((g) => ({ ...g, image_url: urlData.publicUrl }));
+      showToast("Image uploaded", "success");
+    } catch {
+      showToast("Upload failed", "error");
+    } finally {
+      setUploadingGuideImage(false);
+    }
+  }
+
+  async function handleSaveGuide(e: React.FormEvent) {
+    e.preventDefault();
+    setSavingGuide(true);
+    try {
+      const body: Record<string, unknown> = {
+        title: guideForm.title,
+        summary: guideForm.summary || null,
+        content: guideForm.content,
+        image_url: guideForm.image_url || null,
+        category_id: guideForm.category_id || null,
+        sort_order: parseInt(guideForm.sort_order) || 0,
+        active: guideForm.active,
+      };
+
+      if (editingGuide) {
+        body.id = editingGuide.id;
+      }
+
+      const res = await fetch("/api/admin/coffee/guides", {
+        method: editingGuide ? "PATCH" : "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(body),
+      });
+
+      if (res.ok) {
+        showToast(editingGuide ? "Guide updated" : "Guide created", "success");
+        resetGuideForm();
+        fetchGuides();
+      } else {
+        const data = await res.json();
+        showToast(data.error || "Failed to save guide", "error");
+      }
+    } catch {
+      showToast("Failed to save guide", "error");
+    } finally {
+      setSavingGuide(false);
+    }
+  }
+
+  async function handleDeleteGuide(id: string) {
+    if (!confirm("Are you sure you want to delete this guide?")) return;
+    setDeletingGuide(id);
+    try {
+      const res = await fetch("/api/admin/coffee/guides", {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ id }),
+      });
+      if (res.ok) {
+        showToast("Guide deleted", "success");
+        fetchGuides();
+      } else {
+        showToast("Failed to delete guide", "error");
+      }
+    } catch {
+      showToast("Failed to delete guide", "error");
+    } finally {
+      setDeletingGuide(null);
+    }
+  }
+
+  async function handleToggleGuideActive(guide: Guide) {
+    try {
+      const res = await fetch("/api/admin/coffee/guides", {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ id: guide.id, active: !guide.active }),
+      });
+      if (res.ok) {
+        fetchGuides();
+      }
+    } catch {}
+  }
+
   if (loading) {
     return (
       <div className="flex min-h-[60vh] items-center justify-center">
@@ -453,6 +642,7 @@ export default function AdminCoffeePage() {
     { key: "products", label: "Products", icon: <Package className="h-4 w-4" />, count: products.length },
     { key: "orders", label: "Orders", icon: <ShoppingCart className="h-4 w-4" />, count: orders.length },
     { key: "applications", label: "Applications", icon: <FileText className="h-4 w-4" />, count: applications.filter((a) => a.status === "pending").length },
+    { key: "guides", label: "How-to Guides", icon: <BookOpen className="h-4 w-4" />, count: guides.length },
   ];
 
   return (
@@ -938,6 +1128,233 @@ export default function AdminCoffeePage() {
                 )}
               </tbody>
             </table>
+          </div>
+        </div>
+      )}
+
+      {activeTab === "guides" && (
+        <div>
+          <div className="mb-4 flex items-center justify-between">
+            <p className="text-sm text-gray-500">{guides.length} guide(s)</p>
+            <button
+              type="button"
+              onClick={() => { resetGuideForm(); setShowGuideForm(true); }}
+              className="flex items-center gap-1.5 rounded-xl bg-green-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-green-700 cursor-pointer"
+            >
+              <Plus className="h-4 w-4" />
+              Add Guide
+            </button>
+          </div>
+
+          {showGuideForm && (
+            <div className="mb-6 rounded-2xl border border-gray-100 bg-white p-6 shadow-sm">
+              <div className="mb-4 flex items-center justify-between">
+                <h2 className="text-lg font-bold text-gray-900">{editingGuide ? "Edit Guide" : "New Guide"}</h2>
+                <button type="button" onClick={resetGuideForm} className="text-gray-400 hover:text-gray-600 cursor-pointer">
+                  <X className="h-5 w-5" />
+                </button>
+              </div>
+              <form onSubmit={handleSaveGuide} className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                <div className="sm:col-span-2">
+                  <label className="mb-1.5 block text-sm font-medium text-gray-700">Title</label>
+                  <input
+                    type="text"
+                    required
+                    value={guideForm.title}
+                    onChange={(e) => setGuideForm((g) => ({ ...g, title: e.target.value }))}
+                    className={inputClass}
+                    placeholder="e.g. How to Clean Your Coffee Machine"
+                  />
+                </div>
+                <div>
+                  <label className="mb-1.5 block text-sm font-medium text-gray-700">Category</label>
+                  <select
+                    value={guideForm.category_id}
+                    onChange={(e) => setGuideForm((g) => ({ ...g, category_id: e.target.value }))}
+                    className={inputClass}
+                  >
+                    <option value="">None</option>
+                    {categories.map((cat) => (
+                      <option key={cat.id} value={cat.id}>{cat.name}</option>
+                    ))}
+                  </select>
+                </div>
+                <div className="sm:col-span-2 lg:col-span-3">
+                  <label className="mb-1.5 block text-sm font-medium text-gray-700">Summary</label>
+                  <input
+                    type="text"
+                    value={guideForm.summary}
+                    onChange={(e) => setGuideForm((g) => ({ ...g, summary: e.target.value }))}
+                    className={inputClass}
+                    placeholder="Brief description shown on guide cards"
+                  />
+                </div>
+                <div className="sm:col-span-2 lg:col-span-3">
+                  <label className="mb-1.5 block text-sm font-medium text-gray-700">Cover Image</label>
+                  <div className="flex items-start gap-4">
+                    {guideForm.image_url && (
+                      <div className="relative h-24 w-24 shrink-0 overflow-hidden rounded-xl border border-gray-200 bg-gray-50">
+                        <img src={guideForm.image_url} alt="Preview" className="h-full w-full object-contain" />
+                        <button
+                          type="button"
+                          onClick={() => setGuideForm((g) => ({ ...g, image_url: "" }))}
+                          className="absolute -right-1 -top-1 rounded-full bg-red-500 p-0.5 text-white shadow-sm hover:bg-red-600 cursor-pointer"
+                        >
+                          <X className="h-3 w-3" />
+                        </button>
+                      </div>
+                    )}
+                    <div className="flex-1">
+                      <label className="flex cursor-pointer items-center justify-center gap-2 rounded-xl border-2 border-dashed border-gray-300 px-4 py-4 text-sm text-gray-500 transition-colors hover:border-green-400 hover:text-green-600">
+                        {uploadingGuideImage ? (
+                          <>
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                            Uploading...
+                          </>
+                        ) : (
+                          <>
+                            <Plus className="h-4 w-4" />
+                            {guideForm.image_url ? "Replace Image" : "Upload Image"}
+                          </>
+                        )}
+                        <input
+                          type="file"
+                          accept="image/*"
+                          className="hidden"
+                          disabled={uploadingGuideImage}
+                          onChange={(e) => {
+                            const file = e.target.files?.[0];
+                            if (file) handleGuideImageUpload(file);
+                            e.target.value = "";
+                          }}
+                        />
+                      </label>
+                      <p className="mt-1.5 text-xs text-gray-400">JPG, PNG, WebP — max 5MB</p>
+                    </div>
+                  </div>
+                </div>
+                <div className="sm:col-span-2 lg:col-span-3">
+                  <label className="mb-1.5 block text-sm font-medium text-gray-700">Content</label>
+                  <textarea
+                    rows={8}
+                    required
+                    value={guideForm.content}
+                    onChange={(e) => setGuideForm((g) => ({ ...g, content: e.target.value }))}
+                    className={inputClass + " resize-none"}
+                    placeholder="Write your guide content here. You can use line breaks for formatting."
+                  />
+                </div>
+                <div>
+                  <label className="mb-1.5 block text-sm font-medium text-gray-700">Sort Order</label>
+                  <input
+                    type="number"
+                    value={guideForm.sort_order}
+                    onChange={(e) => setGuideForm((g) => ({ ...g, sort_order: e.target.value }))}
+                    className={inputClass}
+                  />
+                </div>
+                <div className="flex items-center gap-2 sm:col-span-2 lg:col-span-3">
+                  <label className="flex items-center gap-2 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={guideForm.active}
+                      onChange={(e) => setGuideForm((g) => ({ ...g, active: e.target.checked }))}
+                      className="h-4 w-4 rounded border-gray-300 text-green-600 focus:ring-green-500 cursor-pointer"
+                    />
+                    <span className="text-sm font-medium text-gray-700">Active</span>
+                  </label>
+                  <div className="ml-auto flex gap-2">
+                    <button
+                      type="button"
+                      onClick={resetGuideForm}
+                      className="rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-50 cursor-pointer"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      type="submit"
+                      disabled={savingGuide}
+                      className="flex items-center gap-1.5 rounded-lg bg-green-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-green-700 disabled:opacity-50 cursor-pointer"
+                    >
+                      {savingGuide && <Loader2 className="h-4 w-4 animate-spin" />}
+                      {editingGuide ? "Update" : "Create"}
+                    </button>
+                  </div>
+                </div>
+              </form>
+            </div>
+          )}
+
+          <div className="overflow-hidden rounded-2xl border border-gray-100 bg-white shadow-sm">
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-gray-100 bg-gray-50">
+                    <th className="px-5 py-3 text-left font-semibold text-gray-600">Title</th>
+                    <th className="px-5 py-3 text-left font-semibold text-gray-600">Category</th>
+                    <th className="px-5 py-3 text-left font-semibold text-gray-600">Summary</th>
+                    <th className="px-5 py-3 text-center font-semibold text-gray-600">Active</th>
+                    <th className="px-5 py-3 text-right font-semibold text-gray-600">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {guides.length === 0 ? (
+                    <tr>
+                      <td colSpan={5} className="px-5 py-12 text-center text-gray-500">No guides yet</td>
+                    </tr>
+                  ) : (
+                    guides.map((guide) => (
+                      <tr key={guide.id} className="border-b border-gray-50 last:border-0 hover:bg-gray-50/50">
+                        <td className="px-5 py-3">
+                          <div className="flex items-center gap-3">
+                            {guide.image_url && (
+                              <div className="h-10 w-10 shrink-0 overflow-hidden rounded-lg bg-gray-100">
+                                <img src={guide.image_url} alt="" className="h-full w-full object-cover" />
+                              </div>
+                            )}
+                            <span className="font-medium text-gray-900">{guide.title}</span>
+                          </div>
+                        </td>
+                        <td className="px-5 py-3 text-gray-600">{guide.coffee_categories?.name || "—"}</td>
+                        <td className="px-5 py-3 text-gray-600 max-w-xs truncate">{guide.summary || "—"}</td>
+                        <td className="px-5 py-3 text-center">
+                          <button
+                            type="button"
+                            onClick={() => handleToggleGuideActive(guide)}
+                            className={`h-5 w-9 rounded-full transition-colors cursor-pointer ${guide.active ? "bg-green-600" : "bg-gray-300"}`}
+                          >
+                            <div className={`h-4 w-4 rounded-full bg-white shadow transition-transform ${guide.active ? "translate-x-4" : "translate-x-0.5"}`} />
+                          </button>
+                        </td>
+                        <td className="px-5 py-3">
+                          <div className="flex items-center justify-end gap-1">
+                            <button
+                              type="button"
+                              onClick={() => startEditGuide(guide)}
+                              className="rounded-lg p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 cursor-pointer"
+                            >
+                              <Pencil className="h-4 w-4" />
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => handleDeleteGuide(guide.id)}
+                              disabled={deletingGuide === guide.id}
+                              className="rounded-lg p-1.5 text-red-400 transition-colors hover:bg-red-50 hover:text-red-600 disabled:opacity-50 cursor-pointer"
+                            >
+                              {deletingGuide === guide.id ? (
+                                <Loader2 className="h-4 w-4 animate-spin" />
+                              ) : (
+                                <Trash2 className="h-4 w-4" />
+                              )}
+                            </button>
+                          </div>
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
           </div>
         </div>
       )}

--- a/src/app/api/admin/coffee/guides/route.ts
+++ b/src/app/api/admin/coffee/guides/route.ts
@@ -1,0 +1,138 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+
+export async function GET(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  try {
+    const { data, error } = await supabaseAdmin
+      .from("coffee_guides")
+      .select("*, coffee_categories(id, name, slug)")
+      .order("sort_order", { ascending: true });
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ guides: data || [] });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Unknown error";
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  try {
+    const body = await req.json();
+
+    if (!body.title?.trim() || !body.content?.trim()) {
+      return NextResponse.json({ error: "Title and content are required" }, { status: 400 });
+    }
+
+    const slug = body.slug?.trim() ||
+      body.title.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+
+    const { data, error } = await supabaseAdmin
+      .from("coffee_guides")
+      .insert({
+        title: body.title.trim(),
+        slug,
+        summary: body.summary?.trim() || null,
+        content: body.content.trim(),
+        image_url: body.image_url || null,
+        category_id: body.category_id || null,
+        sort_order: body.sort_order ?? 0,
+        active: body.active ?? true,
+      })
+      .select("*, coffee_categories(id, name, slug)")
+      .single();
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ guide: data }, { status: 201 });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Unknown error";
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}
+
+export async function PATCH(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  try {
+    const body = await req.json();
+    const { id, ...fields } = body;
+
+    if (!id) {
+      return NextResponse.json({ error: "id required" }, { status: 400 });
+    }
+
+    const allowedFields = [
+      "title", "slug", "summary", "content", "image_url",
+      "category_id", "sort_order", "active",
+    ];
+    const updates: Record<string, unknown> = { updated_at: new Date().toISOString() };
+    for (const field of allowedFields) {
+      if (field in fields) updates[field] = fields[field];
+    }
+
+    const { data, error } = await supabaseAdmin
+      .from("coffee_guides")
+      .update(updates)
+      .eq("id", id)
+      .select("*, coffee_categories(id, name, slug)")
+      .single();
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ guide: data });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Unknown error";
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}
+
+export async function DELETE(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  try {
+    const { id } = await req.json();
+
+    if (!id) {
+      return NextResponse.json({ error: "id required" }, { status: 400 });
+    }
+
+    const { error } = await supabaseAdmin
+      .from("coffee_guides")
+      .delete()
+      .eq("id", id);
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Unknown error";
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/api/coffee/guides/route.ts
+++ b/src/app/api/coffee/guides/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+
+export async function GET(req: NextRequest) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const category = searchParams.get("category");
+
+    let query = supabaseAdmin
+      .from("coffee_guides")
+      .select("*, coffee_categories(id, name, slug)")
+      .eq("active", true)
+      .order("sort_order", { ascending: true });
+
+    if (category) {
+      query = query.eq("coffee_categories.slug", category);
+    }
+
+    const { data, error } = await query;
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ guides: data || [] });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Unknown error";
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/coffee/page.tsx
+++ b/src/app/coffee/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
-import { Search, ShoppingCart, Coffee, Lock, Loader2, X, AlertCircle } from "lucide-react";
+import { Search, ShoppingCart, Coffee, Lock, Loader2, X, AlertCircle, BookOpen } from "lucide-react";
 import { createBrowserClient } from "@/lib/supabase";
 import type { Profile } from "@/lib/types";
 import CoffeeCartDrawer from "@/app/components/CoffeeCartDrawer";
@@ -12,6 +12,16 @@ interface Category {
   name: string;
   slug: string;
   sort_order: number;
+}
+
+interface Guide {
+  id: string;
+  title: string;
+  slug: string;
+  summary: string | null;
+  content: string;
+  image_url: string | null;
+  coffee_categories: { id: string; name: string; slug: string } | null;
 }
 
 interface Product {
@@ -44,6 +54,8 @@ export default function CoffeeMarketplacePage() {
   const [adding, setAdding] = useState<string | null>(null);
   const [toast, setToast] = useState<{ message: string; type: "success" | "error" } | null>(null);
   const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
+  const [guides, setGuides] = useState<Guide[]>([]);
+  const [selectedGuide, setSelectedGuide] = useState<Guide | null>(null);
 
   useEffect(() => {
     const supabase = createBrowserClient();
@@ -94,6 +106,19 @@ export default function CoffeeMarketplacePage() {
       } catch {}
     }
     fetchCategories();
+  }, []);
+
+  useEffect(() => {
+    async function fetchGuides() {
+      try {
+        const res = await fetch("/api/coffee/guides");
+        if (res.ok) {
+          const data = await res.json();
+          setGuides(data.guides || []);
+        }
+      } catch {}
+    }
+    fetchGuides();
   }, []);
 
   const fetchCartCount = useCallback(async () => {
@@ -365,6 +390,54 @@ export default function CoffeeMarketplacePage() {
         )}
       </div>
 
+      {guides.length > 0 && (
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 pb-16">
+          <div className="border-t border-gray-800 pt-12">
+            <div className="flex items-center gap-3 mb-6">
+              <BookOpen className="h-6 w-6 text-green-400" />
+              <h2 className="text-2xl font-bold text-white">How-to Guides</h2>
+            </div>
+            <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+              {guides.map((guide) => (
+                <div
+                  key={guide.id}
+                  className="flex flex-col rounded-2xl bg-gray-900 border border-gray-800 shadow-sm transition-all hover:shadow-lg hover:border-gray-700 cursor-pointer"
+                  onClick={() => setSelectedGuide(guide)}
+                >
+                  {guide.image_url ? (
+                    <div className="h-40 overflow-hidden rounded-t-2xl bg-gray-800">
+                      <img
+                        src={guide.image_url}
+                        alt={guide.title}
+                        className="h-full w-full object-cover"
+                      />
+                    </div>
+                  ) : (
+                    <div className="flex h-32 items-center justify-center rounded-t-2xl bg-gray-800">
+                      <BookOpen className="h-12 w-12 text-gray-600" />
+                    </div>
+                  )}
+                  <div className="flex flex-1 flex-col p-5">
+                    {guide.coffee_categories && (
+                      <span className="mb-2 inline-block w-fit rounded-full bg-green-900/40 px-2.5 py-0.5 text-xs font-medium text-green-400">
+                        {guide.coffee_categories.name}
+                      </span>
+                    )}
+                    <h3 className="text-base font-bold text-white">{guide.title}</h3>
+                    {guide.summary && (
+                      <p className="mt-1 text-sm text-gray-400 line-clamp-2">{guide.summary}</p>
+                    )}
+                    <span className="mt-auto pt-3 text-sm font-medium text-green-400 hover:text-green-300">
+                      Read Guide →
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+
       {token && cartCount > 0 && (
         <button
           type="button"
@@ -487,6 +560,59 @@ export default function CoffeeMarketplacePage() {
           </>
         );
       })()}
+
+      {selectedGuide && (
+        <>
+          <div
+            className="fixed inset-0 z-[9980] bg-black/60 backdrop-blur-sm"
+            onClick={() => setSelectedGuide(null)}
+            aria-hidden="true"
+          />
+          <div className="fixed inset-0 z-[9981] flex items-center justify-center p-4 sm:p-6">
+            <div
+              className="relative max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-2xl bg-white shadow-2xl"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <button
+                type="button"
+                onClick={() => setSelectedGuide(null)}
+                className="absolute right-4 top-4 z-10 rounded-full bg-white/80 p-2 text-gray-500 shadow-sm backdrop-blur transition-colors hover:bg-white hover:text-gray-900 cursor-pointer"
+              >
+                <X className="h-5 w-5" />
+              </button>
+
+              {selectedGuide.image_url ? (
+                <div className="h-56 overflow-hidden rounded-t-2xl bg-gray-100 sm:h-72">
+                  <img
+                    src={selectedGuide.image_url}
+                    alt={selectedGuide.title}
+                    className="h-full w-full object-cover"
+                  />
+                </div>
+              ) : (
+                <div className="flex h-40 items-center justify-center rounded-t-2xl bg-gray-100">
+                  <BookOpen className="h-16 w-16 text-gray-300" />
+                </div>
+              )}
+
+              <div className="p-6 sm:p-8">
+                {selectedGuide.coffee_categories && (
+                  <span className="mb-3 inline-block rounded-full bg-green-100 px-3 py-1 text-xs font-medium text-green-700">
+                    {selectedGuide.coffee_categories.name}
+                  </span>
+                )}
+                <h2 className="text-2xl font-bold text-gray-900">{selectedGuide.title}</h2>
+                {selectedGuide.summary && (
+                  <p className="mt-2 text-sm font-medium text-gray-500">{selectedGuide.summary}</p>
+                )}
+                <div className="mt-6 whitespace-pre-wrap text-sm leading-relaxed text-gray-700">
+                  {selectedGuide.content}
+                </div>
+              </div>
+            </div>
+          </div>
+        </>
+      )}
 
       {token && (
         <CoffeeCartDrawer

--- a/supabase/migrations/20250530_coffee_guides.sql
+++ b/supabase/migrations/20250530_coffee_guides.sql
@@ -1,0 +1,20 @@
+-- How-to Guides for the Coffee Marketplace
+CREATE TABLE IF NOT EXISTS coffee_guides (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  title text NOT NULL,
+  slug text UNIQUE NOT NULL,
+  summary text,
+  content text NOT NULL,
+  image_url text,
+  category_id uuid REFERENCES coffee_categories(id) ON DELETE SET NULL,
+  sort_order integer DEFAULT 0,
+  active boolean DEFAULT true,
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now()
+);
+
+ALTER TABLE coffee_guides ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Anyone can view active guides"
+  ON coffee_guides FOR SELECT
+  USING (active = true);


### PR DESCRIPTION
Adds a full CRUD system for how-to guides in the coffee marketplace:
- New coffee_guides table with title, summary, content, image, category, sort order
- Admin API routes for create/read/update/delete guides
- Public API route for fetching active guides
- "How-to Guides" tab in coffee admin with form, image upload, and table listing
- Guides section on the public coffee marketplace with card grid and detail modal

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2