### PR TITLE
Apex billing for Location Placement Agreements (operator-only, hidden…

### DIFF
--- a/src/app/api/sales/agreements/[id]/route.ts
+++ b/src/app/api/sales/agreements/[id]/route.ts
@@ -155,6 +155,9 @@ export async function PATCH(
     "include_compensation",
     "include_duration_termination",
     "include_responsibilities",
+    // Apex billing (operator-only)
+    "apex_placement_fee",
+    "apex_placement_fee_notes",
     // Sales rep tracking
     "rep_name",
     "rep_email",

--- a/src/app/api/sales/agreements/[id]/send-apex-placement-invoice/route.ts
+++ b/src/app/api/sales/agreements/[id]/send-apex-placement-invoice/route.ts
@@ -1,0 +1,134 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser } from "@/lib/salesAuth";
+import { Resend } from "resend";
+
+const FROM_EMAIL = process.env.FROM_EMAIL || "receipts@bytebitevending.com";
+
+function getResend() {
+  return new Resend(process.env.RESEND_API_KEY);
+}
+
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const user = await getSalesUser(req);
+  if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id } = await params;
+
+  const { data: ag, error } = await supabaseAdmin
+    .from("purchase_agreements")
+    .select("*")
+    .eq("id", id)
+    .single();
+
+  if (error || !ag) return NextResponse.json({ error: "Agreement not found" }, { status: 404 });
+
+  if (ag.agreement_type !== "location_placement") {
+    return NextResponse.json({ error: "Apex Placement Fee only applies to Location Placement Agreements" }, { status: 400 });
+  }
+
+  if (ag.apex_placement_invoice_status === "sent" || ag.apex_placement_invoice_status === "paid") {
+    return NextResponse.json({ error: "Apex placement invoice has already been sent" }, { status: 400 });
+  }
+
+  const amount = Number(ag.apex_placement_fee) || 0;
+  if (amount <= 0) {
+    return NextResponse.json({ error: "Set the Apex Placement Fee before sending an invoice" }, { status: 400 });
+  }
+
+  const recipientEmail = ag.placement_operator_email;
+  if (!recipientEmail) {
+    return NextResponse.json({ error: "Operator email missing on the agreement" }, { status: 400 });
+  }
+
+  const operatorName = ag.placement_operator_company || ag.placement_operator_contact || "Operator";
+  const locationName = ag.location_business_name || "Location";
+
+  let qbInvoiceId: string | null = null;
+  let qbSent = false;
+  const qbConfigured = !!(process.env.QB_CLIENT_ID && process.env.QB_CLIENT_SECRET);
+
+  if (qbConfigured) {
+    try {
+      const { createInvoice, sendInvoiceEmail } = await import("@/lib/quickbooks");
+      const invoice = await Promise.race([
+        createInvoice({
+          customerEmail: recipientEmail,
+          customerName: operatorName,
+          customerPhone: ag.placement_operator_phone || undefined,
+          lineItems: [{ description: `Location Placement Services — ${locationName}`, amount, quantity: 1 }],
+          memo: `Apex Placement Fee — Agreement #${(ag.id || "").slice(0, 8).toUpperCase()}`,
+        }),
+        new Promise<never>((_, reject) => setTimeout(() => reject(new Error("QB timeout")), 8000)),
+      ]);
+      qbInvoiceId = invoice.Id;
+      await Promise.race([
+        sendInvoiceEmail(invoice.Id, recipientEmail),
+        new Promise<never>((_, reject) => setTimeout(() => reject(new Error("QB email timeout")), 5000)),
+      ]);
+      qbSent = true;
+    } catch {
+      // Fall through
+    }
+  }
+
+  if (!qbSent && process.env.RESEND_API_KEY) {
+    try {
+      await getResend().emails.send({
+        from: FROM_EMAIL,
+        to: recipientEmail,
+        cc: ["james@apexaivending.com"],
+        subject: `Invoice — Location Placement Services for ${locationName}`,
+        html: `
+<div style="max-width:640px;margin:0 auto;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:32px 24px;">
+  <div style="text-align:center;margin-bottom:24px;">
+    <h1 style="color:#16a34a;font-size:24px;margin:0;">Apex AI Vending</h1>
+    <p style="color:#6b7280;font-size:14px;margin:4px 0 0;">Location Placement Services Invoice</p>
+  </div>
+  <div style="background:#f9fafb;border-radius:12px;padding:24px;margin-bottom:24px;">
+    <p style="margin:0 0 16px;font-size:14px;color:#374151;">
+      Hello ${ag.placement_operator_contact || operatorName},
+    </p>
+    <p style="margin:0 0 16px;font-size:14px;color:#374151;line-height:1.6;">
+      Per your executed Location Placement Agreement for <strong>${locationName}</strong>, please find your placement services invoice below.
+    </p>
+    <table style="width:100%;border-collapse:collapse;font-size:14px;margin-top:16px;">
+      <tr style="border-top:2px solid #e5e7eb;">
+        <td style="padding:8px 0 0;color:#111;font-weight:700;">Location Placement Services — ${locationName}</td>
+        <td style="padding:8px 0 0;text-align:right;color:#16a34a;font-weight:700;font-size:18px;">$${amount.toLocaleString("en-US", { minimumFractionDigits: 2 })}</td>
+      </tr>
+    </table>
+    ${ag.apex_placement_fee_notes ? `<p style="margin:16px 0 0;font-size:13px;color:#6b7280;border-top:1px solid #e5e7eb;padding-top:12px;"><strong>Notes:</strong> ${ag.apex_placement_fee_notes}</p>` : ""}
+  </div>
+  <p style="font-size:13px;color:#6b7280;text-align:center;">
+    Questions? Contact <a href="mailto:james@apexaivending.com" style="color:#16a34a;">james@apexaivending.com</a>
+    or call <a href="tel:+18888511462" style="color:#16a34a;">(888) 851-1462</a>
+  </p>
+</div>
+        `.trim(),
+      });
+    } catch (e) {
+      return NextResponse.json({ error: e instanceof Error ? e.message : "Email failed" }, { status: 500 });
+    }
+  } else if (!qbSent) {
+    return NextResponse.json({ error: "No email service configured (RESEND_API_KEY or QuickBooks)" }, { status: 500 });
+  }
+
+  await supabaseAdmin
+    .from("purchase_agreements")
+    .update({
+      apex_placement_invoice_status: "sent",
+      apex_placement_invoice_sent_at: new Date().toISOString(),
+      apex_placement_qb_invoice_id: qbInvoiceId,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", id);
+
+  await supabaseAdmin.from("agreement_activity_log").insert({
+    agreement_id: id,
+    user_id: user.id,
+    activity_type: "apex_placement_invoice_sent",
+    description: `Apex Placement Fee invoice ($${amount.toFixed(2)}) sent to ${recipientEmail}`,
+  });
+
+  return NextResponse.json({ success: true, amount, sent_to: recipientEmail });
+}

--- a/src/app/sales/agreements/[id]/page.tsx
+++ b/src/app/sales/agreements/[id]/page.tsx
@@ -117,6 +117,10 @@ interface Agreement {
   include_compensation: boolean | null;
   include_duration_termination: boolean | null;
   include_responsibilities: boolean | null;
+  apex_placement_fee: number | null;
+  apex_placement_fee_notes: string | null;
+  apex_placement_invoice_status: string | null;
+  apex_placement_invoice_sent_at: string | null;
   effective_date: string | null;
   governing_state: string | null;
   venue_state: string | null;
@@ -215,6 +219,8 @@ type FormData = {
   include_compensation: boolean;
   include_duration_termination: boolean;
   include_responsibilities: boolean;
+  apex_placement_fee: string;
+  apex_placement_fee_notes: string;
 };
 
 const AGREEMENT_STATUS_COLORS: Record<string, string> = {
@@ -306,6 +312,8 @@ function agreementToForm(ag: Agreement): FormData {
     include_compensation: ag.include_compensation !== false,
     include_duration_termination: ag.include_duration_termination !== false,
     include_responsibilities: ag.include_responsibilities !== false,
+    apex_placement_fee: String(ag.apex_placement_fee ?? 0),
+    apex_placement_fee_notes: ag.apex_placement_fee_notes || "",
   };
 }
 
@@ -327,6 +335,7 @@ function StandaloneAgreementEditor() {
   const [apexSigning, setApexSigning] = useState(false);
   const [apexSignForm, setApexSignForm] = useState({ signer_name: "", signer_title: "", signature_data: "" });
   const [creatingOrder, setCreatingOrder] = useState(false);
+  const [sendingApexInvoice, setSendingApexInvoice] = useState(false);
   const [toast, setToast] = useState<{ message: string; type: "success" | "error" } | null>(null);
 
   useEffect(() => {
@@ -469,6 +478,8 @@ function StandaloneAgreementEditor() {
       include_compensation: form.include_compensation,
       include_duration_termination: form.include_duration_termination,
       include_responsibilities: form.include_responsibilities,
+      apex_placement_fee: Number(form.apex_placement_fee) || 0,
+      apex_placement_fee_notes: form.apex_placement_fee_notes || null,
     };
 
     const res = await fetch(`/api/sales/agreements/${agreement.id}`, {
@@ -654,6 +665,25 @@ function StandaloneAgreementEditor() {
       showToast(err.error || "Failed to create order", "error");
     }
     setCreatingOrder(false);
+  }
+
+  async function handleSendApexPlacementInvoice() {
+    if (!agreement) return;
+    if (!confirm(`Send the Apex Placement Fee invoice ($${Number(form?.apex_placement_fee || 0).toFixed(2)}) to ${form?.placement_operator_email || "the operator"}?`)) return;
+
+    setSendingApexInvoice(true);
+    const res = await fetch(`/api/sales/agreements/${agreement.id}/send-apex-placement-invoice`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.ok) {
+      showToast("Apex Placement invoice sent to operator");
+      await fetchAgreement();
+    } else {
+      const err = await res.json().catch(() => ({}));
+      showToast(err.error || "Failed to send Apex Placement invoice", "error");
+    }
+    setSendingApexInvoice(false);
   }
 
   if (loading) {
@@ -1196,6 +1226,26 @@ function StandaloneAgreementEditor() {
                   <Shield className="h-4 w-4" /> {agreement.agreement_type === "location_placement" ? "Operator Countersign" : "Apex Countersign"}
                 </button>
               )}
+              {agreement.agreement_type === "location_placement" &&
+                Number(form?.apex_placement_fee || 0) > 0 &&
+                agreement.apex_placement_invoice_status !== "sent" &&
+                agreement.apex_placement_invoice_status !== "paid" && (
+                  <button
+                    onClick={handleSendApexPlacementInvoice}
+                    disabled={sendingApexInvoice}
+                    className="w-full rounded-lg bg-amber-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-amber-700 cursor-pointer inline-flex items-center justify-center gap-2 disabled:opacity-50"
+                    title="Bill the operator for the Apex Placement Fee"
+                  >
+                    {sendingApexInvoice ? <Loader2 className="h-4 w-4 animate-spin" /> : <DollarSign className="h-4 w-4" />}
+                    Send Apex Placement Invoice
+                  </button>
+                )}
+              {agreement.agreement_type === "location_placement" &&
+                agreement.apex_placement_invoice_status === "sent" && (
+                  <div className="w-full rounded-lg border border-amber-200 bg-amber-50 px-4 py-2.5 text-xs text-amber-800 text-center">
+                    Apex placement invoice sent{agreement.apex_placement_invoice_sent_at ? ` on ${new Date(agreement.apex_placement_invoice_sent_at).toLocaleDateString()}` : ""}
+                  </div>
+                )}
               {!isCancelled && !isSigned && agreement.agreement_status !== "draft" && (
                 <button
                   onClick={handleCancel}
@@ -1424,6 +1474,50 @@ function LocationPlacementSections({
             Standard responsibility language is included. The Operator handles installation, maintenance, stocking, and removal; the Location provides electrical access and reasonable host cooperation.
           </p>
         )}
+      </div>
+
+      {/* Apex Billing (operator-only — never shown to the location) */}
+      <div className="rounded-xl border border-amber-200 bg-amber-50/40 p-5">
+        <h3 className="text-sm font-semibold text-amber-900 flex items-center gap-2 mb-1">
+          <DollarSign className="h-4 w-4 text-amber-600" /> Apex Billing — Operator Only
+        </h3>
+        <p className="text-xs text-amber-800/70 mb-4">
+          This is what Apex charges the operator for placing this location. It&apos;s hidden from the location&apos;s view of the agreement and only shown to the operator.
+        </p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <CurrencyField label="Apex Placement Fee" value={form.apex_placement_fee} onChange={(v) => updateField("apex_placement_fee", v)} disabled={isReadOnly} />
+          <div className="flex items-center">
+            <ReadOnlyField label="Status" value={
+              form.location_business_name && (
+                {
+                  not_sent: "Not Invoiced",
+                  sent: "Invoice Sent",
+                  paid: "Paid",
+                  void: "Void",
+                }[(form as unknown as { apex_placement_invoice_status?: string }).apex_placement_invoice_status || "not_sent"]
+              ) || "Not Invoiced"
+            } />
+          </div>
+        </div>
+        <div className="mt-4">
+          <TextareaField label="Billing Notes (operator only)" value={form.apex_placement_fee_notes} onChange={(v) => updateField("apex_placement_fee_notes", v)} disabled={isReadOnly} rows={2} hint="Internal/operator notes about the billing — never shown to the location." />
+        </div>
+        <div className="mt-4 flex items-start gap-3 rounded-lg border border-blue-100 bg-blue-50/50 p-3">
+          <input
+            id="auto-invoice-placement"
+            type="checkbox"
+            checked={form.auto_send_invoice_on_signing}
+            onChange={(e) => updateBool("auto_send_invoice_on_signing", e.target.checked)}
+            disabled={isReadOnly}
+            className="mt-0.5 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500 cursor-pointer disabled:cursor-not-allowed"
+          />
+          <label htmlFor="auto-invoice-placement" className="flex-1 cursor-pointer">
+            <span className="block text-sm font-medium text-gray-900">Auto-invoice operator on signing</span>
+            <span className="block text-xs text-gray-500 mt-0.5">
+              When both parties have signed, automatically invoice the operator for the Apex Placement Fee.
+            </span>
+          </label>
+        </div>
       </div>
 
       {/* Sales Rep */}

--- a/src/lib/generateAgreementPdf.ts
+++ b/src/lib/generateAgreementPdf.ts
@@ -648,7 +648,9 @@ export async function handleFullySignedAgreement(agreementId: string): Promise<v
   let pdfBytes: Uint8Array;
   if (isLocationPlacement) {
     const { generateLocationPlacementPdf } = await import("./generateLocationPlacementPdf");
-    pdfBytes = await generateLocationPlacementPdf(ag, signatures || [], initials || []);
+    // Signed copy goes to operator + james@ + rep — never the location —
+    // so include the Apex Billing addendum.
+    pdfBytes = await generateLocationPlacementPdf(ag, signatures || [], initials || [], "operator");
   } else {
     pdfBytes = await generatePurchaseAgreementPdf(ag, signatures || [], initials || []);
   }
@@ -844,7 +846,7 @@ export async function handleFullySignedAgreement(agreementId: string): Promise<v
     description: `Fully signed PDF generated, emailed to ${recipientSummary}, and saved to account documents.`,
   });
 
-  // Auto-create order + invoice only for purchase agreements
+  // Auto-create order + invoice for purchase agreements
   if (!isLocationPlacement && ag.auto_send_invoice_on_signing && !ag.order_id) {
     try {
       await autoCreateOrderAndSendInvoice(ag);
@@ -857,6 +859,159 @@ export async function handleFullySignedAgreement(agreementId: string): Promise<v
       });
     }
   }
+
+  // Auto-invoice the operator for the Apex Placement Fee on a fully-signed
+  // location placement agreement (when the toggle is on AND a fee is set).
+  if (
+    isLocationPlacement &&
+    ag.auto_send_invoice_on_signing &&
+    Number(ag.apex_placement_fee) > 0 &&
+    ag.apex_placement_invoice_status !== "sent" &&
+    ag.apex_placement_invoice_status !== "paid"
+  ) {
+    try {
+      await sendApexPlacementFeeInvoice(ag);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      await supabaseAdmin.from("agreement_activity_log").insert({
+        agreement_id: agreementId,
+        activity_type: "auto_invoice_failed",
+        description: `Apex placement fee invoice failed: ${msg}`,
+      });
+    }
+  }
+}
+
+/* ================================================================== */
+/*  sendApexPlacementFeeInvoice                                       */
+/*  Bills the operator (placement_operator_email) for the Apex        */
+/*  Placement Fee. Uses QuickBooks if configured, falls back to       */
+/*  Resend. Records status on the agreement row.                      */
+/* ================================================================== */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function sendApexPlacementFeeInvoice(ag: any): Promise<void> {
+  const amount = Number(ag.apex_placement_fee) || 0;
+  if (amount <= 0) return;
+
+  const recipientEmail = ag.placement_operator_email;
+  if (!recipientEmail) {
+    throw new Error("Operator email missing — cannot send placement fee invoice");
+  }
+
+  const operatorName = ag.placement_operator_company || ag.placement_operator_contact || "Operator";
+  const locationName = ag.location_business_name || "Location";
+
+  let qbInvoiceId: string | null = null;
+  let qbSent = false;
+  const qbConfigured = !!(process.env.QB_CLIENT_ID && process.env.QB_CLIENT_SECRET);
+
+  if (qbConfigured) {
+    try {
+      const { createInvoice, sendInvoiceEmail } = await import("@/lib/quickbooks");
+      const invoicePromise = createInvoice({
+        customerEmail: recipientEmail,
+        customerName: operatorName,
+        customerPhone: ag.placement_operator_phone || undefined,
+        lineItems: [
+          {
+            description: `Location Placement Services — ${locationName}`,
+            amount,
+            quantity: 1,
+          },
+        ],
+        memo: `Apex Placement Fee — Agreement #${(ag.id || "").slice(0, 8).toUpperCase()}`,
+      });
+      const timeoutPromise = new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("QB timeout")), 8000),
+      );
+      const invoice = await Promise.race([invoicePromise, timeoutPromise]);
+      qbInvoiceId = invoice.Id;
+
+      await Promise.race([
+        sendInvoiceEmail(invoice.Id, recipientEmail),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error("QB email timeout")), 5000),
+        ),
+      ]);
+      qbSent = true;
+    } catch {
+      // Fall through to Resend
+    }
+  }
+
+  if (!qbSent && process.env.RESEND_API_KEY) {
+    await getResend().emails.send({
+      from: FROM_EMAIL,
+      to: recipientEmail,
+      cc: ["james@apexaivending.com"],
+      subject: `Invoice — Location Placement Services for ${locationName}`,
+      html: `
+<div style="max-width:640px;margin:0 auto;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:32px 24px;">
+  <div style="text-align:center;margin-bottom:24px;">
+    <h1 style="color:#16a34a;font-size:24px;margin:0;">Apex AI Vending</h1>
+    <p style="color:#6b7280;font-size:14px;margin:4px 0 0;">Location Placement Services Invoice</p>
+  </div>
+  <div style="background:#f9fafb;border-radius:12px;padding:24px;margin-bottom:24px;">
+    <p style="margin:0 0 16px;font-size:14px;color:#374151;">
+      Hello ${ag.placement_operator_contact || operatorName},
+    </p>
+    <p style="margin:0 0 16px;font-size:14px;color:#374151;line-height:1.6;">
+      The Location Placement Agreement for <strong>${locationName}</strong> has been fully executed. Please find your invoice for placement services below.
+    </p>
+    <table style="width:100%;border-collapse:collapse;font-size:13px;margin-top:16px;">
+      <thead>
+        <tr style="background:#e5e7eb;">
+          <th style="padding:8px 12px;text-align:left;color:#374151;">Item</th>
+          <th style="padding:8px 12px;text-align:right;color:#374151;">Amount</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td style="padding:8px 12px;border-bottom:1px solid #e5e7eb;color:#111;">
+            Location Placement Services — ${locationName}
+          </td>
+          <td style="padding:8px 12px;border-bottom:1px solid #e5e7eb;color:#374151;text-align:right;">
+            $${amount.toLocaleString("en-US", { minimumFractionDigits: 2 })}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <table style="width:100%;border-collapse:collapse;font-size:14px;margin-top:16px;">
+      <tr style="border-top:2px solid #e5e7eb;">
+        <td style="padding:8px 0 0;color:#111;font-weight:700;">Total Due</td>
+        <td style="padding:8px 0 0;text-align:right;color:#16a34a;font-weight:700;font-size:18px;">
+          $${amount.toLocaleString("en-US", { minimumFractionDigits: 2 })}
+        </td>
+      </tr>
+    </table>
+    ${ag.apex_placement_fee_notes ? `<p style="margin:16px 0 0;font-size:13px;color:#6b7280;border-top:1px solid #e5e7eb;padding-top:12px;"><strong>Notes:</strong> ${ag.apex_placement_fee_notes}</p>` : ""}
+  </div>
+  <p style="font-size:13px;color:#6b7280;text-align:center;">
+    Questions? Contact us at <a href="mailto:james@apexaivending.com" style="color:#16a34a;">james@apexaivending.com</a>
+    or call <a href="tel:+18888511462" style="color:#16a34a;">(888) 851-1462</a>
+  </p>
+</div>
+      `.trim(),
+    });
+  } else if (!qbSent) {
+    throw new Error("No email service available — set RESEND_API_KEY or QuickBooks creds");
+  }
+
+  await supabaseAdmin
+    .from("purchase_agreements")
+    .update({
+      apex_placement_invoice_status: "sent",
+      apex_placement_invoice_sent_at: new Date().toISOString(),
+      apex_placement_qb_invoice_id: qbInvoiceId,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", ag.id);
+
+  await supabaseAdmin.from("agreement_activity_log").insert({
+    agreement_id: ag.id,
+    activity_type: "apex_placement_invoice_sent",
+    description: `Apex Placement Fee invoice ($${amount.toFixed(2)}) sent to ${recipientEmail}`,
+  });
 }
 
 /* ================================================================== */

--- a/src/lib/generateLocationPlacementPdf.ts
+++ b/src/lib/generateLocationPlacementPdf.ts
@@ -4,8 +4,10 @@ import { PDFDocument, StandardFonts, rgb, PDFFont, PDFPage } from "pdf-lib";
 /*  PDF Generation — Location Placement Agreement                     */
 /* ================================================================== */
 
+export type LocationPlacementAudience = "operator" | "location";
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function generateLocationPlacementPdf(ag: any, signatures: any[], initials: any[]): Promise<Uint8Array> {
+export async function generateLocationPlacementPdf(ag: any, signatures: any[], initials: any[], audience: LocationPlacementAudience = "operator"): Promise<Uint8Array> {
   const doc = await PDFDocument.create();
   const helvetica = await doc.embedFont(StandardFonts.Helvetica);
   const helveticaBold = await doc.embedFont(StandardFonts.HelveticaBold);
@@ -331,6 +333,34 @@ export async function generateLocationPlacementPdf(ag: any, signatures: any[], i
     "This Agreement constitutes the entire understanding between the parties and supersedes all prior agreements regarding its subject matter. Amendments must be in writing and signed by both parties.",
     helvetica, 9, gray
   );
+
+  /* ================================================================ */
+  /*  Operator-only billing addendum (never shown to the location)    */
+  /* ================================================================ */
+  if (audience === "operator" && Number(ag.apex_placement_fee) > 0) {
+    checkPage(80);
+    y -= 16;
+    drawLine(y);
+    y -= 22;
+    drawText(page, "SCHEDULE A — APEX BILLING (OPERATOR COPY ONLY)", LEFT, y, helveticaBold, 10, green);
+    y -= 18;
+    drawWrapped(
+      "This schedule is included only on the operator's executed copy of the Agreement and is not part of the Location's copy. It memorializes the placement fee owed by the Operator to Apex AI Vending for sourcing and securing this Location.",
+      helvetica, 9, gray
+    );
+    y -= 6;
+    labelValue("Apex Placement Fee:", money(ag.apex_placement_fee));
+    labelValue("Payable To:", "Apex AI Vending LLC");
+    if (ag.apex_placement_fee_notes) {
+      y -= 2;
+      drawWrapped(`Notes: ${ag.apex_placement_fee_notes}`, helvetica, 9, gray);
+    }
+    y -= 4;
+    drawWrapped(
+      "The Apex Placement Fee is due upon execution of this Agreement unless otherwise stated above. Apex AI Vending will invoice the Operator separately.",
+      helvetica, 9, gray
+    );
+  }
 
   /* ================================================================ */
   /*  Signature blocks                                                */

--- a/supabase/migrations/094_location_placement_billing.sql
+++ b/supabase/migrations/094_location_placement_billing.sql
@@ -1,0 +1,11 @@
+-- Location Placement Agreement billing
+-- Apex bills the operator for finding/placing the location.
+-- The fee is shown to the operator + internal team, hidden from the location.
+
+ALTER TABLE purchase_agreements
+  ADD COLUMN IF NOT EXISTS apex_placement_fee numeric DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS apex_placement_fee_notes text,
+  ADD COLUMN IF NOT EXISTS apex_placement_invoice_status text DEFAULT 'not_sent'
+    CHECK (apex_placement_invoice_status IN ('not_sent', 'sent', 'paid', 'void')),
+  ADD COLUMN IF NOT EXISTS apex_placement_invoice_sent_at timestamptz,
+  ADD COLUMN IF NOT EXISTS apex_placement_qb_invoice_id text;


### PR DESCRIPTION
… from location)

Apex bills the operator for placing the location. The fee is visible to the operator + internal team, never to the location.

Database (migration 094):
- purchase_agreements.apex_placement_fee numeric DEFAULT 0
- purchase_agreements.apex_placement_fee_notes text
- purchase_agreements.apex_placement_invoice_status enum
- purchase_agreements.apex_placement_invoice_sent_at timestamptz
- purchase_agreements.apex_placement_qb_invoice_id text

Editor (LocationPlacementSections):
- New 'Apex Billing — Operator Only' card (amber styling to flag as internal) with the placement fee, billing notes, and the existing auto_send_invoice_on_signing toggle relabeled for this context
- Sidebar action: 'Send Apex Placement Invoice' button shows up on saved agreements with a fee > 0 and an unsent status; switches to a 'sent on <date>' confirmation chip after sending

Visibility:
- Location's sign page never sees the fee — the public sign API already returns only whitelisted fields, and apex_placement_fee is not on that list
- PDF generator now takes an audience param ('operator' | 'location'). The fully-signed PDF (only ever emailed to operator + james@ + rep) uses the 'operator' audience and renders a 'SCHEDULE A — APEX BILLING (OPERATOR COPY ONLY)' addendum. Default is 'operator' so rep downloads + manual previews still show it.

Billing:
- handleFullySignedAgreement: when location_placement + auto_send_invoice_on_signing + apex_placement_fee > 0, invoices the operator (placement_operator_email) for the fee.
- New POST /api/sales/agreements/[id]/send-apex-placement-invoice for manual billing when the toggle is off.
- Both routes use QuickBooks if configured, falling back to a Resend invoice email. Status + timestamp + qb_invoice_id are persisted.
- Activity log captures every send.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2