### PR TITLE
Add Order Management System with full CRM-to-order workflow

### DIFF
--- a/src/app/api/sales/orders/[id]/activity/route.ts
+++ b/src/app/api/sales/orders/[id]/activity/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser } from "@/lib/salesAuth";
+
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const user = await getSalesUser(req);
+  if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id } = await params;
+  const body = await req.json();
+
+  const { data, error } = await supabaseAdmin
+    .from("order_activity_log")
+    .insert({
+      order_id: id,
+      user_id: user.id,
+      activity_type: body.activity_type || "note",
+      description: body.description || "",
+    })
+    .select()
+    .single();
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json(data, { status: 201 });
+}

--- a/src/app/api/sales/orders/[id]/documents/route.ts
+++ b/src/app/api/sales/orders/[id]/documents/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser } from "@/lib/salesAuth";
+
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const user = await getSalesUser(req);
+  if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id } = await params;
+
+  const formData = await req.formData();
+  const file = formData.get("file") as File | null;
+  const documentType = formData.get("document_type") as string || "other";
+
+  if (!file) {
+    return NextResponse.json({ error: "No file provided" }, { status: 400 });
+  }
+
+  const bytes = await file.arrayBuffer();
+  const buffer = new Uint8Array(bytes);
+  const timestamp = Date.now();
+  const storagePath = `orders/${id}/${timestamp}_${file.name}`;
+
+  const { error: uploadErr } = await supabaseAdmin.storage
+    .from("sales-documents")
+    .upload(storagePath, buffer, {
+      contentType: file.type,
+      upsert: false,
+    });
+
+  if (uploadErr) {
+    return NextResponse.json({ error: uploadErr.message }, { status: 500 });
+  }
+
+  const { data: urlData } = supabaseAdmin.storage
+    .from("sales-documents")
+    .getPublicUrl(storagePath);
+
+  const { data, error } = await supabaseAdmin
+    .from("order_documents")
+    .insert({
+      order_id: id,
+      document_type: documentType,
+      file_name: file.name,
+      file_url: urlData.publicUrl,
+      uploaded_by: user.id,
+    })
+    .select()
+    .single();
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  await supabaseAdmin.from("order_activity_log").insert({
+    order_id: id,
+    user_id: user.id,
+    activity_type: "document_uploaded",
+    description: `Uploaded: ${file.name}`,
+  });
+
+  return NextResponse.json(data, { status: 201 });
+}

--- a/src/app/api/sales/orders/[id]/items/[itemId]/route.ts
+++ b/src/app/api/sales/orders/[id]/items/[itemId]/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser } from "@/lib/salesAuth";
+
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string; itemId: string }> }) {
+  const user = await getSalesUser(req);
+  if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id, itemId } = await params;
+  const body = await req.json();
+
+  const allowed = [
+    "item_type", "service_name", "description", "quantity", "unit_price",
+    "total_price", "status", "location_service_price", "deposit_required",
+    "location_deposit_amount", "location_deposit_paid", "location_remaining_balance",
+  ];
+  const updates: Record<string, unknown> = { updated_at: new Date().toISOString() };
+  for (const key of allowed) {
+    if (key in body) updates[key] = body[key];
+  }
+
+  if (body.quantity !== undefined || body.unit_price !== undefined) {
+    const qty = Number(body.quantity) || 1;
+    const price = Number(body.unit_price) || 0;
+    updates.total_price = qty * price;
+    updates.price = price;
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from("order_items")
+    .update(updates)
+    .eq("id", itemId)
+    .eq("order_id", id)
+    .select()
+    .single();
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  // Recalculate order total
+  const { data: items } = await supabaseAdmin
+    .from("order_items")
+    .select("total_price")
+    .eq("order_id", id);
+
+  const newTotal = (items || []).reduce((sum, i) => sum + Number(i.total_price || 0), 0);
+  await supabaseAdmin
+    .from("sales_orders")
+    .update({ total_value: newTotal, remaining_balance: newTotal, updated_at: new Date().toISOString() })
+    .eq("id", id);
+
+  return NextResponse.json(data);
+}
+
+export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string; itemId: string }> }) {
+  const user = await getSalesUser(req);
+  if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id, itemId } = await params;
+
+  const { error } = await supabaseAdmin
+    .from("order_items")
+    .delete()
+    .eq("id", itemId)
+    .eq("order_id", id);
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  // Recalculate order total
+  const { data: items } = await supabaseAdmin
+    .from("order_items")
+    .select("total_price")
+    .eq("order_id", id);
+
+  const newTotal = (items || []).reduce((sum, i) => sum + Number(i.total_price || 0), 0);
+  await supabaseAdmin
+    .from("sales_orders")
+    .update({ total_value: newTotal, remaining_balance: newTotal, updated_at: new Date().toISOString() })
+    .eq("id", id);
+
+  await supabaseAdmin.from("order_activity_log").insert({
+    order_id: id,
+    user_id: user.id,
+    activity_type: "item_removed",
+    description: "Item removed from order",
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/sales/orders/[id]/items/route.ts
+++ b/src/app/api/sales/orders/[id]/items/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser } from "@/lib/salesAuth";
+
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const user = await getSalesUser(req);
+  if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id } = await params;
+  const body = await req.json();
+
+  const qty = Number(body.quantity) || 1;
+  const unitPrice = Number(body.unit_price) || 0;
+  const totalPrice = qty * unitPrice;
+
+  const { data, error } = await supabaseAdmin
+    .from("order_items")
+    .insert({
+      order_id: id,
+      service_name: body.item_name || body.service_name || "",
+      price: unitPrice,
+      item_type: body.item_type || "other",
+      description: body.description || null,
+      quantity: qty,
+      unit_price: unitPrice,
+      total_price: totalPrice,
+      status: "pending",
+      location_service_price: body.location_service_price || null,
+      deposit_required: body.deposit_required || false,
+      location_deposit_amount: body.location_deposit_amount || null,
+      location_deposit_paid: false,
+      location_remaining_balance: body.location_service_price
+        ? (body.location_service_price - (body.location_deposit_amount || 0))
+        : null,
+    })
+    .select()
+    .single();
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  // Recalculate order total
+  const { data: items } = await supabaseAdmin
+    .from("order_items")
+    .select("total_price")
+    .eq("order_id", id);
+
+  const newTotal = (items || []).reduce((sum, i) => sum + Number(i.total_price || 0), 0);
+  await supabaseAdmin
+    .from("sales_orders")
+    .update({ total_value: newTotal, remaining_balance: newTotal, updated_at: new Date().toISOString() })
+    .eq("id", id);
+
+  await supabaseAdmin.from("order_activity_log").insert({
+    order_id: id,
+    user_id: user.id,
+    activity_type: "item_added",
+    description: `Added item: ${body.item_name || body.service_name || "Item"}`,
+  });
+
+  return NextResponse.json(data, { status: 201 });
+}

--- a/src/app/api/sales/orders/[id]/route.ts
+++ b/src/app/api/sales/orders/[id]/route.ts
@@ -9,12 +9,28 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
 
   const { data, error } = await supabaseAdmin
     .from("sales_orders")
-    .select("*, sales_accounts:account_id(*), order_items(*)")
+    .select("*, sales_accounts:account_id(*), order_items(*), assigned_profile:assigned_rep_id(full_name, email)")
     .eq("id", id)
     .single();
 
   if (error) return NextResponse.json({ error: error.message }, { status: 404 });
-  return NextResponse.json(data);
+
+  // Fetch activity log
+  const { data: activities } = await supabaseAdmin
+    .from("order_activity_log")
+    .select("*, profiles:user_id(full_name)")
+    .eq("order_id", id)
+    .order("created_at", { ascending: false })
+    .limit(50);
+
+  // Fetch documents
+  const { data: documents } = await supabaseAdmin
+    .from("order_documents")
+    .select("*, profiles:uploaded_by(full_name)")
+    .eq("order_id", id)
+    .order("created_at", { ascending: false });
+
+  return NextResponse.json({ ...data, activities: activities || [], documents: documents || [] });
 }
 
 export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
@@ -23,8 +39,13 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
   const { id } = await params;
   const body = await req.json();
 
-  const allowed = ["status", "notes", "recipient_email"];
-  const updates: Record<string, unknown> = {};
+  const allowed = [
+    "status", "order_status", "order_type", "notes", "recipient_email",
+    "total_value", "deposit_amount", "deposit_paid", "remaining_balance",
+    "payment_status", "invoice_status", "agreement_status", "fulfillment_status",
+    "next_required_action", "assigned_rep_id",
+  ];
+  const updates: Record<string, unknown> = { updated_at: new Date().toISOString() };
   for (const key of allowed) {
     if (key in body) updates[key] = body[key];
   }
@@ -37,6 +58,18 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     .single();
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  // Log status change if order_status was updated
+  if (body.order_status || body.payment_status || body.fulfillment_status) {
+    const desc = body._activity_description || `Status updated`;
+    await supabaseAdmin.from("order_activity_log").insert({
+      order_id: id,
+      user_id: user.id,
+      activity_type: "status_change",
+      description: desc,
+    });
+  }
+
   return NextResponse.json(data);
 }
 
@@ -49,9 +82,7 @@ export async function DELETE(req: NextRequest, { params }: { params: Promise<{ i
     return NextResponse.json({ error: "Only admins can delete orders" }, { status: 403 });
   }
 
-  // order_items cascade via FK; documents linked to order are removed
   await supabaseAdmin.from("sales_documents").delete().eq("order_id", id);
-
   const { error } = await supabaseAdmin.from("sales_orders").delete().eq("id", id);
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
   return NextResponse.json({ ok: true });

--- a/src/app/api/sales/orders/[id]/status/route.ts
+++ b/src/app/api/sales/orders/[id]/status/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser } from "@/lib/salesAuth";
+
+const STATUS_ACTIONS: Record<string, { order_status?: string; payment_status?: string; invoice_status?: string; agreement_status?: string; fulfillment_status?: string; next_action?: string | null }> = {
+  send_invoice: { invoice_status: "sent", order_status: "invoice_sent", next_action: "Follow up on payment" },
+  send_agreement: { agreement_status: "sent", order_status: "agreement_sent", next_action: "Follow up on signature" },
+  mark_agreement_signed: { agreement_status: "signed", order_status: "awaiting_payment", next_action: "Confirm payment" },
+  mark_deposit_paid: { payment_status: "deposit_paid", order_status: "deposit_paid", next_action: "Collect remaining balance" },
+  mark_paid: { payment_status: "paid", order_status: "paid", next_action: "Order machine from supplier" },
+  mark_machine_ordered: { fulfillment_status: "ordered", order_status: "machine_ordered", next_action: "Schedule shipment" },
+  mark_location_search: { fulfillment_status: "location_search", order_status: "location_search_active", next_action: "Find and confirm location" },
+  mark_coffee_setup: { fulfillment_status: "coffee_setup", order_status: "coffee_program_setup", next_action: "Complete coffee program setup" },
+  mark_shipped: { fulfillment_status: "shipped", order_status: "shipped", next_action: "Confirm delivery" },
+  mark_delivered: { fulfillment_status: "delivered", order_status: "delivered", next_action: "Mark completed" },
+  mark_completed: { fulfillment_status: "completed", order_status: "completed", next_action: null },
+  mark_cancelled: { order_status: "cancelled", fulfillment_status: "cancelled", next_action: null },
+};
+
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const user = await getSalesUser(req);
+  if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id } = await params;
+  const body = await req.json();
+  const { action } = body;
+
+  const statusUpdate = STATUS_ACTIONS[action];
+  if (!statusUpdate) {
+    return NextResponse.json({ error: "Invalid action" }, { status: 400 });
+  }
+
+  const updates: Record<string, unknown> = { updated_at: new Date().toISOString() };
+  if (statusUpdate.order_status) updates.order_status = statusUpdate.order_status;
+  if (statusUpdate.payment_status) updates.payment_status = statusUpdate.payment_status;
+  if (statusUpdate.invoice_status) updates.invoice_status = statusUpdate.invoice_status;
+  if (statusUpdate.agreement_status) updates.agreement_status = statusUpdate.agreement_status;
+  if (statusUpdate.fulfillment_status) updates.fulfillment_status = statusUpdate.fulfillment_status;
+  if (statusUpdate.next_action !== undefined) updates.next_required_action = statusUpdate.next_action;
+
+  if (action === "mark_deposit_paid") {
+    updates.deposit_paid = true;
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from("sales_orders")
+    .update(updates)
+    .eq("id", id)
+    .select()
+    .single();
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  const description = action.replace(/_/g, " ").replace(/^mark /, "Marked ").replace(/^send /, "Sent ");
+  await supabaseAdmin.from("order_activity_log").insert({
+    order_id: id,
+    user_id: user.id,
+    activity_type: "status_change",
+    description: description.charAt(0).toUpperCase() + description.slice(1),
+  });
+
+  return NextResponse.json(data);
+}

--- a/src/app/api/sales/orders/route.ts
+++ b/src/app/api/sales/orders/route.ts
@@ -6,43 +6,105 @@ export async function GET(req: NextRequest) {
   const user = await getSalesUser(req);
   if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
 
+  const { searchParams } = new URL(req.url);
+  const status = searchParams.get("status");
+  const search = searchParams.get("search");
+
   let query = supabaseAdmin
     .from("sales_orders")
-    .select("*, sales_accounts:account_id(business_name), order_items(*)")
+    .select("*, sales_accounts:account_id(id, business_name, contact_name, email, phone), order_items(*), assigned_profile:assigned_rep_id(full_name)")
     .order("created_at", { ascending: false })
     .limit(200);
 
   if (user.role === "sales") {
-    query = query.eq("created_by", user.id);
+    query = query.or(`created_by.eq.${user.id},assigned_rep_id.eq.${user.id}`);
+  }
+
+  if (status && status !== "all") {
+    query = query.eq("order_status", status);
   }
 
   const { data, error } = await query;
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  return NextResponse.json(data || []);
+
+  let results = data || [];
+
+  if (search) {
+    const s = search.toLowerCase();
+    results = results.filter((o: Record<string, unknown>) => {
+      const acct = o.sales_accounts as { business_name?: string; contact_name?: string } | null;
+      const orderNum = String(o.order_number || "");
+      return (
+        acct?.business_name?.toLowerCase().includes(s) ||
+        acct?.contact_name?.toLowerCase().includes(s) ||
+        orderNum.includes(s) ||
+        (o.id as string).toLowerCase().includes(s)
+      );
+    });
+  }
+
+  return NextResponse.json(results);
 }
 
-/** POST /api/sales/orders — manually create an order, optionally with items */
 export async function POST(req: NextRequest) {
   const user = await getSalesUser(req);
   if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
 
   const body = await req.json();
-  const { account_id, deal_id, recipient_email, notes, items } = body;
+  const {
+    account_id, lead_id, deal_id, recipient_email, notes, items,
+    order_type, next_required_action, assigned_rep_id,
+  } = body;
 
-  type Item = { service_name: string; price?: number; notes?: string };
+  type Item = {
+    item_type?: string;
+    item_name?: string;
+    service_name?: string;
+    description?: string;
+    quantity?: number;
+    unit_price?: number;
+    price?: number;
+    location_service_price?: number;
+    deposit_required?: boolean;
+    location_deposit_amount?: number;
+  };
   const itemList: Item[] = Array.isArray(items) ? items : [];
-  const total = itemList.reduce((sum, i) => sum + (Number(i.price) || 0), 0);
+  const total = itemList.reduce((sum, i) => {
+    const qty = Number(i.quantity) || 1;
+    const price = Number(i.unit_price || i.price) || 0;
+    return sum + qty * price;
+  }, 0);
+
+  const depositTotal = itemList.reduce((sum, i) => {
+    if (i.deposit_required && i.location_deposit_amount) {
+      return sum + Number(i.location_deposit_amount);
+    }
+    return sum;
+  }, 0);
 
   const { data: order, error } = await supabaseAdmin
     .from("sales_orders")
     .insert({
       account_id: account_id || null,
+      lead_id: lead_id || null,
       deal_id: deal_id || null,
       created_by: user.id,
+      assigned_rep_id: assigned_rep_id || user.id,
       total_value: total,
       status: "draft",
+      order_status: "draft",
+      order_type: order_type || null,
+      deposit_amount: depositTotal,
+      deposit_paid: false,
+      remaining_balance: total,
+      payment_status: "unpaid",
+      invoice_status: "not_sent",
+      agreement_status: "not_sent",
+      fulfillment_status: "pending",
+      next_required_action: next_required_action || "Collect customer business information",
       recipient_email: recipient_email || null,
       notes: notes || null,
+      updated_at: new Date().toISOString(),
     })
     .select("*")
     .single();
@@ -51,17 +113,41 @@ export async function POST(req: NextRequest) {
 
   if (itemList.length > 0) {
     const rows = itemList
-      .filter((i) => i.service_name)
-      .map((i) => ({
-        order_id: order.id,
-        service_name: i.service_name,
-        price: Number(i.price) || 0,
-        notes: i.notes || null,
-      }));
+      .filter((i) => i.item_name || i.service_name)
+      .map((i) => {
+        const qty = Number(i.quantity) || 1;
+        const unitPrice = Number(i.unit_price || i.price) || 0;
+        return {
+          order_id: order.id,
+          service_name: i.item_name || i.service_name || "",
+          price: unitPrice,
+          item_type: i.item_type || "other",
+          description: i.description || null,
+          quantity: qty,
+          unit_price: unitPrice,
+          total_price: qty * unitPrice,
+          status: "pending",
+          location_service_price: i.location_service_price || null,
+          deposit_required: i.deposit_required || false,
+          location_deposit_amount: i.location_deposit_amount || null,
+          location_deposit_paid: false,
+          location_remaining_balance: i.location_service_price
+            ? (i.location_service_price - (i.location_deposit_amount || 0))
+            : null,
+        };
+      });
     if (rows.length > 0) {
       await supabaseAdmin.from("order_items").insert(rows);
     }
   }
+
+  // Log creation activity
+  await supabaseAdmin.from("order_activity_log").insert({
+    order_id: order.id,
+    user_id: user.id,
+    activity_type: "created",
+    description: "Order created",
+  });
 
   return NextResponse.json(order, { status: 201 });
 }

--- a/src/app/sales/leads/page.tsx
+++ b/src/app/sales/leads/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { useRouter } from "next/navigation";
 import { createBrowserClient } from "@/lib/supabase";
 import { Plus, Loader2, Search, X, UserPlus, ArrowRight, Trash2, PhoneOff, Phone, Upload, FileSpreadsheet, AlertCircle, CheckCircle2, AlertTriangle, CheckSquare, Pencil, Building2, Mail, Send, Clock, ShieldCheck, Paperclip } from "lucide-react";
 import { ENTITY_TYPES, IMMEDIATE_NEEDS, type SalesLead, type EntityType, type ImmediateNeed } from "@/lib/salesTypes";
@@ -125,6 +126,7 @@ function autoMapColumns(headers: string[]): Record<number, LeadFieldKey | ""> {
 }
 
 export default function LeadsPage() {
+  const router = useRouter();
   const [leads, setLeads] = useState<SalesLead[]>([]);
   const [loading, setLoading] = useState(true);
   const [token, setToken] = useState("");
@@ -554,6 +556,17 @@ export default function LeadsPage() {
       body: JSON.stringify({ status }),
     });
     fetchLeads();
+
+    if (status === "won") {
+      const lead = leads.find((l) => l.id === id);
+      const createOrder = confirm("Lead marked as Won! Create an Order from this lead?");
+      if (createOrder) {
+        const params = new URLSearchParams();
+        params.set("lead_id", id);
+        if (lead?.account_id) params.set("account_id", lead.account_id);
+        router.push(`/sales/orders/new?${params}`);
+      }
+    }
   }
 
   function openEdit(lead: SalesLead) {
@@ -737,6 +750,7 @@ export default function LeadsPage() {
     new: "bg-blue-50 text-blue-700 ring-blue-200",
     contacted: "bg-yellow-50 text-yellow-700 ring-yellow-200",
     qualified: "bg-green-50 text-green-700 ring-green-200",
+    won: "bg-emerald-50 text-emerald-700 ring-emerald-200",
     unqualified: "bg-gray-100 text-gray-600 ring-gray-200",
     lost: "bg-red-50 text-red-700 ring-red-200",
   };
@@ -1260,6 +1274,7 @@ export default function LeadsPage() {
                       <option value="new">New</option>
                       <option value="contacted">Contacted</option>
                       <option value="qualified">Qualified</option>
+                      <option value="won">Won</option>
                       <option value="unqualified">Unqualified</option>
                       <option value="lost">Lost</option>
                     </select>

--- a/src/app/sales/orders/[id]/page.tsx
+++ b/src/app/sales/orders/[id]/page.tsx
@@ -3,255 +3,594 @@
 import { useState, useEffect, useCallback } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { createBrowserClient } from "@/lib/supabase";
-import { ArrowLeft, Loader2, Send, CheckCircle2, Circle, Plus, X } from "lucide-react";
-import type { SalesOrder, FulfillmentItem } from "@/lib/salesTypes";
+import {
+  Loader2, ArrowLeft, Plus, Upload, AlertCircle, CheckCircle2,
+  Package, MapPin, Coffee, Monitor, Wrench, DollarSign,
+  FileText, Clock, User, Building2, Trash2,
+} from "lucide-react";
+
+interface OrderItem {
+  id: string;
+  item_type: string;
+  service_name: string;
+  description: string | null;
+  quantity: number;
+  unit_price: number;
+  total_price: number;
+  status: string;
+  location_service_price: number | null;
+  deposit_required: boolean;
+  location_deposit_amount: number | null;
+  location_deposit_paid: boolean;
+  location_remaining_balance: number | null;
+}
+
+interface Activity {
+  id: string;
+  activity_type: string;
+  description: string;
+  created_at: string;
+  profiles: { full_name: string } | null;
+}
+
+interface OrderDocument {
+  id: string;
+  document_type: string;
+  file_name: string;
+  file_url: string;
+  created_at: string;
+  profiles: { full_name: string } | null;
+}
+
+interface OrderDetail {
+  id: string;
+  order_number: number;
+  order_status: string;
+  order_type: string | null;
+  total_value: number;
+  deposit_amount: number;
+  deposit_paid: boolean;
+  remaining_balance: number;
+  payment_status: string;
+  invoice_status: string;
+  agreement_status: string;
+  fulfillment_status: string;
+  next_required_action: string | null;
+  notes: string | null;
+  lead_id: string | null;
+  created_at: string;
+  updated_at: string;
+  sales_accounts: { id: string; business_name: string; contact_name: string; email: string; phone: string; address: string } | null;
+  assigned_profile: { full_name: string; email: string } | null;
+  order_items: OrderItem[];
+  activities: Activity[];
+  documents: OrderDocument[];
+}
+
+const ITEM_TYPES = [
+  { value: "machine_sale", label: "Machine Sale", icon: Package },
+  { value: "location_services", label: "Location Services", icon: MapPin },
+  { value: "coffee_program", label: "Coffee Program", icon: Coffee },
+  { value: "vendera_ai_cooler", label: "VendEra AI Cooler", icon: Monitor },
+  { value: "combo_machine", label: "Combo Machine", icon: Package },
+  { value: "financing", label: "Financing", icon: DollarSign },
+  { value: "other", label: "Other Services", icon: Wrench },
+];
+
+const STATUS_ACTIONS = [
+  { action: "send_invoice", label: "Send Invoice", color: "bg-blue-600 hover:bg-blue-700" },
+  { action: "send_agreement", label: "Send Agreement", color: "bg-indigo-600 hover:bg-indigo-700" },
+  { action: "mark_agreement_signed", label: "Mark Signed", color: "bg-purple-600 hover:bg-purple-700" },
+  { action: "mark_deposit_paid", label: "Mark Deposit Paid", color: "bg-emerald-600 hover:bg-emerald-700" },
+  { action: "mark_paid", label: "Mark Paid", color: "bg-green-600 hover:bg-green-700" },
+  { action: "mark_machine_ordered", label: "Mark Machine Ordered", color: "bg-violet-600 hover:bg-violet-700" },
+  { action: "mark_location_search", label: "Location Search Active", color: "bg-cyan-600 hover:bg-cyan-700" },
+  { action: "mark_coffee_setup", label: "Coffee Program Setup", color: "bg-amber-600 hover:bg-amber-700" },
+  { action: "mark_shipped", label: "Mark Shipped", color: "bg-sky-600 hover:bg-sky-700" },
+  { action: "mark_delivered", label: "Mark Delivered", color: "bg-teal-600 hover:bg-teal-700" },
+  { action: "mark_completed", label: "Mark Completed", color: "bg-green-700 hover:bg-green-800" },
+  { action: "mark_cancelled", label: "Cancel Order", color: "bg-red-600 hover:bg-red-700" },
+];
+
+const STATUS_COLORS: Record<string, string> = {
+  draft: "bg-gray-50 text-gray-600 ring-gray-200",
+  awaiting_customer_info: "bg-yellow-50 text-yellow-700 ring-yellow-200",
+  invoice_sent: "bg-blue-50 text-blue-700 ring-blue-200",
+  agreement_sent: "bg-indigo-50 text-indigo-700 ring-indigo-200",
+  awaiting_signature: "bg-indigo-50 text-indigo-700 ring-indigo-200",
+  awaiting_payment: "bg-orange-50 text-orange-700 ring-orange-200",
+  deposit_paid: "bg-emerald-50 text-emerald-700 ring-emerald-200",
+  paid: "bg-green-50 text-green-700 ring-green-200",
+  machine_ordered: "bg-purple-50 text-purple-700 ring-purple-200",
+  location_search_active: "bg-cyan-50 text-cyan-700 ring-cyan-200",
+  coffee_program_setup: "bg-amber-50 text-amber-700 ring-amber-200",
+  shipped: "bg-sky-50 text-sky-700 ring-sky-200",
+  delivered: "bg-teal-50 text-teal-700 ring-teal-200",
+  completed: "bg-green-50 text-green-700 ring-green-200",
+  cancelled: "bg-red-50 text-red-600 ring-red-200",
+};
+
+function formatStatus(s: string): string {
+  return s.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
 
 export default function OrderDetailPage() {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
-  const [order, setOrder] = useState<SalesOrder | null>(null);
-  const [checklist, setChecklist] = useState<FulfillmentItem[]>([]);
+  const [order, setOrder] = useState<OrderDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [token, setToken] = useState("");
-  const [sending, setSending] = useState(false);
   const [showAddItem, setShowAddItem] = useState(false);
-  const [newLabel, setNewLabel] = useState("");
+  const [actionLoading, setActionLoading] = useState("");
+  const [noteText, setNoteText] = useState("");
+
+  const [newItem, setNewItem] = useState({
+    item_type: "machine_sale",
+    item_name: "",
+    description: "",
+    quantity: "1",
+    unit_price: "",
+    deposit_required: false,
+    location_deposit_amount: "100",
+    location_service_price: "",
+  });
 
   useEffect(() => {
     const supabase = createBrowserClient();
-    async function init() {
-      const { data: { session } } = await supabase.auth.getSession();
+    supabase.auth.getSession().then(({ data: { session } }) => {
       if (session?.access_token) setToken(session.access_token);
-    }
-    init();
+    });
   }, []);
 
   const fetchOrder = useCallback(async () => {
-    if (!token || !id) return;
+    if (!token) return;
     setLoading(true);
-    const [orderRes, checklistRes] = await Promise.all([
-      fetch(`/api/sales/orders/${id}`, { headers: { Authorization: `Bearer ${token}` } }),
-      fetch(`/api/sales/orders/${id}/fulfillment`, { headers: { Authorization: `Bearer ${token}` } }),
-    ]);
-    if (orderRes.ok) setOrder(await orderRes.json());
-    if (checklistRes.ok) setChecklist(await checklistRes.json());
+    const res = await fetch(`/api/sales/orders/${id}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.ok) setOrder(await res.json());
     setLoading(false);
   }, [token, id]);
 
   useEffect(() => { fetchOrder(); }, [fetchOrder]);
 
-  async function handleToggleItem(item: FulfillmentItem) {
-    await fetch(`/api/sales/orders/${id}/fulfillment`, {
-      method: "PATCH",
+  async function handleStatusAction(action: string) {
+    setActionLoading(action);
+    await fetch(`/api/sales/orders/${id}/status`, {
+      method: "POST",
       headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
-      body: JSON.stringify({ item_id: item.id, completed: !item.completed }),
+      body: JSON.stringify({ action }),
     });
-    fetchOrder();
+    await fetchOrder();
+    setActionLoading("");
   }
 
   async function handleAddItem() {
-    if (!newLabel.trim()) return;
-    await fetch(`/api/sales/orders/${id}/fulfillment`, {
+    const res = await fetch(`/api/sales/orders/${id}/items`, {
       method: "POST",
       headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
-      body: JSON.stringify({ label: newLabel.trim() }),
+      body: JSON.stringify({
+        item_type: newItem.item_type,
+        item_name: newItem.item_name,
+        description: newItem.description || null,
+        quantity: Number(newItem.quantity) || 1,
+        unit_price: Number(newItem.unit_price) || 0,
+        deposit_required: newItem.deposit_required,
+        location_deposit_amount: newItem.deposit_required ? Number(newItem.location_deposit_amount) || 100 : null,
+        location_service_price: newItem.item_type === "location_services" ? Number(newItem.location_service_price) || 0 : null,
+      }),
     });
-    setNewLabel("");
-    setShowAddItem(false);
+    if (res.ok) {
+      setShowAddItem(false);
+      setNewItem({ item_type: "machine_sale", item_name: "", description: "", quantity: "1", unit_price: "", deposit_required: false, location_deposit_amount: "100", location_service_price: "" });
+      fetchOrder();
+    }
+  }
+
+  async function handleDeleteItem(itemId: string) {
+    if (!confirm("Remove this item?")) return;
+    await fetch(`/api/sales/orders/${id}/items/${itemId}`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${token}` },
+    });
     fetchOrder();
   }
 
-  async function handleSend() {
-    setSending(true);
-    const res = await fetch(`/api/sales/orders/${id}/send`, {
+  async function handleAddNote() {
+    if (!noteText.trim()) return;
+    await fetch(`/api/sales/orders/${id}/activity`, {
       method: "POST",
-      headers: { Authorization: `Bearer ${token}` },
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ activity_type: "note", description: noteText.trim() }),
     });
-    const result = await res.json().catch(() => ({}));
-    if (result.emailSent) {
-      const ccInfo = result.cc?.length ? `\nCC: ${result.cc.join(", ")}` : "";
-      alert(`Order sent to ${result.recipient}${ccInfo}`);
-      fetchOrder();
-    } else {
-      alert(`Email failed: ${result.emailError || "Unknown error"}`);
-    }
-    setSending(false);
+    setNoteText("");
+    fetchOrder();
   }
 
-  async function handleMarkCompleted() {
+  async function handleUploadDoc(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const formData = new FormData();
+    formData.append("file", file);
+    formData.append("document_type", "general");
+    await fetch(`/api/sales/orders/${id}/documents`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+      body: formData,
+    });
+    fetchOrder();
+    e.target.value = "";
+  }
+
+  async function handleNextAction(value: string) {
     await fetch(`/api/sales/orders/${id}`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
-      body: JSON.stringify({ status: "completed" }),
+      body: JSON.stringify({ next_required_action: value }),
     });
     fetchOrder();
   }
 
-  if (loading) {
-    return <div className="flex justify-center py-20"><Loader2 className="h-8 w-8 animate-spin text-green-600" /></div>;
+  if (loading || !order) {
+    return (
+      <div className="flex justify-center items-center py-20">
+        <Loader2 className="h-6 w-6 animate-spin text-green-600" />
+      </div>
+    );
   }
-
-  if (!order) {
-    return <div className="p-6 text-center text-gray-400">Order not found</div>;
-  }
-
-  const items = order.order_items || [];
-  const completedCount = checklist.filter((c) => c.completed).length;
-  const totalItems = checklist.length;
-
-  const statusColor: Record<string, string> = {
-    draft: "bg-gray-50 text-gray-600 ring-gray-200",
-    sent: "bg-blue-50 text-blue-700 ring-blue-200",
-    completed: "bg-green-50 text-green-700 ring-green-200",
-  };
 
   return (
-    <div className="p-6 max-w-4xl">
-      <button onClick={() => router.push("/sales/orders")} className="mb-4 inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 cursor-pointer">
+    <div className="p-6 max-w-6xl">
+      <button onClick={() => router.push("/sales/orders")} className="flex items-center gap-1 text-sm text-gray-500 hover:text-green-600 mb-4 cursor-pointer">
         <ArrowLeft className="h-4 w-4" /> Back to Orders
       </button>
 
-      <div className="rounded-xl border border-gray-200 bg-white p-6">
-        <div className="flex items-start justify-between mb-6">
-          <div>
-            <h1 className="text-xl font-bold text-gray-900">
-              Order {order.id.slice(0, 8).toUpperCase()}
-            </h1>
-            <p className="text-sm text-gray-500 mt-1">
-              {(order.sales_accounts as { business_name: string } | null)?.business_name || "No account"}
-            </p>
-          </div>
+      <div className="flex items-start justify-between mb-6">
+        <div>
           <div className="flex items-center gap-3">
-            <span className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ring-1 ring-inset capitalize ${statusColor[order.status] || ""}`}>
-              {order.status}
+            <h1 className="text-2xl font-bold text-gray-900">
+              Order #{order.order_number || order.id.slice(0, 6).toUpperCase()}
+            </h1>
+            <span className={`rounded-full px-3 py-1 text-xs font-medium ring-1 ring-inset ${STATUS_COLORS[order.order_status] || STATUS_COLORS.draft}`}>
+              {formatStatus(order.order_status || "draft")}
             </span>
-            <p className="text-2xl font-bold text-green-600">
-              ${Number(order.total_value).toLocaleString("en-US", { minimumFractionDigits: 2 })}
-            </p>
           </div>
+          <p className="text-sm text-gray-500 mt-1">
+            Created {new Date(order.created_at).toLocaleDateString()} · Updated {new Date(order.updated_at || order.created_at).toLocaleDateString()}
+          </p>
         </div>
+      </div>
 
-        {/* Order items */}
-        {items.length > 0 && (
-          <div className="mb-6">
-            <h2 className="text-sm font-semibold text-gray-900 mb-3">Items</h2>
-            <div className="overflow-x-auto rounded-lg border border-gray-200">
-              <table className="w-full text-left text-sm">
-                <thead className="border-b border-gray-100 bg-gray-50/50">
-                  <tr>
-                    <th className="px-4 py-2.5 font-medium text-gray-500">Service</th>
-                    <th className="px-4 py-2.5 font-medium text-gray-500 text-right">Price</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-gray-50">
-                  {items.map((item) => (
-                    <tr key={item.id}>
-                      <td className="px-4 py-2.5 text-gray-900">{item.service_name}</td>
-                      <td className="px-4 py-2.5 text-right font-medium text-gray-900">
-                        ${Number(item.price).toLocaleString("en-US", { minimumFractionDigits: 2 })}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
+      {/* Next Required Action */}
+      {order.next_required_action && order.order_status !== "completed" && order.order_status !== "cancelled" && (
+        <div className="mb-6 rounded-xl border border-amber-200 bg-amber-50 p-4 flex items-center gap-3">
+          <AlertCircle className="h-5 w-5 text-amber-600 shrink-0" />
+          <div className="flex-1">
+            <p className="text-xs font-medium text-amber-600 uppercase">Next Required Action</p>
+            <p className="text-sm font-semibold text-amber-800">{order.next_required_action}</p>
           </div>
-        )}
+          <button
+            onClick={() => {
+              const val = prompt("Update next action:", order.next_required_action || "");
+              if (val !== null) handleNextAction(val);
+            }}
+            className="text-xs text-amber-600 hover:text-amber-800 underline cursor-pointer"
+          >
+            Edit
+          </button>
+        </div>
+      )}
 
-        {/* Fulfillment Checklist */}
-        <div className="mb-6">
-          <div className="flex items-center justify-between mb-3">
-            <div>
-              <h2 className="text-sm font-semibold text-gray-900">Fulfillment Checklist</h2>
-              {totalItems > 0 && (
-                <p className="text-xs text-gray-500 mt-0.5">
-                  {completedCount}/{totalItems} completed
-                </p>
-              )}
-            </div>
-            <button
-              onClick={() => setShowAddItem(!showAddItem)}
-              className="inline-flex items-center gap-1 text-sm text-green-600 hover:text-green-700 cursor-pointer"
-            >
-              <Plus className="h-4 w-4" /> Add Step
-            </button>
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Left column */}
+        <div className="lg:col-span-2 space-y-6">
+          {/* Customer Info */}
+          <div className="rounded-xl border border-gray-200 bg-white p-5">
+            <h3 className="text-sm font-semibold text-gray-900 flex items-center gap-2 mb-3">
+              <Building2 className="h-4 w-4 text-gray-400" /> Customer
+            </h3>
+            {order.sales_accounts ? (
+              <div className="grid grid-cols-2 gap-3 text-sm">
+                <div>
+                  <span className="text-gray-400 text-xs">Business</span>
+                  <p className="font-medium text-gray-900">{order.sales_accounts.business_name}</p>
+                </div>
+                <div>
+                  <span className="text-gray-400 text-xs">Contact</span>
+                  <p className="text-gray-700">{order.sales_accounts.contact_name || "—"}</p>
+                </div>
+                <div>
+                  <span className="text-gray-400 text-xs">Email</span>
+                  <p className="text-gray-700">{order.sales_accounts.email || "—"}</p>
+                </div>
+                <div>
+                  <span className="text-gray-400 text-xs">Phone</span>
+                  <p className="text-gray-700">{order.sales_accounts.phone || "—"}</p>
+                </div>
+              </div>
+            ) : (
+              <p className="text-sm text-gray-400">No account linked</p>
+            )}
           </div>
 
-          {totalItems > 0 && (
-            <div className="mb-3 h-2 rounded-full bg-gray-100 overflow-hidden">
-              <div
-                className="h-full rounded-full bg-green-500 transition-all duration-300"
-                style={{ width: `${totalItems > 0 ? (completedCount / totalItems) * 100 : 0}%` }}
-              />
-            </div>
-          )}
-
-          {showAddItem && (
-            <div className="mb-3 flex gap-2">
-              <input
-                autoFocus
-                value={newLabel}
-                onChange={(e) => setNewLabel(e.target.value)}
-                onKeyDown={(e) => e.key === "Enter" && handleAddItem()}
-                placeholder="Checklist step description"
-                className="flex-1 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none"
-              />
-              <button onClick={handleAddItem} className="rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 cursor-pointer">Add</button>
-              <button onClick={() => { setShowAddItem(false); setNewLabel(""); }} className="rounded-lg border border-gray-200 px-2 py-2 text-sm text-gray-500 hover:bg-gray-50 cursor-pointer">
-                <X className="h-4 w-4" />
+          {/* Order Items */}
+          <div className="rounded-xl border border-gray-200 bg-white p-5">
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-sm font-semibold text-gray-900 flex items-center gap-2">
+                <Package className="h-4 w-4 text-gray-400" /> Order Items
+              </h3>
+              <button
+                onClick={() => setShowAddItem(true)}
+                className="inline-flex items-center gap-1 text-xs text-green-600 hover:text-green-700 font-medium cursor-pointer"
+              >
+                <Plus className="h-3.5 w-3.5" /> Add Item
               </button>
             </div>
-          )}
 
-          {checklist.length === 0 ? (
-            <p className="py-4 text-center text-sm text-gray-400 rounded-lg border border-dashed border-gray-200">
-              No checklist items yet
-            </p>
-          ) : (
-            <div className="space-y-1">
-              {checklist.map((item) => (
-                <button
-                  key={item.id}
-                  onClick={() => handleToggleItem(item)}
-                  className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left hover:bg-gray-50 transition-colors cursor-pointer"
-                >
-                  {item.completed ? (
-                    <CheckCircle2 className="h-5 w-5 text-green-500 flex-shrink-0" />
-                  ) : (
-                    <Circle className="h-5 w-5 text-gray-300 flex-shrink-0" />
+            {order.order_items.length === 0 ? (
+              <p className="text-sm text-gray-400 py-4 text-center">No items yet.</p>
+            ) : (
+              <div className="space-y-2">
+                {order.order_items.map((item) => {
+                  const ItemIcon = ITEM_TYPES.find((t) => t.value === item.item_type)?.icon || Wrench;
+                  return (
+                    <div key={item.id} className="flex items-center gap-3 rounded-lg border border-gray-100 p-3 hover:bg-gray-50">
+                      <ItemIcon className="h-4 w-4 text-gray-400 shrink-0" />
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm font-medium text-gray-900 truncate">{item.service_name}</p>
+                        <p className="text-xs text-gray-400">
+                          {formatStatus(item.item_type)} · Qty: {item.quantity}
+                          {item.deposit_required && item.location_deposit_amount != null && (
+                            <span className="ml-2 text-amber-600">
+                              Deposit: ${Number(item.location_deposit_amount).toFixed(2)}
+                              {item.location_deposit_paid ? " (Paid)" : " (Pending)"}
+                            </span>
+                          )}
+                        </p>
+                      </div>
+                      <span className="text-sm font-medium text-gray-900">
+                        ${Number(item.total_price || 0).toLocaleString("en-US", { minimumFractionDigits: 2 })}
+                      </span>
+                      <button onClick={() => handleDeleteItem(item.id)} className="p-1 text-gray-300 hover:text-red-500 cursor-pointer">
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </button>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+
+            {/* Add item form */}
+            {showAddItem && (
+              <div className="mt-4 rounded-lg border border-green-200 bg-green-50/50 p-4">
+                <div className="grid grid-cols-2 gap-3">
+                  <select
+                    value={newItem.item_type}
+                    onChange={(e) => setNewItem((f) => ({ ...f, item_type: e.target.value }))}
+                    className="rounded-lg border border-gray-200 px-3 py-2 text-sm"
+                  >
+                    {ITEM_TYPES.map((t) => (
+                      <option key={t.value} value={t.value}>{t.label}</option>
+                    ))}
+                  </select>
+                  <input
+                    placeholder="Item name"
+                    value={newItem.item_name}
+                    onChange={(e) => setNewItem((f) => ({ ...f, item_name: e.target.value }))}
+                    className="rounded-lg border border-gray-200 px-3 py-2 text-sm"
+                  />
+                  <input
+                    type="number"
+                    placeholder="Quantity"
+                    value={newItem.quantity}
+                    onChange={(e) => setNewItem((f) => ({ ...f, quantity: e.target.value }))}
+                    className="rounded-lg border border-gray-200 px-3 py-2 text-sm"
+                  />
+                  <input
+                    type="number"
+                    placeholder="Unit price"
+                    value={newItem.unit_price}
+                    onChange={(e) => setNewItem((f) => ({ ...f, unit_price: e.target.value }))}
+                    className="rounded-lg border border-gray-200 px-3 py-2 text-sm"
+                  />
+                  {newItem.item_type === "location_services" && (
+                    <>
+                      <input
+                        type="number"
+                        placeholder="Location service total price"
+                        value={newItem.location_service_price}
+                        onChange={(e) => setNewItem((f) => ({ ...f, location_service_price: e.target.value }))}
+                        className="rounded-lg border border-gray-200 px-3 py-2 text-sm"
+                      />
+                      <div className="flex items-center gap-2">
+                        <input
+                          type="checkbox"
+                          checked={newItem.deposit_required}
+                          onChange={(e) => setNewItem((f) => ({ ...f, deposit_required: e.target.checked }))}
+                          className="h-4 w-4 rounded border-gray-300 text-green-600"
+                        />
+                        <label className="text-xs text-gray-600">$100 deposit required</label>
+                      </div>
+                    </>
                   )}
-                  <span className={`text-sm ${item.completed ? "text-gray-400 line-through" : "text-gray-700"}`}>
-                    {item.label}
-                  </span>
-                </button>
-              ))}
+                </div>
+                <textarea
+                  placeholder="Description (optional)"
+                  value={newItem.description}
+                  onChange={(e) => setNewItem((f) => ({ ...f, description: e.target.value }))}
+                  className="mt-3 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm"
+                  rows={2}
+                />
+                <div className="mt-3 flex gap-2">
+                  <button onClick={handleAddItem} className="rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 cursor-pointer">Add</button>
+                  <button onClick={() => setShowAddItem(false)} className="rounded-lg border border-gray-200 px-4 py-2 text-sm text-gray-600 hover:bg-gray-50 cursor-pointer">Cancel</button>
+                </div>
+              </div>
+            )}
+
+            {/* Totals */}
+            {order.order_items.length > 0 && (
+              <div className="mt-4 pt-4 border-t border-gray-100">
+                <div className="flex justify-between text-sm">
+                  <span className="text-gray-500">Total Value</span>
+                  <span className="font-bold text-gray-900">${Number(order.total_value || 0).toLocaleString("en-US", { minimumFractionDigits: 2 })}</span>
+                </div>
+                {Number(order.deposit_amount) > 0 && (
+                  <div className="flex justify-between text-sm mt-1">
+                    <span className="text-gray-500">Deposit {order.deposit_paid ? "(Paid)" : "(Pending)"}</span>
+                    <span className={order.deposit_paid ? "text-green-600 font-medium" : "text-amber-600 font-medium"}>
+                      ${Number(order.deposit_amount).toLocaleString("en-US", { minimumFractionDigits: 2 })}
+                    </span>
+                  </div>
+                )}
+                <div className="flex justify-between text-sm mt-1">
+                  <span className="text-gray-500">Remaining</span>
+                  <span className="font-medium text-gray-700">${Number(order.remaining_balance || order.total_value || 0).toLocaleString("en-US", { minimumFractionDigits: 2 })}</span>
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Documents */}
+          <div className="rounded-xl border border-gray-200 bg-white p-5">
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-sm font-semibold text-gray-900 flex items-center gap-2">
+                <FileText className="h-4 w-4 text-gray-400" /> Documents
+              </h3>
+              <label className="inline-flex items-center gap-1 text-xs text-green-600 hover:text-green-700 font-medium cursor-pointer">
+                <Upload className="h-3.5 w-3.5" /> Upload
+                <input type="file" className="hidden" onChange={handleUploadDoc} />
+              </label>
             </div>
-          )}
+            {order.documents.length === 0 ? (
+              <p className="text-sm text-gray-400 py-2">No documents uploaded.</p>
+            ) : (
+              <div className="space-y-2">
+                {order.documents.map((doc) => (
+                  <a key={doc.id} href={doc.file_url} target="_blank" rel="noopener noreferrer" className="flex items-center gap-2 rounded-lg border border-gray-100 p-2 hover:bg-gray-50 text-sm">
+                    <FileText className="h-4 w-4 text-gray-400" />
+                    <span className="flex-1 text-gray-700 truncate">{doc.file_name}</span>
+                    <span className="text-xs text-gray-400">{new Date(doc.created_at).toLocaleDateString()}</span>
+                  </a>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Activity Log */}
+          <div className="rounded-xl border border-gray-200 bg-white p-5">
+            <h3 className="text-sm font-semibold text-gray-900 flex items-center gap-2 mb-3">
+              <Clock className="h-4 w-4 text-gray-400" /> Activity
+            </h3>
+            <div className="flex gap-2 mb-4">
+              <input
+                type="text"
+                placeholder="Add a note..."
+                value={noteText}
+                onChange={(e) => setNoteText(e.target.value)}
+                onKeyDown={(e) => e.key === "Enter" && handleAddNote()}
+                className="flex-1 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none"
+              />
+              <button onClick={handleAddNote} disabled={!noteText.trim()} className="rounded-lg bg-gray-100 px-3 py-2 text-sm text-gray-600 hover:bg-gray-200 disabled:opacity-50 cursor-pointer">Add</button>
+            </div>
+            {order.activities.length === 0 ? (
+              <p className="text-sm text-gray-400 py-2">No activity yet.</p>
+            ) : (
+              <div className="space-y-3 max-h-80 overflow-y-auto">
+                {order.activities.map((a) => (
+                  <div key={a.id} className="flex gap-3">
+                    <div className="mt-1 h-2 w-2 rounded-full bg-green-400 shrink-0" />
+                    <div className="flex-1">
+                      <p className="text-sm text-gray-700">{a.description}</p>
+                      <p className="text-xs text-gray-400 mt-0.5">
+                        {a.profiles?.full_name || "System"} · {new Date(a.created_at).toLocaleString()}
+                      </p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
         </div>
 
-        {/* Actions */}
-        <div className="flex gap-3">
-          {order.status === "draft" && (
-            <button
-              onClick={handleSend}
-              disabled={sending}
-              className="inline-flex items-center gap-2 rounded-lg bg-green-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-green-700 disabled:opacity-50 cursor-pointer"
-            >
-              {sending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
-              {sending ? "Sending..." : "Send Order"}
-            </button>
+        {/* Right column */}
+        <div className="space-y-6">
+          {/* Status Summary */}
+          <div className="rounded-xl border border-gray-200 bg-white p-5">
+            <h3 className="text-sm font-semibold text-gray-900 mb-3">Status</h3>
+            <div className="space-y-3">
+              <StatusRow label="Payment" value={order.payment_status} />
+              <StatusRow label="Invoice" value={order.invoice_status} />
+              <StatusRow label="Agreement" value={order.agreement_status} />
+              <StatusRow label="Fulfillment" value={order.fulfillment_status} />
+            </div>
+          </div>
+
+          {/* Assigned Rep */}
+          <div className="rounded-xl border border-gray-200 bg-white p-5">
+            <h3 className="text-sm font-semibold text-gray-900 flex items-center gap-2 mb-2">
+              <User className="h-4 w-4 text-gray-400" /> Assigned Rep
+            </h3>
+            <p className="text-sm text-gray-700">{order.assigned_profile?.full_name || "Unassigned"}</p>
+            {order.assigned_profile?.email && (
+              <p className="text-xs text-gray-400">{order.assigned_profile.email}</p>
+            )}
+          </div>
+
+          {/* Actions */}
+          {order.order_status !== "completed" && order.order_status !== "cancelled" && (
+            <div className="rounded-xl border border-gray-200 bg-white p-5">
+              <h3 className="text-sm font-semibold text-gray-900 mb-3">Actions</h3>
+              <div className="grid grid-cols-1 gap-2">
+                {STATUS_ACTIONS.map((sa) => (
+                  <button
+                    key={sa.action}
+                    onClick={() => handleStatusAction(sa.action)}
+                    disabled={actionLoading === sa.action}
+                    className={`w-full rounded-lg px-3 py-2 text-xs font-medium text-white transition-colors cursor-pointer disabled:opacity-50 ${sa.color}`}
+                  >
+                    {actionLoading === sa.action ? "..." : sa.label}
+                  </button>
+                ))}
+              </div>
+            </div>
           )}
-          {order.status === "sent" && (
-            <button
-              onClick={handleMarkCompleted}
-              className="inline-flex items-center gap-2 rounded-lg bg-green-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-green-700 cursor-pointer"
-            >
-              <CheckCircle2 className="h-4 w-4" />
-              Mark Completed
-            </button>
+
+          {(order.order_status === "completed" || order.order_status === "cancelled") && (
+            <div className={`rounded-xl p-5 text-center ${order.order_status === "completed" ? "bg-green-50 border border-green-200" : "bg-red-50 border border-red-200"}`}>
+              <CheckCircle2 className={`mx-auto h-8 w-8 ${order.order_status === "completed" ? "text-green-600" : "text-red-500"}`} />
+              <p className={`mt-2 font-semibold ${order.order_status === "completed" ? "text-green-800" : "text-red-700"}`}>
+                {order.order_status === "completed" ? "Order Completed" : "Order Cancelled"}
+              </p>
+            </div>
           )}
         </div>
       </div>
+    </div>
+  );
+}
+
+function StatusRow({ label, value }: { label: string; value: string }) {
+  const colors: Record<string, string> = {
+    unpaid: "text-gray-500",
+    paid: "text-green-600",
+    deposit_paid: "text-emerald-600",
+    not_sent: "text-gray-400",
+    sent: "text-blue-600",
+    signed: "text-green-600",
+    pending: "text-yellow-600",
+    ordered: "text-purple-600",
+    shipped: "text-sky-600",
+    delivered: "text-teal-600",
+    completed: "text-green-700",
+    cancelled: "text-red-600",
+  };
+  return (
+    <div className="flex items-center justify-between">
+      <span className="text-xs text-gray-500">{label}</span>
+      <span className={`text-xs font-medium capitalize ${colors[value] || "text-gray-500"}`}>
+        {formatStatus(value || "—")}
+      </span>
     </div>
   );
 }

--- a/src/app/sales/orders/new/page.tsx
+++ b/src/app/sales/orders/new/page.tsx
@@ -1,0 +1,320 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { createBrowserClient } from "@/lib/supabase";
+import { Suspense } from "react";
+import {
+  Loader2, ArrowLeft, Plus, X, Package, MapPin, Coffee, Monitor, Wrench, DollarSign,
+} from "lucide-react";
+
+interface Account {
+  id: string;
+  business_name: string;
+  contact_name: string | null;
+  email: string | null;
+  phone: string | null;
+}
+
+const ITEM_TYPES = [
+  { value: "machine_sale", label: "Machine Sale", icon: Package },
+  { value: "location_services", label: "Location Services", icon: MapPin },
+  { value: "coffee_program", label: "Coffee Program", icon: Coffee },
+  { value: "vendera_ai_cooler", label: "VendEra AI Cooler", icon: Monitor },
+  { value: "combo_machine", label: "Combo Machine", icon: Package },
+  { value: "financing", label: "Financing", icon: DollarSign },
+  { value: "other", label: "Other Services", icon: Wrench },
+];
+
+interface ItemForm {
+  item_type: string;
+  item_name: string;
+  description: string;
+  quantity: string;
+  unit_price: string;
+  deposit_required: boolean;
+  location_deposit_amount: string;
+  location_service_price: string;
+}
+
+function NewOrderContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const leadId = searchParams.get("lead_id");
+  const accountId = searchParams.get("account_id");
+
+  const [token, setToken] = useState("");
+  const [accounts, setAccounts] = useState<Account[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  const [form, setForm] = useState({
+    account_id: accountId || "",
+    lead_id: leadId || "",
+    order_type: "",
+    notes: "",
+    next_required_action: "Collect customer business information",
+  });
+
+  const [items, setItems] = useState<ItemForm[]>([
+    { item_type: "machine_sale", item_name: "", description: "", quantity: "1", unit_price: "", deposit_required: false, location_deposit_amount: "100", location_service_price: "" },
+  ]);
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (session?.access_token) setToken(session.access_token);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!token) return;
+    fetch("/api/sales/accounts", { headers: { Authorization: `Bearer ${token}` } })
+      .then((r) => r.json())
+      .then((data) => {
+        setAccounts(data || []);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, [token]);
+
+  function addItem() {
+    setItems((prev) => [...prev, { item_type: "machine_sale", item_name: "", description: "", quantity: "1", unit_price: "", deposit_required: false, location_deposit_amount: "100", location_service_price: "" }]);
+  }
+
+  function removeItem(idx: number) {
+    setItems((prev) => prev.filter((_, i) => i !== idx));
+  }
+
+  function updateItem(idx: number, field: string, value: string | boolean) {
+    setItems((prev) => prev.map((item, i) => i === idx ? { ...item, [field]: value } : item));
+  }
+
+  async function handleCreate() {
+    setSaving(true);
+    const cleanItems = items
+      .filter((i) => i.item_name.trim())
+      .map((i) => ({
+        item_type: i.item_type,
+        item_name: i.item_name.trim(),
+        description: i.description.trim() || null,
+        quantity: Number(i.quantity) || 1,
+        unit_price: Number(i.unit_price) || 0,
+        deposit_required: i.deposit_required,
+        location_deposit_amount: i.deposit_required ? Number(i.location_deposit_amount) || 100 : null,
+        location_service_price: i.item_type === "location_services" ? Number(i.location_service_price) || 0 : null,
+      }));
+
+    const res = await fetch("/api/sales/orders", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({
+        account_id: form.account_id || null,
+        lead_id: form.lead_id || null,
+        order_type: form.order_type || null,
+        notes: form.notes || null,
+        next_required_action: form.next_required_action || null,
+        items: cleanItems,
+      }),
+    });
+
+    if (res.ok) {
+      const order = await res.json();
+      router.push(`/sales/orders/${order.id}`);
+    } else {
+      const err = await res.json().catch(() => ({}));
+      alert(err.error || "Failed to create order");
+      setSaving(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-20">
+        <Loader2 className="h-6 w-6 animate-spin text-green-600" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 max-w-3xl">
+      <button onClick={() => router.back()} className="flex items-center gap-1 text-sm text-gray-500 hover:text-green-600 mb-4 cursor-pointer">
+        <ArrowLeft className="h-4 w-4" /> Back
+      </button>
+
+      <h1 className="text-2xl font-bold text-gray-900 mb-6">Create New Order</h1>
+
+      {/* Order Info */}
+      <div className="rounded-xl border border-gray-200 bg-white p-5 mb-6">
+        <h3 className="text-sm font-semibold text-gray-900 mb-3">Order Details</h3>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <div>
+            <label className="text-xs text-gray-500 mb-1 block">Account</label>
+            <select
+              value={form.account_id}
+              onChange={(e) => setForm((f) => ({ ...f, account_id: e.target.value }))}
+              className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none"
+            >
+              <option value="">Select account...</option>
+              {accounts.map((a) => (
+                <option key={a.id} value={a.id}>{a.business_name}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="text-xs text-gray-500 mb-1 block">Order Type</label>
+            <select
+              value={form.order_type}
+              onChange={(e) => setForm((f) => ({ ...f, order_type: e.target.value }))}
+              className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none"
+            >
+              <option value="">General</option>
+              <option value="machine_sale">Machine Sale</option>
+              <option value="location_services">Location Services</option>
+              <option value="coffee_program">Coffee Program</option>
+              <option value="combo">Combo / Bundle</option>
+            </select>
+          </div>
+        </div>
+        <div className="mt-3">
+          <label className="text-xs text-gray-500 mb-1 block">Next Required Action</label>
+          <input
+            value={form.next_required_action}
+            onChange={(e) => setForm((f) => ({ ...f, next_required_action: e.target.value }))}
+            className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none"
+          />
+        </div>
+        <div className="mt-3">
+          <label className="text-xs text-gray-500 mb-1 block">Notes</label>
+          <textarea
+            value={form.notes}
+            onChange={(e) => setForm((f) => ({ ...f, notes: e.target.value }))}
+            className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none"
+            rows={2}
+          />
+        </div>
+      </div>
+
+      {/* Items */}
+      <div className="rounded-xl border border-gray-200 bg-white p-5 mb-6">
+        <div className="flex items-center justify-between mb-3">
+          <h3 className="text-sm font-semibold text-gray-900">Items</h3>
+          <button onClick={addItem} className="inline-flex items-center gap-1 text-xs text-green-600 hover:text-green-700 font-medium cursor-pointer">
+            <Plus className="h-3.5 w-3.5" /> Add Item
+          </button>
+        </div>
+
+        <div className="space-y-4">
+          {items.map((item, idx) => (
+            <div key={idx} className="rounded-lg border border-gray-100 p-4 relative">
+              {items.length > 1 && (
+                <button
+                  onClick={() => removeItem(idx)}
+                  className="absolute top-2 right-2 p-1 text-gray-300 hover:text-red-500 cursor-pointer"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              )}
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="text-xs text-gray-500 mb-1 block">Type</label>
+                  <select
+                    value={item.item_type}
+                    onChange={(e) => updateItem(idx, "item_type", e.target.value)}
+                    className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm"
+                  >
+                    {ITEM_TYPES.map((t) => (
+                      <option key={t.value} value={t.value}>{t.label}</option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className="text-xs text-gray-500 mb-1 block">Name</label>
+                  <input
+                    placeholder="e.g. VendEra AI Cooler"
+                    value={item.item_name}
+                    onChange={(e) => updateItem(idx, "item_name", e.target.value)}
+                    className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm"
+                  />
+                </div>
+                <div>
+                  <label className="text-xs text-gray-500 mb-1 block">Quantity</label>
+                  <input
+                    type="number"
+                    min="1"
+                    value={item.quantity}
+                    onChange={(e) => updateItem(idx, "quantity", e.target.value)}
+                    className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm"
+                  />
+                </div>
+                <div>
+                  <label className="text-xs text-gray-500 mb-1 block">Unit Price ($)</label>
+                  <input
+                    type="number"
+                    value={item.unit_price}
+                    onChange={(e) => updateItem(idx, "unit_price", e.target.value)}
+                    className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm"
+                  />
+                </div>
+                {item.item_type === "location_services" && (
+                  <>
+                    <div>
+                      <label className="text-xs text-gray-500 mb-1 block">Service Total Price ($)</label>
+                      <input
+                        type="number"
+                        value={item.location_service_price}
+                        onChange={(e) => updateItem(idx, "location_service_price", e.target.value)}
+                        className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm"
+                      />
+                    </div>
+                    <div className="flex items-end">
+                      <label className="flex items-center gap-2 cursor-pointer pb-2">
+                        <input
+                          type="checkbox"
+                          checked={item.deposit_required}
+                          onChange={(e) => updateItem(idx, "deposit_required", e.target.checked)}
+                          className="h-4 w-4 rounded border-gray-300 text-green-600"
+                        />
+                        <span className="text-xs text-gray-600">$100 deposit required</span>
+                      </label>
+                    </div>
+                  </>
+                )}
+              </div>
+              {item.item_name && item.unit_price && (
+                <p className="text-xs text-gray-400 mt-2">
+                  Subtotal: ${((Number(item.quantity) || 1) * (Number(item.unit_price) || 0)).toLocaleString("en-US", { minimumFractionDigits: 2 })}
+                </p>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Create button */}
+      <div className="flex gap-3">
+        <button
+          onClick={handleCreate}
+          disabled={saving || items.every((i) => !i.item_name.trim())}
+          className="rounded-lg bg-green-600 px-6 py-2.5 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-50 cursor-pointer"
+        >
+          {saving ? "Creating..." : "Create Order"}
+        </button>
+        <button
+          onClick={() => router.back()}
+          className="rounded-lg border border-gray-200 px-6 py-2.5 text-sm text-gray-600 hover:bg-gray-50 cursor-pointer"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default function NewOrderPage() {
+  return (
+    <Suspense fallback={<div className="flex justify-center py-20"><Loader2 className="h-6 w-6 animate-spin text-green-600" /></div>}>
+      <NewOrderContent />
+    </Suspense>
+  );
+}

--- a/src/app/sales/orders/page.tsx
+++ b/src/app/sales/orders/page.tsx
@@ -3,28 +3,99 @@
 import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { createBrowserClient } from "@/lib/supabase";
-import { Loader2, ClipboardList, Plus, Trash2, X } from "lucide-react";
-import type { SalesOrder, SalesAccount } from "@/lib/salesTypes";
+import {
+  Loader2, ClipboardList, Plus, Search, AlertCircle,
+  ChevronRight, Package, MapPin, Coffee, Monitor, Wrench, DollarSign,
+} from "lucide-react";
 
-interface NewOrderItem {
+interface OrderItem {
+  id: string;
+  item_type: string;
   service_name: string;
-  price: string;
+  quantity: number;
+  total_price: number;
+}
+
+interface Order {
+  id: string;
+  order_number: number;
+  order_status: string;
+  order_type: string | null;
+  total_value: number;
+  payment_status: string;
+  invoice_status: string;
+  agreement_status: string;
+  fulfillment_status: string;
+  next_required_action: string | null;
+  created_at: string;
+  updated_at: string;
+  sales_accounts: { id: string; business_name: string; contact_name: string; email: string; phone: string } | null;
+  order_items: OrderItem[];
+  assigned_profile: { full_name: string } | null;
+}
+
+const STATUS_FILTERS = [
+  { key: "all", label: "All" },
+  { key: "draft", label: "Draft" },
+  { key: "awaiting_customer_info", label: "Awaiting Info" },
+  { key: "invoice_sent", label: "Invoice Sent" },
+  { key: "awaiting_signature", label: "Awaiting Signature" },
+  { key: "awaiting_payment", label: "Awaiting Payment" },
+  { key: "deposit_paid", label: "Deposit Paid" },
+  { key: "paid", label: "Paid" },
+  { key: "machine_ordered", label: "Fulfillment" },
+  { key: "completed", label: "Completed" },
+  { key: "cancelled", label: "Cancelled" },
+];
+
+const STATUS_COLORS: Record<string, string> = {
+  draft: "bg-gray-50 text-gray-600 ring-gray-200",
+  awaiting_customer_info: "bg-yellow-50 text-yellow-700 ring-yellow-200",
+  invoice_sent: "bg-blue-50 text-blue-700 ring-blue-200",
+  agreement_sent: "bg-indigo-50 text-indigo-700 ring-indigo-200",
+  awaiting_signature: "bg-indigo-50 text-indigo-700 ring-indigo-200",
+  awaiting_payment: "bg-orange-50 text-orange-700 ring-orange-200",
+  deposit_paid: "bg-emerald-50 text-emerald-700 ring-emerald-200",
+  paid: "bg-green-50 text-green-700 ring-green-200",
+  machine_ordered: "bg-purple-50 text-purple-700 ring-purple-200",
+  location_search_active: "bg-cyan-50 text-cyan-700 ring-cyan-200",
+  coffee_program_setup: "bg-amber-50 text-amber-700 ring-amber-200",
+  shipped: "bg-sky-50 text-sky-700 ring-sky-200",
+  delivered: "bg-teal-50 text-teal-700 ring-teal-200",
+  completed: "bg-green-50 text-green-700 ring-green-200",
+  cancelled: "bg-red-50 text-red-600 ring-red-200",
+};
+
+const ITEM_ICONS: Record<string, React.ElementType> = {
+  machine_sale: Package,
+  location_services: MapPin,
+  coffee_program: Coffee,
+  vendera_ai_cooler: Monitor,
+  combo_machine: Package,
+  financing: DollarSign,
+  other: Wrench,
+};
+
+function formatStatus(s: string): string {
+  return s.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function itemsSummary(items: OrderItem[]): string {
+  if (!items || items.length === 0) return "No items";
+  if (items.length === 1) {
+    return `${items[0].quantity}x ${items[0].service_name}`;
+  }
+  const total = items.reduce((s, i) => s + (i.quantity || 1), 0);
+  return `${total} items`;
 }
 
 export default function OrdersPage() {
   const router = useRouter();
-  const [orders, setOrders] = useState<SalesOrder[]>([]);
-  const [accounts, setAccounts] = useState<SalesAccount[]>([]);
+  const [orders, setOrders] = useState<Order[]>([]);
   const [loading, setLoading] = useState(true);
   const [token, setToken] = useState("");
-  const [showAdd, setShowAdd] = useState(false);
-  const [form, setForm] = useState({
-    account_id: "",
-    recipient_email: "",
-    notes: "",
-  });
-  const [items, setItems] = useState<NewOrderItem[]>([{ service_name: "", price: "" }]);
-  const [saving, setSaving] = useState(false);
+  const [statusFilter, setStatusFilter] = useState("all");
+  const [search, setSearch] = useState("");
 
   useEffect(() => {
     const supabase = createBrowserClient();
@@ -33,74 +104,31 @@ export default function OrdersPage() {
     });
   }, []);
 
-  const fetchAll = useCallback(async () => {
+  const fetchOrders = useCallback(async () => {
     if (!token) return;
     setLoading(true);
-    const headers = { Authorization: `Bearer ${token}` };
-    const [ordersRes, accountsRes] = await Promise.all([
-      fetch("/api/sales/orders", { headers }),
-      fetch("/api/sales/accounts", { headers }),
-    ]);
-    if (ordersRes.ok) setOrders(await ordersRes.json());
-    if (accountsRes.ok) setAccounts(await accountsRes.json());
-    setLoading(false);
-  }, [token]);
-
-  useEffect(() => { fetchAll(); }, [fetchAll]);
-
-  async function handleCreate() {
-    setSaving(true);
-    const cleanItems = items
-      .filter((i) => i.service_name.trim())
-      .map((i) => ({ service_name: i.service_name.trim(), price: Number(i.price) || 0 }));
-    const res = await fetch("/api/sales/orders", {
-      method: "POST",
-      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
-      body: JSON.stringify({
-        account_id: form.account_id || null,
-        recipient_email: form.recipient_email || null,
-        notes: form.notes || null,
-        items: cleanItems,
-      }),
-    });
-    setSaving(false);
-    if (!res.ok) {
-      const err = await res.json().catch(() => ({}));
-      alert(err.error || "Failed to create order");
-      return;
-    }
-    setForm({ account_id: "", recipient_email: "", notes: "" });
-    setItems([{ service_name: "", price: "" }]);
-    setShowAdd(false);
-    fetchAll();
-  }
-
-  async function handleDelete(id: string) {
-    if (!confirm("Delete this order?")) return;
-    const res = await fetch(`/api/sales/orders/${id}`, {
-      method: "DELETE",
+    const params = new URLSearchParams();
+    if (statusFilter !== "all") params.set("status", statusFilter);
+    if (search) params.set("search", search);
+    const res = await fetch(`/api/sales/orders?${params}`, {
       headers: { Authorization: `Bearer ${token}` },
     });
-    if (!res.ok) {
-      const err = await res.json().catch(() => ({}));
-      alert(err.error || "Failed to delete");
-      return;
-    }
-    fetchAll();
-  }
+    if (res.ok) setOrders(await res.json());
+    setLoading(false);
+  }, [token, statusFilter, search]);
 
-  const statusColor: Record<string, string> = {
-    draft: "bg-gray-50 text-gray-600 ring-gray-200",
-    sent: "bg-blue-50 text-blue-700 ring-blue-200",
-    completed: "bg-green-50 text-green-700 ring-green-200",
-  };
+  useEffect(() => { fetchOrders(); }, [fetchOrders]);
 
   return (
     <div className="p-6">
+      {/* Header */}
       <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">Orders</h1>
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Orders</h1>
+          <p className="text-sm text-gray-500 mt-0.5">Manage post-sale execution and fulfillment</p>
+        </div>
         <button
-          onClick={() => setShowAdd(!showAdd)}
+          onClick={() => router.push("/sales/orders/new")}
           className="inline-flex items-center gap-1.5 rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 cursor-pointer"
         >
           <Plus className="h-4 w-4" />
@@ -108,146 +136,98 @@ export default function OrdersPage() {
         </button>
       </div>
 
-      {showAdd && (
-        <div className="mb-6 rounded-xl border border-gray-200 bg-white p-5">
-          <h3 className="text-sm font-semibold text-gray-900 mb-3">New Order</h3>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <select
-              value={form.account_id}
-              onChange={(e) => setForm((f) => ({ ...f, account_id: e.target.value }))}
-              className="rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none"
-            >
-              <option value="">Select account...</option>
-              {accounts.map((a) => (
-                <option key={a.id} value={a.id}>{a.business_name}</option>
-              ))}
-            </select>
-            <input
-              type="email"
-              placeholder="Recipient email"
-              value={form.recipient_email}
-              onChange={(e) => setForm((f) => ({ ...f, recipient_email: e.target.value }))}
-              className="rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none"
-            />
-          </div>
-          <textarea
-            placeholder="Notes"
-            value={form.notes}
-            onChange={(e) => setForm((f) => ({ ...f, notes: e.target.value }))}
-            className="mt-3 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none"
-            rows={2}
+      {/* Filters */}
+      <div className="mb-4 flex flex-col sm:flex-row gap-3">
+        <div className="relative flex-1 max-w-xs">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+          <input
+            type="text"
+            placeholder="Search customer or order #..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full rounded-lg border border-gray-200 pl-9 pr-3 py-2 text-sm focus:border-green-500 focus:outline-none"
           />
-
-          <div className="mt-4">
-            <p className="text-xs font-semibold text-gray-700 mb-2">Items</p>
-            <div className="space-y-2">
-              {items.map((item, idx) => (
-                <div key={idx} className="flex gap-2">
-                  <input
-                    placeholder="Service / Item"
-                    value={item.service_name}
-                    onChange={(e) =>
-                      setItems((prev) => prev.map((it, i) => i === idx ? { ...it, service_name: e.target.value } : it))
-                    }
-                    className="flex-1 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none"
-                  />
-                  <input
-                    type="number"
-                    placeholder="Price"
-                    value={item.price}
-                    onChange={(e) =>
-                      setItems((prev) => prev.map((it, i) => i === idx ? { ...it, price: e.target.value } : it))
-                    }
-                    className="w-28 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none"
-                  />
-                  <button
-                    onClick={() => setItems((prev) => prev.filter((_, i) => i !== idx))}
-                    className="rounded-lg p-2 text-gray-400 hover:bg-red-50 hover:text-red-600 cursor-pointer"
-                  >
-                    <X className="h-4 w-4" />
-                  </button>
-                </div>
-              ))}
-            </div>
-            <button
-              onClick={() => setItems((prev) => [...prev, { service_name: "", price: "" }])}
-              className="mt-2 text-xs text-green-600 hover:text-green-700 cursor-pointer"
-            >
-              + Add item
-            </button>
-          </div>
-
-          <div className="mt-4 flex gap-2">
-            <button
-              onClick={handleCreate}
-              disabled={saving}
-              className="rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-50 cursor-pointer"
-            >
-              {saving ? "Saving..." : "Create Order"}
-            </button>
-            <button
-              onClick={() => setShowAdd(false)}
-              className="rounded-lg border border-gray-200 px-4 py-2 text-sm text-gray-600 hover:bg-gray-50 cursor-pointer"
-            >
-              Cancel
-            </button>
-          </div>
         </div>
-      )}
+        <div className="flex flex-wrap gap-1.5">
+          {STATUS_FILTERS.map((f) => (
+            <button
+              key={f.key}
+              onClick={() => setStatusFilter(f.key)}
+              className={`rounded-full px-3 py-1 text-xs font-medium transition-colors cursor-pointer ${
+                statusFilter === f.key
+                  ? "bg-green-600 text-white"
+                  : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+              }`}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+      </div>
 
+      {/* Orders List */}
       {loading ? (
-        <div className="flex justify-center py-16"><Loader2 className="h-6 w-6 animate-spin text-green-600" /></div>
+        <div className="flex justify-center py-16">
+          <Loader2 className="h-6 w-6 animate-spin text-green-600" />
+        </div>
       ) : orders.length === 0 ? (
         <div className="py-16 text-center">
           <ClipboardList className="mx-auto h-10 w-10 text-gray-300 mb-3" />
-          <p className="text-sm text-gray-400">No orders yet. Use &quot;New Order&quot; or finalize a deal.</p>
+          <p className="text-sm text-gray-400">
+            {statusFilter !== "all" ? "No orders match this filter." : "No orders yet. Win a lead or create one manually."}
+          </p>
         </div>
       ) : (
-        <div className="overflow-x-auto rounded-xl border border-gray-200 bg-white">
-          <table className="w-full text-left text-sm">
-            <thead className="border-b border-gray-100 bg-gray-50/50">
-              <tr>
-                <th className="px-4 py-3 font-medium text-gray-500">Order ID</th>
-                <th className="px-4 py-3 font-medium text-gray-500">Customer</th>
-                <th className="px-4 py-3 font-medium text-gray-500">Items</th>
-                <th className="px-4 py-3 font-medium text-gray-500 text-right">Total</th>
-                <th className="px-4 py-3 font-medium text-gray-500">Status</th>
-                <th className="px-4 py-3 font-medium text-gray-500">Sent To</th>
-                <th className="px-4 py-3 font-medium text-gray-500">Date</th>
-                <th className="px-4 py-3 font-medium text-gray-500"></th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-50">
-              {orders.map((order) => (
-                <tr key={order.id} className="hover:bg-gray-50/50 cursor-pointer" onClick={() => router.push(`/sales/orders/${order.id}`)}>
-                  <td className="px-4 py-3 font-mono text-xs text-gray-600">{order.id.slice(0, 8).toUpperCase()}</td>
-                  <td className="px-4 py-3 text-gray-900">
-                    {(order.sales_accounts as { business_name: string } | null)?.business_name || "—"}
-                  </td>
-                  <td className="px-4 py-3 text-gray-600">{order.order_items?.length || 0} items</td>
-                  <td className="px-4 py-3 text-right font-medium text-green-600">
-                    ${Number(order.total_value).toLocaleString("en-US", { minimumFractionDigits: 2 })}
-                  </td>
-                  <td className="px-4 py-3">
-                    <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset capitalize ${statusColor[order.status] || ""}`}>
-                      {order.status}
+        <div className="space-y-2">
+          {orders.map((order) => {
+            const Icon = order.order_items?.[0]?.item_type
+              ? ITEM_ICONS[order.order_items[0].item_type] || Wrench
+              : ClipboardList;
+            return (
+              <div
+                key={order.id}
+                onClick={() => router.push(`/sales/orders/${order.id}`)}
+                className="group flex items-center gap-4 rounded-xl border border-gray-200 bg-white p-4 hover:border-green-200 hover:shadow-sm transition-all cursor-pointer"
+              >
+                {/* Icon */}
+                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-gray-50 group-hover:bg-green-50 transition-colors">
+                  <Icon className="h-5 w-5 text-gray-400 group-hover:text-green-600" />
+                </div>
+
+                {/* Main info */}
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="font-mono text-xs text-gray-400">#{order.order_number || order.id.slice(0, 6).toUpperCase()}</span>
+                    <span className="font-semibold text-gray-900 truncate">
+                      {order.sales_accounts?.business_name || "Unassigned"}
                     </span>
-                  </td>
-                  <td className="px-4 py-3 text-xs text-gray-500">{order.recipient_email || "—"}</td>
-                  <td className="px-4 py-3 text-xs text-gray-400">{new Date(order.created_at).toLocaleDateString()}</td>
-                  <td className="px-4 py-3">
-                    <button
-                      onClick={() => handleDelete(order.id)}
-                      title="Delete"
-                      className="rounded-lg p-1.5 text-gray-400 hover:bg-red-50 hover:text-red-600 cursor-pointer"
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+                  </div>
+                  <div className="mt-0.5 flex items-center gap-3 text-xs text-gray-500">
+                    <span>{itemsSummary(order.order_items)}</span>
+                    <span>${Number(order.total_value || 0).toLocaleString("en-US", { minimumFractionDigits: 2 })}</span>
+                    {order.assigned_profile?.full_name && (
+                      <span className="text-gray-400">{order.assigned_profile.full_name}</span>
+                    )}
+                  </div>
+                </div>
+
+                {/* Next action */}
+                {order.next_required_action && (
+                  <div className="hidden md:flex items-center gap-1.5 rounded-lg bg-amber-50 border border-amber-200 px-3 py-1.5 max-w-[220px]">
+                    <AlertCircle className="h-3.5 w-3.5 text-amber-600 shrink-0" />
+                    <span className="text-xs font-medium text-amber-700 truncate">{order.next_required_action}</span>
+                  </div>
+                )}
+
+                {/* Status */}
+                <span className={`shrink-0 rounded-full px-2.5 py-1 text-xs font-medium ring-1 ring-inset ${STATUS_COLORS[order.order_status] || STATUS_COLORS.draft}`}>
+                  {formatStatus(order.order_status || "draft")}
+                </span>
+
+                <ChevronRight className="h-4 w-4 text-gray-300 group-hover:text-green-500 shrink-0" />
+              </div>
+            );
+          })}
         </div>
       )}
     </div>

--- a/supabase/migrations/082_order_management.sql
+++ b/supabase/migrations/082_order_management.sql
@@ -1,0 +1,63 @@
+-- Order Management System: extend sales_orders and order_items, add activity log and documents
+
+-- Extend sales_orders with full order management fields
+ALTER TABLE sales_orders ADD COLUMN IF NOT EXISTS lead_id UUID REFERENCES sales_leads(id);
+ALTER TABLE sales_orders ADD COLUMN IF NOT EXISTS assigned_rep_id UUID REFERENCES auth.users(id);
+ALTER TABLE sales_orders ADD COLUMN IF NOT EXISTS order_number SERIAL;
+ALTER TABLE sales_orders ADD COLUMN IF NOT EXISTS order_status TEXT DEFAULT 'draft';
+ALTER TABLE sales_orders ADD COLUMN IF NOT EXISTS order_type TEXT;
+ALTER TABLE sales_orders ADD COLUMN IF NOT EXISTS deposit_amount NUMERIC DEFAULT 0;
+ALTER TABLE sales_orders ADD COLUMN IF NOT EXISTS deposit_paid BOOLEAN DEFAULT false;
+ALTER TABLE sales_orders ADD COLUMN IF NOT EXISTS remaining_balance NUMERIC DEFAULT 0;
+ALTER TABLE sales_orders ADD COLUMN IF NOT EXISTS payment_status TEXT DEFAULT 'unpaid';
+ALTER TABLE sales_orders ADD COLUMN IF NOT EXISTS invoice_status TEXT DEFAULT 'not_sent';
+ALTER TABLE sales_orders ADD COLUMN IF NOT EXISTS agreement_status TEXT DEFAULT 'not_sent';
+ALTER TABLE sales_orders ADD COLUMN IF NOT EXISTS fulfillment_status TEXT DEFAULT 'pending';
+ALTER TABLE sales_orders ADD COLUMN IF NOT EXISTS next_required_action TEXT;
+ALTER TABLE sales_orders ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT now();
+
+-- Extend order_items with richer fields
+ALTER TABLE order_items ADD COLUMN IF NOT EXISTS item_type TEXT DEFAULT 'other';
+ALTER TABLE order_items ADD COLUMN IF NOT EXISTS description TEXT;
+ALTER TABLE order_items ADD COLUMN IF NOT EXISTS quantity INTEGER DEFAULT 1;
+ALTER TABLE order_items ADD COLUMN IF NOT EXISTS unit_price NUMERIC DEFAULT 0;
+ALTER TABLE order_items ADD COLUMN IF NOT EXISTS total_price NUMERIC DEFAULT 0;
+ALTER TABLE order_items ADD COLUMN IF NOT EXISTS status TEXT DEFAULT 'pending';
+ALTER TABLE order_items ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT now();
+-- Location service deposit fields
+ALTER TABLE order_items ADD COLUMN IF NOT EXISTS location_service_price NUMERIC;
+ALTER TABLE order_items ADD COLUMN IF NOT EXISTS deposit_required BOOLEAN DEFAULT false;
+ALTER TABLE order_items ADD COLUMN IF NOT EXISTS location_deposit_amount NUMERIC;
+ALTER TABLE order_items ADD COLUMN IF NOT EXISTS location_deposit_paid BOOLEAN DEFAULT false;
+ALTER TABLE order_items ADD COLUMN IF NOT EXISTS location_remaining_balance NUMERIC;
+
+-- Order activity log
+CREATE TABLE IF NOT EXISTS order_activity_log (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  order_id UUID NOT NULL REFERENCES sales_orders(id) ON DELETE CASCADE,
+  user_id UUID REFERENCES auth.users(id),
+  activity_type TEXT NOT NULL,
+  description TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_order_activity_order ON order_activity_log(order_id);
+
+-- Order documents
+CREATE TABLE IF NOT EXISTS order_documents (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  order_id UUID NOT NULL REFERENCES sales_orders(id) ON DELETE CASCADE,
+  document_type TEXT,
+  file_name TEXT,
+  file_url TEXT NOT NULL,
+  uploaded_by UUID REFERENCES auth.users(id),
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_order_documents_order ON order_documents(order_id);
+
+-- Performance indexes
+CREATE INDEX IF NOT EXISTS idx_sales_orders_order_status ON sales_orders(order_status);
+CREATE INDEX IF NOT EXISTS idx_sales_orders_assigned_rep ON sales_orders(assigned_rep_id);
+CREATE INDEX IF NOT EXISTS idx_sales_orders_lead_id ON sales_orders(lead_id);
+
+-- Add 'won' status to sales_leads if not present (for CRM simplification)
+-- The status column is just text, so no enum change needed


### PR DESCRIPTION
- Migration 082: Extends sales_orders with order_status, payment/invoice/ agreement/fulfillment status, next_required_action, deposit tracking. Extends order_items with item_type, quantity, unit_price, location deposit fields. Creates order_activity_log and order_documents tables.

- API routes: Full CRUD for orders, items, activity log, documents. Status action endpoint handles workflow transitions (send invoice, mark paid, mark shipped, etc.) with automatic next-action updates.

- Orders dashboard: Filterable list with status pills, next-action badges, item summaries. Replaces old basic orders table.

- Order detail page: Customer info, items with add/remove, pricing with deposit tracking, document uploads, activity log with notes, status cards, and full action button panel.

- New Order page: Create orders standalone or from lead conversion. Supports all item types (machine, location services, coffee, VendEra AI cooler, combo, financing, other). Location services items support $100 deposit tracking with remaining balance calculation.

- Lead-to-order handoff: Added "Won" status to leads. When a lead is marked Won, prompts to create an order pre-filled with lead data.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2