### PR TITLE
Fix signup role defaulting to location_manager for all users

### DIFF
--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -41,7 +41,7 @@ export async function GET(req: NextRequest) {
     const resolvedRole =
       meta.role && meta.role !== "admin" && meta.role !== "sales"
         ? meta.role
-        : "location_manager";
+        : "operator";
 
     const newProfile: Record<string, unknown> = {
       id: user.id,

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -61,7 +61,9 @@ function CallbackContent() {
 
       if (isSignup) {
         const urlRole = searchParams.get("role");
-        const signupRole = urlRole || consumeSignupRole();
+        const storedRole = consumeSignupRole();
+        const metaRole = session.user.user_metadata?.role;
+        const signupRole = urlRole || storedRole || metaRole || null;
         const leadData = consumeSignupLead();
 
         isEmployeeSignup = signupRole === "employee";

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -18,15 +18,23 @@ export function consumeRedirectAfterLogin(): string | null {
   return path;
 }
 
-/** Store the role selected during signup (before OAuth redirect) */
+/** Store the role selected during signup (before OAuth redirect) — uses BOTH localStorage and cookie for resilience */
 export function storeSignupRole(role: string): void {
   localStorage.setItem(SIGNUP_ROLE_KEY, role);
+  document.cookie = `vc_signup_role=${encodeURIComponent(role)};path=/;max-age=600;SameSite=Lax`;
 }
 
-/** Retrieve and clear the stored signup role */
+/** Retrieve and clear the stored signup role — checks cookie first (survives OAuth redirects better) */
 export function consumeSignupRole(): string | null {
-  const role = localStorage.getItem(SIGNUP_ROLE_KEY);
-  if (role) localStorage.removeItem(SIGNUP_ROLE_KEY);
+  // Try cookie first (more reliable across OAuth redirects)
+  const cookieMatch = document.cookie.match(/(?:^|;\s*)vc_signup_role=([^;]*)/);
+  const cookieRole = cookieMatch ? decodeURIComponent(cookieMatch[1]) : null;
+  // Also check localStorage
+  const lsRole = localStorage.getItem(SIGNUP_ROLE_KEY);
+  const role = cookieRole || lsRole;
+  // Clean up both
+  localStorage.removeItem(SIGNUP_ROLE_KEY);
+  document.cookie = "vc_signup_role=;path=/;max-age=0";
   return role;
 }
 


### PR DESCRIPTION
Root cause: When a new OAuth user's profile is auto-created, the role from localStorage was often lost during the OAuth redirect (Safari ITP, incognito, cross-domain). The fallback default was "location_manager", so everyone appeared as "Location" in the admin panel.

Fixes:
- Store signup role in BOTH localStorage and a cookie (cookies survive OAuth redirects more reliably than localStorage)
- Changed auto-create default from "location_manager" to "operator" (most common signup role, and the PATCH immediately corrects it)
- Callback now checks three sources for the role: URL param, cookie/ localStorage, and user_metadata — uses first available
- Cookie cleans itself up after consumption (10 min max-age)


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2