### PR TITLE
Auto-select Locator role when signing up via Sell a Location

### DIFF
--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -11,7 +11,7 @@ import { TOOLTIP_COPY } from "@/lib/tooltipCopy";
 
 const navLinks = [
   { label: "Locations for Sale", href: "/signup?redirect=/browse-requests" },
-  { label: "Sell a Location", href: "/signup?redirect=/marketplace" },
+  { label: "Sell a Location", href: "/signup?role=locator&redirect=/marketplace" },
   { label: "Machines for Sale", href: "/signup?redirect=/machines-for-sale" },
   { label: "Routes for Sale", href: "/signup?redirect=/routes-for-sale" },
   { label: "Browse Operators", href: "/signup?redirect=/browse-operators" },

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -18,7 +18,7 @@ const roles: { value: Role; label: string; icon: typeof Truck; description: stri
   },
   {
     value: "location_manager",
-    label: "Location",
+    label: "Locator",
     icon: Building2,
     description: "I have a property and want a vending machine placed",
   },
@@ -41,8 +41,13 @@ export default function SignupPage() {
 function SignupContent() {
   const searchParams = useSearchParams();
   const redirectTo = searchParams.get("redirect") || "/dashboard";
-  const [step, setStep] = useState<1 | 2 | 3>(1);
-  const [role, setRole] = useState<Role | null>(null);
+  const roleParam = searchParams.get("role");
+  const presetRole = (roleParam === "locator" || roleParam === "location_manager") ? "location_manager" as Role
+    : roleParam === "operator" ? "operator" as Role
+    : roleParam === "employee" ? "employee" as Role
+    : null;
+  const [step, setStep] = useState<1 | 2 | 3>(presetRole ? 2 : 1);
+  const [role, setRole] = useState<Role | null>(presetRole);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState<"google" | "microsoft" | null>(null);
   const [existingEmail, setExistingEmail] = useState<string | null>(null);


### PR DESCRIPTION
- Rename role label from "Location" to "Locator"
- Accept ?role=locator query param on signup page to auto-select role and skip step 1
- Update Sell a Location nav link to pass role=locator so users go straight to the info form

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2