### PR TITLE
Fix CRM visibility for admin-role users in profiles table

### DIFF
--- a/src/lib/adminAuth.ts
+++ b/src/lib/adminAuth.ts
@@ -29,6 +29,17 @@ export async function getAdminUserId(req: NextRequest): Promise<string | null> {
     return user.id;
   }
 
+  // Check profile role in database
+  const { data: profile } = await supabaseAdmin
+    .from("profiles")
+    .select("role")
+    .eq("id", user.id)
+    .single();
+
+  if (profile?.role === "admin") {
+    return user.id;
+  }
+
   return null;
 }
 


### PR DESCRIPTION
The admin check only looked at a hardcoded email list, so users with role="admin" in the profiles table (like Katrina Cacdac) couldn't see the CRM link. Now getAdminUserId() also checks the profile role column.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2