### PR TITLE
Add internal customer receipts for order payments

### DIFF
--- a/src/app/api/sales/orders/[id]/send-receipt/route.ts
+++ b/src/app/api/sales/orders/[id]/send-receipt/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSalesUser } from "@/lib/salesAuth";
+import { sendOrderReceipt } from "@/lib/sendOrderReceipt";
+
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const user = await getSalesUser(req);
+  if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id } = await params;
+
+  const body = await req.json().catch(() => ({}));
+  const paymentType = body.payment_type === "deposit" ? "deposit" : "full";
+
+  const result = await sendOrderReceipt({
+    orderId: id,
+    paymentType,
+    paymentMethod: body.payment_method || null,
+    paymentReference: body.payment_reference || null,
+    userId: user.id,
+  });
+
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error || "Failed to send receipt" }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true, recipient_email: result.recipientEmail, file_url: result.fileUrl });
+}

--- a/src/app/api/sales/orders/[id]/status/route.ts
+++ b/src/app/api/sales/orders/[id]/status/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { getSalesUser } from "@/lib/salesAuth";
+import { sendOrderReceipt } from "@/lib/sendOrderReceipt";
 
 const STATUS_ACTIONS: Record<string, { order_status?: string; payment_status?: string; invoice_status?: string; agreement_status?: string; fulfillment_status?: string; next_action?: string | null }> = {
   send_invoice: { invoice_status: "sent", order_status: "invoice_sent", next_action: "Follow up on payment" },
@@ -57,6 +58,42 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
     activity_type: "status_change",
     description: description.charAt(0).toUpperCase() + description.slice(1),
   });
+
+  // Auto-send customer receipt when a payment is marked
+  if (action === "mark_paid" || action === "mark_deposit_paid") {
+    const paymentType: "deposit" | "full" = action === "mark_deposit_paid" ? "deposit" : "full";
+    const alreadySentField = paymentType === "deposit"
+      ? (data as { deposit_receipt_status?: string }).deposit_receipt_status
+      : (data as { receipt_status?: string }).receipt_status;
+
+    if (alreadySentField !== "sent") {
+      try {
+        const result = await sendOrderReceipt({
+          orderId: id,
+          paymentType,
+          paymentMethod: body.payment_method || null,
+          paymentReference: body.payment_reference || null,
+          userId: user.id,
+        });
+        if (!result.ok) {
+          await supabaseAdmin.from("order_activity_log").insert({
+            order_id: id,
+            user_id: user.id,
+            activity_type: "receipt_failed",
+            description: `Auto-receipt failed: ${result.error || "unknown"}`,
+          });
+        }
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        await supabaseAdmin.from("order_activity_log").insert({
+          order_id: id,
+          user_id: user.id,
+          activity_type: "receipt_failed",
+          description: `Auto-receipt failed: ${msg}`,
+        });
+      }
+    }
+  }
 
   return NextResponse.json(data);
 }

--- a/src/app/sales/orders/[id]/page.tsx
+++ b/src/app/sales/orders/[id]/page.tsx
@@ -59,6 +59,12 @@ interface OrderDetail {
   fulfillment_status: string;
   location_remaining_invoice_status?: string;
   location_remaining_invoice_sent_at?: string | null;
+  receipt_status?: string;
+  receipt_sent_at?: string | null;
+  deposit_receipt_status?: string;
+  deposit_receipt_sent_at?: string | null;
+  payment_method?: string | null;
+  payment_reference?: string | null;
   next_required_action: string | null;
   notes: string | null;
   lead_id: string | null;
@@ -203,6 +209,31 @@ export default function OrderDetailPage() {
     });
     const data = await res.json().catch(() => ({}));
     if (!res.ok) alert(data.error || "Failed to send remaining balance invoice");
+    await fetchOrder();
+    setActionLoading("");
+  }
+
+  async function handleSendReceipt(paymentType: "deposit" | "full") {
+    const label = paymentType === "deposit" ? "deposit" : "payment";
+    const method = prompt(`Payment method (e.g. "Wire Transfer", "ACH", "Credit Card") for this ${label} receipt:`) || "";
+    if (method === null) return;
+    const reference = prompt(`Reference number for this ${label} receipt (optional):`) || "";
+    if (!confirm(`Send the ${label} receipt to the customer?`)) return;
+
+    setActionLoading(paymentType === "deposit" ? "send_deposit_receipt" : "send_receipt");
+    const res = await fetch(`/api/sales/orders/${id}/send-receipt`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({
+        payment_type: paymentType,
+        payment_method: method || null,
+        payment_reference: reference || null,
+      }),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      alert(data.error || "Failed to send receipt");
+    }
     await fetchOrder();
     setActionLoading("");
   }
@@ -732,6 +763,73 @@ export default function OrderDetailPage() {
               </div>
             );
           })()}
+
+          {/* Customer Receipts */}
+          {(order.payment_status === "paid" || order.payment_status === "deposit_paid" || order.receipt_status === "sent" || order.deposit_receipt_status === "sent") && (
+            <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-5">
+              <h3 className="text-sm font-semibold text-emerald-900 mb-2 flex items-center gap-2">
+                <CheckCircle2 className="h-4 w-4" /> Customer Receipts
+              </h3>
+              <div className="space-y-2">
+                {/* Deposit receipt */}
+                {(order.payment_status === "deposit_paid" || order.deposit_receipt_status === "sent") && (
+                  <div className="flex items-center justify-between gap-2 text-xs">
+                    <div className="text-emerald-800">
+                      <p className="font-medium">Deposit Receipt</p>
+                      {order.deposit_receipt_status === "sent" && order.deposit_receipt_sent_at && (
+                        <p className="text-emerald-600 text-[10px]">Sent {new Date(order.deposit_receipt_sent_at).toLocaleDateString()}</p>
+                      )}
+                    </div>
+                    {order.deposit_receipt_status !== "sent" ? (
+                      <button
+                        onClick={() => handleSendReceipt("deposit")}
+                        disabled={actionLoading === "send_deposit_receipt"}
+                        className="rounded-lg px-3 py-1.5 text-xs font-semibold text-white bg-emerald-600 hover:bg-emerald-700 disabled:opacity-50 cursor-pointer"
+                      >
+                        {actionLoading === "send_deposit_receipt" ? "Sending..." : "Send Receipt"}
+                      </button>
+                    ) : (
+                      <button
+                        onClick={() => handleSendReceipt("deposit")}
+                        disabled={actionLoading === "send_deposit_receipt"}
+                        className="rounded-lg px-2.5 py-1 text-[11px] font-medium text-emerald-700 hover:bg-emerald-100 cursor-pointer disabled:opacity-50"
+                      >
+                        Resend
+                      </button>
+                    )}
+                  </div>
+                )}
+                {/* Full payment receipt */}
+                {(order.payment_status === "paid" || order.receipt_status === "sent") && (
+                  <div className="flex items-center justify-between gap-2 text-xs">
+                    <div className="text-emerald-800">
+                      <p className="font-medium">Payment Receipt</p>
+                      {order.receipt_status === "sent" && order.receipt_sent_at && (
+                        <p className="text-emerald-600 text-[10px]">Sent {new Date(order.receipt_sent_at).toLocaleDateString()}</p>
+                      )}
+                    </div>
+                    {order.receipt_status !== "sent" ? (
+                      <button
+                        onClick={() => handleSendReceipt("full")}
+                        disabled={actionLoading === "send_receipt"}
+                        className="rounded-lg px-3 py-1.5 text-xs font-semibold text-white bg-emerald-600 hover:bg-emerald-700 disabled:opacity-50 cursor-pointer"
+                      >
+                        {actionLoading === "send_receipt" ? "Sending..." : "Send Receipt"}
+                      </button>
+                    ) : (
+                      <button
+                        onClick={() => handleSendReceipt("full")}
+                        disabled={actionLoading === "send_receipt"}
+                        className="rounded-lg px-2.5 py-1 text-[11px] font-medium text-emerald-700 hover:bg-emerald-100 cursor-pointer disabled:opacity-50"
+                      >
+                        Resend
+                      </button>
+                    )}
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
 
           {(order.order_status === "completed" || order.order_status === "cancelled") && (
             <div className={`rounded-xl p-5 text-center ${order.order_status === "completed" ? "bg-green-50 border border-green-200" : "bg-red-50 border border-red-200"}`}>

--- a/src/lib/generateReceiptPdf.ts
+++ b/src/lib/generateReceiptPdf.ts
@@ -1,0 +1,256 @@
+import { PDFDocument, StandardFonts, rgb, PDFFont, PDFPage } from "pdf-lib";
+
+interface ReceiptItem {
+  service_name: string;
+  description?: string | null;
+  quantity: number;
+  unit_price: number;
+  total_price: number;
+}
+
+export interface ReceiptData {
+  order_number: string | number;
+  invoice_number?: string | null;
+  paid_at: string;
+  payment_type: "deposit" | "full";
+  payment_method?: string | null;
+  payment_reference?: string | null;
+  amount_paid: number;
+  total_value: number;
+  balance_remaining: number;
+
+  customer_name: string;
+  customer_company?: string | null;
+  customer_email?: string | null;
+  customer_phone?: string | null;
+  customer_address?: string | null;
+
+  items: ReceiptItem[];
+  notes?: string | null;
+}
+
+export async function generateReceiptPdf(data: ReceiptData): Promise<Uint8Array> {
+  const doc = await PDFDocument.create();
+  const helvetica = await doc.embedFont(StandardFonts.Helvetica);
+  const helveticaBold = await doc.embedFont(StandardFonts.HelveticaBold);
+  const green = rgb(0.086, 0.635, 0.294);
+  const gray = rgb(0.42, 0.42, 0.42);
+  const dark = rgb(0.07, 0.07, 0.07);
+  const lightBg = rgb(0.96, 0.96, 0.96);
+  const paidGreen = rgb(0.05, 0.55, 0.24);
+
+  const PAGE_W = 612;
+  const PAGE_H = 792;
+  const LEFT = 50;
+  const RIGHT = 562;
+  const MAX_W = RIGHT - LEFT;
+  const BOTTOM_MARGIN = 80;
+
+  let page: PDFPage = doc.addPage([PAGE_W, PAGE_H]);
+  let y = 740;
+
+  function drawText(p: PDFPage, text: string, x: number, yPos: number, font: PDFFont, size: number, color = dark) {
+    p.drawText(text, { x, y: yPos, size, font, color });
+  }
+
+  function drawLine(yPos: number, color = rgb(0.85, 0.85, 0.85)) {
+    page.drawLine({ start: { x: LEFT, y: yPos }, end: { x: RIGHT, y: yPos }, thickness: 0.5, color });
+  }
+
+  function wrapText(text: string, font: PDFFont, size: number, maxWidth: number): string[] {
+    const words = text.split(" ");
+    const lines: string[] = [];
+    let current = "";
+    for (const word of words) {
+      const test = current ? `${current} ${word}` : word;
+      if (font.widthOfTextAtSize(test, size) > maxWidth) {
+        if (current) lines.push(current);
+        current = word;
+      } else {
+        current = test;
+      }
+    }
+    if (current) lines.push(current);
+    return lines;
+  }
+
+  function checkPage(needed: number) {
+    if (y - needed < BOTTOM_MARGIN) {
+      const pageNum = doc.getPageCount();
+      drawText(page, `Page ${pageNum}`, RIGHT - helvetica.widthOfTextAtSize(`Page ${pageNum}`, 7), 30, helvetica, 7, gray);
+      page = doc.addPage([PAGE_W, PAGE_H]);
+      y = 740;
+    }
+  }
+
+  function money(n: number): string {
+    return `$${Number(n || 0).toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+  }
+
+  // Header — green bar
+  page.drawRectangle({ x: 0, y: PAGE_H - 60, width: PAGE_W, height: 60, color: green });
+  drawText(page, "Apex AI Vending", LEFT, PAGE_H - 40, helveticaBold, 20, rgb(1, 1, 1));
+  drawText(page, "Payment Receipt", RIGHT - helvetica.widthOfTextAtSize("Payment Receipt", 12), PAGE_H - 40, helvetica, 12, rgb(1, 1, 1));
+
+  y = PAGE_H - 90;
+
+  // PAID stamp
+  const stampText = data.payment_type === "deposit" ? "DEPOSIT RECEIVED" : "PAID IN FULL";
+  const stampWidth = helveticaBold.widthOfTextAtSize(stampText, 14) + 24;
+  const stampX = RIGHT - stampWidth;
+  page.drawRectangle({
+    x: stampX,
+    y: y - 4,
+    width: stampWidth,
+    height: 26,
+    color: rgb(0.9, 0.98, 0.92),
+    borderColor: paidGreen,
+    borderWidth: 1.5,
+  });
+  drawText(page, stampText, stampX + 12, y + 6, helveticaBold, 12, paidGreen);
+
+  // Left: order info
+  drawText(page, `Order #: ${data.order_number}`, LEFT, y + 8, helvetica, 9, gray);
+  const paidDate = new Date(data.paid_at).toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" });
+  drawText(page, `Paid: ${paidDate}`, LEFT, y - 6, helvetica, 9, gray);
+  if (data.invoice_number) {
+    drawText(page, `Invoice #: ${data.invoice_number}`, LEFT + 180, y + 8, helvetica, 9, gray);
+  }
+
+  y -= 30;
+  drawLine(y);
+  y -= 20;
+
+  // Customer
+  drawText(page, "BILLED TO", LEFT, y, helveticaBold, 8, green);
+  y -= 14;
+  if (data.customer_company) {
+    drawText(page, data.customer_company, LEFT, y, helveticaBold, 10, dark);
+    y -= 12;
+  }
+  if (data.customer_name && data.customer_name !== data.customer_company) {
+    drawText(page, data.customer_name, LEFT, y, helvetica, 9, dark);
+    y -= 12;
+  }
+  if (data.customer_email) {
+    drawText(page, data.customer_email, LEFT, y, helvetica, 9, gray);
+    y -= 12;
+  }
+  if (data.customer_phone) {
+    drawText(page, data.customer_phone, LEFT, y, helvetica, 9, gray);
+    y -= 12;
+  }
+  if (data.customer_address) {
+    const addrLines = wrapText(data.customer_address, helvetica, 9, 260);
+    for (const line of addrLines) {
+      drawText(page, line, LEFT, y, helvetica, 9, gray);
+      y -= 12;
+    }
+  }
+
+  y -= 8;
+  drawLine(y);
+  y -= 20;
+
+  // Items table
+  checkPage(30);
+  page.drawRectangle({ x: LEFT, y: y - 4, width: MAX_W, height: 20, color: lightBg });
+  drawText(page, "Item", LEFT + 6, y, helveticaBold, 9, dark);
+  drawText(page, "Qty", LEFT + 320, y, helveticaBold, 9, dark);
+  drawText(page, "Unit Price", LEFT + 370, y, helveticaBold, 9, dark);
+  const totalHeader = "Amount";
+  drawText(page, totalHeader, RIGHT - 6 - helveticaBold.widthOfTextAtSize(totalHeader, 9), y, helveticaBold, 9, dark);
+  y -= 22;
+
+  for (const item of data.items) {
+    checkPage(20);
+    const nameLines = wrapText(item.service_name, helvetica, 9, 290);
+    for (let i = 0; i < nameLines.length; i++) {
+      drawText(page, nameLines[i], LEFT + 6, y, helvetica, 9, dark);
+      if (i === 0) {
+        drawText(page, String(item.quantity), LEFT + 320, y, helvetica, 9, dark);
+        drawText(page, money(item.unit_price), LEFT + 370, y, helvetica, 9, dark);
+        const amt = money(item.total_price);
+        drawText(page, amt, RIGHT - 6 - helvetica.widthOfTextAtSize(amt, 9), y, helvetica, 9, dark);
+      }
+      y -= 14;
+    }
+    if (item.description) {
+      const descLines = wrapText(item.description, helvetica, 8, 290);
+      for (const line of descLines) {
+        checkPage(12);
+        drawText(page, line, LEFT + 12, y, helvetica, 8, gray);
+        y -= 11;
+      }
+    }
+    drawLine(y + 4, rgb(0.94, 0.94, 0.94));
+    y -= 4;
+  }
+
+  y -= 6;
+  checkPage(60);
+  drawLine(y);
+  y -= 18;
+
+  // Totals
+  const drawRow = (label: string, value: string, bold = false, colorOverride?: [number, number, number]) => {
+    const font = bold ? helveticaBold : helvetica;
+    const size = bold ? 10 : 9;
+    const c = colorOverride ? rgb(...colorOverride) : bold ? dark : gray;
+    drawText(page, label, LEFT + 320, y, font, size, c);
+    const valColor = colorOverride ? rgb(...colorOverride) : bold ? green : dark;
+    drawText(page, value, RIGHT - 6 - font.widthOfTextAtSize(value, size), y, font, size, valColor);
+    y -= 14;
+  };
+
+  drawRow("Order Total", money(data.total_value));
+  drawRow(data.payment_type === "deposit" ? "Deposit Received" : "Amount Paid", money(data.amount_paid), true);
+  if (data.balance_remaining > 0.005) {
+    drawRow("Balance Remaining", money(data.balance_remaining), false, [0.7, 0.4, 0]);
+  } else {
+    drawRow("Balance Remaining", "$0.00", false);
+  }
+
+  y -= 6;
+  drawLine(y);
+  y -= 20;
+
+  // Payment details
+  drawText(page, "PAYMENT DETAILS", LEFT, y, helveticaBold, 8, green);
+  y -= 14;
+  drawText(page, "Method:", LEFT, y, helvetica, 9, gray);
+  drawText(page, data.payment_method || "Not specified", LEFT + 60, y, helvetica, 9, dark);
+  y -= 12;
+  if (data.payment_reference) {
+    drawText(page, "Reference:", LEFT, y, helvetica, 9, gray);
+    drawText(page, data.payment_reference, LEFT + 60, y, helvetica, 9, dark);
+    y -= 12;
+  }
+  drawText(page, "Date:", LEFT, y, helvetica, 9, gray);
+  drawText(page, paidDate, LEFT + 60, y, helvetica, 9, dark);
+  y -= 20;
+
+  // Notes
+  if (data.notes) {
+    checkPage(30);
+    drawText(page, "NOTES", LEFT, y, helveticaBold, 8, green);
+    y -= 14;
+    const noteLines = wrapText(data.notes, helvetica, 9, MAX_W);
+    for (const line of noteLines) {
+      checkPage(14);
+      drawText(page, line, LEFT, y, helvetica, 9, gray);
+      y -= 12;
+    }
+  }
+
+  // Footer
+  const pageCount = doc.getPageCount();
+  for (let i = 0; i < pageCount; i++) {
+    const p = doc.getPage(i);
+    drawText(p, "Apex AI Vending LLC · vendingconnector.com · james@apexaivending.com", LEFT, 30, helvetica, 7, gray);
+    const numStr = `Page ${i + 1} of ${pageCount}`;
+    drawText(p, numStr, RIGHT - helvetica.widthOfTextAtSize(numStr, 7), 30, helvetica, 7, gray);
+  }
+
+  return doc.save();
+}

--- a/src/lib/sendOrderReceipt.ts
+++ b/src/lib/sendOrderReceipt.ts
@@ -1,0 +1,230 @@
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { generateReceiptPdf, ReceiptData } from "@/lib/generateReceiptPdf";
+import { Resend } from "resend";
+
+const FROM_EMAIL = process.env.FROM_EMAIL || "receipts@bytebitevending.com";
+const ADMIN_CC = "james@apexaivending.com";
+
+function getResend() {
+  return new Resend(process.env.RESEND_API_KEY);
+}
+
+export interface SendReceiptParams {
+  orderId: string;
+  paymentType: "deposit" | "full";
+  paymentMethod?: string | null;
+  paymentReference?: string | null;
+  userId?: string | null;
+}
+
+export async function sendOrderReceipt(params: SendReceiptParams): Promise<{
+  ok: boolean;
+  error?: string;
+  fileUrl?: string;
+  recipientEmail?: string;
+}> {
+  const { orderId, paymentType, paymentMethod, paymentReference, userId } = params;
+
+  const { data: order, error: orderErr } = await supabaseAdmin
+    .from("sales_orders")
+    .select("*, sales_accounts:account_id(*), order_items(*)")
+    .eq("id", orderId)
+    .single();
+
+  if (orderErr || !order) return { ok: false, error: "Order not found" };
+
+  const recipientEmail = order.recipient_email || order.sales_accounts?.email;
+  if (!recipientEmail) {
+    return { ok: false, error: "No recipient email on order or account" };
+  }
+
+  const account = order.sales_accounts;
+  const items = order.order_items || [];
+  const totalValue = Number(order.total_value) || 0;
+  const depositAmount = Number(order.deposit_amount) || 0;
+
+  const amountPaid = paymentType === "deposit" ? depositAmount : totalValue;
+  const balanceRemaining = paymentType === "deposit"
+    ? Math.max(0, totalValue - depositAmount)
+    : 0;
+
+  const receiptData: ReceiptData = {
+    order_number: order.order_number || order.id.slice(0, 8).toUpperCase(),
+    invoice_number: order.qb_invoice_id || null,
+    paid_at: new Date().toISOString(),
+    payment_type: paymentType,
+    payment_method: paymentMethod || order.payment_method || null,
+    payment_reference: paymentReference || order.payment_reference || null,
+    amount_paid: amountPaid,
+    total_value: totalValue,
+    balance_remaining: balanceRemaining,
+    customer_name: account?.contact_name || "",
+    customer_company: account?.business_name || null,
+    customer_email: recipientEmail,
+    customer_phone: account?.phone || null,
+    customer_address: account?.address || null,
+    items: items.map((item: {
+      service_name?: string;
+      description?: string | null;
+      quantity?: number;
+      unit_price?: number;
+      total_price?: number;
+    }) => ({
+      service_name: item.service_name || "Item",
+      description: item.description || null,
+      quantity: Number(item.quantity) || 1,
+      unit_price: Number(item.unit_price) || 0,
+      total_price: Number(item.total_price) || 0,
+    })),
+    notes: order.notes || null,
+  };
+
+  const pdfBytes = await generateReceiptPdf(receiptData);
+  const pdfBuffer = Buffer.from(pdfBytes);
+
+  const businessSlug = (account?.business_name || "customer").replace(/[^a-zA-Z0-9]/g, "_");
+  const label = paymentType === "deposit" ? "Deposit-Receipt" : "Receipt";
+  const fileName = `${label}-${businessSlug}-${orderId.slice(0, 8)}.pdf`;
+  const storagePath = `receipts/${orderId}/${fileName}`;
+
+  // Upload PDF
+  let fileUrl = "";
+  try {
+    const { error: uploadErr } = await supabaseAdmin.storage
+      .from("sales-documents")
+      .upload(storagePath, pdfBuffer, { contentType: "application/pdf", upsert: true });
+    if (!uploadErr) {
+      const { data: urlData } = supabaseAdmin.storage
+        .from("sales-documents")
+        .getPublicUrl(storagePath);
+      fileUrl = urlData?.publicUrl || "";
+    }
+  } catch {
+    // Non-fatal — email still gets sent
+  }
+
+  // Record in sales_documents so it shows in the account
+  if (order.account_id) {
+    try {
+      await supabaseAdmin.from("sales_documents").insert({
+        account_id: order.account_id,
+        order_id: orderId,
+        file_url: fileUrl || null,
+        file_name: `${paymentType === "deposit" ? "Deposit Receipt" : "Payment Receipt"} — ${account?.business_name || "Customer"}`,
+        type: "receipt",
+      });
+    } catch {
+      // Non-fatal
+    }
+  }
+
+  // Send email
+  if (!process.env.RESEND_API_KEY) {
+    return { ok: false, error: "RESEND_API_KEY not configured" };
+  }
+
+  const businessName = account?.business_name || "Customer";
+  const contactName = account?.contact_name || "there";
+  const subject = paymentType === "deposit"
+    ? `Deposit received — Order #${order.order_number || orderId.slice(0, 8).toUpperCase()}`
+    : `Payment received — Order #${order.order_number || orderId.slice(0, 8).toUpperCase()}`;
+
+  const ccList = [ADMIN_CC];
+  // Also CC assigned rep
+  if (order.assigned_rep_id) {
+    try {
+      const { data: rep } = await supabaseAdmin
+        .from("profiles")
+        .select("email")
+        .eq("id", order.assigned_rep_id)
+        .single();
+      if (rep?.email && rep.email !== recipientEmail && !ccList.includes(rep.email)) {
+        ccList.push(rep.email);
+      }
+    } catch {}
+  }
+
+  try {
+    await getResend().emails.send({
+      from: FROM_EMAIL,
+      to: recipientEmail,
+      cc: ccList,
+      subject,
+      html: `
+<div style="max-width:640px;margin:0 auto;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:32px 24px;color:#111827;">
+  <div style="text-align:center;margin-bottom:24px;">
+    <h1 style="color:#16a34a;font-size:24px;margin:0;">Apex AI Vending</h1>
+    <p style="color:#6b7280;font-size:14px;margin:4px 0 0;">${paymentType === "deposit" ? "Deposit Received" : "Payment Received"}</p>
+  </div>
+  <div style="background:#f9fafb;border-radius:12px;padding:24px;margin-bottom:24px;">
+    <p style="margin:0 0 16px;font-size:14px;color:#374151;">Hi ${contactName},</p>
+    <p style="margin:0 0 16px;font-size:14px;color:#374151;line-height:1.6;">
+      Thank you for your payment. We&apos;ve received your ${paymentType === "deposit" ? "deposit" : "payment"} for order
+      <strong>#${order.order_number || orderId.slice(0, 8).toUpperCase()}</strong>. Your receipt is attached to this email.
+    </p>
+    <table style="width:100%;border-collapse:collapse;font-size:14px;margin:16px 0;">
+      <tr>
+        <td style="padding:6px 0;color:#6b7280;">Business</td>
+        <td style="padding:6px 0;text-align:right;color:#111;font-weight:600;">${businessName}</td>
+      </tr>
+      <tr>
+        <td style="padding:6px 0;color:#6b7280;">Order Total</td>
+        <td style="padding:6px 0;text-align:right;color:#111;">$${totalValue.toLocaleString("en-US", { minimumFractionDigits: 2 })}</td>
+      </tr>
+      <tr>
+        <td style="padding:6px 0;color:#6b7280;">${paymentType === "deposit" ? "Deposit Received" : "Amount Paid"}</td>
+        <td style="padding:6px 0;text-align:right;color:#16a34a;font-weight:700;font-size:16px;">$${amountPaid.toLocaleString("en-US", { minimumFractionDigits: 2 })}</td>
+      </tr>
+      ${balanceRemaining > 0.005 ? `<tr>
+        <td style="padding:6px 0;color:#6b7280;">Balance Remaining</td>
+        <td style="padding:6px 0;text-align:right;color:#b45309;font-weight:600;">$${balanceRemaining.toLocaleString("en-US", { minimumFractionDigits: 2 })}</td>
+      </tr>` : ""}
+      ${paymentMethod ? `<tr>
+        <td style="padding:6px 0;color:#6b7280;">Method</td>
+        <td style="padding:6px 0;text-align:right;color:#111;">${paymentMethod}</td>
+      </tr>` : ""}
+    </table>
+    <p style="margin:16px 0 0;font-size:13px;color:#6b7280;">
+      A full itemized receipt is attached as a PDF for your records.
+    </p>
+  </div>
+  <p style="font-size:13px;color:#6b7280;text-align:center;">
+    Questions? Contact <a href="mailto:james@apexaivending.com" style="color:#16a34a;">james@apexaivending.com</a>
+    or call <a href="tel:+18888511462" style="color:#16a34a;">(888) 851-1462</a>
+  </p>
+</div>
+      `.trim(),
+      attachments: [
+        {
+          filename: fileName,
+          content: pdfBuffer.toString("base64"),
+        },
+      ],
+    });
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "Email send failed" };
+  }
+
+  // Mark receipt as sent
+  const nowIso = new Date().toISOString();
+  const receiptField = paymentType === "deposit" ? "deposit_receipt_status" : "receipt_status";
+  const sentAtField = paymentType === "deposit" ? "deposit_receipt_sent_at" : "receipt_sent_at";
+  const updates: Record<string, unknown> = {
+    [receiptField]: "sent",
+    [sentAtField]: nowIso,
+    updated_at: nowIso,
+  };
+  if (paymentMethod) updates.payment_method = paymentMethod;
+  if (paymentReference) updates.payment_reference = paymentReference;
+
+  await supabaseAdmin.from("sales_orders").update(updates).eq("id", orderId);
+
+  await supabaseAdmin.from("order_activity_log").insert({
+    order_id: orderId,
+    user_id: userId || null,
+    activity_type: paymentType === "deposit" ? "deposit_receipt_sent" : "receipt_sent",
+    description: `${paymentType === "deposit" ? "Deposit receipt" : "Payment receipt"} emailed to ${recipientEmail}`,
+  });
+
+  return { ok: true, fileUrl, recipientEmail };
+}

--- a/supabase/migrations/095_order_receipts.sql
+++ b/supabase/migrations/095_order_receipts.sql
@@ -1,0 +1,12 @@
+-- Customer receipts for orders
+-- Track whether a receipt has been sent for a payment event.
+
+ALTER TABLE sales_orders
+  ADD COLUMN IF NOT EXISTS receipt_status text DEFAULT 'not_sent'
+    CHECK (receipt_status IN ('not_sent', 'sent')),
+  ADD COLUMN IF NOT EXISTS receipt_sent_at timestamptz,
+  ADD COLUMN IF NOT EXISTS payment_method text,
+  ADD COLUMN IF NOT EXISTS payment_reference text,
+  ADD COLUMN IF NOT EXISTS deposit_receipt_status text DEFAULT 'not_sent'
+    CHECK (deposit_receipt_status IN ('not_sent', 'sent')),
+  ADD COLUMN IF NOT EXISTS deposit_receipt_sent_at timestamptz;


### PR DESCRIPTION
Auto-send a branded receipt when an order is marked paid or a deposit is paid, plus a manual 'Send Receipt' button on the order detail sidebar. Receipts go to the order's recipient_email, CC the assigned rep and james@apexaivending.com, and get attached to the account as a document.

Migration 095: adds receipt_status / receipt_sent_at, deposit_receipt_status / deposit_receipt_sent_at, payment_method, and payment_reference columns to sales_orders.

New PDF (src/lib/generateReceiptPdf.ts): branded receipt with a PAID IN FULL / DEPOSIT RECEIVED stamp, billed-to block, itemized line items, order total / amount paid / balance remaining, and payment details (method, reference, date).

Shared sender (src/lib/sendOrderReceipt.ts):
- Generates PDF, uploads to sales-documents/receipts/{orderId}
- Records in sales_documents (type='receipt')
- Emails via Resend with the PDF attached
- Updates receipt_status + receipt_sent_at on the order
- Logs to order_activity_log

API routes:
- POST /api/sales/orders/[id]/send-receipt — manual send
- /api/sales/orders/[id]/status auto-fires the receipt when mark_paid or mark_deposit_paid runs, using body.payment_method / payment_reference if the caller passes them; guards against double-sending by checking the existing receipt_status.

UI: new emerald 'Customer Receipts' card on the order sidebar that appears once the order has a paid or deposit_paid status. Shows one row per receipt type (deposit / payment) with a Send Receipt button before it's sent and a Resend button after (with the sent date).


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2