### PR TITLE
Fix locator signup: hide business name field, harden role persistence

### DIFF
--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -88,7 +88,7 @@ function CallbackContent() {
             if (leadData?.contact_name) profileUpdate.full_name = leadData.contact_name;
             if (leadData?.phone) profileUpdate.phone = leadData.phone;
 
-            await fetch("/api/auth/me", {
+            const patchRes = await fetch("/api/auth/me", {
               method: "PATCH",
               headers: {
                 "Content-Type": "application/json",
@@ -96,6 +96,18 @@ function CallbackContent() {
               },
               body: JSON.stringify(profileUpdate),
             });
+
+            // If the full update failed, retry with just the role
+            if (!patchRes.ok) {
+              await fetch("/api/auth/me", {
+                method: "PATCH",
+                headers: {
+                  "Content-Type": "application/json",
+                  Authorization: `Bearer ${session.access_token}`,
+                },
+                body: JSON.stringify({ role: profileRole }),
+              });
+            }
           } catch {
             // Profile update is best-effort
           }

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -117,15 +117,16 @@ function SignupContent() {
     if (!leadForm.city.trim()) { setError("City is required"); return; }
     if (!leadForm.state.trim()) { setError("State is required"); return; }
     if (!leadForm.zip.trim()) { setError("Zip code is required"); return; }
-    if (!leadForm.business_name.trim()) { setError("Business name is required"); return; }
+    if (role !== "locator" && !leadForm.business_name.trim()) { setError("Business name is required"); return; }
     setError(null);
     setStep(3);
   }
 
   function storeLead() {
     const entityType = role === "operator" ? "operator" : role === "locator" ? "locator" : role === "location_manager" ? "location" : "";
+    const businessName = leadForm.business_name.trim() || `${leadForm.first_name.trim()} ${leadForm.last_name.trim()}`;
     storeSignupLead({
-      business_name: leadForm.business_name.trim(),
+      business_name: businessName,
       contact_name: `${leadForm.first_name.trim()} ${leadForm.last_name.trim()}`,
       email: leadForm.email.trim(),
       phone: leadForm.phone.trim(),
@@ -304,10 +305,12 @@ function SignupContent() {
               </div>
 
               <div className="space-y-4">
-                <div>
-                  <label className="block text-xs font-medium text-gray-500 mb-1">Business Name <span className="text-red-500">*</span></label>
-                  <input value={leadForm.business_name} onChange={(e) => setLeadForm((f) => ({ ...f, business_name: e.target.value }))} placeholder="Your business or company name" className={inputClass} />
-                </div>
+                {role !== "locator" && (
+                  <div>
+                    <label className="block text-xs font-medium text-gray-500 mb-1">Business Name <span className="text-red-500">*</span></label>
+                    <input value={leadForm.business_name} onChange={(e) => setLeadForm((f) => ({ ...f, business_name: e.target.value }))} placeholder="Your business or company name" className={inputClass} />
+                  </div>
+                )}
                 <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                   <div>
                     <label className="block text-xs font-medium text-gray-500 mb-1">First Name <span className="text-red-500">*</span></label>

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -115,6 +115,7 @@ export async function signInWithGoogle(): Promise<void> {
 export async function signUpWithGoogle(role?: string): Promise<void> {
   const supabase = createBrowserClient();
   storeAuthFlow("signup");
+  if (role) storeSignupRole(role);
   const redirectUrl = new URL(`${getSiteUrl()}/auth/callback`);
   redirectUrl.searchParams.set("flow", "signup");
   if (role) redirectUrl.searchParams.set("role", role);
@@ -150,6 +151,7 @@ export async function signInWithMicrosoft(): Promise<void> {
 export async function signUpWithMicrosoft(role?: string): Promise<void> {
   const supabase = createBrowserClient();
   storeAuthFlow("signup");
+  if (role) storeSignupRole(role);
   const redirectUrl = new URL(`${getSiteUrl()}/auth/callback`);
   redirectUrl.searchParams.set("flow", "signup");
   if (role) redirectUrl.searchParams.set("role", role);


### PR DESCRIPTION
- Hide business name field for locators during signup (not required)
- Skip business name validation for locator role
- Fallback to full name when business name empty (for CRM lead)
- Store role in localStorage as backup in signUpWithGoogle/Microsoft
- Retry role PATCH with minimal payload if initial PATCH fails
- Ensures role selection survives OAuth redirects more reliably


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2