### PR TITLE
Fix PDF with real signatures/initials, add Create Order from Agreement

### DIFF
--- a/src/app/api/sales/agreements/[id]/create-order/route.ts
+++ b/src/app/api/sales/agreements/[id]/create-order/route.ts
@@ -1,0 +1,145 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser } from "@/lib/salesAuth";
+
+/* ------------------------------------------------------------------ */
+/*  POST — Create a sales order from an agreement                     */
+/*  Carries all agreement data into the order to prevent variances     */
+/* ------------------------------------------------------------------ */
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const user = await getSalesUser(req);
+  if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id } = await params;
+
+  const { data: ag, error: agErr } = await supabaseAdmin
+    .from("purchase_agreements")
+    .select("*")
+    .eq("id", id)
+    .single();
+
+  if (agErr || !ag)
+    return NextResponse.json({ error: "Agreement not found" }, { status: 404 });
+
+  // Build order items from agreement data
+  const items: Array<Record<string, unknown>> = [];
+
+  // Machine sale item
+  if (ag.machine_quantity > 0) {
+    const unitPrice = Number(ag.machine_unit_price) || 0;
+    const qty = Number(ag.machine_quantity) || 1;
+    items.push({
+      item_type: "machine_sale",
+      service_name: ag.machine_model || "VendEra AI Machine",
+      description: ag.machine_notes || null,
+      quantity: qty,
+      unit_price: unitPrice,
+      price: unitPrice,
+      total_price: qty * unitPrice,
+      discount_percent: 0,
+      status: "pending",
+      deposit_required: false,
+    });
+  }
+
+  // Location services item
+  if (Number(ag.locations_purchased) > 0) {
+    const locFee = Number(ag.location_fee_per_secured) || 0;
+    const locQty = Number(ag.locations_purchased) || 0;
+    items.push({
+      item_type: "location_services",
+      service_name: "Location Sourcing & Placement",
+      description: `${locQty} locations at $${locFee.toFixed(2)} each. Timeline: ${ag.location_service_timeline_days || 180} days.`,
+      quantity: locQty,
+      unit_price: locFee,
+      price: locFee,
+      total_price: locQty * locFee,
+      discount_percent: 0,
+      status: "pending",
+      location_service_price: locQty * locFee,
+      deposit_required: false,
+    });
+  }
+
+  // Freight item (if freight > 0)
+  const freightTotal = Number(ag.freight_total) || 0;
+  if (freightTotal > 0) {
+    items.push({
+      item_type: "other",
+      service_name: "Shipping & Freight",
+      description: `${ag.machine_quantity || 1} machine(s) at $${(Number(ag.freight_per_machine) || 0).toFixed(2)} each`,
+      quantity: 1,
+      unit_price: freightTotal,
+      price: freightTotal,
+      total_price: freightTotal,
+      discount_percent: 0,
+      status: "pending",
+      deposit_required: false,
+    });
+  }
+
+  const totalValue = items.reduce((sum, i) => sum + (Number(i.total_price) || 0), 0);
+
+  // Create the order
+  const { data: order, error: orderErr } = await supabaseAdmin
+    .from("sales_orders")
+    .insert({
+      account_id: ag.account_id || null,
+      lead_id: null,
+      deal_id: null,
+      created_by: user.id,
+      assigned_rep_id: ag.created_by || user.id,
+      total_value: totalValue,
+      status: "draft",
+      order_status: "draft",
+      document_type: "order",
+      order_type: "machine_purchase",
+      deposit_amount: 0,
+      deposit_paid: false,
+      remaining_balance: totalValue,
+      payment_status: "unpaid",
+      invoice_status: "not_sent",
+      agreement_status: ag.agreement_status === "signed" ? "signed" : "not_sent",
+      fulfillment_status: "pending",
+      next_required_action: ag.agreement_status === "signed"
+        ? "Send invoice for payment"
+        : "Agreement pending signature",
+      recipient_email: ag.operator_email || null,
+      notes: `Created from agreement. Operator: ${ag.operator_company_name || ""}. ${ag.machine_quantity || 1}x ${ag.machine_model || "VendEra AI Machine"}.`,
+      updated_at: new Date().toISOString(),
+    })
+    .select("*")
+    .single();
+
+  if (orderErr)
+    return NextResponse.json({ error: orderErr.message }, { status: 500 });
+
+  // Insert order items
+  if (items.length > 0) {
+    const orderItems = items.map((item) => ({
+      order_id: order.id,
+      ...item,
+      location_deposit_paid: false,
+    }));
+
+    await supabaseAdmin.from("order_items").insert(orderItems);
+  }
+
+  // Link the agreement to this order
+  await supabaseAdmin
+    .from("purchase_agreements")
+    .update({ order_id: order.id, updated_at: new Date().toISOString() })
+    .eq("id", ag.id);
+
+  // Log activity on the agreement
+  await supabaseAdmin.from("agreement_activity_log").insert({
+    agreement_id: ag.id,
+    user_id: user.id,
+    activity_type: "order_created",
+    description: `Order created from agreement — Order #${order.order_number || order.id.slice(0, 6)}`,
+  });
+
+  return NextResponse.json({ order_id: order.id, order_number: order.order_number }, { status: 201 });
+}

--- a/src/app/api/sales/agreements/[id]/pdf/route.ts
+++ b/src/app/api/sales/agreements/[id]/pdf/route.ts
@@ -23,8 +23,22 @@ export async function GET(
   if (error || !ag)
     return NextResponse.json({ error: "Agreement not found" }, { status: 404 });
 
+  // Fetch signatures and initials
+  const [{ data: signatures }, { data: initials }] = await Promise.all([
+    supabaseAdmin
+      .from("agreement_signatures")
+      .select("*")
+      .eq("agreement_id", id)
+      .order("signed_at", { ascending: false }),
+    supabaseAdmin
+      .from("agreement_initials")
+      .select("*")
+      .eq("agreement_id", id)
+      .order("initialed_at", { ascending: true }),
+  ]);
+
   try {
-    const pdfBytes = await generatePurchaseAgreementPdf(ag);
+    const pdfBytes = await generatePurchaseAgreementPdf(ag, signatures || [], initials || []);
     const fileName = `Purchase-Agreement-${(ag.operator_company_name || "draft").replace(/[^a-zA-Z0-9]/g, "_")}-${id.slice(0, 8)}.pdf`;
 
     return new NextResponse(Buffer.from(pdfBytes), {
@@ -45,7 +59,7 @@ export async function GET(
 /* ================================================================== */
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function generatePurchaseAgreementPdf(ag: any): Promise<Uint8Array> {
+async function generatePurchaseAgreementPdf(ag: any, signatures: any[], initials: any[]): Promise<Uint8Array> {
   const doc = await PDFDocument.create();
   const helvetica = await doc.embedFont(StandardFonts.Helvetica);
   const helveticaBold = await doc.embedFont(StandardFonts.HelveticaBold);
@@ -138,12 +152,41 @@ async function generatePurchaseAgreementPdf(ag: any): Promise<Uint8Array> {
     y -= 6;
     drawText(page, `Section ${num}: ${title}`, LEFT, y, helveticaBold, 9, dark);
     y -= 16;
+    currentSectionNum = num;
+    currentScheduleKey = "";
+  }
+
+  const SECTION_KEY_MAP: Record<number, string> = {
+    3: "section_3", 4: "section_4", 5: "section_5", 6: "section_6",
+    7: "section_7", 8: "section_8",
+  };
+  const SCHEDULE_KEY_MAP: Record<string, string> = {
+    A: "schedule_a", B: "schedule_b", C: "schedule_c",
+  };
+  let currentSectionNum = 0;
+  let currentScheduleKey = "";
+
+  function getInitialsForSection(): string | null {
+    const key = currentScheduleKey
+      ? SCHEDULE_KEY_MAP[currentScheduleKey]
+      : SECTION_KEY_MAP[currentSectionNum];
+    if (!key) return null;
+    const found = initials.find(
+      (i: { section_key: string; signer_type: string }) =>
+        i.section_key === key && i.signer_type === "operator",
+    );
+    return found ? found.initials_data : null;
   }
 
   function initialsPlaceholder() {
     checkPage(20);
     y -= 4;
-    drawText(page, "Operator Initials: [______]", RIGHT - 180, y, helvetica, 8, gray);
+    const initialsData = getInitialsForSection();
+    if (initialsData) {
+      drawText(page, `Operator Initials:  ${initialsData}`, RIGHT - 220, y, helveticaBold, 9, green);
+    } else {
+      drawText(page, "Operator Initials: [______]", RIGHT - 180, y, helvetica, 8, gray);
+    }
     y -= 14;
   }
 
@@ -359,6 +402,8 @@ async function generatePurchaseAgreementPdf(ag: any): Promise<Uint8Array> {
   y -= 20;
   drawText(page, "SCHEDULE A: EQUIPMENT DETAILS", LEFT, y, helveticaBold, 10, green);
   y -= 20;
+  currentScheduleKey = "A";
+  currentSectionNum = 0;
 
   // Table header background
   checkPage(80);
@@ -402,6 +447,7 @@ async function generatePurchaseAgreementPdf(ag: any): Promise<Uint8Array> {
   y -= 20;
   drawText(page, "SCHEDULE B: LOCATION SERVICES", LEFT, y, helveticaBold, 10, green);
   y -= 20;
+  currentScheduleKey = "B";
 
   labelValue("Locations Purchased", String(ag.locations_purchased || 0));
   labelValue("Fee per Location Secured", money(ag.location_fee_per_secured));
@@ -425,6 +471,7 @@ async function generatePurchaseAgreementPdf(ag: any): Promise<Uint8Array> {
   y -= 20;
   drawText(page, "SCHEDULE C: DELIVERY & ADDRESSES", LEFT, y, helveticaBold, 10, green);
   y -= 20;
+  currentScheduleKey = "C";
 
   labelValue("Billing Address", ag.operator_billing_address || "—");
   labelValue("Delivery Address", ag.operator_delivery_address || "—");
@@ -449,44 +496,96 @@ async function generatePurchaseAgreementPdf(ag: any): Promise<Uint8Array> {
   );
   y -= 12;
 
+  // Look up actual signatures
+  const operatorSig = signatures.find((s: { signer_type: string }) => s.signer_type === "operator");
+  const apexSig = signatures.find((s: { signer_type: string }) => s.signer_type === "apex");
+
   // Operator signature block
   drawText(page, "OPERATOR", LEFT, y, helveticaBold, 9, gray);
   y -= 20;
+  if (operatorSig) {
+    drawText(page, operatorSig.signature_data, LEFT, y, helveticaBold, 14, dark);
+    y -= 8;
+  }
   drawLine(y + 2);
   drawText(page, "Signature", LEFT, y - 10, helvetica, 8, gray);
+  if (operatorSig) {
+    drawText(page, `Electronically signed`, LEFT + 100, y - 10, helvetica, 7, green);
+  }
   y -= 28;
+  if (operatorSig) {
+    drawText(page, operatorSig.signer_name, LEFT, y + 6, helveticaBold, 10, dark);
+  }
   drawLine(y + 2);
   drawText(page, "Printed Name", LEFT, y - 10, helvetica, 8, gray);
   if (ag.operator_signed_at) {
     drawText(page, `Signed: ${new Date(ag.operator_signed_at).toLocaleDateString()}`, LEFT + 300, y - 10, helvetica, 8, green);
   }
   y -= 28;
+  if (operatorSig?.signer_title) {
+    drawText(page, operatorSig.signer_title, LEFT, y + 6, helvetica, 9, dark);
+  }
   drawLine(y + 2);
   drawText(page, "Title", LEFT, y - 10, helvetica, 8, gray);
   y -= 28;
+  if (ag.operator_signed_at) {
+    drawText(page, new Date(ag.operator_signed_at).toLocaleDateString(), LEFT, y + 6, helvetica, 9, dark);
+  }
   drawLine(y + 2);
   drawText(page, "Date", LEFT, y - 10, helvetica, 8, gray);
+  if (operatorSig?.signer_company) {
+    y -= 16;
+    drawText(page, `Company: ${operatorSig.signer_company}`, LEFT, y, helvetica, 8, gray);
+  }
+  if (operatorSig?.signer_email) {
+    y -= 14;
+    drawText(page, `Email: ${operatorSig.signer_email}`, LEFT, y, helvetica, 8, gray);
+  }
+  if (operatorSig?.ip_address) {
+    y -= 14;
+    drawText(page, `IP: ${operatorSig.ip_address}`, LEFT, y, helvetica, 7, gray);
+  }
 
   y -= 30;
 
   // Apex signature block
-  checkPage(120);
+  checkPage(160);
   drawText(page, "APEX AI VENDING LLC", LEFT, y, helveticaBold, 9, gray);
   y -= 20;
+  if (apexSig) {
+    drawText(page, apexSig.signature_data, LEFT, y, helveticaBold, 14, dark);
+    y -= 8;
+  }
   drawLine(y + 2);
   drawText(page, "Signature", LEFT, y - 10, helvetica, 8, gray);
+  if (apexSig) {
+    drawText(page, `Electronically signed`, LEFT + 100, y - 10, helvetica, 7, green);
+  }
   y -= 28;
+  if (apexSig) {
+    drawText(page, apexSig.signer_name, LEFT, y + 6, helveticaBold, 10, dark);
+  }
   drawLine(y + 2);
   drawText(page, "Printed Name", LEFT, y - 10, helvetica, 8, gray);
   if (ag.apex_signed_at) {
     drawText(page, `Signed: ${new Date(ag.apex_signed_at).toLocaleDateString()}`, LEFT + 300, y - 10, helvetica, 8, green);
   }
   y -= 28;
+  if (apexSig?.signer_title) {
+    drawText(page, apexSig.signer_title, LEFT, y + 6, helvetica, 9, dark);
+  }
   drawLine(y + 2);
   drawText(page, "Title", LEFT, y - 10, helvetica, 8, gray);
   y -= 28;
+  if (ag.apex_signed_at) {
+    drawText(page, new Date(ag.apex_signed_at).toLocaleDateString(), LEFT, y + 6, helvetica, 9, dark);
+  }
   drawLine(y + 2);
   drawText(page, "Date", LEFT, y - 10, helvetica, 8, gray);
+  if (apexSig?.signer_email) {
+    y -= 16;
+    drawText(page, `Email: ${apexSig.signer_email}`, LEFT, y, helvetica, 8, gray);
+  }
 
   // Final footer on last page
   drawText(page, "Apex AI Vending — Purchase Agreement", LEFT, 30, helvetica, 7, gray);

--- a/src/app/sales/agreements/[id]/page.tsx
+++ b/src/app/sales/agreements/[id]/page.tsx
@@ -26,6 +26,7 @@ import {
   Clock,
   Activity,
   Ban,
+  ClipboardList,
 } from "lucide-react";
 
 interface AgreementActivity {
@@ -213,6 +214,7 @@ function StandaloneAgreementEditor() {
   const [showApexSign, setShowApexSign] = useState(false);
   const [apexSigning, setApexSigning] = useState(false);
   const [apexSignForm, setApexSignForm] = useState({ signer_name: "", signer_title: "", signature_data: "" });
+  const [creatingOrder, setCreatingOrder] = useState(false);
   const [toast, setToast] = useState<{ message: string; type: "success" | "error" } | null>(null);
 
   useEffect(() => {
@@ -439,6 +441,31 @@ function StandaloneAgreementEditor() {
       showToast(err.error || "Failed to countersign", "error");
     }
     setApexSigning(false);
+  }
+
+  async function handleCreateOrder() {
+    if (!agreement) return;
+    if (agreement.order_id) {
+      router.push(`/sales/orders/${agreement.order_id}`);
+      return;
+    }
+    if (!confirm("Create a sales order from this agreement? All agreement data will carry over automatically.")) return;
+
+    setCreatingOrder(true);
+    const res = await fetch(`/api/sales/agreements/${agreement.id}/create-order`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+    });
+
+    if (res.ok) {
+      const data = await res.json();
+      showToast("Order created from agreement");
+      router.push(`/sales/orders/${data.order_id}`);
+    } else {
+      const err = await res.json().catch(() => ({ error: "Failed to create order" }));
+      showToast(err.error || "Failed to create order", "error");
+    }
+    setCreatingOrder(false);
   }
 
   if (loading) {
@@ -855,6 +882,14 @@ function StandaloneAgreementEditor() {
                 className="w-full rounded-lg border border-gray-200 px-4 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50 cursor-pointer inline-flex items-center justify-center gap-2"
               >
                 <Download className="h-4 w-4" /> Download PDF
+              </button>
+              <button
+                onClick={handleCreateOrder}
+                disabled={creatingOrder}
+                className="w-full rounded-lg bg-emerald-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50 cursor-pointer inline-flex items-center justify-center gap-2"
+              >
+                {creatingOrder ? <Loader2 className="h-4 w-4 animate-spin" /> : <ClipboardList className="h-4 w-4" />}
+                {agreement.order_id ? "View Linked Order" : "Create Order from Agreement"}
               </button>
               {agreement.agreement_status === "partially_signed" && (
                 <button

--- a/src/app/sales/orders/[id]/agreement/page.tsx
+++ b/src/app/sales/orders/[id]/agreement/page.tsx
@@ -474,7 +474,7 @@ export default function AgreementEditorPage() {
   // -----------------------------------------------------------------------
   function handleDownloadPdf() {
     if (!agreement) return;
-    window.open(`/api/agreements/${agreement.id}/pdf`, "_blank");
+    window.open(`/api/sales/agreements/${agreement.id}/pdf`, "_blank");
   }
 
   // -----------------------------------------------------------------------


### PR DESCRIPTION
- PDF now fetches actual signatures and initials from DB and renders them in the document (operator name, title, company, email, IP, signed dates, plus initials on each section)
- Fix PDF URL in order-based editor (was pointing to wrong route)
- Add POST /api/sales/agreements/[id]/create-order to auto-create an order with all agreement data (machines, locations, freight)
- Add "Create Order from Agreement" button in standalone editor
- No manual inputs needed — agreement data carries over exactly


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2