### PR TITLE
Fix password reset link landing in /complete-profile instead of /rese…

### DIFF
--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -30,6 +30,17 @@ function CallbackContent() {
         return;
       }
 
+      // Password recovery tokens MUST land on /reset-password — never
+      // auto-establish a session here or redirect to /complete-profile.
+      // The /reset-password page handles setSession and the password update.
+      if (typeof window !== "undefined" && window.location.hash) {
+        const recoveryParams = new URLSearchParams(window.location.hash.substring(1));
+        if (recoveryParams.get("type") === "recovery") {
+          window.location.replace(`/reset-password${window.location.hash}`);
+          return;
+        }
+      }
+
       const supabase = createBrowserClient();
       const code = searchParams.get("code");
 

--- a/src/app/components/MagicLinkHashCatcher.tsx
+++ b/src/app/components/MagicLinkHashCatcher.tsx
@@ -22,7 +22,21 @@ export default function MagicLinkHashCatcher() {
     if (typeof window === "undefined") return;
     const hash = window.location.hash || "";
     if (!hash.includes("access_token=")) return;
-    if (window.location.pathname.startsWith("/auth/callback")) return;
+
+    // Pages that handle the hash themselves — don't intercept
+    const path = window.location.pathname;
+    if (path.startsWith("/auth/callback")) return;
+    if (path.startsWith("/reset-password")) return;
+
+    // Password recovery tokens go to /reset-password, NOT through the
+    // sign-in callback (which would auto-log-in and route to /complete-
+    // profile or /dashboard, bypassing the password-set step).
+    const hashParams = new URLSearchParams(hash.substring(1));
+    const tokenType = hashParams.get("type");
+    if (tokenType === "recovery") {
+      window.location.replace(`/reset-password${hash}`);
+      return;
+    }
 
     const flow = consumeAuthFlow();
     const params = new URLSearchParams();

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -59,6 +59,10 @@ export default function ResetPasswordPage() {
         return;
       }
       setDone(true);
+      // Recovery session is already active — drop the user into the app.
+      setTimeout(() => {
+        window.location.href = "/dashboard";
+      }, 1500);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to reset password");
     }
@@ -82,18 +86,18 @@ export default function ResetPasswordPage() {
             </h1>
             <p className="text-sm text-black-primary/60">
               {done
-                ? "Your password has been changed. You can now sign in with your new password."
+                ? "Your password has been changed. Taking you to your dashboard..."
                 : "Enter a new password for your account."}
             </p>
           </div>
 
           {done ? (
-            <Link
-              href="/login"
-              className="block w-full text-center py-3 px-4 bg-green-primary hover:bg-green-hover text-white font-semibold rounded-xl transition-colors"
-            >
-              Sign In
-            </Link>
+            <div className="flex flex-col items-center gap-3">
+              <Loader2 className="w-6 h-6 animate-spin text-green-primary" />
+              <Link href="/dashboard" className="text-sm text-green-primary hover:underline">
+                Continue to dashboard
+              </Link>
+            </div>
           ) : !sessionReady ? (
             <div className="text-center py-4">
               <Loader2 className="w-6 h-6 animate-spin text-green-primary mx-auto" />


### PR DESCRIPTION
…t-password

Three intercepts were swallowing the recovery hash and routing the user through the normal sign-in flow (which auto-logged-in and redirected to /complete-profile based on missing profile fields):

1. MagicLinkHashCatcher (root layout): now inspects the hash for type=recovery and routes those tokens to /reset-password instead of /auth/callback. Also skips entirely when already on /reset-password.

2. /auth/callback: detects type=recovery at the very top of the handler and replaces the location with /reset-password before touching the session or any profile-completeness check.

3. /reset-password: was previously the right destination; after a successful supabase.auth.updateUser({ password }) it now shows a "Taking you to your dashboard..." spinner and auto-redirects to /dashboard (the recovery session is already active). User can also click "Continue to dashboard" link.

Result: clicking the reset link from email goes straight to the password form, the user sets their new password, and only then are they routed into the app.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2