### PR TITLE
Add discount % dropdown, auto-send on submission, and rep email copy

### DIFF
--- a/src/app/api/sales/orders/[id]/send/route.ts
+++ b/src/app/api/sales/orders/[id]/send/route.ts
@@ -134,11 +134,16 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
   } else {
     // ORDER: Create QB invoice and send payment link
     try {
-      const lineItems = items.map((item: { service_name: string; unit_price: number; price?: number; quantity: number }) => ({
-        description: item.service_name,
-        amount: Number(item.unit_price) || Number(item.price) || 0,
-        quantity: Number(item.quantity) || 1,
-      }));
+      const lineItems = items.map((item: { service_name: string; unit_price: number; price?: number; quantity: number; discount_percent?: number }) => {
+        const unitPrice = Number(item.unit_price) || Number(item.price) || 0;
+        const discount = Number(item.discount_percent) || 0;
+        const effectivePrice = unitPrice * (1 - discount / 100);
+        return {
+          description: item.service_name + (discount > 0 ? ` (${discount}% off)` : ""),
+          amount: effectivePrice,
+          quantity: Number(item.quantity) || 1,
+        };
+      });
 
       const invoice = await createInvoice({
         customerEmail: recipientEmail,
@@ -188,7 +193,7 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
   if (emailSent) {
     await supabaseAdmin
       .from("sales_orders")
-      .update({ status: "sent", updated_at: new Date().toISOString() })
+      .update({ status: "sent", order_status: "invoice_sent", updated_at: new Date().toISOString() })
       .eq("id", orderId);
 
     await supabaseAdmin.from("order_activity_log").insert({
@@ -199,6 +204,21 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
         ? `Quote emailed to ${recipientEmail}`
         : `Invoice/payment link sent to ${recipientEmail}`,
     });
+
+    // Send confirmation copy to the sales rep
+    if (repProfile?.email && process.env.RESEND_API_KEY && repProfile.email !== recipientEmail) {
+      const docLabel = isQuote ? "Quote" : "Order";
+      try {
+        await getResend().emails.send({
+          from: FROM_EMAIL,
+          to: repProfile.email,
+          subject: `${docLabel} Sent — ${account?.business_name || "Customer"}`,
+          html: `<p>Your ${docLabel.toLowerCase()} for <strong>${account?.business_name || "Customer"}</strong> has been sent to ${recipientEmail}.</p><hr/>${docHtml}`,
+        });
+      } catch {
+        // Non-critical — don't fail the main flow
+      }
+    }
   }
 
   return NextResponse.json({
@@ -217,14 +237,15 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
 function generateDocumentHtml(
   order: Record<string, unknown>,
   account: Record<string, unknown> | null,
-  items: Array<{ service_name: string; price: number; unit_price?: number; quantity?: number; notes: string | null }>,
+  items: Array<{ service_name: string; price: number; unit_price?: number; quantity?: number; discount_percent?: number; notes: string | null }>,
   isQuote: boolean,
   repEmail?: string | null,
 ) {
   const total = items.reduce((s, i) => {
     const qty = Number(i.quantity) || 1;
     const price = Number(i.unit_price || i.price) || 0;
-    return s + qty * price;
+    const discount = Number(i.discount_percent) || 0;
+    return s + qty * price * (1 - discount / 100);
   }, 0);
   const date = new Date().toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" });
   const docLabel = isQuote ? "Quote" : "Service Order";
@@ -234,11 +255,14 @@ function generateDocumentHtml(
     .map((item) => {
       const qty = Number(item.quantity) || 1;
       const price = Number(item.unit_price || item.price) || 0;
+      const discount = Number(item.discount_percent) || 0;
+      const lineTotal = qty * price * (1 - discount / 100);
+      const discountLabel = discount > 0 ? ` <span style="color:#16a34a;font-size:11px;">(${discount}% off)</span>` : "";
       return `<tr>
-        <td style="padding:10px 12px;border-bottom:1px solid #e5e7eb;">${item.service_name}</td>
+        <td style="padding:10px 12px;border-bottom:1px solid #e5e7eb;">${item.service_name}${discountLabel}</td>
         <td style="padding:10px 12px;border-bottom:1px solid #e5e7eb;text-align:center;">${qty}</td>
         <td style="padding:10px 12px;border-bottom:1px solid #e5e7eb;text-align:right;">$${price.toLocaleString("en-US", { minimumFractionDigits: 2 })}</td>
-        <td style="padding:10px 12px;border-bottom:1px solid #e5e7eb;text-align:right;">$${(qty * price).toLocaleString("en-US", { minimumFractionDigits: 2 })}</td>
+        <td style="padding:10px 12px;border-bottom:1px solid #e5e7eb;text-align:right;">$${lineTotal.toLocaleString("en-US", { minimumFractionDigits: 2 })}</td>
       </tr>`;
     })
     .join("");

--- a/src/app/api/sales/orders/route.ts
+++ b/src/app/api/sales/orders/route.ts
@@ -69,6 +69,7 @@ export async function POST(req: NextRequest) {
     quantity?: number;
     unit_price?: number;
     price?: number;
+    discount_percent?: number;
     location_service_price?: number;
     deposit_required?: boolean;
     location_deposit_amount?: number;
@@ -77,7 +78,8 @@ export async function POST(req: NextRequest) {
   const total = itemList.reduce((sum, i) => {
     const qty = Number(i.quantity) || 1;
     const price = Number(i.unit_price || i.price) || 0;
-    return sum + qty * price;
+    const discount = Number(i.discount_percent) || 0;
+    return sum + qty * price * (1 - discount / 100);
   }, 0);
 
   const depositTotal = itemList.reduce((sum, i) => {
@@ -123,6 +125,8 @@ export async function POST(req: NextRequest) {
       .map((i) => {
         const qty = Number(i.quantity) || 1;
         const unitPrice = Number(i.unit_price || i.price) || 0;
+        const discount = Number(i.discount_percent) || 0;
+        const lineTotal = qty * unitPrice * (1 - discount / 100);
         return {
           order_id: order.id,
           service_name: i.item_name || i.service_name || "",
@@ -131,7 +135,8 @@ export async function POST(req: NextRequest) {
           description: i.description || null,
           quantity: qty,
           unit_price: unitPrice,
-          total_price: qty * unitPrice,
+          discount_percent: discount,
+          total_price: lineTotal,
           status: "pending",
           location_service_price: i.location_service_price || null,
           deposit_required: i.deposit_required || false,

--- a/src/app/sales/orders/[id]/page.tsx
+++ b/src/app/sales/orders/[id]/page.tsx
@@ -16,6 +16,7 @@ interface OrderItem {
   description: string | null;
   quantity: number;
   unit_price: number;
+  discount_percent: number;
   total_price: number;
   status: string;
   location_service_price: number | null;
@@ -344,6 +345,9 @@ export default function OrderDetailPage() {
                         <p className="text-sm font-medium text-gray-900 truncate">{item.service_name}</p>
                         <p className="text-xs text-gray-400">
                           {formatStatus(item.item_type)} · Qty: {item.quantity}
+                          {Number(item.discount_percent) > 0 && (
+                            <span className="ml-2 text-green-600 font-medium">{item.discount_percent}% off</span>
+                          )}
                           {item.deposit_required && item.location_deposit_amount != null && (
                             <span className="ml-2 text-amber-600">
                               Deposit: ${Number(item.location_deposit_amount).toFixed(2)}

--- a/src/app/sales/orders/new/page.tsx
+++ b/src/app/sales/orders/new/page.tsx
@@ -41,10 +41,13 @@ interface ItemForm {
   description: string;
   quantity: string;
   unit_price: string;
+  discount_percent: string;
   deposit_required: boolean;
   location_deposit_amount: string;
   location_service_price: string;
 }
+
+const DISCOUNT_OPTIONS = ["0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50"];
 
 function NewOrderContent() {
   const router = useRouter();
@@ -71,7 +74,7 @@ function NewOrderContent() {
   });
 
   const [items, setItems] = useState<ItemForm[]>([
-    { item_type: "machine_sale", item_name: "", description: "", quantity: "1", unit_price: "", deposit_required: false, location_deposit_amount: "100", location_service_price: "" },
+    { item_type: "machine_sale", item_name: "", description: "", quantity: "1", unit_price: "", discount_percent: "0", deposit_required: false, location_deposit_amount: "100", location_service_price: "" },
   ]);
 
   useEffect(() => {
@@ -96,7 +99,7 @@ function NewOrderContent() {
   }, [token]);
 
   function addItem() {
-    setItems((prev) => [...prev, { item_type: "machine_sale", item_name: "", description: "", quantity: "1", unit_price: "", deposit_required: false, location_deposit_amount: "100", location_service_price: "" }]);
+    setItems((prev) => [...prev, { item_type: "machine_sale", item_name: "", description: "", quantity: "1", unit_price: "", discount_percent: "0", deposit_required: false, location_deposit_amount: "100", location_service_price: "" }]);
   }
 
   function removeItem(idx: number) {
@@ -135,6 +138,7 @@ function NewOrderContent() {
         description: i.description.trim() || null,
         quantity: Number(i.quantity) || 1,
         unit_price: Number(i.unit_price) || 0,
+        discount_percent: Number(i.discount_percent) || 0,
         deposit_required: i.deposit_required,
         location_deposit_amount: i.deposit_required ? Number(i.location_deposit_amount) || 100 : null,
         location_service_price: i.item_type === "location_services" ? Number(i.location_service_price) || 0 : null,
@@ -156,6 +160,11 @@ function NewOrderContent() {
 
     if (res.ok) {
       const order = await res.json();
+      // Auto-send the order/quote email
+      await fetch(`/api/sales/orders/${order.id}/send`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+      }).catch(() => {});
       router.push(`/sales/orders/${order.id}`);
     } else {
       const err = await res.json().catch(() => ({}));
@@ -343,6 +352,18 @@ function NewOrderContent() {
                     className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm"
                   />
                 </div>
+                <div>
+                  <label className="text-xs text-gray-500 mb-1 block">Discount %</label>
+                  <select
+                    value={item.discount_percent}
+                    onChange={(e) => updateItem(idx, "discount_percent", e.target.value)}
+                    className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm"
+                  >
+                    {DISCOUNT_OPTIONS.map((d) => (
+                      <option key={d} value={d}>{d}% off</option>
+                    ))}
+                  </select>
+                </div>
                 {item.item_type === "location_services" && (
                   <>
                     <div>
@@ -370,7 +391,10 @@ function NewOrderContent() {
               </div>
               {item.item_name && item.unit_price && (
                 <p className="text-xs text-gray-400 mt-2">
-                  Subtotal: ${((Number(item.quantity) || 1) * (Number(item.unit_price) || 0)).toLocaleString("en-US", { minimumFractionDigits: 2 })}
+                  Subtotal: ${((Number(item.quantity) || 1) * (Number(item.unit_price) || 0) * (1 - (Number(item.discount_percent) || 0) / 100)).toLocaleString("en-US", { minimumFractionDigits: 2 })}
+                  {Number(item.discount_percent) > 0 && (
+                    <span className="ml-2 text-green-600 font-medium">({item.discount_percent}% off)</span>
+                  )}
                 </p>
               )}
             </div>

--- a/supabase/migrations/086_order_items_discount.sql
+++ b/supabase/migrations/086_order_items_discount.sql
@@ -1,0 +1,3 @@
+-- Add discount_percent to order_items for catalog-based pricing with discount increments
+
+ALTER TABLE order_items ADD COLUMN IF NOT EXISTS discount_percent NUMERIC(5,2) DEFAULT 0;


### PR DESCRIPTION
- Add discount_percent column to order_items (migration 086)
- Add discount dropdown (0-50% in 5% increments) on each line item in new order form
- Subtotal auto-calculates with discount applied
- Auto-send email on order/quote creation (no more spinning green circle)
- Orders: QB invoice with payment link sent to customer, confirmation copy to rep
- Quotes: noreply email to customer with rep email in memo, copy to rep
- Order status auto-updates to "invoice_sent" after successful send
- Show discount badge on order detail page items
- Include discount in email HTML document and QB invoice line items


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2