### PR TITLE
Add magic-link hash catcher for Yahoo OAuth landing on '/'

### DIFF
--- a/src/app/components/MagicLinkHashCatcher.tsx
+++ b/src/app/components/MagicLinkHashCatcher.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { consumeAuthFlow } from "@/lib/auth";
+
+/**
+ * Catches a Supabase magic-link hash that landed on a non-callback route
+ * (e.g. the homepage instead of /auth/callback). This happens when the
+ * `redirect_to` URL passed to Supabase's verify endpoint isn't on the
+ * project's Redirect URL allowlist — Supabase silently falls back to
+ * the Site URL.
+ *
+ * Forwards the user to /auth/callback (preserving the hash) so the
+ * existing flow logic runs.
+ */
+export default function MagicLinkHashCatcher() {
+  const didRun = useRef(false);
+
+  useEffect(() => {
+    if (didRun.current) return;
+    didRun.current = true;
+    if (typeof window === "undefined") return;
+    const hash = window.location.hash || "";
+    if (!hash.includes("access_token=")) return;
+    if (window.location.pathname.startsWith("/auth/callback")) return;
+
+    const flow = consumeAuthFlow();
+    const params = new URLSearchParams();
+    if (flow) params.set("flow", flow);
+
+    const target = `/auth/callback${params.toString() ? `?${params.toString()}` : ""}${hash}`;
+    window.location.replace(target);
+  }, []);
+
+  return null;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import "./globals.css";
 import Navbar from "./components/Navbar";
 import Footer from "./components/Footer";
 import FinancingFab from "./components/FinancingFab";
+import MagicLinkHashCatcher from "./components/MagicLinkHashCatcher";
 
 export const metadata: Metadata = {
   metadataBase: new URL(
@@ -50,6 +51,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className="bg-light min-h-screen flex flex-col antialiased">
+        <MagicLinkHashCatcher />
         <Navbar />
         <main className="flex-1">{children}</main>
         <Footer />


### PR DESCRIPTION
Supabase silently drops `redirect_to` values that aren't on the project's Redirect URL allowlist and falls back to the Site URL — which for us is '/'. So Yahoo's full OAuth flow succeeds but the user lands on the homepage with the session hash, never reaching /auth/callback to finish the flow.

This adds a tiny client component in the root layout that detects an `access_token=...` hash on any non-callback route and forwards the user (preserving the hash) to /auth/callback so the existing session-establishment + profile-completion logic runs.

This is a safety net — the cleaner fix is to add
https://vendingconnector.com/auth/callback to the Supabase project's Redirect URL allowlist so the redirect lands there in the first place.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2