### PR TITLE
Add Sales Manager role

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -381,6 +381,7 @@ function UsersManager({ token, onSuccess }: { token: string; onSuccess: (msg: st
       requestor: "Location",
       admin: "Admin",
       sales: "Sales",
+      sales_manager: "Sales Manager",
       director_of_sales: "Dir. of Sales",
       market_leader: "Market Leader",
     };
@@ -418,6 +419,7 @@ function UsersManager({ token, onSuccess }: { token: string; onSuccess: (msg: st
           <option value="admin">Admins</option>
           <option value="director_of_sales">Directors of Sales</option>
           <option value="market_leader">Market Leaders</option>
+          <option value="sales_manager">Sales Managers</option>
           <option value="sales">Sales Reps</option>
           <option value="operator">Operators</option>
           <option value="locator">Locators</option>
@@ -688,6 +690,7 @@ function UsersManager({ token, onSuccess }: { token: string; onSuccess: (msg: st
                   <option value="location_manager">Location Manager</option>
                   <option value="requestor">Location</option>
                   <option value="sales">Sales Rep</option>
+                  <option value="sales_manager">Sales Manager</option>
                   <option value="market_leader">Market Leader</option>
                   <option value="director_of_sales">Director of Sales</option>
                   <option value="admin">Admin</option>

--- a/src/app/api/sales/leads/route.ts
+++ b/src/app/api/sales/leads/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
-import { getSalesUser, isElevatedRole } from "@/lib/salesAuth";
+import { getSalesUser, isElevatedRole, canSeeTeamAssignedLeads } from "@/lib/salesAuth";
 import { createAndSendAgreement } from "@/lib/locationAgreement";
 
 export async function GET(req: NextRequest) {
@@ -13,7 +13,16 @@ export async function GET(req: NextRequest) {
     .order("created_at", { ascending: false })
     .limit(500);
 
-  if (!isElevatedRole(user.role)) {
+  // Lead visibility by role:
+  //  - admin / director_of_sales / market_leader: all leads, assigned + unassigned
+  //  - sales_manager: all ASSIGNED leads across the team, NO unassigned
+  //  - sales: only their own assigned leads
+  if (isElevatedRole(user.role)) {
+    // no filter — see everything
+  } else if (canSeeTeamAssignedLeads(user.role)) {
+    // sales_manager — assigned leads only, across the whole team
+    query = query.not("assigned_to", "is", null);
+  } else {
     query = query.eq("assigned_to", user.id);
   }
 

--- a/src/app/sales/team/page.tsx
+++ b/src/app/sales/team/page.tsx
@@ -51,6 +51,7 @@ const FILTERS = [
 const ROLE_LABELS: Record<string, string> = {
   admin: "Admin",
   sales: "Sales Rep",
+  sales_manager: "Sales Manager",
   director_of_sales: "Director of Sales",
   market_leader: "Market Leader",
 };
@@ -90,7 +91,7 @@ export default function TeamPage() {
         .then((r) => r.ok ? r.json() : [])
         .then((users: TeamMember[]) => {
           const me = users.find((u) => u.id === session.user.id);
-          if (!me || (me.role !== "admin" && me.role !== "director_of_sales" && me.role !== "market_leader")) {
+          if (!me || (me.role !== "admin" && me.role !== "director_of_sales" && me.role !== "market_leader" && me.role !== "sales_manager")) {
             router.push("/sales");
           } else {
             setAuthorized(true);

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -10,7 +10,11 @@ export function getRoleLevel(role: SalesRole): RoleLevel {
   switch (role) {
     case "admin": return 1;
     case "director_of_sales": return 2;
+    // Sales Manager and Market Leader share nav-level access (Team page, etc.)
+    // but Sales Manager has restricted lead visibility — see the leads API
+    // for the explicit role-based filter.
     case "market_leader": return 3;
+    case "sales_manager": return 3;
     case "sales": return 4;
     default: return 4;
   }

--- a/src/lib/salesAuth.ts
+++ b/src/lib/salesAuth.ts
@@ -4,10 +4,20 @@ import { cookies } from "next/headers";
 import { createServerClient } from "@supabase/ssr";
 import { supabaseAdmin } from "./supabaseAdmin";
 
-export type SalesRole = "admin" | "director_of_sales" | "market_leader" | "sales";
+export type SalesRole = "admin" | "director_of_sales" | "market_leader" | "sales_manager" | "sales";
 
 export function isElevatedRole(role: SalesRole): boolean {
   return role === "admin" || role === "director_of_sales" || role === "market_leader";
+}
+
+/**
+ * Can the role see assigned leads across the whole team?
+ * - Elevated roles see everything (including unassigned).
+ * - sales_manager sees all assigned leads but NOT unassigned.
+ * - sales only sees their own.
+ */
+export function canSeeTeamAssignedLeads(role: SalesRole): boolean {
+  return isElevatedRole(role) || role === "sales_manager";
 }
 
 export interface SalesUser {
@@ -70,7 +80,7 @@ export async function getSalesUser(req: NextRequest): Promise<SalesUser | null> 
     .eq("id", userId)
     .single();
 
-  const allowedRoles = ["admin", "director_of_sales", "market_leader", "sales"];
+  const allowedRoles = ["admin", "director_of_sales", "market_leader", "sales_manager", "sales"];
   if (!profile || !allowedRoles.includes(profile.role)) {
     return null;
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,4 @@
-export type UserRole = "operator" | "locator" | "location_manager" | "admin" | "sales" | "director_of_sales" | "market_leader";
+export type UserRole = "operator" | "locator" | "location_manager" | "admin" | "sales" | "sales_manager" | "director_of_sales" | "market_leader";
 
 export type LocationType =
   | "office"


### PR DESCRIPTION
A new role between Market Leader and Sales Rep:
- NO admin panel access (admin gate is unchanged; only roles 'admin' or hardcoded admin emails pass it)
- Sees ALL assigned leads across the entire team
- Does NOT see unassigned leads (the bucket that Market Leader+ uses for triage)

Implementation:
- Added 'sales_manager' to UserRole and SalesRole unions
- Added to allowedRoles in getSalesUser so they can reach /api/sales/*
- New canSeeTeamAssignedLeads() helper returns true for all elevated roles plus sales_manager
- /api/sales/leads/route.ts now branches three ways:
    - elevated (admin/DOS/market_leader): no filter
    - sales_manager: query.not('assigned_to', 'is', null) — all assigned, no unassigned
    - sales: own only (existing behavior)
- getRoleLevel returns 3 for sales_manager (same nav access as Market Leader — includes the Team page)
- Team page gate now lets sales_manager view team members
- ROLE_LABELS / admin role-filter dropdown / admin role-edit dropdown / role badge mapping all include 'sales_manager'/'Sales Manager'


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2