### PR TITLE
Fix agreement field variances and excluded-section bleed-through

### DIFF
--- a/src/app/api/sales/agreements/[id]/route.ts
+++ b/src/app/api/sales/agreements/[id]/route.ts
@@ -131,35 +131,34 @@ export async function PATCH(
     if (key in body) updates[key] = body[key];
   }
 
-  // Auto-recalculate derived fields
-  const qty =
-    Number(updates.machine_quantity ?? body._current_machine_quantity) || 0;
-  const unitPrice =
-    Number(updates.machine_unit_price ?? body._current_machine_unit_price) || 0;
-  const freightPerMachine =
-    Number(updates.freight_per_machine ?? body._current_freight_per_machine) || 0;
-  const locationsPurchased =
-    Number(updates.locations_purchased ?? body._current_locations_purchased) || 0;
-  const locationFee =
-    Number(updates.location_fee_per_secured ?? body._current_location_fee_per_secured) || 0;
+  // Auto-recalculate derived fields. Re-fetch current row so unchanged
+  // inputs to a computed field don't fall back to 0.
+  const { data: current } = await supabaseAdmin
+    .from("purchase_agreements")
+    .select("machine_quantity, machine_unit_price, freight_per_machine, locations_purchased, location_fee_per_secured, include_equipment, include_location_services, include_shipping_storage")
+    .eq("id", id)
+    .single();
 
-  // Only recalculate when we have values to work with
-  if (qty > 0 && unitPrice > 0) {
-    updates.equipment_subtotal = qty * unitPrice;
-  }
-  if (qty > 0 && freightPerMachine > 0) {
-    updates.freight_total = freightPerMachine * qty;
-  }
-  if (locationsPurchased > 0 && locationFee > 0) {
-    updates.max_location_service_value = locationsPurchased * locationFee;
-  }
+  const qty = Number(updates.machine_quantity ?? current?.machine_quantity) || 0;
+  const unitPrice = Number(updates.machine_unit_price ?? current?.machine_unit_price) || 0;
+  const freightPerMachine = Number(updates.freight_per_machine ?? current?.freight_per_machine) || 0;
+  const locationsPurchased = Number(updates.locations_purchased ?? current?.locations_purchased) || 0;
+  const locationFee = Number(updates.location_fee_per_secured ?? current?.location_fee_per_secured) || 0;
 
-  // Recalculate total if equipment or freight changed
-  const eqSub = Number(updates.equipment_subtotal) || 0;
-  const frTotal = Number(updates.freight_total) || 0;
-  if (eqSub > 0 || frTotal > 0) {
-    updates.total_due_prior_to_procurement = eqSub + frTotal;
-  }
+  const includeEquipment = (updates.include_equipment ?? current?.include_equipment) !== false;
+  const includeLocationServices = (updates.include_location_services ?? current?.include_location_services) !== false;
+  const includeShippingStorage = (updates.include_shipping_storage ?? current?.include_shipping_storage) !== false;
+
+  // Always recalculate so zeroing inputs zeros the subtotal, and so
+  // excluded sections contribute nothing to the totals.
+  updates.equipment_subtotal = includeEquipment ? qty * unitPrice : 0;
+  updates.freight_total = includeShippingStorage ? qty * freightPerMachine : 0;
+  updates.max_location_service_value = includeLocationServices ? locationsPurchased * locationFee : 0;
+
+  updates.total_due_prior_to_procurement =
+    Number(updates.equipment_subtotal) +
+    Number(updates.freight_total) +
+    Number(updates.max_location_service_value);
 
   const { data, error } = await supabaseAdmin
     .from("purchase_agreements")

--- a/src/app/sales/agreements/[id]/page.tsx
+++ b/src/app/sales/agreements/[id]/page.tsx
@@ -279,10 +279,10 @@ function StandaloneAgreementEditor() {
     const locPurchased = Number(form.locations_purchased) || 0;
     const locFee = Number(form.location_fee_per_secured) || 0;
 
-    const equipmentSubtotal = qty * unitPrice;
-    const freightTotal = freightPerMachine * qty;
-    const maxLocationServiceValue = locPurchased * locFee;
-    const totalDue = equipmentSubtotal + freightTotal;
+    const equipmentSubtotal = form.include_equipment ? qty * unitPrice : 0;
+    const freightTotal = form.include_shipping_storage ? qty * freightPerMachine : 0;
+    const maxLocationServiceValue = form.include_location_services ? locPurchased * locFee : 0;
+    const totalDue = equipmentSubtotal + freightTotal + maxLocationServiceValue;
 
     return { equipmentSubtotal, freightTotal, maxLocationServiceValue, totalDue };
   }, [form]);
@@ -1204,21 +1204,25 @@ function AgreementPreviewModal({ form, computed, agreement, onClose }: {
           <p><strong>{companyName}</strong>, with its principal office at {billingAddr} (&ldquo;Operator&rdquo; or &ldquo;Buyer&rdquo;).</p>
           <p className="text-xs text-gray-500 italic">Operator Contact: {legalName}, {title} | Email: {email} | Phone: {phone}</p>
 
-          <hr className="my-4" />
-          <h2 className="text-base font-bold text-gray-900 mt-6 mb-2">SCHEDULE A &mdash; EQUIPMENT PURCHASE</h2>
-          <div className="rounded-lg border border-gray-200 overflow-hidden mb-4">
-            <table className="w-full text-sm">
-              <thead className="bg-gray-50"><tr><th className="text-left px-4 py-2 font-medium text-gray-600">Item</th><th className="text-center px-4 py-2 font-medium text-gray-600">Qty</th><th className="text-right px-4 py-2 font-medium text-gray-600">Unit Price</th><th className="text-right px-4 py-2 font-medium text-gray-600">Subtotal</th></tr></thead>
-              <tbody><tr className="border-t border-gray-100"><td className="px-4 py-2">{machineModel}</td><td className="px-4 py-2 text-center">{qty}</td><td className="px-4 py-2 text-right">${currency(unitPrice)}</td><td className="px-4 py-2 text-right font-medium">${currency(computed.equipmentSubtotal)}</td></tr></tbody>
-            </table>
-          </div>
+          {form.include_equipment && (
+            <>
+              <hr className="my-4" />
+              <h2 className="text-base font-bold text-gray-900 mt-6 mb-2">SCHEDULE A &mdash; EQUIPMENT PURCHASE</h2>
+              <div className="rounded-lg border border-gray-200 overflow-hidden mb-4">
+                <table className="w-full text-sm">
+                  <thead className="bg-gray-50"><tr><th className="text-left px-4 py-2 font-medium text-gray-600">Item</th><th className="text-center px-4 py-2 font-medium text-gray-600">Qty</th><th className="text-right px-4 py-2 font-medium text-gray-600">Unit Price</th><th className="text-right px-4 py-2 font-medium text-gray-600">Subtotal</th></tr></thead>
+                  <tbody><tr className="border-t border-gray-100"><td className="px-4 py-2">{machineModel}</td><td className="px-4 py-2 text-center">{qty}</td><td className="px-4 py-2 text-right">${currency(unitPrice)}</td><td className="px-4 py-2 text-right font-medium">${currency(computed.equipmentSubtotal)}</td></tr></tbody>
+                </table>
+              </div>
 
-          <p><strong>1. Equipment Purchase.</strong> Apex agrees to sell and Operator agrees to purchase {qty} {machineModel} machine{qty > 1 ? "s" : ""} (the &ldquo;Equipment&rdquo;) at a per-unit price of ${currency(unitPrice)}, for a total equipment cost of <strong>${currency(computed.equipmentSubtotal)}</strong>.</p>
-          <p><strong>2. Machine Specifications.</strong> Each VendEra AI Smart Vending Machine includes: AI-powered product recognition, touchscreen display, cashless payment system, remote monitoring capabilities, cloud-based inventory management, and temperature control system.</p>
-          <p><strong>3. Warranty.</strong> Each machine is covered by a standard manufacturer&rsquo;s warranty of twelve (12) months from the date of delivery.</p>
-          <p className="text-center text-xs text-gray-500 italic my-4">[Operator Initials: ___]</p>
+              <p><strong>1. Equipment Purchase.</strong> Apex agrees to sell and Operator agrees to purchase {qty} {machineModel} machine{qty > 1 ? "s" : ""} (the &ldquo;Equipment&rdquo;) at a per-unit price of ${currency(unitPrice)}, for a total equipment cost of <strong>${currency(computed.equipmentSubtotal)}</strong>.</p>
+              <p><strong>2. Machine Specifications.</strong> Each VendEra AI Smart Vending Machine includes: AI-powered product recognition, touchscreen display, cashless payment system, remote monitoring capabilities, cloud-based inventory management, and temperature control system.</p>
+              <p><strong>3. Warranty.</strong> Each machine is covered by a standard manufacturer&rsquo;s warranty of twelve (12) months from the date of delivery.</p>
+              <p className="text-center text-xs text-gray-500 italic my-4">[Operator Initials: ___]</p>
+            </>
+          )}
 
-          {locPurchased > 0 && (
+          {form.include_location_services && locPurchased > 0 && (
             <>
               <hr className="my-4" />
               <h2 className="text-base font-bold text-gray-900 mt-6 mb-2">SCHEDULE B &mdash; LOCATION SERVICES</h2>
@@ -1236,31 +1240,42 @@ function AgreementPreviewModal({ form, computed, agreement, onClose }: {
             </>
           )}
 
-          <hr className="my-4" />
-          <h2 className="text-base font-bold text-gray-900 mt-6 mb-2">SCHEDULE C &mdash; SHIPPING, STORAGE &amp; PAYMENT</h2>
-          <div className="rounded-lg border border-gray-200 overflow-hidden mb-4">
-            <table className="w-full text-sm">
-              <thead className="bg-gray-50"><tr><th className="text-left px-4 py-2 font-medium text-gray-600">Item</th><th className="text-right px-4 py-2 font-medium text-gray-600">Amount</th></tr></thead>
-              <tbody>
-                <tr className="border-t border-gray-100"><td className="px-4 py-2">Standard Freight Rate</td><td className="px-4 py-2 text-right">${currency(stdFreight)} / machine</td></tr>
-                <tr className="border-t border-gray-100"><td className="px-4 py-2">Discounted Freight Rate</td><td className="px-4 py-2 text-right">${currency(discFreight)} / machine</td></tr>
-                <tr className="border-t border-gray-100"><td className="px-4 py-2">Freight per Machine</td><td className="px-4 py-2 text-right">${currency(freightPer)}</td></tr>
-                <tr className="border-t border-gray-100 font-medium"><td className="px-4 py-2">Freight Total</td><td className="px-4 py-2 text-right">${currency(computed.freightTotal)}</td></tr>
-                <tr className="border-t border-gray-100"><td className="px-4 py-2">Storage Fee</td><td className="px-4 py-2 text-right">${currency(storageFee)} / machine / month</td></tr>
-                <tr className="border-t border-gray-100"><td className="px-4 py-2">Free Storage Period</td><td className="px-4 py-2 text-right">{freeStorageMonths} month{freeStorageMonths !== 1 ? "s" : ""}</td></tr>
-              </tbody>
-            </table>
-          </div>
-          <p><strong>8. Shipping.</strong> Standard freight is ${currency(stdFreight)} per machine. Discounted rate of ${currency(freightPer)} per machine, total <strong>${currency(computed.freightTotal)}</strong>. Delivery: {deliveryAddr || "[Delivery Address]"}.</p>
-          <p><strong>9. Storage.</strong> {freeStorageMonths} month{freeStorageMonths !== 1 ? "s" : ""} free storage. After that, ${currency(storageFee)} per machine per month.</p>
-          <p className="text-center text-xs text-gray-500 italic my-4">[Operator Initials: ___]</p>
+          {form.include_shipping_storage && (
+            <>
+              <hr className="my-4" />
+              <h2 className="text-base font-bold text-gray-900 mt-6 mb-2">SCHEDULE C &mdash; SHIPPING &amp; STORAGE</h2>
+              <div className="rounded-lg border border-gray-200 overflow-hidden mb-4">
+                <table className="w-full text-sm">
+                  <thead className="bg-gray-50"><tr><th className="text-left px-4 py-2 font-medium text-gray-600">Item</th><th className="text-right px-4 py-2 font-medium text-gray-600">Amount</th></tr></thead>
+                  <tbody>
+                    {stdFreight > 0 && (<tr className="border-t border-gray-100"><td className="px-4 py-2">Standard Freight Rate</td><td className="px-4 py-2 text-right">${currency(stdFreight)} / machine</td></tr>)}
+                    {discFreight > 0 && (<tr className="border-t border-gray-100"><td className="px-4 py-2">Discounted Freight Rate</td><td className="px-4 py-2 text-right">${currency(discFreight)} / machine</td></tr>)}
+                    <tr className="border-t border-gray-100"><td className="px-4 py-2">Freight per Machine</td><td className="px-4 py-2 text-right">${currency(freightPer)}</td></tr>
+                    <tr className="border-t border-gray-100 font-medium"><td className="px-4 py-2">Freight Total ({qty} machine{qty > 1 ? "s" : ""})</td><td className="px-4 py-2 text-right">${currency(computed.freightTotal)}</td></tr>
+                    {storageFee > 0 && (<tr className="border-t border-gray-100"><td className="px-4 py-2">Storage Fee</td><td className="px-4 py-2 text-right">${currency(storageFee)} / machine / month</td></tr>)}
+                    <tr className="border-t border-gray-100"><td className="px-4 py-2">Free Storage Period</td><td className="px-4 py-2 text-right">{freeStorageMonths} month{freeStorageMonths !== 1 ? "s" : ""}</td></tr>
+                  </tbody>
+                </table>
+              </div>
+              <p><strong>8. Shipping.</strong> Freight is ${currency(freightPer)} per machine for a total of <strong>${currency(computed.freightTotal)}</strong>. Delivery: {deliveryAddr || "[Delivery Address]"}.</p>
+              <p><strong>9. Storage.</strong> {freeStorageMonths} month{freeStorageMonths !== 1 ? "s" : ""} free storage. After that, ${currency(storageFee)} per machine per month.</p>
+              <p className="text-center text-xs text-gray-500 italic my-4">[Operator Initials: ___]</p>
+            </>
+          )}
 
           <hr className="my-4" />
           <h2 className="text-base font-bold text-gray-900 mt-6 mb-2">PAYMENT SUMMARY</h2>
           <div className="rounded-lg border-2 border-green-200 bg-green-50 p-4 mb-4">
             <div className="space-y-2 text-sm">
-              <div className="flex justify-between"><span>Equipment ({qty}x {machineModel})</span><span className="font-medium">${currency(computed.equipmentSubtotal)}</span></div>
-              <div className="flex justify-between"><span>Shipping &amp; Freight</span><span className="font-medium">${currency(computed.freightTotal)}</span></div>
+              {form.include_equipment && computed.equipmentSubtotal > 0 && (
+                <div className="flex justify-between"><span>Equipment ({qty}x {machineModel})</span><span className="font-medium">${currency(computed.equipmentSubtotal)}</span></div>
+              )}
+              {form.include_location_services && computed.maxLocationServiceValue > 0 && (
+                <div className="flex justify-between"><span>Location Services ({locPurchased} location{locPurchased > 1 ? "s" : ""})</span><span className="font-medium">${currency(computed.maxLocationServiceValue)}</span></div>
+              )}
+              {form.include_shipping_storage && computed.freightTotal > 0 && (
+                <div className="flex justify-between"><span>Shipping &amp; Freight</span><span className="font-medium">${currency(computed.freightTotal)}</span></div>
+              )}
               <div className="border-t border-green-200 pt-2 flex justify-between text-base font-bold text-green-800"><span>Total Due Prior to Procurement</span><span>${currency(computed.totalDue)}</span></div>
             </div>
           </div>

--- a/src/app/sign/[token]/page.tsx
+++ b/src/app/sign/[token]/page.tsx
@@ -81,6 +81,10 @@ interface PurchaseAgreement {
   payment_due_date: string | null;
   payment_method_notes: string | null;
 
+  include_equipment?: boolean;
+  include_location_services?: boolean;
+  include_shipping_storage?: boolean;
+
   effective_date: string | null;
   governing_state: string | null;
   venue_state: string | null;
@@ -556,11 +560,13 @@ function SigningContent() {
               <p className="text-xs font-medium text-green-700 uppercase tracking-wider mb-2">
                 Agreement Details
               </p>
-              <p className="text-sm text-gray-700">
-                <span className="font-semibold">
-                  {agreement.machine_quantity}x {agreement.machine_model}
-                </span>
-              </p>
+              {agreement.include_equipment !== false && (
+                <p className="text-sm text-gray-700">
+                  <span className="font-semibold">
+                    {agreement.machine_quantity}x {agreement.machine_model}
+                  </span>
+                </p>
+              )}
               <p className="text-sm text-gray-700">
                 Operator: {agreement.operator_company_name}
               </p>
@@ -782,6 +788,7 @@ function SigningContent() {
             </div>
 
             {/* ============ SECTION 3: Equipment Purchase ============ */}
+            {agreement.include_equipment !== false && (<>
             <SectionHeader num={3} title="Equipment Purchase" requiresInitials />
             <div>
               <p>
@@ -849,8 +856,10 @@ function SigningContent() {
                 onInitialed={handleInitialed}
               />
             </div>
+            </>)}
 
             {/* ============ SECTION 4: Shipping & Freight ============ */}
+            {agreement.include_shipping_storage !== false && (<>
             <SectionHeader
               num={4}
               title="Shipping &amp; Freight"
@@ -914,8 +923,10 @@ function SigningContent() {
                 onInitialed={handleInitialed}
               />
             </div>
+            </>)}
 
             {/* ============ SECTION 5: Location Services ============ */}
+            {agreement.include_location_services !== false && (<>
             <SectionHeader
               num={5}
               title="Location Services"
@@ -1001,6 +1012,7 @@ function SigningContent() {
                 onInitialed={handleInitialed}
               />
             </div>
+            </>)}
 
             {/* ============ SECTION 6: Payment Terms ============ */}
             <SectionHeader

--- a/src/lib/generateAgreementPdf.ts
+++ b/src/lib/generateAgreementPdf.ts
@@ -276,13 +276,13 @@ export async function generatePurchaseAgreementPdf(ag: any, signatures: any[], i
   }
 
   if (includeShippingStorage) {
-    sectionHeader(5, "Shipping & Freight");
+    sectionHeader(5, "Shipping & Storage");
     labelValue("Freight per Machine", money(ag.freight_per_machine));
-    labelValue("Freight Total", money(ag.freight_total));
-    if (ag.standard_freight_rate) labelValue("Standard Rate", money(ag.standard_freight_rate));
-    if (ag.discounted_freight_rate) labelValue("Discounted Rate", money(ag.discounted_freight_rate));
-    if (ag.storage_fee_per_machine_month) labelValue("Storage Fee/Month", money(ag.storage_fee_per_machine_month));
-    if (ag.free_storage_months) labelValue("Free Storage Months", String(ag.free_storage_months));
+    labelValue(`Freight Total (${ag.machine_quantity || 0} machine${(ag.machine_quantity || 0) === 1 ? "" : "s"})`, money(ag.freight_total));
+    if (Number(ag.standard_freight_rate) > 0) labelValue("Standard Freight Rate", money(ag.standard_freight_rate));
+    if (Number(ag.discounted_freight_rate) > 0) labelValue("Discounted Freight Rate", money(ag.discounted_freight_rate));
+    labelValue("Storage Fee per Machine / Month", money(ag.storage_fee_per_machine_month));
+    labelValue("Free Storage Period", `${ag.free_storage_months || 0} month${(ag.free_storage_months || 0) === 1 ? "" : "s"}`);
     y -= 4;
     drawWrapped(
       "Freight charges cover shipping from the distribution center to the Operator's designated delivery address. Machines are shipped via common carrier. Risk of loss transfers to Operator upon delivery. Storage fees apply if Operator is unable to accept delivery within the free storage period.",
@@ -377,7 +377,7 @@ export async function generatePurchaseAgreementPdf(ag: any, signatures: any[], i
     y -= 16;
     drawLine(y);
     y -= 16;
-    if (includeShippingStorage) {
+    if (includeShippingStorage && Number(ag.freight_total) > 0) {
       drawText(page, "Freight", LEFT + 4, y, helvetica, 8.5, dark);
       drawText(page, `${money(ag.freight_per_machine)} x ${ag.machine_quantity || 0}`, LEFT + 310, y, helvetica, 8.5, dark);
       drawText(page, money(ag.freight_total), LEFT + 450, y, helveticaBold, 8.5, dark);
@@ -385,11 +385,8 @@ export async function generatePurchaseAgreementPdf(ag: any, signatures: any[], i
       drawLine(y);
       y -= 16;
     }
-    drawText(page, "TOTAL DUE PRIOR TO PROCUREMENT", LEFT + 4, y, helveticaBold, 9, dark);
-    drawText(page, money(ag.total_due_prior_to_procurement), LEFT + 450, y, helveticaBold, 10, green);
-    y -= 10;
     if (ag.machine_notes) {
-      y -= 10;
+      y -= 4;
       drawWrapped(`Notes: ${ag.machine_notes}`, helvetica, 8, gray);
     }
     initialsPlaceholder();
@@ -420,6 +417,40 @@ export async function generatePurchaseAgreementPdf(ag: any, signatures: any[], i
     );
     initialsPlaceholder();
   }
+
+  /* ================================================================ */
+  /*  PAYMENT SUMMARY — always shown, reflects only included sections */
+  /* ================================================================ */
+  checkPage(80);
+  y -= 10;
+  drawLine(y);
+  y -= 20;
+  drawText(page, "PAYMENT SUMMARY", LEFT, y, helveticaBold, 10, green);
+  y -= 18;
+  if (includeEquipment && Number(ag.equipment_subtotal) > 0) {
+    drawText(page, `Equipment (${ag.machine_quantity || 0}x ${ag.machine_model || "VendEra AI Machine"})`, LEFT + 4, y, helvetica, 9, dark);
+    const s = money(ag.equipment_subtotal);
+    drawText(page, s, RIGHT - 4 - helvetica.widthOfTextAtSize(s, 9), y, helvetica, 9, dark);
+    y -= 14;
+  }
+  if (includeLocationServices && Number(ag.max_location_service_value) > 0) {
+    drawText(page, `Location Services (${ag.locations_purchased || 0} location${(ag.locations_purchased || 0) === 1 ? "" : "s"})`, LEFT + 4, y, helvetica, 9, dark);
+    const s = money(ag.max_location_service_value);
+    drawText(page, s, RIGHT - 4 - helvetica.widthOfTextAtSize(s, 9), y, helvetica, 9, dark);
+    y -= 14;
+  }
+  if (includeShippingStorage && Number(ag.freight_total) > 0) {
+    drawText(page, `Shipping & Freight (${ag.machine_quantity || 0} machine${(ag.machine_quantity || 0) === 1 ? "" : "s"})`, LEFT + 4, y, helvetica, 9, dark);
+    const s = money(ag.freight_total);
+    drawText(page, s, RIGHT - 4 - helvetica.widthOfTextAtSize(s, 9), y, helvetica, 9, dark);
+    y -= 14;
+  }
+  y -= 2;
+  drawLine(y + 6);
+  drawText(page, "TOTAL DUE PRIOR TO PROCUREMENT", LEFT + 4, y, helveticaBold, 10, dark);
+  const totalStr = money(ag.total_due_prior_to_procurement);
+  drawText(page, totalStr, RIGHT - 4 - helveticaBold.widthOfTextAtSize(totalStr, 12), y, helveticaBold, 12, green);
+  y -= 16;
 
   /* ================================================================ */
   /*  SCHEDULE C — Delivery & Addresses                               */


### PR DESCRIPTION
API recalc now always runs (so zeroing inputs zeros the subtotal) and respects the include_equipment / include_location_services / include_shipping_storage toggles. total_due_prior_to_procurement now sums only the included sections and adds the location services value.

Editor's computed totals mirror the same logic. The Agreement Preview modal now wraps each schedule (A, B, C) in its include_* flag and the Payment Summary skips line items for excluded sections.

PDF now always shows storage fee/free period in section 5, adds a Payment Summary block before Schedule C that's outside any toggle so the total still shows even when equipment is excluded, and Schedule A adds a location services subtotal row when applicable.

Operator-facing sign page wraps sections 3, 4, and 5 in the matching include_* flag and hides the equipment summary line at the top when equipment is excluded.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2