### PR TITLE
Fix PDF crash when text has newlines or non-WinAnsi chars

### DIFF
--- a/src/lib/generateAgreementPdf.ts
+++ b/src/lib/generateAgreementPdf.ts
@@ -1,6 +1,7 @@
 import { PDFDocument, StandardFonts, rgb, PDFFont, PDFPage } from "pdf-lib";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { Resend } from "resend";
+import { pdfSafeInline, pdfSafeMultiline } from "./pdfSafeText";
 
 const FROM_EMAIL = process.env.FROM_EMAIL || "receipts@bytebitevending.com";
 
@@ -55,7 +56,7 @@ export async function generatePurchaseAgreementPdf(ag: any, signatures: any[], i
     size: number,
     color = dark,
   ) {
-    p.drawText(text, { x, y: yPos, size, font, color });
+    p.drawText(pdfSafeInline(text), { x, y: yPos, size, font, color });
   }
 
   function drawLine(yPos: number) {
@@ -91,11 +92,24 @@ export async function generatePurchaseAgreementPdf(ag: any, signatures: any[], i
     color = gray,
     indent = 0,
   ) {
-    const lines = wrapText(text, font, size, MAX_W - indent);
-    for (const line of lines) {
-      checkPage(size + 6);
-      drawText(page, line, LEFT + indent, y, font, size, color);
-      y -= size + 4;
+    // Preserve author-provided paragraph breaks by splitting on newlines
+    // first, then word-wrap each paragraph.
+    const safe = pdfSafeMultiline(text);
+    const paragraphs = safe.split("\n");
+    for (let p = 0; p < paragraphs.length; p++) {
+      const para = paragraphs[p];
+      if (para === "") {
+        // Blank line — just advance
+        checkPage(size + 4);
+        y -= size + 4;
+        continue;
+      }
+      const lines = wrapText(para, font, size, MAX_W - indent);
+      for (const line of lines) {
+        checkPage(size + 6);
+        drawText(page, line, LEFT + indent, y, font, size, color);
+        y -= size + 4;
+      }
     }
   }
 

--- a/src/lib/generateLocationPlacementPdf.ts
+++ b/src/lib/generateLocationPlacementPdf.ts
@@ -1,4 +1,5 @@
 import { PDFDocument, StandardFonts, rgb, PDFFont, PDFPage } from "pdf-lib";
+import { pdfSafeInline, pdfSafeMultiline } from "./pdfSafeText";
 
 /* ================================================================== */
 /*  PDF Generation — Location Placement Agreement                     */
@@ -42,7 +43,7 @@ export async function generateLocationPlacementPdf(ag: any, signatures: any[], i
   }
 
   function drawText(p: PDFPage, text: string, x: number, yPos: number, font: PDFFont, size: number, color = dark) {
-    p.drawText(text, { x, y: yPos, size, font, color });
+    p.drawText(pdfSafeInline(text), { x, y: yPos, size, font, color });
   }
 
   function drawLine(yPos: number) {
@@ -72,11 +73,21 @@ export async function generateLocationPlacementPdf(ag: any, signatures: any[], i
   }
 
   function drawWrapped(text: string, font: PDFFont, size: number, color = dark, indent = 0) {
-    const lines = wrapText(text, font, size, MAX_W - indent);
-    for (const line of lines) {
-      checkPage(size + 4);
-      drawText(page, line, LEFT + indent, y, font, size, color);
-      y -= size + 4;
+    // Split on author-provided newlines first, then word-wrap each paragraph.
+    const safe = pdfSafeMultiline(text);
+    const paragraphs = safe.split("\n");
+    for (const para of paragraphs) {
+      if (para === "") {
+        checkPage(size + 4);
+        y -= size + 4;
+        continue;
+      }
+      const lines = wrapText(para, font, size, MAX_W - indent);
+      for (const line of lines) {
+        checkPage(size + 4);
+        drawText(page, line, LEFT + indent, y, font, size, color);
+        y -= size + 4;
+      }
     }
   }
 

--- a/src/lib/generateProposalPdf.ts
+++ b/src/lib/generateProposalPdf.ts
@@ -1,4 +1,5 @@
 import { PDFDocument, StandardFonts, rgb, PDFFont, PDFPage } from "pdf-lib";
+import { pdfSafeInline, pdfSafeMultiline } from "./pdfSafeText";
 
 interface ProposalData {
   proposal_number: string;
@@ -51,7 +52,7 @@ export async function generateProposalPdf(proposal: ProposalData, items: Proposa
   let y = 740;
 
   function drawText(p: PDFPage, text: string, x: number, yPos: number, font: PDFFont, size: number, color = dark) {
-    p.drawText(text, { x, y: yPos, size, font, color });
+    p.drawText(pdfSafeInline(text), { x, y: yPos, size, font, color });
   }
 
   function drawLine(yPos: number, color = rgb(0.85, 0.85, 0.85)) {
@@ -199,11 +200,19 @@ export async function generateProposalPdf(proposal: ProposalData, items: Proposa
     y -= 20;
     drawText(page, "NOTES", LEFT, y, helveticaBold, 8, green);
     y -= 16;
-    const noteLines = wrapText(proposal.notes, helvetica, 9, MAX_W);
-    for (const line of noteLines) {
-      checkPage(14);
-      drawText(page, line, LEFT, y, helvetica, 9, gray);
-      y -= 14;
+    const safeNotes = pdfSafeMultiline(proposal.notes);
+    for (const paragraph of safeNotes.split("\n")) {
+      if (paragraph === "") {
+        checkPage(14);
+        y -= 6;
+        continue;
+      }
+      const noteLines = wrapText(paragraph, helvetica, 9, MAX_W);
+      for (const line of noteLines) {
+        checkPage(14);
+        drawText(page, line, LEFT, y, helvetica, 9, gray);
+        y -= 14;
+      }
     }
   }
 

--- a/src/lib/generateReceiptPdf.ts
+++ b/src/lib/generateReceiptPdf.ts
@@ -1,4 +1,5 @@
 import { PDFDocument, StandardFonts, rgb, PDFFont, PDFPage } from "pdf-lib";
+import { pdfSafeInline, pdfSafeMultiline } from "./pdfSafeText";
 
 interface ReceiptItem {
   service_name: string;
@@ -50,7 +51,7 @@ export async function generateReceiptPdf(data: ReceiptData): Promise<Uint8Array>
   let y = 740;
 
   function drawText(p: PDFPage, text: string, x: number, yPos: number, font: PDFFont, size: number, color = dark) {
-    p.drawText(text, { x, y: yPos, size, font, color });
+    p.drawText(pdfSafeInline(text), { x, y: yPos, size, font, color });
   }
 
   function drawLine(yPos: number, color = rgb(0.85, 0.85, 0.85)) {
@@ -235,11 +236,19 @@ export async function generateReceiptPdf(data: ReceiptData): Promise<Uint8Array>
     checkPage(30);
     drawText(page, "NOTES", LEFT, y, helveticaBold, 8, green);
     y -= 14;
-    const noteLines = wrapText(data.notes, helvetica, 9, MAX_W);
-    for (const line of noteLines) {
-      checkPage(14);
-      drawText(page, line, LEFT, y, helvetica, 9, gray);
-      y -= 12;
+    const safe = pdfSafeMultiline(data.notes);
+    for (const paragraph of safe.split("\n")) {
+      if (paragraph === "") {
+        checkPage(14);
+        y -= 6;
+        continue;
+      }
+      const noteLines = wrapText(paragraph, helvetica, 9, MAX_W);
+      for (const line of noteLines) {
+        checkPage(14);
+        drawText(page, line, LEFT, y, helvetica, 9, gray);
+        y -= 12;
+      }
     }
   }
 

--- a/src/lib/pdfSafeText.ts
+++ b/src/lib/pdfSafeText.ts
@@ -1,0 +1,65 @@
+/**
+ * Sanitize a string for pdf-lib's WinAnsi encoder.
+ * pdf-lib's default WinAnsi encoding rejects:
+ *  - newlines (\n, \r) inside drawText — must be pre-split
+ *  - characters outside the WinAnsi range (many curly quotes, emoji, etc.)
+ *
+ * This helper normalizes common typographic characters, strips control
+ * characters, and returns a WinAnsi-safe string.
+ */
+
+const REPLACEMENTS: Record<string, string> = {
+  // Smart quotes
+  "‘": "'",
+  "’": "'",
+  "“": '"',
+  "”": '"',
+  // Dashes
+  "–": "-", // en dash
+  "—": "-", // em dash
+  // Non-breaking space
+  " ": " ",
+  // Ellipsis
+  "…": "...",
+  // Bullets
+  "•": "-",
+  "⁃": "-",
+  // Trademarks / registered / copyright — WinAnsi includes these, keep as-is
+};
+
+/**
+ * For single-line contexts (labels, field values). Strips newlines and
+ * replaces them with spaces. Also normalizes typography.
+ */
+export function pdfSafeInline(input: unknown): string {
+  if (input == null) return "";
+  let s = String(input);
+  for (const [from, to] of Object.entries(REPLACEMENTS)) {
+    s = s.split(from).join(to);
+  }
+  // Collapse any newline variant into a single space
+  s = s.replace(/\r\n|\r|\n/g, " ");
+  // Strip other control chars
+  s = s.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F]/g, "");
+  // Fallback for any remaining char pdf-lib WinAnsi can't encode
+  s = s.replace(/[^\x09\x20-\x7E\xA0-\xFF]/g, "?");
+  return s;
+}
+
+/**
+ * For multiline contexts (notes, paragraphs). Preserves newlines so the
+ * caller can split on \n and draw each line separately.
+ */
+export function pdfSafeMultiline(input: unknown): string {
+  if (input == null) return "";
+  let s = String(input);
+  for (const [from, to] of Object.entries(REPLACEMENTS)) {
+    s = s.split(from).join(to);
+  }
+  s = s.replace(/\r\n|\r/g, "\n");
+  // Strip control chars except \n and \t
+  s = s.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F]/g, "");
+  // Fallback for any non-WinAnsi char
+  s = s.replace(/[^\x09\x0A\x20-\x7E\xA0-\xFF]/g, "?");
+  return s;
+}


### PR DESCRIPTION
pdf-lib's default WinAnsi encoder rejects newlines inside drawText (0x0A), so any user-provided note (machine_notes, customer_notes, shipping_notes, apex_placement_fee_notes, etc.) with a line break crashed the PDF generation with 'WinAnsi cannot encode "\n" (0x000a)'. Same class of error would fire on curly quotes, em dashes, or emoji.

New src/lib/pdfSafeText.ts exposes two helpers:
- pdfSafeInline(s) — collapses newlines to spaces, normalizes smart quotes/dashes/ellipsis to ASCII, strips control chars, and replaces any non-WinAnsi character with '?'. For single-line contexts.
- pdfSafeMultiline(s) — preserves \\n so the caller can split on paragraph breaks, otherwise the same normalization.

Applied to all four PDF generators:
- generateAgreementPdf (purchase agreement) — drawText now sanitizes inline; drawWrapped splits on \\n before word-wrapping so multi-paragraph notes render correctly.
- generateLocationPlacementPdf — same treatment.
- generateReceiptPdf — same, plus notes block splits on paragraph breaks.
- generateProposalPdf — same, plus notes block splits on paragraph breaks.

Every drawText call across all four generators now goes through pdfSafeInline before hitting pdf-lib, so no user-facing text can trigger the WinAnsi encoder error regardless of source.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2