### PR TITLE
Show pack count on proposal PDF, client view, and email

### DIFF
--- a/src/app/api/coffee/pricing-proposals/[id]/send/route.ts
+++ b/src/app/api/coffee/pricing-proposals/[id]/send/route.ts
@@ -53,13 +53,18 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
     const companyName = proposal.company_name || "Your Vending Partner";
     const itemRows = items
       .map(
-        (item: { product_name: string; quantity: number; retail_price: number; retail_subtotal: number }) => `
+        (item: { product_name: string; pack_quantity?: number; quantity: number; retail_price: number; retail_subtotal: number }) => {
+          const packLabel = item.pack_quantity && item.pack_quantity > 1
+            ? ` <span style="color: #9ca3af; font-size: 11px;">(${item.pack_quantity} packets/box)</span>`
+            : "";
+          return `
         <tr>
-          <td style="padding: 8px 12px; border-bottom: 1px solid #e5e7eb; color: #111827;">${item.product_name}</td>
+          <td style="padding: 8px 12px; border-bottom: 1px solid #e5e7eb; color: #111827;">${item.product_name}${packLabel}</td>
           <td style="padding: 8px 12px; border-bottom: 1px solid #e5e7eb; color: #374151; text-align: center;">${item.quantity}</td>
           <td style="padding: 8px 12px; border-bottom: 1px solid #e5e7eb; color: #374151; text-align: right;">$${Number(item.retail_price).toFixed(2)}</td>
           <td style="padding: 8px 12px; border-bottom: 1px solid #e5e7eb; color: #374151; text-align: right;">$${Number(item.retail_subtotal).toFixed(2)}</td>
-        </tr>`
+        </tr>`;
+        }
       )
       .join("");
 

--- a/src/app/api/coffee/proposals/[token]/route.ts
+++ b/src/app/api/coffee/proposals/[token]/route.ts
@@ -6,7 +6,7 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ tok
 
   const { data: proposal, error } = await supabaseAdmin
     .from("coffee_pricing_proposals")
-    .select("id, proposal_number, status, client_name, client_company, client_email, client_phone, company_name, company_email, company_phone, company_website, company_address, company_city, company_state, company_zip, total_retail, notes, valid_until, created_at, coffee_pricing_proposal_items(id, product_name, category, unit, retail_price, quantity, retail_subtotal, sort_order)")
+    .select("id, proposal_number, status, client_name, client_company, client_email, client_phone, company_name, company_email, company_phone, company_website, company_address, company_city, company_state, company_zip, total_retail, notes, valid_until, created_at, coffee_pricing_proposal_items(id, product_name, category, unit, pack_quantity, retail_price, quantity, retail_subtotal, sort_order)")
     .eq("share_token", token)
     .single();
 

--- a/src/app/coffee/proposals/[token]/page.tsx
+++ b/src/app/coffee/proposals/[token]/page.tsx
@@ -8,6 +8,7 @@ interface ProposalItem {
   product_name: string;
   category: string | null;
   unit: string;
+  pack_quantity?: number;
   retail_price: number;
   quantity: number;
   retail_subtotal: number;
@@ -169,7 +170,12 @@ export default function PublicProposalPage({ params }: { params: Promise<{ token
                   </tr>
                   {catItems.map(item => (
                     <tr key={item.id} className="border-b border-gray-50 last:border-0">
-                      <td className="px-5 py-3 text-gray-900">{item.product_name}</td>
+                      <td className="px-5 py-3 text-gray-900">
+                        {item.product_name}
+                        {item.pack_quantity && item.pack_quantity > 1 && (
+                          <span className="ml-1.5 text-xs text-gray-400">({item.pack_quantity} packets/box)</span>
+                        )}
+                      </td>
                       <td className="px-5 py-3 text-center text-gray-600">{item.quantity}</td>
                       <td className="px-5 py-3 text-right text-gray-600">${Number(item.retail_price).toFixed(2)}</td>
                       <td className="px-5 py-3 text-right font-medium text-gray-900">${Number(item.retail_subtotal).toFixed(2)}</td>

--- a/src/lib/generateProposalPdf.ts
+++ b/src/lib/generateProposalPdf.ts
@@ -24,6 +24,7 @@ interface ProposalItem {
   product_name: string;
   category: string | null;
   unit: string;
+  pack_quantity?: number;
   retail_price: number;
   quantity: number;
   retail_subtotal: number;
@@ -161,7 +162,10 @@ export async function generateProposalPdf(proposal: ProposalData, items: Proposa
     }
 
     checkPage(20);
-    const nameLines = wrapText(item.product_name, helvetica, 9, 280);
+    const displayName = item.pack_quantity && item.pack_quantity > 1
+      ? `${item.product_name} (${item.pack_quantity} packets/box)`
+      : item.product_name;
+    const nameLines = wrapText(displayName, helvetica, 9, 280);
     for (let i = 0; i < nameLines.length; i++) {
       drawText(page, nameLines[i], LEFT + 6, y, helvetica, 9, dark);
       if (i === 0) {


### PR DESCRIPTION
Displays "(N packets/box)" descriptor next to product names so clients can see how many packets they get per box. Applies to the PDF, the public proposal page, and the email line items. Pack quantity also added to the public proposal API select.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2