### PR TITLE
Fix agreement card showing both sent and not-sent states

### DIFF
--- a/src/app/sales/pipelines/[id]/items/[itemId]/page.tsx
+++ b/src/app/sales/pipelines/[id]/items/[itemId]/page.tsx
@@ -780,6 +780,7 @@ export default function PipelineItemDetailPage() {
         setResendResult(`Agreement sent to ${data.sent_to}`);
         setShowManualEmailInput(false);
         setManualAgreementEmail("");
+        load();
       } else {
         setResendResult(`Error: ${data.error}`);
         if (data.error?.includes("No email found")) {


### PR DESCRIPTION
After successfully sending a location agreement, the page data was not refreshed so item.location_agreement stayed null. The yellow "Not Sent" card remained visible with a green "Agreement sent to..." message inside it. Now calls load() after send to refresh the item data, which swaps the card to the proper "Agreement Sent" view.

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2