### PR TITLE
Fix location services deposit: non-refundable text, resilient DB insert

### DIFF
--- a/src/app/api/request-location/route.ts
+++ b/src/app/api/request-location/route.ts
@@ -91,7 +91,7 @@ export async function POST(req: Request) {
     );
   }
 
-  const { data: lead, error: dbError } = await supabaseAdmin.from("sales_leads").insert({
+  const leadRow: Record<string, unknown> = {
     business_name,
     contact_name,
     phone,
@@ -105,11 +105,24 @@ export async function POST(req: Request) {
     notes: `Location services request — ${machine_count} machine(s) requested for ZIP(s) ${zip_code} in ${state}${referringRepName ? ` (referred by ${referringRepName})` : ""}`,
     created_by: referringRep,
     assigned_to: referringRep,
+  };
+
+  // Try with deposit columns (requires migration 081)
+  let { data: lead, error: dbError } = await supabaseAdmin.from("sales_leads").insert({
+    ...leadRow,
     deposit_status: "pending",
     deposit_amount_cents: DEPOSIT_CENTS,
   }).select("id").single();
 
-  if (dbError) {
+  // Fallback if deposit columns don't exist yet
+  if (dbError && dbError.message?.includes("deposit_")) {
+    console.warn("[request-location] deposit columns missing, inserting without them");
+    const fallback = await supabaseAdmin.from("sales_leads").insert(leadRow).select("id").single();
+    lead = fallback.data;
+    dbError = fallback.error;
+  }
+
+  if (dbError || !lead) {
     console.error("[request-location] db error", dbError);
     return NextResponse.json(
       { error: "Failed to save request" },
@@ -152,10 +165,14 @@ export async function POST(req: Request) {
       },
     });
 
-    await supabaseAdmin
-      .from("sales_leads")
-      .update({ qb_invoice_id: invoice.Id })
-      .eq("id", lead.id);
+    try {
+      await supabaseAdmin
+        .from("sales_leads")
+        .update({ qb_invoice_id: invoice.Id })
+        .eq("id", lead.id);
+    } catch {
+      // column may not exist if migration 081 hasn't run
+    }
 
     await sendInvoiceEmail(invoice.Id, email);
 

--- a/src/app/request-location/page.tsx
+++ b/src/app/request-location/page.tsx
@@ -226,7 +226,7 @@ function RequestLocationInner() {
         <div className="rounded-2xl border border-green-100 bg-white p-6 shadow-lg sm:p-8">
           <div className="mb-6 rounded-lg bg-amber-50 border border-amber-200 px-4 py-3">
             <p className="text-sm text-amber-800">
-              <strong>$100.00 deposit required</strong> — A refundable deposit is collected to begin your location search. You will be redirected to complete payment after submitting.
+              <strong>$100.00 non-refundable deposit required</strong> — A deposit is collected to begin your location search. You will be redirected to complete payment after submitting.
             </p>
           </div>
 


### PR DESCRIPTION
- Change deposit text from "refundable" to "non-refundable"
- Make DB insert resilient to missing migration 081 columns (deposit_status, deposit_amount_cents, qb_invoice_id)
- Falls back to insert without deposit columns if migration hasn't run yet
- Payment via QB invoice is still mandatory regardless

https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2