### PR TITLE
Remove Stripe from marketplace checkout, use QuickBooks only

### DIFF
--- a/src/app/api/user-listings/[id]/checkout/route.ts
+++ b/src/app/api/user-listings/[id]/checkout/route.ts
@@ -1,7 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import Stripe from "stripe";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
-import { isQuickBooks } from "@/lib/paymentProvider";
 import { createInvoice, sendInvoiceEmail, getInvoice } from "@/lib/quickbooks";
 
 const PLATFORM_FEE_RATE = 0.15;
@@ -58,116 +56,53 @@ export async function POST(
   const platformFeeCents = Math.round(amountCents * PLATFORM_FEE_RATE);
   const typeLabel = listing.listing_type === "lead" ? "Vending Lead" : listing.listing_type === "location" ? "Location" : "Route";
 
-  if (isQuickBooks()) {
-    try {
-      const invoice = await createInvoice({
-        customerEmail: user.email || "",
-        customerName: user.user_metadata?.full_name || user.email || "Buyer",
-        lineItems: [
-          {
-            description: `${typeLabel} — ${listing.title} (${listing.city || ""}, ${listing.state})`.trim(),
-            amount: amountCents / 100,
-          },
-        ],
-        memo: `Marketplace purchase — ${listing.title}`,
-        metadata: {
-          type: "marketplace_purchase",
-          listing_id: listing.id,
-          buyer_id: user.id,
-          seller_id: listing.seller_id,
+  try {
+    const invoice = await createInvoice({
+      customerEmail: user.email || "",
+      customerName: user.user_metadata?.full_name || user.email || "Buyer",
+      lineItems: [
+        {
+          description: `${typeLabel} — ${listing.title} (${listing.city || ""}, ${listing.state})`.trim(),
+          amount: amountCents / 100,
         },
-      });
-
-      await supabaseAdmin.from("user_listing_purchases").insert({
+      ],
+      memo: `Marketplace purchase — ${listing.title}`,
+      metadata: {
+        type: "marketplace_purchase",
         listing_id: listing.id,
         buyer_id: user.id,
         seller_id: listing.seller_id,
-        amount_cents: amountCents,
-        platform_fee_cents: platformFeeCents,
-        seller_payout_cents: amountCents - platformFeeCents,
-        qb_invoice_id: invoice.Id,
-        payment_provider: "quickbooks",
-        status: "pending",
-        payout_status: "pending",
-      });
-
-      await sendInvoiceEmail(invoice.Id, user.email || undefined);
-
-      const fullInvoice = await getInvoice(invoice.Id);
-      if (fullInvoice.InvoiceLink) {
-        return NextResponse.json({ url: fullInvoice.InvoiceLink });
-      }
-
-      return NextResponse.json({
-        url: `${siteUrl}/marketplace/${listing.id}?invoice_sent=true`,
-        invoiceSent: true,
-        invoiceId: invoice.Id,
-      });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : "QuickBooks error";
-      console.error("[marketplace-checkout] QB error:", message);
-      return NextResponse.json({ error: message }, { status: 500 });
-    }
-  }
-
-  // Stripe Connect path
-  const { data: sellerProfile } = await supabaseAdmin
-    .from("profiles")
-    .select("stripe_account_id, stripe_onboarding_complete")
-    .eq("id", listing.seller_id)
-    .single();
-
-  if (!sellerProfile?.stripe_account_id || !sellerProfile.stripe_onboarding_complete) {
-    return NextResponse.json(
-      { error: "Seller's payment account is not set up. Contact them directly." },
-      { status: 400 }
-    );
-  }
-
-  const stripe = new Stripe(process.env.STRIPE_CONNECT_SECRET_KEY!);
-
-  const session = await stripe.checkout.sessions.create({
-    mode: "payment",
-    payment_method_types: ["card"],
-    line_items: [
-      {
-        price_data: {
-          currency: "usd",
-          unit_amount: amountCents,
-          product_data: {
-            name: listing.title,
-            description: `${typeLabel} in ${listing.city || ""}, ${listing.state}`.trim(),
-          },
-        },
-        quantity: 1,
       },
-    ],
-    payment_intent_data: {
-      application_fee_amount: platformFeeCents,
-      transfer_data: {
-        destination: sellerProfile.stripe_account_id,
-      },
-    },
-    metadata: {
-      type: "marketplace_purchase",
+    });
+
+    await supabaseAdmin.from("user_listing_purchases").insert({
       listing_id: listing.id,
       buyer_id: user.id,
       seller_id: listing.seller_id,
-    },
-    success_url: `${siteUrl}/marketplace/${listing.id}?purchased=true`,
-    cancel_url: `${siteUrl}/marketplace/${listing.id}?canceled=true`,
-  });
+      amount_cents: amountCents,
+      platform_fee_cents: platformFeeCents,
+      seller_payout_cents: amountCents - platformFeeCents,
+      qb_invoice_id: invoice.Id,
+      payment_provider: "quickbooks",
+      status: "pending",
+      payout_status: "pending",
+    });
 
-  await supabaseAdmin.from("user_listing_purchases").insert({
-    listing_id: listing.id,
-    buyer_id: user.id,
-    seller_id: listing.seller_id,
-    amount_cents: amountCents,
-    platform_fee_cents: platformFeeCents,
-    seller_payout_cents: amountCents - platformFeeCents,
-    stripe_checkout_session_id: session.id,
-    status: "pending",
-  });
+    await sendInvoiceEmail(invoice.Id, user.email || undefined);
 
-  return NextResponse.json({ url: session.url });
+    const fullInvoice = await getInvoice(invoice.Id);
+    if (fullInvoice.InvoiceLink) {
+      return NextResponse.json({ url: fullInvoice.InvoiceLink });
+    }
+
+    return NextResponse.json({
+      url: `${siteUrl}/marketplace/${listing.id}?invoice_sent=true`,
+      invoiceSent: true,
+      invoiceId: invoice.Id,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Payment error";
+    console.error("[marketplace-checkout] error:", message);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
 }

--- a/src/app/machines-for-sale/[id]/checkout/page.tsx
+++ b/src/app/machines-for-sale/[id]/checkout/page.tsx
@@ -714,7 +714,7 @@ export default function CheckoutFormPage() {
           </button>
 
           <p className="text-xs text-gray-400 text-center mt-3">
-            You will be redirected to Stripe for secure payment processing.
+            You will be redirected for secure payment processing.
           </p>
         </form>
       </div>

--- a/src/app/marketplace/[id]/page.tsx
+++ b/src/app/marketplace/[id]/page.tsx
@@ -245,7 +245,7 @@ export default function ListingDetailPage() {
               <p className="text-red-600 text-sm mt-3">{error}</p>
             )}
             <p className="text-xs text-gray-400 mt-3">
-              Secure payment via Stripe. Contact details are shared after purchase.
+              Secure payment via invoice. Contact details are shared after purchase.
             </p>
           </div>
 


### PR DESCRIPTION
- Remove Stripe Connect fallback from user-listings checkout route
- Remove Stripe import (no longer needed)
- Update frontend text from "Stripe" to "invoice" / generic payment
- Also fix machine checkout page text referencing Stripe

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2