### PR TITLE
Fix signup profile fields not saving (phone, address, name, etc.)

### DIFF
--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -116,23 +116,24 @@ function CallbackContent() {
           }
         }
       } else {
-        // Clean up any stale signup role from prior flows
         consumeSignupRole();
-
-        // Check if profile is missing required fields — redirect to complete
-        try {
-          const profileRes = await fetch("/api/auth/me", {
-            headers: { Authorization: `Bearer ${session.access_token}` },
-          });
-          if (profileRes.ok) {
-            const profile = await profileRes.json();
-            if (!profile.phone || !profile.address) {
-              window.location.href = "/complete-profile";
-              return;
-            }
-          }
-        } catch {}
       }
+
+      // Always verify profile is complete — for BOTH signup and login.
+      // localStorage data can be lost during OAuth redirect (domain mismatch,
+      // browser clearing storage, etc.), so the signup PATCH may silently fail.
+      try {
+        const profileRes = await fetch("/api/auth/me", {
+          headers: { Authorization: `Bearer ${session.access_token}` },
+        });
+        if (profileRes.ok) {
+          const profile = await profileRes.json();
+          if (!profile.phone || !profile.address || !profile.city || !profile.state || !profile.zip) {
+            window.location.href = "/complete-profile";
+            return;
+          }
+        }
+      } catch {}
 
       const savedRedirect = consumeRedirectAfterLogin();
       window.location.href = savedRedirect || (isEmployeeSignup ? "/sales" : "/dashboard");

--- a/src/app/complete-profile/page.tsx
+++ b/src/app/complete-profile/page.tsx
@@ -13,6 +13,8 @@ export default function CompleteProfilePage() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
   const [form, setForm] = useState({
+    full_name: "",
+    company_name: "",
     phone: "",
     address: "",
     city: "",
@@ -36,11 +38,13 @@ export default function CompleteProfilePage() {
         });
         if (res.ok) {
           const profile = await res.json();
-          if (profile.phone && profile.address) {
+          if (profile.phone && profile.address && profile.city && profile.state && profile.zip) {
             router.push("/dashboard");
             return;
           }
           setForm({
+            full_name: profile.full_name || "",
+            company_name: profile.company_name || "",
             phone: profile.phone || "",
             address: profile.address || "",
             city: profile.city || "",
@@ -56,6 +60,7 @@ export default function CompleteProfilePage() {
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
+    if (!form.full_name.trim()) { setError("Full name is required"); return; }
     if (!form.phone.trim()) { setError("Phone number is required"); return; }
     if (!form.address.trim()) { setError("Address is required"); return; }
     if (!form.city.trim()) { setError("City is required"); return; }
@@ -114,6 +119,26 @@ export default function CompleteProfilePage() {
           )}
 
           <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label className="block text-xs font-medium text-gray-500 mb-1">Full Name <span className="text-red-500">*</span></label>
+              <input
+                type="text"
+                value={form.full_name}
+                onChange={(e) => setForm((f) => ({ ...f, full_name: e.target.value }))}
+                placeholder="Your full name"
+                className={inputClass}
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-gray-500 mb-1">Company Name</label>
+              <input
+                type="text"
+                value={form.company_name}
+                onChange={(e) => setForm((f) => ({ ...f, company_name: e.target.value }))}
+                placeholder="Your business name (optional)"
+                className={inputClass}
+              />
+            </div>
             <div>
               <label className="block text-xs font-medium text-gray-500 mb-1">Phone <span className="text-red-500">*</span></label>
               <input


### PR DESCRIPTION
The signup flow stores form data in localStorage before the OAuth redirect, then reads it back in the auth callback to PATCH the profile. But localStorage can be lost if the OAuth redirect changes domains (www vs non-www), or if the browser clears storage, or due to React double-mount consuming the data early.

Fix: always verify profile completeness after BOTH signup and login flows. If any required field (phone, address, city, state, zip) is missing, redirect to /complete-profile which now also collects full_name and company_name.

This guarantees no user reaches the dashboard with an incomplete profile, regardless of whether the localStorage-based PATCH succeeded.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2