### PR TITLE
Use hard navigation for auth-state transition links

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -391,20 +391,20 @@ export default function DashboardPage() {
             Please log in or create an account to access your Vending Connector dashboard.
           </p>
           <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
-            <Link
+            <a
               href="/login"
               className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-green-primary px-6 py-3 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-green-hover sm:w-auto"
             >
               <LogIn className="h-4 w-4" />
               Log In
-            </Link>
-            <Link
+            </a>
+            <a
               href="/signup"
               className="inline-flex w-full items-center justify-center gap-2 rounded-xl border-2 border-gray-200 bg-white px-6 py-3 text-sm font-semibold text-black-primary transition-colors hover:border-green-200 hover:bg-green-50 sm:w-auto"
             >
               <UserPlus className="h-4 w-4" />
               Create Account
-            </Link>
+            </a>
           </div>
         </div>
       </div>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -203,9 +203,9 @@ function LoginContent() {
         {/* Footer link */}
         <p className="text-center mt-6 text-sm text-black-primary/60">
           Don&apos;t have an account?{" "}
-          <Link href="/signup" className="text-green-primary hover:underline font-medium">
+          <a href="/signup" className="text-green-primary hover:underline font-medium">
             Create one
-          </Link>
+          </a>
         </p>
       </div>
     </div>

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -539,9 +539,9 @@ function SignupContent() {
         {/* Footer link */}
         <p className="text-center mt-6 text-sm text-black-primary/60">
           Already have an account?{" "}
-          <Link href="/login" className="text-green-primary hover:underline font-medium">
+          <a href="/login" className="text-green-primary hover:underline font-medium">
             Sign in
-          </Link>
+          </a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
The signed-out dashboard prompt and the login/signup footer links used Next.js <Link> which intermittently failed to navigate — clicks were firing before React hydration completed, leaving the user stuck on the same page. Switching to plain <a> tags triggers a full page navigation, which is the correct behavior for transitioning between auth states (login → signup → dashboard) since it also resets stale client state.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2