### PR TITLE
Add email/password authentication (additive — OAuth unchanged)

### DIFF
--- a/src/app/api/auth/resend-verification/route.ts
+++ b/src/app/api/auth/resend-verification/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { createAndSendVerificationEmail } from "@/lib/emailVerification";
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const email = String(body.email || "").trim().toLowerCase();
+    if (!email) return NextResponse.json({ error: "Email is required" }, { status: 400 });
+
+    // Look up user
+    const { data: users } = await supabaseAdmin.auth.admin.listUsers();
+    const user = users?.users?.find((u) => u.email?.toLowerCase() === email);
+
+    // Even if no user, return success-like response to avoid email enumeration.
+    if (!user) {
+      return NextResponse.json({ ok: true });
+    }
+
+    // If already verified, return success without sending
+    const { data: profile } = await supabaseAdmin
+      .from("profiles")
+      .select("email_verified, full_name")
+      .eq("id", user.id)
+      .single();
+
+    if (profile?.email_verified) {
+      return NextResponse.json({ ok: true, alreadyVerified: true });
+    }
+
+    const firstName = profile?.full_name?.split(" ")[0];
+    const result = await createAndSendVerificationEmail({
+      userId: user.id,
+      email,
+      firstName,
+    });
+
+    if (!result.ok) {
+      return NextResponse.json({ error: result.error || "Failed to send verification email" }, { status: 429 });
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/api/auth/signup-email/route.ts
+++ b/src/app/api/auth/signup-email/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { createAndSendVerificationEmail } from "@/lib/emailVerification";
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const firstName = String(body.first_name || "").trim();
+    const lastName = String(body.last_name || "").trim();
+    const companyName = String(body.company_name || "").trim();
+    const email = String(body.email || "").trim().toLowerCase();
+    const password = String(body.password || "");
+    const role = String(body.role || "operator").trim();
+
+    if (!firstName) return NextResponse.json({ error: "First name is required" }, { status: 400 });
+    if (!lastName) return NextResponse.json({ error: "Last name is required" }, { status: 400 });
+    if (!email) return NextResponse.json({ error: "Email is required" }, { status: 400 });
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      return NextResponse.json({ error: "Please enter a valid email address" }, { status: 400 });
+    }
+    if (!password || password.length < 8) {
+      return NextResponse.json({ error: "Password must be at least 8 characters" }, { status: 400 });
+    }
+
+    // Check if a user with this email already exists (OAuth or email/password)
+    const { data: existingList } = await supabaseAdmin.auth.admin.listUsers();
+    const existing = existingList?.users?.find((u) => u.email?.toLowerCase() === email);
+    if (existing) {
+      return NextResponse.json(
+        {
+          error:
+            "An account already exists with this email. Please sign in using your existing method or contact support to add password login.",
+          code: "ACCOUNT_EXISTS",
+        },
+        { status: 409 },
+      );
+    }
+
+    const fullName = `${firstName} ${lastName}`.trim();
+
+    // Create the Supabase auth user. We start with email_confirm=false so they
+    // need to click our verification email before email_confirmed_at is set.
+    const { data: created, error: createErr } = await supabaseAdmin.auth.admin.createUser({
+      email,
+      password,
+      email_confirm: false,
+      user_metadata: {
+        full_name: fullName,
+        first_name: firstName,
+        last_name: lastName,
+        role,
+        provider: "email",
+      },
+    });
+
+    if (createErr || !created.user) {
+      return NextResponse.json(
+        { error: createErr?.message || "Failed to create account" },
+        { status: 500 },
+      );
+    }
+
+    const userId = created.user.id;
+
+    // Ensure profile row reflects our intended values (handle_new_user trigger
+    // may have inserted a baseline).
+    await supabaseAdmin
+      .from("profiles")
+      .upsert(
+        {
+          id: userId,
+          full_name: fullName,
+          email,
+          role,
+          company_name: companyName || null,
+          email_verified: false,
+        },
+        { onConflict: "id" },
+      );
+
+    // Send verification email
+    const verifyResult = await createAndSendVerificationEmail({
+      userId,
+      email,
+      firstName,
+    });
+
+    if (!verifyResult.ok) {
+      // Account was created but email failed — log and return success anyway.
+      // The user can resend from /resend-verification.
+      console.error("[signup-email] verification email failed:", verifyResult.error);
+    }
+
+    return NextResponse.json({ ok: true, user_id: userId, email });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/api/auth/verify-email/route.ts
+++ b/src/app/api/auth/verify-email/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifyEmailToken } from "@/lib/emailVerification";
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const token = String(body.token || "");
+    const result = await verifyEmailToken(token);
+    if (!result.ok) {
+      return NextResponse.json({ error: result.error || "Verification failed" }, { status: 400 });
+    }
+    return NextResponse.json({ ok: true, email: result.email });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/check-email/page.tsx
+++ b/src/app/check-email/page.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { Suspense } from "react";
+import { useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { Mail } from "lucide-react";
+
+function CheckEmailContent() {
+  const searchParams = useSearchParams();
+  const email = searchParams.get("email") || "";
+
+  return (
+    <div className="min-h-[calc(100vh-160px)] flex items-center justify-center px-4 py-12">
+      <div className="w-full max-w-md">
+        <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-8 text-center">
+          <div className="mx-auto w-16 h-16 rounded-full bg-green-50 flex items-center justify-center mb-6">
+            <Mail className="w-8 h-8 text-green-primary" />
+          </div>
+          <h1 className="text-2xl font-bold text-black-primary mb-2">Check your email</h1>
+          <p className="text-sm text-black-primary/60 mb-6">
+            We&apos;ve sent a verification link to {email ? (
+              <strong className="text-black-primary">{email}</strong>
+            ) : (
+              "your inbox"
+            )}. Click the link in the email to verify your account.
+          </p>
+          <div className="space-y-3">
+            <Link
+              href={`/resend-verification${email ? `?email=${encodeURIComponent(email)}` : ""}`}
+              className="block w-full py-3 px-4 border border-gray-200 text-black-primary hover:bg-gray-50 font-medium rounded-xl transition-colors"
+            >
+              Resend verification email
+            </Link>
+            <Link
+              href="/login"
+              className="block w-full py-3 px-4 text-sm text-black-primary/60 hover:text-black-primary transition-colors"
+            >
+              Back to login
+            </Link>
+          </div>
+          <p className="mt-6 text-xs text-black-primary/40">
+            Didn&apos;t get the email? Check your spam folder.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function CheckEmailPage() {
+  return (
+    <Suspense fallback={null}>
+      <CheckEmailContent />
+    </Suspense>
+  );
+}

--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { Mail, Loader2 } from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
+
+export default function ForgotPasswordPage() {
+  const [email, setEmail] = useState("");
+  const [sending, setSending] = useState(false);
+  const [sent, setSent] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!email.trim()) {
+      setError("Email is required");
+      return;
+    }
+    setSending(true);
+    setError(null);
+    try {
+      const supabase = createBrowserClient();
+      const redirectTo =
+        (typeof window !== "undefined" ? window.location.origin : "https://vendingconnector.com") +
+        "/reset-password";
+      const { error: resetErr } = await supabase.auth.resetPasswordForEmail(
+        email.trim().toLowerCase(),
+        { redirectTo }
+      );
+      if (resetErr) {
+        // Don't reveal whether the email exists — show success either way.
+        // But surface a real error if it's something else like rate limit.
+        if (resetErr.message?.toLowerCase().includes("rate")) {
+          setError(resetErr.message);
+          setSending(false);
+          return;
+        }
+      }
+      setSent(true);
+    } catch {
+      setError("Network error. Please try again.");
+    }
+    setSending(false);
+  }
+
+  return (
+    <div className="min-h-[calc(100vh-160px)] flex items-center justify-center px-4 py-12">
+      <div className="w-full max-w-md">
+        <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-8">
+          <div className="text-center mb-6">
+            <div className="mx-auto w-16 h-16 rounded-full bg-green-50 flex items-center justify-center mb-4">
+              <Mail className="w-8 h-8 text-green-primary" />
+            </div>
+            <h1 className="text-2xl font-bold text-black-primary mb-2">Forgot password?</h1>
+            <p className="text-sm text-black-primary/60">
+              Enter the email associated with your account and we&apos;ll send you a link to reset your password.
+            </p>
+          </div>
+
+          {sent ? (
+            <div className="p-4 bg-green-50 border border-green-200 rounded-xl text-green-700 text-sm text-center">
+              If an account exists for <strong>{email}</strong>, a reset link has been sent. Check your inbox.
+            </div>
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-3">
+              <div>
+                <label className="block text-xs font-medium text-gray-500 mb-1">Email</label>
+                <input
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  disabled={sending}
+                  placeholder="you@example.com"
+                  className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm focus:border-green-primary focus:outline-none focus:ring-1 focus:ring-green-primary/30 disabled:bg-gray-50"
+                  autoComplete="email"
+                />
+              </div>
+              {error && (
+                <div className="p-3 bg-red-50 border border-red-200 rounded-xl text-red-700 text-sm">
+                  {error}
+                </div>
+              )}
+              <button
+                type="submit"
+                disabled={sending}
+                className="w-full py-3 px-4 bg-green-primary hover:bg-green-hover text-white font-semibold rounded-xl transition-colors disabled:opacity-50 cursor-pointer flex items-center justify-center gap-2"
+              >
+                {sending ? (
+                  <>
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                    Sending reset link...
+                  </>
+                ) : (
+                  "Send Reset Link"
+                )}
+              </button>
+            </form>
+          )}
+
+          <div className="mt-6 text-center">
+            <Link href="/login" className="text-sm text-black-primary/60 hover:text-black-primary">
+              Back to login
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -9,9 +9,11 @@ import { createBrowserClient } from "@/lib/supabase";
 
 function LoginContent() {
   const searchParams = useSearchParams();
-  const [loading, setLoading] = useState<"google" | "microsoft" | "yahoo" | null>(null);
+  const [loading, setLoading] = useState<"google" | "microsoft" | "yahoo" | "email" | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [checking, setChecking] = useState(true);
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
 
   useEffect(() => {
     const urlError = searchParams.get("error");
@@ -74,6 +76,54 @@ function LoginContent() {
     const redirect = searchParams.get("redirect") || "/dashboard";
     storeRedirectAfterLogin(redirect);
     signInWithYahoo();
+  }
+
+  async function handleEmailLogin(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    if (!email.trim()) {
+      setError("Email is required");
+      return;
+    }
+    if (!password) {
+      setError("Password is required");
+      return;
+    }
+    setLoading("email");
+    try {
+      const supabase = createBrowserClient();
+      const { data, error: signInErr } = await supabase.auth.signInWithPassword({
+        email: email.trim().toLowerCase(),
+        password,
+      });
+      if (signInErr || !data.session) {
+        setError(signInErr?.message || "Invalid email or password");
+        setLoading(null);
+        return;
+      }
+
+      // Verify email_verified on profile before letting them in
+      const profileRes = await fetch("/api/auth/me", {
+        headers: { Authorization: `Bearer ${data.session.access_token}` },
+      });
+      if (profileRes.ok) {
+        const profile = await profileRes.json();
+        if (profile.email_verified === false) {
+          window.location.href = "/verify-email-required";
+          return;
+        }
+        if (!profile.phone || !profile.address || !profile.city || !profile.state || !profile.zip) {
+          window.location.href = "/complete-profile";
+          return;
+        }
+      }
+
+      const redirect = searchParams.get("redirect") || "/dashboard";
+      window.location.href = redirect;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Sign in failed");
+      setLoading(null);
+    }
   }
 
   if (checking) {
@@ -192,6 +242,56 @@ function LoginContent() {
               </>
             )}
           </button>
+
+          <div className="relative my-4">
+            <div className="absolute inset-0 flex items-center"><div className="w-full border-t border-gray-200" /></div>
+            <div className="relative flex justify-center"><span className="bg-white px-3 text-xs text-gray-400">or sign in with email</span></div>
+          </div>
+
+          {/* Email/Password Sign In */}
+          <form onSubmit={handleEmailLogin} className="space-y-3">
+            <div>
+              <label className="block text-xs font-medium text-gray-600 mb-1">Email</label>
+              <input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                disabled={!!loading}
+                placeholder="you@example.com"
+                className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm focus:border-green-primary focus:outline-none focus:ring-1 focus:ring-green-primary/30 disabled:bg-gray-50"
+                autoComplete="email"
+              />
+            </div>
+            <div>
+              <div className="flex items-center justify-between mb-1">
+                <label className="block text-xs font-medium text-gray-600">Password</label>
+                <a href="/forgot-password" className="text-xs text-green-primary hover:underline">Forgot password?</a>
+              </div>
+              <input
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                disabled={!!loading}
+                placeholder="Enter your password"
+                className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm focus:border-green-primary focus:outline-none focus:ring-1 focus:ring-green-primary/30 disabled:bg-gray-50"
+                autoComplete="current-password"
+              />
+            </div>
+            <button
+              type="submit"
+              disabled={!!loading}
+              className="w-full py-3 px-4 bg-green-primary hover:bg-green-hover text-white font-semibold rounded-xl transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 cursor-pointer"
+            >
+              {loading === "email" ? (
+                <>
+                  <Loader2 className="w-5 h-5 animate-spin" />
+                  Signing in...
+                </>
+              ) : (
+                "Sign In"
+              )}
+            </button>
+          </form>
 
           <div className="mt-6 text-center">
             <p className="text-xs text-black-primary/40">

--- a/src/app/resend-verification/page.tsx
+++ b/src/app/resend-verification/page.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { Suspense, useState, useEffect } from "react";
+import { useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { Mail, Loader2 } from "lucide-react";
+
+function ResendContent() {
+  const searchParams = useSearchParams();
+  const [email, setEmail] = useState("");
+  const [sending, setSending] = useState(false);
+  const [sent, setSent] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fromUrl = searchParams.get("email");
+    if (fromUrl) setEmail(fromUrl);
+  }, [searchParams]);
+
+  async function handleResend(e: React.FormEvent) {
+    e.preventDefault();
+    if (!email.trim()) {
+      setError("Email is required");
+      return;
+    }
+    setSending(true);
+    setError(null);
+    setSent(false);
+    try {
+      const res = await fetch("/api/auth/resend-verification", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: email.trim().toLowerCase() }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || "Failed to send verification email");
+      } else {
+        setSent(true);
+      }
+    } catch {
+      setError("Network error. Please try again.");
+    }
+    setSending(false);
+  }
+
+  return (
+    <div className="min-h-[calc(100vh-160px)] flex items-center justify-center px-4 py-12">
+      <div className="w-full max-w-md">
+        <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-8">
+          <div className="text-center mb-6">
+            <div className="mx-auto w-16 h-16 rounded-full bg-green-50 flex items-center justify-center mb-4">
+              <Mail className="w-8 h-8 text-green-primary" />
+            </div>
+            <h1 className="text-2xl font-bold text-black-primary mb-2">Resend Verification Email</h1>
+            <p className="text-sm text-black-primary/60">
+              Enter the email address you used to create your account. We&apos;ll send a new verification link.
+            </p>
+          </div>
+
+          {sent ? (
+            <div className="p-4 bg-green-50 border border-green-200 rounded-xl text-green-700 text-sm text-center">
+              Verification email sent! Check your inbox.
+            </div>
+          ) : (
+            <form onSubmit={handleResend} className="space-y-3">
+              <div>
+                <label className="block text-xs font-medium text-gray-500 mb-1">Email</label>
+                <input
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  disabled={sending}
+                  placeholder="you@example.com"
+                  className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm focus:border-green-primary focus:outline-none focus:ring-1 focus:ring-green-primary/30 disabled:bg-gray-50"
+                  autoComplete="email"
+                />
+              </div>
+              {error && (
+                <div className="p-3 bg-red-50 border border-red-200 rounded-xl text-red-700 text-sm">
+                  {error}
+                </div>
+              )}
+              <button
+                type="submit"
+                disabled={sending}
+                className="w-full py-3 px-4 bg-green-primary hover:bg-green-hover text-white font-semibold rounded-xl transition-colors disabled:opacity-50 cursor-pointer flex items-center justify-center gap-2"
+              >
+                {sending ? (
+                  <>
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                    Sending...
+                  </>
+                ) : (
+                  "Resend Verification Email"
+                )}
+              </button>
+            </form>
+          )}
+
+          <div className="mt-6 text-center">
+            <Link href="/login" className="text-sm text-black-primary/60 hover:text-black-primary">
+              Back to login
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function ResendVerificationPage() {
+  return (
+    <Suspense fallback={null}>
+      <ResendContent />
+    </Suspense>
+  );
+}

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import { Lock, Loader2, CheckCircle2 } from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
+
+export default function ResetPasswordPage() {
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [done, setDone] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [sessionReady, setSessionReady] = useState(false);
+
+  useEffect(() => {
+    // Parse access_token hash if present (Supabase reset link uses implicit flow)
+    if (typeof window !== "undefined" && window.location.hash.includes("access_token=")) {
+      const hashParams = new URLSearchParams(window.location.hash.substring(1));
+      const accessToken = hashParams.get("access_token");
+      const refreshToken = hashParams.get("refresh_token");
+      if (accessToken && refreshToken) {
+        const supabase = createBrowserClient();
+        supabase.auth
+          .setSession({ access_token: accessToken, refresh_token: refreshToken })
+          .then(() => {
+            setSessionReady(true);
+            window.history.replaceState(null, "", window.location.pathname);
+          });
+        return;
+      }
+    }
+
+    // Otherwise just check current session
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (session) setSessionReady(true);
+    });
+  }, []);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    if (password.length < 8) {
+      setError("Password must be at least 8 characters");
+      return;
+    }
+    if (password !== confirmPassword) {
+      setError("Passwords do not match");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const supabase = createBrowserClient();
+      const { error: updateErr } = await supabase.auth.updateUser({ password });
+      if (updateErr) {
+        setError(updateErr.message);
+        setSubmitting(false);
+        return;
+      }
+      setDone(true);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to reset password");
+    }
+    setSubmitting(false);
+  }
+
+  return (
+    <div className="min-h-[calc(100vh-160px)] flex items-center justify-center px-4 py-12">
+      <div className="w-full max-w-md">
+        <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-8">
+          <div className="text-center mb-6">
+            <div className="mx-auto w-16 h-16 rounded-full bg-green-50 flex items-center justify-center mb-4">
+              {done ? (
+                <CheckCircle2 className="w-8 h-8 text-green-primary" />
+              ) : (
+                <Lock className="w-8 h-8 text-green-primary" />
+              )}
+            </div>
+            <h1 className="text-2xl font-bold text-black-primary mb-2">
+              {done ? "Password updated" : "Reset your password"}
+            </h1>
+            <p className="text-sm text-black-primary/60">
+              {done
+                ? "Your password has been changed. You can now sign in with your new password."
+                : "Enter a new password for your account."}
+            </p>
+          </div>
+
+          {done ? (
+            <Link
+              href="/login"
+              className="block w-full text-center py-3 px-4 bg-green-primary hover:bg-green-hover text-white font-semibold rounded-xl transition-colors"
+            >
+              Sign In
+            </Link>
+          ) : !sessionReady ? (
+            <div className="text-center py-4">
+              <Loader2 className="w-6 h-6 animate-spin text-green-primary mx-auto" />
+              <p className="text-sm text-black-primary/60 mt-2">Verifying reset link...</p>
+            </div>
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-3">
+              <div>
+                <label className="block text-xs font-medium text-gray-500 mb-1">New Password</label>
+                <input
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  disabled={submitting}
+                  placeholder="At least 8 characters"
+                  className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm focus:border-green-primary focus:outline-none focus:ring-1 focus:ring-green-primary/30 disabled:bg-gray-50"
+                  autoComplete="new-password"
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-gray-500 mb-1">Confirm New Password</label>
+                <input
+                  type="password"
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  disabled={submitting}
+                  placeholder="Re-enter your password"
+                  className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm focus:border-green-primary focus:outline-none focus:ring-1 focus:ring-green-primary/30 disabled:bg-gray-50"
+                  autoComplete="new-password"
+                />
+              </div>
+              {error && (
+                <div className="p-3 bg-red-50 border border-red-200 rounded-xl text-red-700 text-sm">
+                  {error}
+                </div>
+              )}
+              <button
+                type="submit"
+                disabled={submitting}
+                className="w-full py-3 px-4 bg-green-primary hover:bg-green-hover text-white font-semibold rounded-xl transition-colors disabled:opacity-50 cursor-pointer flex items-center justify-center gap-2"
+              >
+                {submitting ? (
+                  <>
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                    Updating password...
+                  </>
+                ) : (
+                  "Update Password"
+                )}
+              </button>
+            </form>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -56,7 +56,9 @@ function SignupContent() {
   const [step, setStep] = useState<1 | 2 | 3>(presetRole ? 2 : 1);
   const [role, setRole] = useState<Role | null>(presetRole);
   const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState<"google" | "microsoft" | "yahoo" | null>(null);
+  const [loading, setLoading] = useState<"google" | "microsoft" | "yahoo" | "email" | null>(null);
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
   const [existingEmail, setExistingEmail] = useState<string | null>(null);
   const [signingOut, setSigningOut] = useState(false);
 
@@ -212,6 +214,73 @@ function SignupContent() {
       signUpWithYahoo(role);
     } catch {
       setError("Failed to connect to Yahoo. Please try again.");
+      setLoading(null);
+    }
+  }
+
+  async function handleEmailSignup(e: React.FormEvent) {
+    e.preventDefault();
+    if (!role) return;
+    setError(null);
+
+    if (!password || password.length < 8) {
+      setError("Password must be at least 8 characters");
+      return;
+    }
+    if (password !== confirmPassword) {
+      setError("Passwords do not match");
+      return;
+    }
+
+    setLoading("email");
+    try {
+      const cleared = await ensureSignedOut();
+      if (!cleared) {
+        setError("Could not clear existing session. Please refresh and try again.");
+        setLoading(null);
+        return;
+      }
+      setExistingEmail(null);
+
+      const res = await fetch("/api/auth/signup-email", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          first_name: leadForm.first_name,
+          last_name: leadForm.last_name,
+          company_name: leadForm.business_name,
+          email: leadForm.email,
+          password,
+          role,
+        }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        if (data.code === "ACCOUNT_EXISTS") {
+          setError(data.error || "An account already exists with this email.");
+        } else {
+          setError(data.error || "Failed to create account");
+        }
+        setLoading(null);
+        return;
+      }
+
+      // Save the lead data so it's persisted when the user verifies & logs in
+      storeSignupRole(role);
+      storeLead();
+      // Also fire the signup-lead API in the background
+      try {
+        await fetch("/api/auth/signup-lead", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ...leadForm, role }),
+        });
+      } catch {}
+
+      window.location.href = `/check-email?email=${encodeURIComponent(leadForm.email)}`;
+    } catch {
+      setError("Failed to create account. Please try again.");
       setLoading(null);
     }
   }
@@ -509,6 +578,56 @@ function SignupContent() {
                   </>
                 )}
               </button>
+
+              <div className="relative my-4">
+                <div className="absolute inset-0 flex items-center"><div className="w-full border-t border-gray-200" /></div>
+                <div className="relative flex justify-center"><span className="bg-white px-3 text-xs text-gray-400">or sign up with email &amp; password</span></div>
+              </div>
+
+              {/* Email + Password Signup */}
+              <form onSubmit={handleEmailSignup} className="space-y-3">
+                <div>
+                  <label className="block text-xs font-medium text-gray-500 mb-1">Password <span className="text-red-500">*</span></label>
+                  <input
+                    type="password"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    disabled={!!loading}
+                    placeholder="At least 8 characters"
+                    className={inputClass}
+                    autoComplete="new-password"
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs font-medium text-gray-500 mb-1">Confirm Password <span className="text-red-500">*</span></label>
+                  <input
+                    type="password"
+                    value={confirmPassword}
+                    onChange={(e) => setConfirmPassword(e.target.value)}
+                    disabled={!!loading}
+                    placeholder="Re-enter your password"
+                    className={inputClass}
+                    autoComplete="new-password"
+                  />
+                </div>
+                <button
+                  type="submit"
+                  disabled={!!loading}
+                  className="w-full py-3 px-4 bg-green-primary hover:bg-green-hover text-white font-semibold rounded-xl transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 cursor-pointer"
+                >
+                  {loading === "email" ? (
+                    <>
+                      <Loader2 className="w-5 h-5 animate-spin" />
+                      Creating account...
+                    </>
+                  ) : (
+                    "Create Account"
+                  )}
+                </button>
+                <p className="text-xs text-black-primary/40 text-center">
+                  We&apos;ll email you a verification link to confirm your address.
+                </p>
+              </form>
 
               {/* Schedule a Call CTA */}
               <div className="mt-6 p-4 bg-slate-50 border border-slate-200 rounded-xl text-center">

--- a/src/app/verify-email-required/page.tsx
+++ b/src/app/verify-email-required/page.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { AlertCircle, Loader2 } from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
+
+export default function VerifyEmailRequiredPage() {
+  const [email, setEmail] = useState("");
+  const [sending, setSending] = useState(false);
+  const [sent, setSent] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (session?.user?.email) setEmail(session.user.email);
+    });
+  }, []);
+
+  async function handleResend() {
+    if (!email) return;
+    setSending(true);
+    setError(null);
+    setSent(false);
+    try {
+      const res = await fetch("/api/auth/resend-verification", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || "Failed to send verification email");
+      } else {
+        setSent(true);
+      }
+    } catch {
+      setError("Network error. Please try again.");
+    }
+    setSending(false);
+  }
+
+  async function handleSignOut() {
+    const supabase = createBrowserClient();
+    await supabase.auth.signOut();
+    window.location.href = "/login";
+  }
+
+  return (
+    <div className="min-h-[calc(100vh-160px)] flex items-center justify-center px-4 py-12">
+      <div className="w-full max-w-md">
+        <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-8 text-center">
+          <div className="mx-auto w-16 h-16 rounded-full bg-amber-50 flex items-center justify-center mb-6">
+            <AlertCircle className="w-8 h-8 text-amber-600" />
+          </div>
+          <h1 className="text-2xl font-bold text-black-primary mb-2">Verify your email</h1>
+          <p className="text-sm text-black-primary/60 mb-6">
+            We need to confirm your email address before you can access this part of Vending Connector.
+            {email && (
+              <>
+                {" "}A verification email was sent to <strong className="text-black-primary">{email}</strong>.
+              </>
+            )}
+          </p>
+
+          {sent && (
+            <div className="mb-4 p-3 bg-green-50 border border-green-200 rounded-xl text-green-700 text-sm">
+              Verification email sent. Check your inbox.
+            </div>
+          )}
+          {error && (
+            <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-xl text-red-700 text-sm">
+              {error}
+            </div>
+          )}
+
+          <button
+            onClick={handleResend}
+            disabled={sending || !email}
+            className="block w-full py-3 px-4 bg-green-primary hover:bg-green-hover text-white font-semibold rounded-xl transition-colors disabled:opacity-50 cursor-pointer mb-3"
+          >
+            {sending ? (
+              <span className="flex items-center justify-center gap-2"><Loader2 className="w-4 h-4 animate-spin" /> Sending...</span>
+            ) : (
+              "Resend Verification Email"
+            )}
+          </button>
+
+          <button
+            onClick={handleSignOut}
+            className="block w-full py-3 px-4 border border-gray-200 text-black-primary hover:bg-gray-50 font-medium rounded-xl transition-colors cursor-pointer"
+          >
+            Sign Out
+          </button>
+
+          <p className="mt-6 text-xs text-black-primary/40">
+            Already verified? <Link href="/login" className="text-green-primary hover:underline">Sign in again</Link>.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/verify-email/page.tsx
+++ b/src/app/verify-email/page.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { Suspense, useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { CheckCircle2, AlertCircle, Loader2 } from "lucide-react";
+
+function VerifyEmailContent() {
+  const searchParams = useSearchParams();
+  const [status, setStatus] = useState<"loading" | "success" | "error">("loading");
+  const [errorMsg, setErrorMsg] = useState("");
+
+  useEffect(() => {
+    const token = searchParams.get("token");
+    if (!token) {
+      setStatus("error");
+      setErrorMsg("No verification token provided");
+      return;
+    }
+
+    fetch("/api/auth/verify-email", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token }),
+    })
+      .then((res) => res.json().then((data) => ({ ok: res.ok, data })))
+      .then(({ ok, data }) => {
+        if (ok) {
+          setStatus("success");
+        } else {
+          setStatus("error");
+          setErrorMsg(data.error || "Verification failed");
+        }
+      })
+      .catch(() => {
+        setStatus("error");
+        setErrorMsg("Network error. Please try again.");
+      });
+  }, [searchParams]);
+
+  return (
+    <div className="min-h-[calc(100vh-160px)] flex items-center justify-center px-4 py-12">
+      <div className="w-full max-w-md">
+        <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-8 text-center">
+          {status === "loading" && (
+            <>
+              <Loader2 className="w-12 h-12 animate-spin text-green-primary mx-auto mb-4" />
+              <h1 className="text-xl font-bold text-black-primary">Verifying your email...</h1>
+            </>
+          )}
+
+          {status === "success" && (
+            <>
+              <div className="mx-auto w-16 h-16 rounded-full bg-green-50 flex items-center justify-center mb-6">
+                <CheckCircle2 className="w-8 h-8 text-green-primary" />
+              </div>
+              <h1 className="text-2xl font-bold text-black-primary mb-2">Email verified!</h1>
+              <p className="text-sm text-black-primary/60 mb-6">
+                Your email has been verified. You can now sign in to your account.
+              </p>
+              <Link
+                href="/login"
+                className="block w-full py-3 px-4 bg-green-primary hover:bg-green-hover text-white font-semibold rounded-xl transition-colors"
+              >
+                Sign In
+              </Link>
+            </>
+          )}
+
+          {status === "error" && (
+            <>
+              <div className="mx-auto w-16 h-16 rounded-full bg-red-50 flex items-center justify-center mb-6">
+                <AlertCircle className="w-8 h-8 text-red-600" />
+              </div>
+              <h1 className="text-2xl font-bold text-black-primary mb-2">Verification failed</h1>
+              <p className="text-sm text-red-700 mb-6">{errorMsg}</p>
+              <div className="space-y-3">
+                <Link
+                  href="/resend-verification"
+                  className="block w-full py-3 px-4 bg-green-primary hover:bg-green-hover text-white font-semibold rounded-xl transition-colors"
+                >
+                  Request new verification link
+                </Link>
+                <Link
+                  href="/login"
+                  className="block w-full py-3 px-4 text-sm text-black-primary/60 hover:text-black-primary transition-colors"
+                >
+                  Back to login
+                </Link>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function VerifyEmailPage() {
+  return (
+    <Suspense fallback={null}>
+      <VerifyEmailContent />
+    </Suspense>
+  );
+}

--- a/src/lib/emailVerification.ts
+++ b/src/lib/emailVerification.ts
@@ -1,0 +1,167 @@
+import { randomBytes, createHash } from "crypto";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { Resend } from "resend";
+
+const FROM_EMAIL = process.env.FROM_EMAIL || "receipts@bytebitevending.com";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://vendingconnector.com";
+const TOKEN_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+function getResend() {
+  return new Resend(process.env.RESEND_API_KEY);
+}
+
+function hashToken(raw: string): string {
+  return createHash("sha256").update(raw).digest("hex");
+}
+
+export function generateRawToken(): string {
+  // 32 bytes -> 64 hex chars, URL safe enough
+  return randomBytes(32).toString("hex");
+}
+
+export async function createAndSendVerificationEmail(params: {
+  userId: string;
+  email: string;
+  firstName?: string;
+}): Promise<{ ok: boolean; error?: string }> {
+  const { userId, email, firstName } = params;
+  if (!process.env.RESEND_API_KEY) {
+    return { ok: false, error: "Email service not configured" };
+  }
+
+  // Rate limit: max 3/hour, 10/day per email
+  const now = new Date();
+  const hourAgo = new Date(now.getTime() - 60 * 60 * 1000).toISOString();
+  const dayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString();
+
+  const { count: hourCount } = await supabaseAdmin
+    .from("email_verification_tokens")
+    .select("*", { count: "exact", head: true })
+    .eq("email", email)
+    .gte("created_at", hourAgo);
+
+  if ((hourCount || 0) >= 3) {
+    return { ok: false, error: "Too many verification emails sent recently. Please try again in an hour." };
+  }
+
+  const { count: dayCount } = await supabaseAdmin
+    .from("email_verification_tokens")
+    .select("*", { count: "exact", head: true })
+    .eq("email", email)
+    .gte("created_at", dayAgo);
+
+  if ((dayCount || 0) >= 10) {
+    return { ok: false, error: "Daily verification email limit reached. Please try again tomorrow." };
+  }
+
+  const rawToken = generateRawToken();
+  const tokenHash = hashToken(rawToken);
+  const expiresAt = new Date(now.getTime() + TOKEN_TTL_MS).toISOString();
+
+  const { error: insertErr } = await supabaseAdmin
+    .from("email_verification_tokens")
+    .insert({
+      user_id: userId,
+      email,
+      token_hash: tokenHash,
+      expires_at: expiresAt,
+    });
+
+  if (insertErr) {
+    return { ok: false, error: "Failed to create verification token" };
+  }
+
+  const verifyUrl = `${SITE_URL}/verify-email?token=${rawToken}`;
+  const greeting = firstName ? `Hi ${firstName}` : "Hello";
+
+  try {
+    await getResend().emails.send({
+      from: FROM_EMAIL,
+      to: email,
+      subject: "Verify your Vending Connector account",
+      html: `
+<div style="max-width:560px;margin:0 auto;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:40px 24px;color:#111827;">
+  <div style="text-align:center;margin-bottom:32px;">
+    <h1 style="color:#16a34a;font-size:24px;margin:0;">Vending Connector</h1>
+    <p style="color:#6b7280;font-size:14px;margin:8px 0 0;">Verify your email address</p>
+  </div>
+
+  <p style="font-size:14px;color:#374151;">${greeting},</p>
+
+  <p style="font-size:14px;color:#374151;line-height:1.6;">
+    Thanks for creating your Vending Connector account. Please verify your email address by clicking the button below.
+  </p>
+
+  <div style="text-align:center;margin:32px 0;">
+    <a href="${verifyUrl}" style="display:inline-block;background:#16a34a;color:#ffffff;text-decoration:none;padding:14px 36px;border-radius:8px;font-weight:600;font-size:16px;">Verify Email</a>
+  </div>
+
+  <p style="font-size:13px;color:#6b7280;">If the button doesn't work, copy and paste this link into your browser:</p>
+  <p style="font-size:12px;word-break:break-all;color:#16a34a;">${verifyUrl}</p>
+
+  <hr style="border:none;border-top:1px solid #e5e7eb;margin:32px 0;"/>
+
+  <p style="font-size:12px;color:#9ca3af;">This link expires in 24 hours. If you didn't create an account, you can safely ignore this email.</p>
+
+  <p style="text-align:center;font-size:12px;color:#9ca3af;margin-top:24px;">Vending Connector &bull; vendingconnector.com</p>
+</div>
+      `.trim(),
+    });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, error: `Failed to send email: ${msg}` };
+  }
+
+  return { ok: true };
+}
+
+export async function verifyEmailToken(rawToken: string): Promise<{
+  ok: boolean;
+  userId?: string;
+  email?: string;
+  error?: string;
+}> {
+  if (!rawToken || rawToken.length < 32) {
+    return { ok: false, error: "Invalid verification token" };
+  }
+
+  const tokenHash = hashToken(rawToken);
+  const { data: tokenRow, error: lookupErr } = await supabaseAdmin
+    .from("email_verification_tokens")
+    .select("id, user_id, email, expires_at, used_at")
+    .eq("token_hash", tokenHash)
+    .maybeSingle();
+
+  if (lookupErr) return { ok: false, error: "Lookup failed" };
+  if (!tokenRow) return { ok: false, error: "Invalid or expired verification link" };
+  if (tokenRow.used_at) return { ok: false, error: "This verification link has already been used" };
+  if (new Date(tokenRow.expires_at) < new Date()) {
+    return { ok: false, error: "Verification link has expired. Please request a new one." };
+  }
+
+  // Mark token used
+  await supabaseAdmin
+    .from("email_verification_tokens")
+    .update({ used_at: new Date().toISOString() })
+    .eq("id", tokenRow.id);
+
+  // Mark Supabase auth email as confirmed (for OAuth-style isVerified checks)
+  try {
+    await supabaseAdmin.auth.admin.updateUserById(tokenRow.user_id, {
+      email_confirm: true,
+    });
+  } catch {
+    // Non-fatal — the profile flag below is what we actually check
+  }
+
+  // Mark profile as verified
+  await supabaseAdmin
+    .from("profiles")
+    .update({
+      email_verified: true,
+      email_verified_at: new Date().toISOString(),
+    })
+    .eq("id", tokenRow.user_id);
+
+  return { ok: true, userId: tokenRow.user_id, email: tokenRow.email };
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -92,6 +92,18 @@ export async function proxy(req: NextRequest) {
     return NextResponse.redirect(loginUrl);
   }
 
+  // Email verification gate for protected routes — block unverified users.
+  // email_confirmed_at on auth.users is set by:
+  //  - OAuth providers (Google/Microsoft/Yahoo) on first sign-in
+  //  - Our email/password verify flow (via auth.admin.updateUserById)
+  // So this check naturally lets all OAuth users through.
+  if (user && isProtected && !user.email_confirmed_at) {
+    const verifyUrl = req.nextUrl.clone();
+    verifyUrl.pathname = "/verify-email-required";
+    verifyUrl.search = "";
+    return NextResponse.redirect(verifyUrl);
+  }
+
   return response;
 }
 

--- a/supabase/migrations/093_email_password_auth.sql
+++ b/supabase/migrations/093_email_password_auth.sql
@@ -1,0 +1,45 @@
+-- Email/Password Auth + Verification
+-- Adds email verification tracking to profiles and a token table for
+-- custom verification emails sent via Resend. Existing OAuth users
+-- are auto-marked as verified.
+
+ALTER TABLE profiles
+  ADD COLUMN IF NOT EXISTS email_verified boolean DEFAULT false,
+  ADD COLUMN IF NOT EXISTS email_verified_at timestamptz;
+
+-- OAuth users come in already verified (Google/Microsoft/Yahoo verified
+-- their email). Backfill so existing accounts aren't locked out.
+UPDATE profiles
+SET email_verified = true,
+    email_verified_at = COALESCE(email_verified_at, created_at, now())
+WHERE email_verified IS NOT TRUE
+  AND id IN (
+    SELECT u.id
+    FROM auth.users u
+    WHERE u.email_confirmed_at IS NOT NULL
+       OR (u.raw_user_meta_data->>'provider') IN ('google', 'azure', 'yahoo')
+  );
+
+CREATE TABLE IF NOT EXISTS email_verification_tokens (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE,
+  email text NOT NULL,
+  token_hash text NOT NULL,
+  expires_at timestamptz NOT NULL,
+  used_at timestamptz,
+  created_at timestamptz DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_verif_tokens_hash ON email_verification_tokens(token_hash);
+CREATE INDEX IF NOT EXISTS idx_verif_tokens_user ON email_verification_tokens(user_id);
+CREATE INDEX IF NOT EXISTS idx_verif_tokens_email_created ON email_verification_tokens(email, created_at DESC);
+
+ALTER TABLE email_verification_tokens ENABLE ROW LEVEL SECURITY;
+
+-- Only service role can access (drop in case re-running)
+DROP POLICY IF EXISTS "Service role only" ON email_verification_tokens;
+CREATE POLICY "Service role only" ON email_verification_tokens
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);


### PR DESCRIPTION
End-to-end email+password auth alongside Google/Microsoft/Yahoo OAuth. Existing OAuth flows are unchanged; OAuth users are auto-verified.

Database (migration 093):
- profiles.email_verified + email_verified_at
- email_verification_tokens table (token_hash + 24h expiry)
- Backfill: OAuth users + Supabase-confirmed users marked verified
- Service-role-only RLS on tokens

Login page (/login):
- Adds email + password fields with Sign In button under the OAuth buttons; "Forgot password?" link beside the password field
- After signin, blocks unverified users to /verify-email-required

Signup page (/signup):
- Adds Password + Confirm Password fields under the OAuth buttons in step 3; creates account via new /api/auth/signup-email and sends the user to /check-email
- ACCOUNT_EXISTS response shows the "use your existing method" message

API routes:
- POST /api/auth/signup-email — creates Supabase user + profile, duplicate-email guard, sends verification email
- POST /api/auth/verify-email — hashes the token, validates the stored hash + expiry, marks the profile email_verified and the auth.users row email_confirm=true
- POST /api/auth/resend-verification — rate limited (3/hour, 10/day per email); returns ok without enumeration when email isn't found

New pages:
- /check-email — post-signup "check your inbox" screen
- /verify-email — handles the verification link click
- /verify-email-required — gating page for unverified logged-in users, with Resend + Sign Out buttons
- /resend-verification — public form to request a new link
- /forgot-password — calls supabase.auth.resetPasswordForEmail
- /reset-password — parses hash tokens and calls auth.updateUser

Email verification gate added to existing proxy.ts: protected routes (dashboard, sales, admin, account, etc.) redirect to /verify-email-required when user.email_confirmed_at is null. OAuth users always pass because providers set email_confirmed_at.

Custom verification email is sent via Resend with a SHA-256 hashed token stored server-side; the raw token is only in the email link.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2