### PR TITLE
Fix infinite spinner: fire send email in background, redirect immedia…

### DIFF
--- a/src/app/sales/orders/new/page.tsx
+++ b/src/app/sales/orders/new/page.tsx
@@ -160,8 +160,8 @@ function NewOrderContent() {
 
     if (res.ok) {
       const order = await res.json();
-      // Auto-send the order/quote email
-      await fetch(`/api/sales/orders/${order.id}/send`, {
+      // Fire-and-forget: send email in background, don't block redirect
+      fetch(`/api/sales/orders/${order.id}/send`, {
         method: "POST",
         headers: { Authorization: `Bearer ${token}` },
       }).catch(() => {});


### PR DESCRIPTION
…tely

The await on the send endpoint was blocking the redirect to the order detail page. Now fires the send as fire-and-forget so the user lands on the order detail page immediately after creation.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2