### PR TITLE
Yahoo OAuth: openid-only scope + decode id_token JWT for email/name

### DIFF
--- a/src/app/api/auth/yahoo/callback/route.ts
+++ b/src/app/api/auth/yahoo/callback/route.ts
@@ -88,9 +88,29 @@ export async function GET(req: NextRequest) {
 
   const yahooUser: YahooUserInfo = await userInfoRes.json();
 
+  // Fallback: pull email/name from the id_token JWT claims when the
+  // userinfo endpoint doesn't include them (happens when the Yahoo app
+  // is configured with OIDC permissions but the scope param can only
+  // include 'openid').
+  if (!yahooUser.email && tokens.id_token) {
+    try {
+      const payload = tokens.id_token.split(".")[1];
+      const claims = JSON.parse(
+        Buffer.from(payload, "base64url").toString("utf8")
+      );
+      if (claims.email) yahooUser.email = claims.email;
+      if (!yahooUser.name && claims.name) yahooUser.name = claims.name;
+      if (!yahooUser.given_name && claims.given_name) yahooUser.given_name = claims.given_name;
+      if (!yahooUser.family_name && claims.family_name) yahooUser.family_name = claims.family_name;
+      if (!yahooUser.picture && claims.picture) yahooUser.picture = claims.picture;
+    } catch {
+      // Ignore decode errors; fall through to the email check below.
+    }
+  }
+
   if (!yahooUser.email) {
     return NextResponse.redirect(
-      `${APP_URL}/login?error=${encodeURIComponent("Yahoo account does not have an email address")}`
+      `${APP_URL}/login?error=${encodeURIComponent("Yahoo did not return an email address. Enable the Email permission under OpenID Connect Permissions in your Yahoo app.")}`
     );
   }
 

--- a/src/app/api/auth/yahoo/route.ts
+++ b/src/app/api/auth/yahoo/route.ts
@@ -28,7 +28,7 @@ export async function GET(req: NextRequest) {
     `client_id=${encodeURIComponent(YAHOO_CLIENT_ID)}`,
     `redirect_uri=${encodeURIComponent(redirectUri)}`,
     `response_type=code`,
-    `scope=${encodeURIComponent("openid email profile")}`,
+    `scope=${encodeURIComponent("openid")}`,
     `nonce=${encodeURIComponent(nonce)}`,
     `state=${encodeURIComponent(state)}`,
   ].join("&");


### PR DESCRIPTION
Yahoo rejects 'email' and 'profile' scopes with invalid_scope on this app even with OpenID Connect Permissions checkboxes enabled. Stick to the 'openid' scope (which Yahoo accepts) and pull email + profile claims from the id_token JWT payload directly. The OIDC Permissions in the Yahoo Developer Console govern which claims Yahoo embeds in the id_token, so the user data still comes through without needing the scope params Yahoo refuses.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2