### PR TITLE
Add Google Maps static map previews to location listing cards

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,7 @@ PAYPAL_MODE=sandbox
 
 # Google Cloud (Lead Generator — project: projectleadgenvendcon)
 GOOGLE_PLACES_API_KEY=your-google-places-api-key
+NEXT_PUBLIC_GOOGLE_MAPS_KEY=your-google-maps-static-api-key
 GOOGLE_OAUTH_CLIENT_ID=your-oauth-client-id
 GOOGLE_OAUTH_CLIENT_SECRET=your-oauth-client-secret
 GOOGLE_OAUTH_REFRESH_TOKEN=your-refresh-token

--- a/src/app/browse-requests/page.tsx
+++ b/src/app/browse-requests/page.tsx
@@ -35,6 +35,7 @@ import {
   US_STATE_NAMES,
 } from "@/lib/types";
 import RequestCard from "../components/RequestCard";
+import StaticMapPreview from "../components/StaticMapPreview";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -320,6 +321,14 @@ function MarketplaceListingCard({ listing }: { listing: MarketplaceListing }) {
           For Sale
         </span>
       </div>
+
+      {listing.city && listing.state && (
+        <StaticMapPreview
+          city={listing.city}
+          state={listing.state}
+          className="w-full h-28 mt-3"
+        />
+      )}
 
       <div className="flex flex-wrap gap-1.5 mt-3">
         <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-700">

--- a/src/app/components/RequestCard.tsx
+++ b/src/app/components/RequestCard.tsx
@@ -16,6 +16,7 @@ import {
 import MachineTypeBadge from "./MachineTypeBadge";
 import UrgencyBadge from "./UrgencyBadge";
 import LocationTypeIcon from "./LocationTypeIcon";
+import StaticMapPreview from "./StaticMapPreview";
 interface RequestCardProps {
   request: VendingRequest;
   saved?: boolean;
@@ -78,6 +79,18 @@ export default function RequestCard({
           </button>
         )}
       </div>
+
+      {/* Map Preview */}
+      {request.city && request.state &&
+        request.city.toLowerCase() !== "unknown" &&
+        request.state.toLowerCase() !== "unknown" && (
+        <StaticMapPreview
+          city={request.city}
+          state={request.state}
+          zip={request.zip}
+          className="w-full h-28 mt-3"
+        />
+      )}
 
       {/* Machine Types */}
       <div className="flex flex-wrap gap-1.5 mt-3">

--- a/src/app/components/StaticMapPreview.tsx
+++ b/src/app/components/StaticMapPreview.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useState } from "react";
+import { MapPin } from "lucide-react";
+
+interface StaticMapPreviewProps {
+  city: string;
+  state: string;
+  zip?: string | null;
+  className?: string;
+}
+
+export default function StaticMapPreview({ city, state, zip, className = "" }: StaticMapPreviewProps) {
+  const [failed, setFailed] = useState(false);
+  const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_KEY;
+
+  if (!apiKey || failed) {
+    return (
+      <div className={`flex items-center justify-center bg-gray-100 rounded-lg ${className}`}>
+        <div className="text-center text-gray-400">
+          <MapPin className="h-5 w-5 mx-auto mb-1" />
+          <span className="text-xs">{city}, {state}</span>
+        </div>
+      </div>
+    );
+  }
+
+  const location = zip ? `${city}, ${state} ${zip}` : `${city}, ${state}`;
+  const encoded = encodeURIComponent(location);
+  const src = `https://maps.googleapis.com/maps/api/staticmap?center=${encoded}&zoom=13&size=400x160&scale=2&maptype=roadmap&style=feature:poi|visibility:off&key=${apiKey}`;
+
+  return (
+    <img
+      src={src}
+      alt={`Map of ${city}, ${state} area`}
+      className={`object-cover rounded-lg ${className}`}
+      loading="lazy"
+      onError={() => setFailed(true)}
+    />
+  );
+}

--- a/src/app/marketplace/page.tsx
+++ b/src/app/marketplace/page.tsx
@@ -13,6 +13,7 @@ import {
   Filter,
 } from "lucide-react";
 import { US_STATES, US_STATE_NAMES } from "@/lib/types";
+import StaticMapPreview from "../components/StaticMapPreview";
 
 interface Listing {
   id: string;
@@ -192,6 +193,13 @@ export default function MarketplacePage() {
                 <h3 className="font-semibold text-gray-900 text-sm mb-1 line-clamp-2 group-hover:text-green-700 transition-colors">
                   {l.title}
                 </h3>
+                {l.city && l.state && (
+                  <StaticMapPreview
+                    city={l.city}
+                    state={l.state}
+                    className="w-full h-24 my-2"
+                  />
+                )}
                 {l.description && (
                   <p className="text-xs text-gray-500 line-clamp-2 mb-2">{l.description}</p>
                 )}


### PR DESCRIPTION
Reusable StaticMapPreview component shows a neighborhood-level map (zoom 13, POIs hidden) on listing cards so users get a rough sense of cross-streets without revealing exact addresses. Applied to:
- RequestCard (browse-requests vending location cards)
- MarketplaceListingCard (browse-requests marketplace cards)
- Marketplace page cards (/marketplace seller listings)

Requires NEXT_PUBLIC_GOOGLE_MAPS_KEY env var with Maps Static API enabled in Google Cloud Console. Gracefully falls back to a city/state text placeholder if key is missing or image fails.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2