### PR TITLE
Surface ?error= query param on login and signup pages

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -14,6 +14,11 @@ function LoginContent() {
   const [checking, setChecking] = useState(true);
 
   useEffect(() => {
+    const urlError = searchParams.get("error");
+    if (urlError) setError(decodeURIComponent(urlError));
+  }, [searchParams]);
+
+  useEffect(() => {
     const supabase = createBrowserClient();
     supabase.auth.getSession().then(async ({ data: { session } }) => {
       if (session?.user) {

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -81,6 +81,11 @@ function SignupContent() {
     });
   }, []);
 
+  useEffect(() => {
+    const urlError = searchParams.get("error");
+    if (urlError) setError(decodeURIComponent(urlError));
+  }, [searchParams]);
+
   async function handleSignOutAndContinue() {
     setSigningOut(true);
     try {


### PR DESCRIPTION
The Yahoo OAuth callback redirects back to /login?error=... on any failure (token exchange, user info, account creation, etc.), but neither page was reading the error from the URL. This made failed Yahoo flows look like a silent page reload — the user thought the button wasn't working.

Now both pages decode and display the error message immediately on mount, so the underlying problem is visible.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2