### PR TITLE
Make agreement emails and order creation respect section toggles

### DIFF
--- a/src/app/api/sales/agreements/[id]/create-order/route.ts
+++ b/src/app/api/sales/agreements/[id]/create-order/route.ts
@@ -23,11 +23,15 @@ export async function POST(
   if (agErr || !ag)
     return NextResponse.json({ error: "Agreement not found" }, { status: 404 });
 
-  // Build order items from agreement data
+  // Respect section toggles when building line items
+  const includeEquipment = ag.include_equipment !== false;
+  const includeLocationServices = ag.include_location_services !== false;
+  const includeShippingStorage = ag.include_shipping_storage !== false;
+
   const items: Array<Record<string, unknown>> = [];
 
   // Machine sale item
-  if (ag.machine_quantity > 0) {
+  if (includeEquipment && ag.machine_quantity > 0 && Number(ag.machine_unit_price) > 0) {
     const unitPrice = Number(ag.machine_unit_price) || 0;
     const qty = Number(ag.machine_quantity) || 1;
     items.push({
@@ -45,7 +49,7 @@ export async function POST(
   }
 
   // Location services item
-  if (Number(ag.locations_purchased) > 0) {
+  if (includeLocationServices && Number(ag.locations_purchased) > 0) {
     const locFee = Number(ag.location_fee_per_secured) || 0;
     const locQty = Number(ag.locations_purchased) || 0;
     items.push({
@@ -63,9 +67,9 @@ export async function POST(
     });
   }
 
-  // Freight item (if freight > 0)
+  // Freight item (if freight > 0 and shipping included)
   const freightTotal = Number(ag.freight_total) || 0;
-  if (freightTotal > 0) {
+  if (includeShippingStorage && freightTotal > 0) {
     items.push({
       item_type: "other",
       service_name: "Shipping & Freight",

--- a/src/app/api/sales/agreements/[id]/send/route.ts
+++ b/src/app/api/sales/agreements/[id]/send/route.ts
@@ -41,17 +41,23 @@ export async function POST(
   if (agErr || !agreement)
     return NextResponse.json({ error: "Agreement not found" }, { status: 404 });
 
-  // Validate required fields
+  // Validate required fields. Equipment fields are only required when
+  // the Equipment section is included.
+  const includeEquipment = agreement.include_equipment !== false;
   const requiredFields: Array<{ key: string; label: string }> = [
     { key: "operator_company_name", label: "Operator company name" },
     { key: "operator_legal_name", label: "Operator legal name" },
     { key: "operator_email", label: "Operator email" },
-    { key: "machine_model", label: "Machine model" },
-    { key: "machine_quantity", label: "Machine quantity" },
-    { key: "machine_unit_price", label: "Machine unit price" },
     { key: "effective_date", label: "Effective date" },
     { key: "apex_representative_name", label: "Apex representative name" },
   ];
+  if (includeEquipment) {
+    requiredFields.push(
+      { key: "machine_model", label: "Machine model" },
+      { key: "machine_quantity", label: "Machine quantity" },
+      { key: "machine_unit_price", label: "Machine unit price" },
+    );
+  }
 
   const missing = requiredFields.filter(
     (f) =>
@@ -101,12 +107,13 @@ export async function POST(
 
   <p>Hi ${agreement.operator_legal_name || agreement.operator_company_name},</p>
 
-  <p>Your purchase agreement for <strong>${agreement.machine_quantity} ${agreement.machine_model}</strong> machine${agreement.machine_quantity > 1 ? "s" : ""} is ready for review and signature.</p>
+  <p>Your purchase agreement is ready for review and signature.</p>
 
   <p>This agreement covers:</p>
   <ul style="color:#374151;line-height:1.8;">
-    <li>Equipment: ${agreement.machine_quantity}x ${agreement.machine_model} @ $${Number(agreement.machine_unit_price).toLocaleString("en-US", { minimumFractionDigits: 2 })} each</li>
-    ${agreement.locations_purchased > 0 ? `<li>Location Services: ${agreement.locations_purchased} location${agreement.locations_purchased > 1 ? "s" : ""}</li>` : ""}
+    ${includeEquipment && agreement.machine_quantity > 0 ? `<li>Equipment: ${agreement.machine_quantity}x ${agreement.machine_model} @ $${Number(agreement.machine_unit_price).toLocaleString("en-US", { minimumFractionDigits: 2 })} each</li>` : ""}
+    ${agreement.include_location_services !== false && Number(agreement.locations_purchased) > 0 ? `<li>Location Services: ${agreement.locations_purchased} location${agreement.locations_purchased > 1 ? "s" : ""} @ $${Number(agreement.location_fee_per_secured || 0).toLocaleString("en-US", { minimumFractionDigits: 2 })} each</li>` : ""}
+    ${agreement.include_shipping_storage !== false && Number(agreement.freight_total) > 0 ? `<li>Shipping &amp; Freight: $${Number(agreement.freight_total).toLocaleString("en-US", { minimumFractionDigits: 2 })}</li>` : ""}
     <li>Total Due Prior to Procurement: <strong>$${Number(agreement.total_due_prior_to_procurement || 0).toLocaleString("en-US", { minimumFractionDigits: 2 })}</strong></li>
   </ul>
 

--- a/src/lib/generateAgreementPdf.ts
+++ b/src/lib/generateAgreementPdf.ts
@@ -693,10 +693,14 @@ export async function handleFullySignedAgreement(agreementId: string): Promise<v
         <td style="padding:8px 12px;border:1px solid #e5e7eb;color:#6b7280;font-size:13px;">Operator</td>
         <td style="padding:8px 12px;border:1px solid #e5e7eb;color:#111;font-size:13px;font-weight:600;">${ag.operator_company_name || "—"}</td>
       </tr>
-      <tr>
+      ${ag.include_equipment !== false && ag.machine_quantity > 0 ? `<tr>
         <td style="padding:8px 12px;border:1px solid #e5e7eb;color:#6b7280;font-size:13px;">Machine(s)</td>
-        <td style="padding:8px 12px;border:1px solid #e5e7eb;color:#111;font-size:13px;">${ag.machine_quantity || 1}x ${ag.machine_model || "VendEra AI Machine"}</td>
-      </tr>
+        <td style="padding:8px 12px;border:1px solid #e5e7eb;color:#111;font-size:13px;">${ag.machine_quantity}x ${ag.machine_model || "VendEra AI Machine"}</td>
+      </tr>` : ""}
+      ${ag.include_location_services !== false && Number(ag.locations_purchased) > 0 ? `<tr>
+        <td style="padding:8px 12px;border:1px solid #e5e7eb;color:#6b7280;font-size:13px;">Location Services</td>
+        <td style="padding:8px 12px;border:1px solid #e5e7eb;color:#111;font-size:13px;">${ag.locations_purchased} location${ag.locations_purchased > 1 ? "s" : ""}</td>
+      </tr>` : ""}
       <tr>
         <td style="padding:8px 12px;border:1px solid #e5e7eb;color:#6b7280;font-size:13px;">Total Due</td>
         <td style="padding:8px 12px;border:1px solid #e5e7eb;color:#16a34a;font-size:13px;font-weight:700;">$${totalDue.toLocaleString("en-US", { minimumFractionDigits: 2 })}</td>


### PR DESCRIPTION
The manual create-order route now skips line items for excluded sections (matches the auto-invoice flow that was already correct).

The send-for-signature email no longer requires machine_model / quantity / unit_price when the Equipment section is excluded, and the "this agreement covers" bullet list now only shows lines for the included sections.

The fully-executed signed email no longer hardcodes a Machine(s) row; it conditionally renders Machine(s) and Location Services rows based on the include_* toggles.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2