### PR TITLE
Allow draft proposals to be viewed via share link

### DIFF
--- a/src/app/api/coffee/proposals/[token]/route.ts
+++ b/src/app/api/coffee/proposals/[token]/route.ts
@@ -14,10 +14,6 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ tok
     return NextResponse.json({ error: "Proposal not found" }, { status: 404 });
   }
 
-  if (proposal.status === "draft") {
-    return NextResponse.json({ error: "This proposal is not yet available" }, { status: 403 });
-  }
-
   if (proposal.valid_until && new Date(proposal.valid_until) < new Date()) {
     await supabaseAdmin
       .from("coffee_pricing_proposals")


### PR DESCRIPTION
Removes the draft-blocking check so operators can preview client view before sending. Token-based access remains the security boundary — anyone with the link can view, status only controls visibility tracking.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2