### PR TITLE
Add marketplace QB checkout with manual seller payouts

### DIFF
--- a/src/app/api/admin/payouts/route.ts
+++ b/src/app/api/admin/payouts/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+
+export async function GET(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+
+  const status = req.nextUrl.searchParams.get("status") || "all";
+
+  let query = supabaseAdmin
+    .from("user_listing_purchases")
+    .select("*, user_listings(title, listing_type, city, state), buyer:profiles!buyer_id(full_name, email), seller:profiles!seller_id(full_name, email, payout_method, payout_email, payout_bank_name, payout_routing_number, payout_account_number, payout_notes)")
+    .eq("status", "completed")
+    .order("created_at", { ascending: false });
+
+  if (status !== "all") {
+    query = query.eq("payout_status", status);
+  }
+
+  const { data, error } = await query;
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  return NextResponse.json({ payouts: data || [] });
+}
+
+export async function PATCH(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+
+  const body = await req.json();
+  const { purchase_id, payout_status, payout_method, payout_reference } = body;
+
+  if (!purchase_id || !payout_status) {
+    return NextResponse.json({ error: "purchase_id and payout_status required" }, { status: 400 });
+  }
+
+  const updates: Record<string, unknown> = {
+    payout_status,
+    updated_at: new Date().toISOString(),
+  };
+  if (payout_method) updates.payout_method = payout_method;
+  if (payout_reference) updates.payout_reference = payout_reference;
+  if (payout_status === "completed") updates.payout_completed_at = new Date().toISOString();
+
+  const { error } = await supabaseAdmin
+    .from("user_listing_purchases")
+    .update(updates)
+    .eq("id", purchase_id);
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -95,6 +95,8 @@ export async function PATCH(req: NextRequest) {
       "full_name", "company_name", "phone", "website", "bio",
       "address", "city", "state", "zip", "role",
       "digest_opt_in", "digest_frequency",
+      "payout_method", "payout_email", "payout_bank_name",
+      "payout_routing_number", "payout_account_number", "payout_notes",
     ];
     // Privileged roles can ONLY be set by an admin via /api/admin/users.
     // Self-service signup must never grant admin/sales access.

--- a/src/app/api/user-listings/[id]/checkout/route.ts
+++ b/src/app/api/user-listings/[id]/checkout/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import Stripe from "stripe";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { isQuickBooks } from "@/lib/paymentProvider";
+import { createInvoice, sendInvoiceEmail, getInvoice } from "@/lib/quickbooks";
 
 const PLATFORM_FEE_RATE = 0.15;
 
@@ -51,6 +53,64 @@ export async function POST(
     return NextResponse.json({ error: "This listing has already been sold" }, { status: 409 });
   }
 
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://vendingconnector.com";
+  const amountCents = Math.round(Number(listing.price) * 100);
+  const platformFeeCents = Math.round(amountCents * PLATFORM_FEE_RATE);
+  const typeLabel = listing.listing_type === "lead" ? "Vending Lead" : listing.listing_type === "location" ? "Location" : "Route";
+
+  if (isQuickBooks()) {
+    try {
+      const invoice = await createInvoice({
+        customerEmail: user.email || "",
+        customerName: user.user_metadata?.full_name || user.email || "Buyer",
+        lineItems: [
+          {
+            description: `${typeLabel} — ${listing.title} (${listing.city || ""}, ${listing.state})`.trim(),
+            amount: amountCents / 100,
+          },
+        ],
+        memo: `Marketplace purchase — ${listing.title}`,
+        metadata: {
+          type: "marketplace_purchase",
+          listing_id: listing.id,
+          buyer_id: user.id,
+          seller_id: listing.seller_id,
+        },
+      });
+
+      await supabaseAdmin.from("user_listing_purchases").insert({
+        listing_id: listing.id,
+        buyer_id: user.id,
+        seller_id: listing.seller_id,
+        amount_cents: amountCents,
+        platform_fee_cents: platformFeeCents,
+        seller_payout_cents: amountCents - platformFeeCents,
+        qb_invoice_id: invoice.Id,
+        payment_provider: "quickbooks",
+        status: "pending",
+        payout_status: "pending",
+      });
+
+      await sendInvoiceEmail(invoice.Id, user.email || undefined);
+
+      const fullInvoice = await getInvoice(invoice.Id);
+      if (fullInvoice.InvoiceLink) {
+        return NextResponse.json({ url: fullInvoice.InvoiceLink });
+      }
+
+      return NextResponse.json({
+        url: `${siteUrl}/marketplace/${listing.id}?invoice_sent=true`,
+        invoiceSent: true,
+        invoiceId: invoice.Id,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "QuickBooks error";
+      console.error("[marketplace-checkout] QB error:", message);
+      return NextResponse.json({ error: message }, { status: 500 });
+    }
+  }
+
+  // Stripe Connect path
   const { data: sellerProfile } = await supabaseAdmin
     .from("profiles")
     .select("stripe_account_id, stripe_onboarding_complete")
@@ -65,10 +125,6 @@ export async function POST(
   }
 
   const stripe = new Stripe(process.env.STRIPE_CONNECT_SECRET_KEY!);
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://vendingconnector.com";
-
-  const amountCents = Math.round(Number(listing.price) * 100);
-  const platformFeeCents = Math.round(amountCents * PLATFORM_FEE_RATE);
 
   const session = await stripe.checkout.sessions.create({
     mode: "payment",
@@ -80,7 +136,7 @@ export async function POST(
           unit_amount: amountCents,
           product_data: {
             name: listing.title,
-            description: `${listing.listing_type === "lead" ? "Vending Lead" : listing.listing_type === "location" ? "Location" : "Route"} in ${listing.city || ""}, ${listing.state}`.trim(),
+            description: `${typeLabel} in ${listing.city || ""}, ${listing.state}`.trim(),
           },
         },
         quantity: 1,

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -48,6 +48,12 @@ function ProfilePageInner() {
     role: "" as string,
     digest_opt_in: true,
     digest_frequency: "weekly" as string,
+    payout_method: "" as string,
+    payout_email: "",
+    payout_bank_name: "",
+    payout_routing_number: "",
+    payout_account_number: "",
+    payout_notes: "",
   });
 
   useEffect(() => {
@@ -83,6 +89,12 @@ function ProfilePageInner() {
           role: data.role || "location_manager",
           digest_opt_in: data.digest_opt_in ?? true,
           digest_frequency: data.digest_frequency || "weekly",
+          payout_method: data.payout_method || "",
+          payout_email: data.payout_email || "",
+          payout_bank_name: data.payout_bank_name || "",
+          payout_routing_number: data.payout_routing_number || "",
+          payout_account_number: data.payout_account_number || "",
+          payout_notes: data.payout_notes || "",
         });
 
         // Handle ?digest=off unsubscribe link
@@ -141,6 +153,12 @@ function ProfilePageInner() {
           role: form.role,
           digest_opt_in: form.digest_opt_in,
           digest_frequency: form.digest_frequency,
+          payout_method: form.payout_method || null,
+          payout_email: form.payout_email || null,
+          payout_bank_name: form.payout_bank_name || null,
+          payout_routing_number: form.payout_routing_number || null,
+          payout_account_number: form.payout_account_number || null,
+          payout_notes: form.payout_notes || null,
         }),
       });
 
@@ -410,6 +428,106 @@ function ProfilePageInner() {
               </div>
             </div>
           )}
+
+          {/* Payout Information */}
+          <div className="rounded-2xl border border-gray-100 bg-white p-6 shadow-sm">
+            <h2 className="mb-1 text-lg font-semibold text-black-primary">
+              Payout Information
+            </h2>
+            <p className="mb-4 text-sm text-black-primary/50">
+              Required if you sell on the marketplace. We&apos;ll use this to send your earnings.
+            </p>
+            <div className="space-y-4">
+              <div>
+                <label className="mb-1.5 block text-sm font-medium text-black-primary">
+                  Payout Method
+                </label>
+                <select
+                  value={form.payout_method}
+                  onChange={(e) => setForm((f) => ({ ...f, payout_method: e.target.value }))}
+                  className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:border-green-primary focus:outline-none focus:ring-1 focus:ring-green-primary"
+                >
+                  <option value="">Select method...</option>
+                  <option value="zelle">Zelle</option>
+                  <option value="paypal">PayPal</option>
+                  <option value="venmo">Venmo</option>
+                  <option value="wire">Wire / ACH Transfer</option>
+                  <option value="check">Check</option>
+                </select>
+              </div>
+
+              {(form.payout_method === "zelle" || form.payout_method === "paypal" || form.payout_method === "venmo") && (
+                <div>
+                  <label className="mb-1.5 block text-sm font-medium text-black-primary">
+                    {form.payout_method === "zelle" ? "Zelle Email or Phone" : form.payout_method === "paypal" ? "PayPal Email" : "Venmo Username or Phone"}
+                  </label>
+                  <input
+                    type="text"
+                    value={form.payout_email}
+                    onChange={(e) => setForm((f) => ({ ...f, payout_email: e.target.value }))}
+                    placeholder={form.payout_method === "venmo" ? "@username or phone" : "email@example.com"}
+                    className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:border-green-primary focus:outline-none focus:ring-1 focus:ring-green-primary"
+                  />
+                </div>
+              )}
+
+              {form.payout_method === "wire" && (
+                <>
+                  <div>
+                    <label className="mb-1.5 block text-sm font-medium text-black-primary">
+                      Bank Name
+                    </label>
+                    <input
+                      type="text"
+                      value={form.payout_bank_name}
+                      onChange={(e) => setForm((f) => ({ ...f, payout_bank_name: e.target.value }))}
+                      placeholder="Chase, Bank of America, etc."
+                      className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:border-green-primary focus:outline-none focus:ring-1 focus:ring-green-primary"
+                    />
+                  </div>
+                  <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                    <div>
+                      <label className="mb-1.5 block text-sm font-medium text-black-primary">
+                        Routing Number
+                      </label>
+                      <input
+                        type="text"
+                        value={form.payout_routing_number}
+                        onChange={(e) => setForm((f) => ({ ...f, payout_routing_number: e.target.value }))}
+                        placeholder="9 digits"
+                        maxLength={9}
+                        className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:border-green-primary focus:outline-none focus:ring-1 focus:ring-green-primary"
+                      />
+                    </div>
+                    <div>
+                      <label className="mb-1.5 block text-sm font-medium text-black-primary">
+                        Account Number
+                      </label>
+                      <input
+                        type="text"
+                        value={form.payout_account_number}
+                        onChange={(e) => setForm((f) => ({ ...f, payout_account_number: e.target.value }))}
+                        className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:border-green-primary focus:outline-none focus:ring-1 focus:ring-green-primary"
+                      />
+                    </div>
+                  </div>
+                </>
+              )}
+
+              <div>
+                <label className="mb-1.5 block text-sm font-medium text-black-primary">
+                  Notes
+                </label>
+                <input
+                  type="text"
+                  value={form.payout_notes}
+                  onChange={(e) => setForm((f) => ({ ...f, payout_notes: e.target.value }))}
+                  placeholder="Any additional payout instructions"
+                  className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:border-green-primary focus:outline-none focus:ring-1 focus:ring-green-primary"
+                />
+              </div>
+            </div>
+          </div>
 
           {/* Save Button */}
           <div className="flex items-center justify-end gap-3">

--- a/src/lib/marketplaceEmail.ts
+++ b/src/lib/marketplaceEmail.ts
@@ -1,6 +1,7 @@
 import { Resend } from "resend";
 
 const FROM_EMAIL = process.env.FROM_EMAIL || "onboarding@bytebitevending.com";
+const ADMIN_EMAIL = "james@apexaivending.com";
 
 function getResend() {
   return new Resend(process.env.RESEND_API_KEY);
@@ -35,7 +36,7 @@ export async function sendMarketplaceSaleEmail(params: SaleParams) {
           <tr style="border-top:1px solid #e5e7eb;"><td style="padding:8px 0;color:#111;font-weight:600;font-size:14px;">Your Payout</td><td style="padding:8px 0;text-align:right;font-weight:700;color:#16a34a;font-size:16px;">${payout}</td></tr>
         </table>
         <p style="color:#6b7280;font-size:13px;line-height:1.6;">
-          Your payout will be deposited to your connected bank account via Stripe. You can check your payout status in your Stripe Express Dashboard.
+          Your payout will be sent to you via your preferred payout method on file. Please ensure your payout details are up to date in your profile settings.
         </p>
         <p style="color:#9ca3af;font-size:12px;margin-top:32px;">— VendingConnector Marketplace</p>
       </div>
@@ -76,6 +77,92 @@ export async function sendMarketplacePurchaseEmail(params: PurchaseParams) {
           The seller has been notified and will provide any additional details. If you have questions, please contact us.
         </p>
         <p style="color:#9ca3af;font-size:12px;margin-top:32px;">— VendingConnector Marketplace</p>
+      </div>
+    `,
+  });
+}
+
+interface AdminPayoutNotificationParams {
+  listingTitle: string;
+  saleAmount: number;
+  platformFee: number;
+  sellerPayout: number;
+  sellerName: string;
+  sellerEmail: string;
+  buyerEmail: string;
+  payoutMethod: string | null;
+  payoutEmail: string | null;
+  payoutBankName: string | null;
+  payoutRoutingNumber: string | null;
+  payoutAccountNumber: string | null;
+  payoutNotes: string | null;
+  purchaseId: string;
+}
+
+export async function sendMarketplacePayoutNotification(params: AdminPayoutNotificationParams) {
+  const {
+    listingTitle, saleAmount, platformFee, sellerPayout,
+    sellerName, sellerEmail, buyerEmail,
+    payoutMethod, payoutEmail, payoutBankName,
+    payoutRoutingNumber, payoutAccountNumber, payoutNotes,
+    purchaseId,
+  } = params;
+
+  const fmt = (n: number) => `$${n.toLocaleString("en-US", { minimumFractionDigits: 2 })}`;
+
+  const hasPayoutInfo = payoutMethod || payoutEmail || payoutBankName;
+
+  const payoutDetailsHtml = hasPayoutInfo
+    ? `
+      <div style="background:#f0fdf4;border:1px solid #bbf7d0;border-radius:8px;padding:16px;margin:16px 0;">
+        <p style="margin:0 0 8px;font-weight:700;color:#166534;font-size:13px;">SELLER PAYOUT DETAILS</p>
+        <table style="font-size:13px;color:#374151;border-collapse:collapse;">
+          ${payoutMethod ? `<tr><td style="padding:3px 12px 3px 0;color:#6b7280;">Method</td><td style="padding:3px 0;font-weight:600;">${payoutMethod}</td></tr>` : ""}
+          ${payoutEmail ? `<tr><td style="padding:3px 12px 3px 0;color:#6b7280;">Email/Zelle</td><td style="padding:3px 0;">${payoutEmail}</td></tr>` : ""}
+          ${payoutBankName ? `<tr><td style="padding:3px 12px 3px 0;color:#6b7280;">Bank</td><td style="padding:3px 0;">${payoutBankName}</td></tr>` : ""}
+          ${payoutRoutingNumber ? `<tr><td style="padding:3px 12px 3px 0;color:#6b7280;">Routing #</td><td style="padding:3px 0;">${payoutRoutingNumber}</td></tr>` : ""}
+          ${payoutAccountNumber ? `<tr><td style="padding:3px 12px 3px 0;color:#6b7280;">Account #</td><td style="padding:3px 0;">${payoutAccountNumber}</td></tr>` : ""}
+          ${payoutNotes ? `<tr><td style="padding:3px 12px 3px 0;color:#6b7280;">Notes</td><td style="padding:3px 0;">${payoutNotes}</td></tr>` : ""}
+        </table>
+      </div>
+    `
+    : `
+      <div style="background:#fef3c7;border:1px solid #fcd34d;border-radius:8px;padding:16px;margin:16px 0;">
+        <p style="margin:0;color:#92400e;font-size:13px;font-weight:600;">⚠ Seller has NOT set up payout details. Contact them at ${sellerEmail} to arrange payment.</p>
+      </div>
+    `;
+
+  await getResend().emails.send({
+    from: FROM_EMAIL,
+    to: ADMIN_EMAIL,
+    subject: `Marketplace Sale — Payout Required — ${listingTitle}`,
+    html: `
+      <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:600px;margin:0 auto;padding:32px 24px;">
+        <div style="margin-bottom:20px;">
+          <span style="font-size:18px;font-weight:700;color:#16a34a;">Vending Connector</span>
+        </div>
+        <div style="background:#dbeafe;border:1px solid #93c5fd;border-radius:8px;padding:14px;margin-bottom:20px;">
+          <p style="margin:0;color:#1e40af;font-size:15px;font-weight:700;">💰 Marketplace Sale — Seller Payout Required</p>
+        </div>
+        <table style="width:100%;font-size:14px;color:#374151;border-collapse:collapse;margin-bottom:8px;">
+          <tr><td style="padding:4px 8px;color:#6b7280;">Listing</td><td style="padding:4px 8px;font-weight:600;">${listingTitle}</td></tr>
+          <tr><td style="padding:4px 8px;color:#6b7280;">Sale Amount</td><td style="padding:4px 8px;">${fmt(saleAmount)}</td></tr>
+          <tr><td style="padding:4px 8px;color:#6b7280;">Platform Fee (15%)</td><td style="padding:4px 8px;">-${fmt(platformFee)}</td></tr>
+          <tr><td style="padding:4px 8px;color:#6b7280;font-weight:600;">Seller Payout</td><td style="padding:4px 8px;font-weight:700;color:#16a34a;">${fmt(sellerPayout)}</td></tr>
+        </table>
+        <hr style="border:none;border-top:1px solid #e5e7eb;margin:16px 0;">
+        <table style="width:100%;font-size:13px;color:#374151;border-collapse:collapse;">
+          <tr><td style="padding:3px 8px;color:#6b7280;">Seller</td><td style="padding:3px 8px;">${sellerName}</td></tr>
+          <tr><td style="padding:3px 8px;color:#6b7280;">Seller Email</td><td style="padding:3px 8px;">${sellerEmail}</td></tr>
+          <tr><td style="padding:3px 8px;color:#6b7280;">Buyer Email</td><td style="padding:3px 8px;">${buyerEmail}</td></tr>
+          <tr><td style="padding:3px 8px;color:#6b7280;">Purchase ID</td><td style="padding:3px 8px;font-family:monospace;font-size:11px;">${purchaseId}</td></tr>
+        </table>
+        ${payoutDetailsHtml}
+        <p style="color:#6b7280;font-size:12px;line-height:1.6;margin-top:16px;">
+          After sending the payout, mark it as completed in the Admin panel under Marketplace.
+        </p>
+        <hr style="border:none;border-top:1px solid #e5e7eb;margin:24px 0;">
+        <p style="color:#9ca3af;font-size:11px;">Vending Connector — vendingconnector.com</p>
       </div>
     `,
   });

--- a/src/lib/paymentHandlers.ts
+++ b/src/lib/paymentHandlers.ts
@@ -552,14 +552,16 @@ export async function handleMarketplacePurchaseCompleted(params: {
 }) {
   const { sessionId, listingId, sellerId, paymentId, buyerEmail } = params;
 
-  await supabaseAdmin
+  const { data: purchase } = await supabaseAdmin
     .from("user_listing_purchases")
     .update({
       status: "completed",
       stripe_payment_intent_id: paymentId,
       updated_at: new Date().toISOString(),
     })
-    .or(`stripe_checkout_session_id.eq.${sessionId},qb_invoice_id.eq.${sessionId}`);
+    .or(`stripe_checkout_session_id.eq.${sessionId},qb_invoice_id.eq.${sessionId}`)
+    .select("id, amount_cents, platform_fee_cents, seller_payout_cents")
+    .single();
 
   await supabaseAdmin
     .from("user_listings")
@@ -575,6 +577,26 @@ export async function handleMarketplacePurchaseCompleted(params: {
   const { data: sellerUser } = sellerId
     ? await supabaseAdmin.auth.admin.getUserById(sellerId)
     : { data: null };
+
+  // Fetch seller payout info for admin notification
+  let sellerProfile: {
+    full_name: string | null;
+    payout_method: string | null;
+    payout_email: string | null;
+    payout_bank_name: string | null;
+    payout_routing_number: string | null;
+    payout_account_number: string | null;
+    payout_notes: string | null;
+  } | null = null;
+
+  if (sellerId) {
+    const { data } = await supabaseAdmin
+      .from("profiles")
+      .select("full_name, payout_method, payout_email, payout_bank_name, payout_routing_number, payout_account_number, payout_notes")
+      .eq("id", sellerId)
+      .single();
+    sellerProfile = data;
+  }
 
   if (sellerUser?.user?.email && listing) {
     try {
@@ -602,6 +624,32 @@ export async function handleMarketplacePurchaseCompleted(params: {
       });
     } catch (e) {
       console.error("[payment-handler] Failed to send marketplace purchase email:", e);
+    }
+  }
+
+  // Send admin payout notification
+  if (listing && purchase) {
+    try {
+      const { sendMarketplacePayoutNotification } = await import("@/lib/marketplaceEmail");
+      const saleAmount = Number(listing.price);
+      await sendMarketplacePayoutNotification({
+        listingTitle: listing.title,
+        saleAmount,
+        platformFee: saleAmount * 0.15,
+        sellerPayout: saleAmount * 0.85,
+        sellerName: sellerProfile?.full_name || "Unknown Seller",
+        sellerEmail: sellerUser?.user?.email || "",
+        buyerEmail: buyerEmail || "",
+        payoutMethod: sellerProfile?.payout_method || null,
+        payoutEmail: sellerProfile?.payout_email || null,
+        payoutBankName: sellerProfile?.payout_bank_name || null,
+        payoutRoutingNumber: sellerProfile?.payout_routing_number || null,
+        payoutAccountNumber: sellerProfile?.payout_account_number || null,
+        payoutNotes: sellerProfile?.payout_notes || null,
+        purchaseId: purchase.id,
+      });
+    } catch (e) {
+      console.error("[payment-handler] Failed to send admin payout notification:", e);
     }
   }
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -55,6 +55,12 @@ export interface Profile {
   coffee_access_enabled?: boolean;
   coffee_agreement_signed?: boolean;
   coffee_application_status?: string | null;
+  payout_method?: string | null;
+  payout_email?: string | null;
+  payout_bank_name?: string | null;
+  payout_routing_number?: string | null;
+  payout_account_number?: string | null;
+  payout_notes?: string | null;
   created_at: string;
 }
 

--- a/supabase/migrations/079_seller_payout_info.sql
+++ b/supabase/migrations/079_seller_payout_info.sql
@@ -1,0 +1,13 @@
+-- Add seller payout info to profiles and payout tracking to purchases
+
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS payout_method TEXT;
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS payout_email TEXT;
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS payout_bank_name TEXT;
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS payout_routing_number TEXT;
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS payout_account_number TEXT;
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS payout_notes TEXT;
+
+ALTER TABLE user_listing_purchases ADD COLUMN IF NOT EXISTS payout_status TEXT DEFAULT 'pending';
+ALTER TABLE user_listing_purchases ADD COLUMN IF NOT EXISTS payout_method TEXT;
+ALTER TABLE user_listing_purchases ADD COLUMN IF NOT EXISTS payout_reference TEXT;
+ALTER TABLE user_listing_purchases ADD COLUMN IF NOT EXISTS payout_completed_at TIMESTAMPTZ;


### PR DESCRIPTION
Replaces Stripe Connect for marketplace purchases with QB invoice flow. Sellers set up payout info (Zelle/PayPal/Venmo/wire/check) in their profile. When a sale completes, admin receives an email with the seller's payout details and amount owed. Admin marks payout as completed in the admin panel.

Changes:
- Migration 079: payout info columns on profiles, payout tracking on purchases
- Profile type + API: new payout_method/email/bank fields
- Marketplace checkout: QB invoice branch (falls back to Stripe Connect)
- Marketplace email: admin payout notification with seller bank details
- Payment handler: fetches seller payout info, sends admin notification
- Profile page: payout info section (method, email/Zelle, bank details)
- Admin payouts API: GET pending payouts, PATCH to mark completed

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2