### PR TITLE
Block dashboard and login redirect for users with incomplete profiles

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -268,6 +268,10 @@ export default function DashboardPage() {
             return;
           }
           const data = await res.json();
+          if (!data.phone || !data.address || !data.city || !data.state || !data.zip) {
+            window.location.href = "/complete-profile";
+            return;
+          }
           setProfile(data);
           setToken(session.access_token);
         } catch {

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -15,8 +15,20 @@ function LoginContent() {
 
   useEffect(() => {
     const supabase = createBrowserClient();
-    supabase.auth.getSession().then(({ data: { session } }) => {
+    supabase.auth.getSession().then(async ({ data: { session } }) => {
       if (session?.user) {
+        try {
+          const res = await fetch("/api/auth/me", {
+            headers: { Authorization: `Bearer ${session.access_token}` },
+          });
+          if (res.ok) {
+            const profile = await res.json();
+            if (!profile.phone || !profile.address || !profile.city || !profile.state || !profile.zip) {
+              window.location.href = "/complete-profile";
+              return;
+            }
+          }
+        } catch {}
         const redirect = searchParams.get("redirect") || "/dashboard";
         window.location.href = redirect;
       } else {


### PR DESCRIPTION
Users with existing sessions could bypass the Navbar profile check by going directly to /login (which auto-redirects to /dashboard) or by loading the dashboard before the async Navbar check completes.

Fix:
- Login page: check profile completeness before redirecting existing sessions, send to /complete-profile if fields are missing
- Dashboard page: check profile completeness on load, redirect to /complete-profile before rendering any dashboard content

Combined with the Navbar check, this creates three layers of enforcement: auth callback → login redirect → dashboard load → Navbar (catch-all).

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2