### PR TITLE
Marketplace Phase 2.4 — QuickBooks payout + invoice worker

### DIFF
--- a/src/app/admin/marketplace/layout.tsx
+++ b/src/app/admin/marketplace/layout.tsx
@@ -2,12 +2,13 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Briefcase, Package, TrendingUp, Users } from "lucide-react";
+import { Briefcase, Package, TrendingUp, Users, DollarSign } from "lucide-react";
 
 const NAV = [
   { href: "/admin/marketplace/contracts", label: "Contracts", icon: Briefcase },
   { href: "/admin/marketplace/submissions", label: "Submissions", icon: Package },
   { href: "/admin/marketplace/tier-proposals", label: "Tier Bumps", icon: TrendingUp },
+  { href: "/admin/marketplace/payouts", label: "Payouts", icon: DollarSign },
   { href: "/admin/marketplace/partners", label: "Partners", icon: Users },
 ];
 

--- a/src/app/admin/marketplace/payouts/page.tsx
+++ b/src/app/admin/marketplace/payouts/page.tsx
@@ -1,0 +1,288 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Loader2, DollarSign, Filter, ArrowLeft, RefreshCw, Send, AlertCircle, CheckCircle2 } from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
+
+interface Payout {
+  id: string;
+  submission_id: string;
+  contract_id: string;
+  partner_id: string;
+  amount: number;
+  currency: string;
+  status: string;
+  qb_bill_id: string | null;
+  qb_error: string | null;
+  qb_last_attempt_at: string | null;
+  triggered_at: string;
+  sent_at: string | null;
+  paid_at: string | null;
+  contract: { title: string; tier: number } | null;
+  partner: { business_name: string | null } | null;
+  submission: { business_name: string; city: string | null; state: string | null } | null;
+}
+
+interface OpInvoice {
+  id: string;
+  submission_id: string;
+  contract_id: string;
+  operator_business_name: string | null;
+  operator_email: string | null;
+  amount: number;
+  currency: string;
+  status: string;
+  qb_invoice_id: string | null;
+  qb_error: string | null;
+  qb_last_attempt_at: string | null;
+  triggered_at: string;
+  sent_at: string | null;
+  paid_at: string | null;
+  contract: { title: string; tier: number } | null;
+  submission: { business_name: string; city: string | null; state: string | null } | null;
+}
+
+const FILTERS = [
+  { key: "queued", label: "Queued" },
+  { key: "sent_to_qb", label: "Sent" },
+  { key: "paid", label: "Paid" },
+  { key: "failed", label: "Failed" },
+  { key: "all", label: "All" },
+];
+
+const STATUS_COLORS: Record<string, string> = {
+  queued: "bg-amber-50 text-amber-700",
+  sent_to_qb: "bg-blue-50 text-blue-700",
+  paid: "bg-emerald-50 text-emerald-700",
+  failed: "bg-red-50 text-red-700",
+  cancelled: "bg-gray-100 text-gray-600",
+};
+
+type Tab = "payouts" | "invoices";
+
+export default function AdminPayoutsPage() {
+  const router = useRouter();
+  const [token, setToken] = useState("");
+  const [tab, setTab] = useState<Tab>("payouts");
+  const [status, setStatus] = useState("queued");
+  const [loading, setLoading] = useState(true);
+  const [payouts, setPayouts] = useState<Payout[]>([]);
+  const [invoices, setInvoices] = useState<OpInvoice[]>([]);
+  const [saving, setSaving] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!token) return;
+    setLoading(true);
+    setError(null);
+    const endpoint = tab === "payouts" ? "payouts" : "operator-invoices";
+    const params = new URLSearchParams();
+    params.set("status", status);
+    const res = await fetch(`/api/admin/marketplace/${endpoint}?${params}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.ok) {
+      const data = await res.json();
+      if (tab === "payouts") setPayouts(data);
+      else setInvoices(data);
+    }
+    setLoading(false);
+  }, [token, tab, status]);
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!session?.access_token) { router.push("/login?redirect=/admin/marketplace/payouts"); return; }
+      setToken(session.access_token);
+    });
+  }, [router]);
+
+  useEffect(() => { load(); }, [load]);
+
+  async function drainAll() {
+    setSaving("drain");
+    setMessage(null);
+    setError(null);
+    const endpoint = tab === "payouts" ? "payouts" : "operator-invoices";
+    const res = await fetch(`/api/admin/marketplace/${endpoint}/drain`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) setError(body.error || "Drain failed");
+    else setMessage(`Drained: ${body.succeeded} succeeded, ${body.failed} failed of ${body.attempted} attempted`);
+    await load();
+    setSaving(null);
+  }
+
+  async function retry(id: string) {
+    setSaving(`retry-${id}`);
+    setMessage(null);
+    setError(null);
+    const endpoint = tab === "payouts" ? "payouts" : "operator-invoices";
+    const res = await fetch(`/api/admin/marketplace/${endpoint}/${id}/retry`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) setError(body.error || "Retry failed");
+    else setMessage(`Sent to QuickBooks (${body.qb_bill_id || body.qb_invoice_id})`);
+    await load();
+    setSaving(null);
+  }
+
+  const rows = tab === "payouts" ? payouts : invoices;
+
+  return (
+    <div className="p-6 max-w-6xl">
+      <Link href="/admin" className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-green-primary mb-4">
+        <ArrowLeft className="h-4 w-4" /> Back to Admin
+      </Link>
+
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
+            <DollarSign className="h-6 w-6 text-green-primary" /> Marketplace Money
+          </h1>
+          <p className="text-sm text-gray-500 mt-1">Payouts owed to placement partners and invoices billed to operators. QuickBooks handles both.</p>
+        </div>
+        <button
+          onClick={drainAll}
+          disabled={saving === "drain"}
+          className="inline-flex items-center gap-1.5 rounded-xl bg-green-primary hover:bg-green-hover px-4 py-2.5 text-sm font-semibold text-white cursor-pointer disabled:opacity-50"
+        >
+          {saving === "drain" ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
+          Drain to QuickBooks
+        </button>
+      </div>
+
+      <div className="mb-4 flex gap-1 border-b border-gray-100">
+        {(["payouts", "invoices"] as const).map((t) => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors cursor-pointer ${tab === t ? "border-green-primary text-green-primary" : "border-transparent text-gray-500 hover:text-gray-700"}`}
+          >
+            {t === "payouts" ? "Partner Payouts (Bills)" : "Operator Invoices"}
+          </button>
+        ))}
+      </div>
+
+      <div className="mb-4 flex items-center gap-2 flex-wrap">
+        <Filter className="h-4 w-4 text-gray-400" />
+        {FILTERS.map((f) => (
+          <button
+            key={f.key}
+            onClick={() => setStatus(f.key)}
+            className={`rounded-lg px-3 py-1.5 text-xs font-medium cursor-pointer ${status === f.key ? "bg-green-100 text-green-700" : "bg-gray-100 text-gray-500 hover:bg-gray-200"}`}
+          >
+            {f.label}
+          </button>
+        ))}
+      </div>
+
+      {message && (
+        <div className="mb-4 flex items-start gap-2 rounded-xl border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-700">
+          <CheckCircle2 className="h-4 w-4 mt-0.5 shrink-0" />
+          <span>{message}</span>
+        </div>
+      )}
+      {error && (
+        <div className="mb-4 flex items-start gap-2 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex justify-center py-20"><Loader2 className="h-6 w-6 animate-spin text-green-primary" /></div>
+      ) : rows.length === 0 ? (
+        <div className="rounded-xl border border-gray-200 bg-white p-12 text-center">
+          <DollarSign className="mx-auto h-12 w-12 text-gray-300 mb-3" />
+          <p className="text-lg font-semibold text-gray-900 mb-1">Nothing here</p>
+          <p className="text-sm text-gray-500">
+            {tab === "payouts" ? "Partner payouts appear when operators accept submissions." : "Operator invoices appear when operators accept submissions."}
+          </p>
+        </div>
+      ) : (
+        <div className="rounded-xl border border-gray-200 bg-white overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="border-b border-gray-100 bg-gray-50/50">
+              <tr>
+                <th className="text-left px-4 py-3 font-medium text-gray-500">Recipient</th>
+                <th className="text-left px-4 py-3 font-medium text-gray-500">Contract</th>
+                <th className="text-left px-4 py-3 font-medium text-gray-500">Location</th>
+                <th className="text-right px-4 py-3 font-medium text-gray-500">Amount</th>
+                <th className="text-left px-4 py-3 font-medium text-gray-500">Status</th>
+                <th className="text-left px-4 py-3 font-medium text-gray-500">QB Ref</th>
+                <th className="text-left px-4 py-3 font-medium text-gray-500">Triggered</th>
+                <th className="px-4 py-3"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {tab === "payouts" && payouts.map((p) => (
+                <tr key={p.id} className="border-t border-gray-50">
+                  <td className="px-4 py-3 text-gray-700">{p.partner?.business_name || `Partner #${p.partner_id.slice(0, 8)}`}</td>
+                  <td className="px-4 py-3 text-gray-700 text-xs">{p.contract?.title || "—"}</td>
+                  <td className="px-4 py-3 text-gray-700 text-xs">{p.submission ? `${p.submission.business_name} · ${[p.submission.city, p.submission.state].filter(Boolean).join(", ")}` : "—"}</td>
+                  <td className="px-4 py-3 text-right font-semibold text-emerald-700">${Number(p.amount).toLocaleString()}</td>
+                  <td className="px-4 py-3">
+                    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium capitalize ${STATUS_COLORS[p.status] || "bg-gray-100 text-gray-600"}`}>
+                      {p.status.replace(/_/g, " ")}
+                    </span>
+                    {p.qb_error && <p className="text-[10px] text-red-500 mt-1 max-w-xs truncate" title={p.qb_error}>{p.qb_error}</p>}
+                  </td>
+                  <td className="px-4 py-3 text-xs text-gray-500 font-mono">{p.qb_bill_id || "—"}</td>
+                  <td className="px-4 py-3 text-xs text-gray-500">{new Date(p.triggered_at).toLocaleDateString()}</td>
+                  <td className="px-4 py-3">
+                    {(p.status === "queued" || p.status === "failed") && (
+                      <button
+                        onClick={() => retry(p.id)}
+                        disabled={saving === `retry-${p.id}`}
+                        className="inline-flex items-center gap-1 rounded-lg border border-gray-200 hover:bg-gray-50 px-2 py-1 text-xs font-medium text-gray-700 cursor-pointer disabled:opacity-50"
+                      >
+                        {saving === `retry-${p.id}` ? <Loader2 className="h-3 w-3 animate-spin" /> : <RefreshCw className="h-3 w-3" />}
+                        Send
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+              {tab === "invoices" && invoices.map((i) => (
+                <tr key={i.id} className="border-t border-gray-50">
+                  <td className="px-4 py-3 text-gray-700">{i.operator_business_name || "—"}<div className="text-xs text-gray-400">{i.operator_email}</div></td>
+                  <td className="px-4 py-3 text-gray-700 text-xs">{i.contract?.title || "—"}</td>
+                  <td className="px-4 py-3 text-gray-700 text-xs">{i.submission ? `${i.submission.business_name} · ${[i.submission.city, i.submission.state].filter(Boolean).join(", ")}` : "—"}</td>
+                  <td className="px-4 py-3 text-right font-semibold text-emerald-700">${Number(i.amount).toLocaleString()}</td>
+                  <td className="px-4 py-3">
+                    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium capitalize ${STATUS_COLORS[i.status] || "bg-gray-100 text-gray-600"}`}>
+                      {i.status.replace(/_/g, " ")}
+                    </span>
+                    {i.qb_error && <p className="text-[10px] text-red-500 mt-1 max-w-xs truncate" title={i.qb_error}>{i.qb_error}</p>}
+                  </td>
+                  <td className="px-4 py-3 text-xs text-gray-500 font-mono">{i.qb_invoice_id || "—"}</td>
+                  <td className="px-4 py-3 text-xs text-gray-500">{new Date(i.triggered_at).toLocaleDateString()}</td>
+                  <td className="px-4 py-3">
+                    {(i.status === "queued" || i.status === "failed") && (
+                      <button
+                        onClick={() => retry(i.id)}
+                        disabled={saving === `retry-${i.id}`}
+                        className="inline-flex items-center gap-1 rounded-lg border border-gray-200 hover:bg-gray-50 px-2 py-1 text-xs font-medium text-gray-700 cursor-pointer disabled:opacity-50"
+                      >
+                        {saving === `retry-${i.id}` ? <Loader2 className="h-3 w-3 animate-spin" /> : <RefreshCw className="h-3 w-3" />}
+                        Send
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/api/admin/marketplace/operator-invoices/[id]/retry/route.ts
+++ b/src/app/api/admin/marketplace/operator-invoices/[id]/retry/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAdminUserId } from "@/lib/adminAuth";
+import { pushOperatorInvoiceToQb } from "@/lib/marketplaceQb";
+
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id } = await params;
+
+  const result = await pushOperatorInvoiceToQb(id);
+  if (!result.ok) return NextResponse.json({ error: result.error || "Failed" }, { status: 400 });
+  return NextResponse.json({ ok: true, qb_invoice_id: result.externalId });
+}

--- a/src/app/api/admin/marketplace/operator-invoices/drain/route.ts
+++ b/src/app/api/admin/marketplace/operator-invoices/drain/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAdminUserId } from "@/lib/adminAuth";
+import { drainOperatorInvoices } from "@/lib/marketplaceQb";
+
+export async function POST(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const summary = await drainOperatorInvoices(50);
+  return NextResponse.json(summary);
+}

--- a/src/app/api/admin/marketplace/operator-invoices/route.ts
+++ b/src/app/api/admin/marketplace/operator-invoices/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+
+export async function GET(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const { searchParams } = new URL(req.url);
+  const status = searchParams.get("status") || "all";
+
+  let query = supabaseAdmin
+    .from("marketplace_operator_invoices")
+    .select("*, contract:contract_id(title, tier), submission:submission_id(business_name, city, state)")
+    .order("triggered_at", { ascending: false });
+  if (status !== "all") query = query.eq("status", status);
+
+  const { data, error } = await query;
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json(data || []);
+}

--- a/src/app/api/admin/marketplace/payouts/[id]/retry/route.ts
+++ b/src/app/api/admin/marketplace/payouts/[id]/retry/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAdminUserId } from "@/lib/adminAuth";
+import { pushPayoutToQb } from "@/lib/marketplaceQb";
+
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id } = await params;
+
+  const result = await pushPayoutToQb(id);
+  if (!result.ok) return NextResponse.json({ error: result.error || "Failed" }, { status: 400 });
+  return NextResponse.json({ ok: true, qb_bill_id: result.externalId });
+}

--- a/src/app/api/admin/marketplace/payouts/drain/route.ts
+++ b/src/app/api/admin/marketplace/payouts/drain/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAdminUserId } from "@/lib/adminAuth";
+import { drainPayouts } from "@/lib/marketplaceQb";
+
+export async function POST(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const summary = await drainPayouts(50);
+  return NextResponse.json(summary);
+}

--- a/src/app/api/admin/marketplace/payouts/route.ts
+++ b/src/app/api/admin/marketplace/payouts/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+
+export async function GET(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const { searchParams } = new URL(req.url);
+  const status = searchParams.get("status") || "all";
+
+  let query = supabaseAdmin
+    .from("marketplace_payouts")
+    .select("*, contract:contract_id(title, tier), partner:partner_id(business_name), submission:submission_id(business_name, city, state)")
+    .order("triggered_at", { ascending: false });
+  if (status !== "all") query = query.eq("status", status);
+
+  const { data, error } = await query;
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json(data || []);
+}

--- a/src/app/api/operator/marketplace/submissions/[id]/decide/route.ts
+++ b/src/app/api/operator/marketplace/submissions/[id]/decide/route.ts
@@ -80,10 +80,27 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
       });
     }
 
-    // Queue payout + invoice (Phase 2.4 wires the actual QuickBooks calls).
+    // Queue payout + invoice, then best-effort push both to QuickBooks in the
+    // background. Any failures are surfaced on /admin/marketplace/payouts and
+    // can be retried there. Non-critical — decision is already recorded.
     try {
       await queuePartnerPayoutForSubmission({ submissionId: id, triggeredBy: user.id });
       await queueOperatorInvoiceForSubmission({ submissionId: id, triggeredBy: user.id });
+
+      const { data: newPayout } = await supabaseAdmin
+        .from("marketplace_payouts")
+        .select("id")
+        .eq("submission_id", id)
+        .maybeSingle();
+      const { data: newInvoice } = await supabaseAdmin
+        .from("marketplace_operator_invoices")
+        .select("id")
+        .eq("submission_id", id)
+        .maybeSingle();
+
+      const { pushPayoutToQb, pushOperatorInvoiceToQb } = await import("@/lib/marketplaceQb");
+      if (newPayout) pushPayoutToQb(newPayout.id).catch(() => undefined);
+      if (newInvoice) pushOperatorInvoiceToQb(newInvoice.id).catch(() => undefined);
     } catch {
       // Non-critical — decision already recorded
     }

--- a/src/app/api/webhooks/quickbooks/route.ts
+++ b/src/app/api/webhooks/quickbooks/route.ts
@@ -44,10 +44,50 @@ export async function POST(req: NextRequest) {
       if (entity.name === "Payment" && (entity.operation === "Create" || entity.operation === "Update")) {
         await handleQBPayment(entity.id, notification.realmId);
       }
+      if (entity.name === "BillPayment" && (entity.operation === "Create" || entity.operation === "Update")) {
+        await handleQBBillPayment(entity.id, notification.realmId);
+      }
     }
   }
 
   return NextResponse.json({ ok: true });
+}
+
+async function handleQBBillPayment(billPaymentId: string, realmId: string) {
+  const { getConnection } = await import("@/lib/quickbooks");
+  const conn = await getConnection();
+  if (conn.realm_id !== realmId) return;
+
+  const base = process.env.QB_ENVIRONMENT === "production"
+    ? "https://quickbooks.api.intuit.com"
+    : "https://sandbox-quickbooks.api.intuit.com";
+
+  const res = await fetch(`${base}/v3/company/${realmId}/billpayment/${billPaymentId}`, {
+    headers: { Authorization: `Bearer ${conn.access_token}`, Accept: "application/json" },
+  });
+  if (!res.ok) return;
+
+  const data = await res.json();
+  const billIds: string[] = [];
+  for (const line of data.BillPayment?.Line || []) {
+    for (const txn of line.LinkedTxn || []) {
+      if (txn.TxnType === "Bill") billIds.push(txn.TxnId);
+    }
+  }
+
+  for (const billId of billIds) {
+    const { data: payout } = await supabaseAdmin
+      .from("marketplace_payouts")
+      .select("id, status")
+      .eq("qb_bill_id", billId)
+      .maybeSingle();
+    if (payout && payout.status !== "paid") {
+      await supabaseAdmin
+        .from("marketplace_payouts")
+        .update({ status: "paid", paid_at: new Date().toISOString(), updated_at: new Date().toISOString() })
+        .eq("id", payout.id);
+    }
+  }
 }
 
 async function handleQBPayment(paymentId: string, realmId: string) {
@@ -241,6 +281,28 @@ async function handleQBPayment(paymentId: string, realmId: string) {
           updated_at: new Date().toISOString(),
         })
         .eq("id", pipelinePayment.id);
+      continue;
+    }
+
+    // Check marketplace_operator_invoices (Phase 2.4 — placement fee billing)
+    const { data: marketplaceOpInvoice } = await supabaseAdmin
+      .from("marketplace_operator_invoices")
+      .select("id, status")
+      .eq("qb_invoice_id", invoiceId)
+      .maybeSingle();
+
+    if (marketplaceOpInvoice) {
+      console.log(`[qb-webhook] Processing marketplace operator invoice payment for QB invoice ${invoiceId}`);
+      if (marketplaceOpInvoice.status !== "paid") {
+        await supabaseAdmin
+          .from("marketplace_operator_invoices")
+          .update({
+            status: "paid",
+            paid_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+          })
+          .eq("id", marketplaceOpInvoice.id);
+      }
       continue;
     }
 

--- a/src/lib/marketplaceQb.ts
+++ b/src/lib/marketplaceQb.ts
@@ -1,0 +1,294 @@
+/**
+ * Phase 2.4 — Drain the marketplace_payouts and marketplace_operator_invoices
+ * queues into QuickBooks. Each drain function is idempotent and safe to call
+ * concurrently — status transitions are guarded by the row's current status.
+ *
+ * pushPayoutToQb / pushOperatorInvoiceToQb — one row at a time.
+ * drainPayouts / drainOperatorInvoices — batch drain the queued rows.
+ *
+ * QB payment lifecycle:
+ *   Bill    (partner payout)   queued → sent_to_qb → paid via webhook (BillPayment)
+ *   Invoice (operator billing) queued → sent_to_qb → paid via webhook (Payment)
+ */
+
+import { supabaseAdmin } from "./supabaseAdmin";
+import {
+  findOrCreateVendor,
+  findOrCreateCustomer,
+  createBill,
+  createInvoice,
+} from "./quickbooks";
+
+const now = () => new Date().toISOString();
+
+interface EnsureVendorArgs {
+  partnerId: string;
+}
+
+async function ensurePartnerVendor({ partnerId }: EnsureVendorArgs): Promise<string | null> {
+  const { data: partner } = await supabaseAdmin
+    .from("placement_partners")
+    .select("id, business_name, qb_vendor_id")
+    .eq("id", partnerId)
+    .maybeSingle();
+  if (!partner) return null;
+  if (partner.qb_vendor_id) return partner.qb_vendor_id;
+
+  const { data: profile } = await supabaseAdmin
+    .from("profiles")
+    .select("full_name, email, phone")
+    .eq("id", partnerId)
+    .maybeSingle();
+
+  const displayName = partner.business_name || profile?.full_name || `Partner ${partnerId.slice(0, 8)}`;
+  const vendor = await findOrCreateVendor({
+    displayName,
+    email: profile?.email || undefined,
+    phone: profile?.phone || undefined,
+  });
+
+  await supabaseAdmin
+    .from("placement_partners")
+    .update({
+      qb_vendor_id: vendor.Id,
+      qb_vendor_created_at: now(),
+      updated_at: now(),
+    })
+    .eq("id", partnerId);
+
+  return vendor.Id;
+}
+
+interface EnsureCustomerArgs {
+  profileId: string | null;
+  fallbackEmail: string | null;
+  fallbackName: string | null;
+}
+
+async function ensureOperatorCustomer({ profileId, fallbackEmail, fallbackName }: EnsureCustomerArgs): Promise<string | null> {
+  let email: string | null = fallbackEmail;
+  let displayName: string | null = fallbackName;
+
+  if (profileId) {
+    const { data: profile } = await supabaseAdmin
+      .from("profiles")
+      .select("full_name, email, phone, company_name, qb_customer_id")
+      .eq("id", profileId)
+      .maybeSingle();
+    if (profile?.qb_customer_id) return profile.qb_customer_id;
+    email = profile?.email || email;
+    displayName = profile?.company_name || profile?.full_name || displayName;
+  }
+
+  if (!email || !displayName) return null;
+
+  const customer = await findOrCreateCustomer({ displayName, email });
+
+  if (profileId) {
+    await supabaseAdmin
+      .from("profiles")
+      .update({
+        qb_customer_id: customer.Id,
+        qb_customer_created_at: now(),
+      })
+      .eq("id", profileId);
+  }
+
+  return customer.Id;
+}
+
+export interface QbPushResult {
+  ok: boolean;
+  error?: string;
+  externalId?: string;
+}
+
+export async function pushPayoutToQb(payoutId: string): Promise<QbPushResult> {
+  const { data: payout } = await supabaseAdmin
+    .from("marketplace_payouts")
+    .select("*")
+    .eq("id", payoutId)
+    .maybeSingle();
+  if (!payout) return { ok: false, error: "Payout not found" };
+  if (payout.status !== "queued" && payout.status !== "failed") {
+    return { ok: false, error: `Payout already ${payout.status}` };
+  }
+
+  const stampAttempt = () =>
+    supabaseAdmin
+      .from("marketplace_payouts")
+      .update({ qb_last_attempt_at: now(), updated_at: now() })
+      .eq("id", payoutId);
+
+  try {
+    await stampAttempt();
+    const vendorId = await ensurePartnerVendor({ partnerId: payout.partner_id });
+    if (!vendorId) throw new Error("Could not resolve QB Vendor for partner");
+
+    const { data: contract } = await supabaseAdmin
+      .from("placement_contracts")
+      .select("title, tier")
+      .eq("id", payout.contract_id)
+      .maybeSingle();
+
+    const bill = await createBill({
+      vendorId,
+      lineItems: [
+        {
+          description: `Placement payout — ${contract?.title || "Contract"} (Tier ${contract?.tier || 1})`,
+          amount: Number(payout.amount),
+        },
+      ],
+      privateNote: `submission_id=${payout.submission_id}; contract_id=${payout.contract_id}; payout_id=${payout.id}`,
+    });
+
+    await supabaseAdmin
+      .from("marketplace_payouts")
+      .update({
+        status: "sent_to_qb",
+        qb_bill_id: bill.Id,
+        qb_error: null,
+        sent_at: now(),
+        updated_at: now(),
+      })
+      .eq("id", payoutId);
+
+    return { ok: true, externalId: bill.Id };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    await supabaseAdmin
+      .from("marketplace_payouts")
+      .update({
+        status: "failed",
+        qb_error: msg.slice(0, 500),
+        updated_at: now(),
+      })
+      .eq("id", payoutId);
+    return { ok: false, error: msg };
+  }
+}
+
+export async function pushOperatorInvoiceToQb(invoiceId: string): Promise<QbPushResult> {
+  const { data: invoice } = await supabaseAdmin
+    .from("marketplace_operator_invoices")
+    .select("*")
+    .eq("id", invoiceId)
+    .maybeSingle();
+  if (!invoice) return { ok: false, error: "Invoice not found" };
+  if (invoice.status !== "queued" && invoice.status !== "failed") {
+    return { ok: false, error: `Invoice already ${invoice.status}` };
+  }
+
+  try {
+    await supabaseAdmin
+      .from("marketplace_operator_invoices")
+      .update({ qb_last_attempt_at: now(), updated_at: now() })
+      .eq("id", invoiceId);
+
+    const customerId = await ensureOperatorCustomer({
+      profileId: invoice.operator_profile_id,
+      fallbackEmail: invoice.operator_email,
+      fallbackName: invoice.operator_business_name,
+    });
+    if (!customerId) throw new Error("Could not resolve QB Customer for operator");
+
+    const { data: contract } = await supabaseAdmin
+      .from("placement_contracts")
+      .select("title, tier")
+      .eq("id", invoice.contract_id)
+      .maybeSingle();
+
+    // createInvoice uses findOrCreateCustomer internally; passing the same
+    // email/name will hit its cache path. We've already ensured the customer
+    // above (which populates the profile cache), so this second call is cheap.
+    const qbInvoice = await createInvoice({
+      customerEmail: invoice.operator_email || "",
+      customerName: invoice.operator_business_name || "Operator",
+      lineItems: [
+        {
+          description: `Placement fee — ${contract?.title || "Contract"} (Tier ${contract?.tier || 1})`,
+          amount: Number(invoice.amount),
+        },
+      ],
+      memo: "Location placement fee for approved marketplace submission.",
+      metadata: {
+        submission_id: invoice.submission_id,
+        contract_id: invoice.contract_id,
+        marketplace_invoice_id: invoice.id,
+      },
+    });
+
+    await supabaseAdmin
+      .from("marketplace_operator_invoices")
+      .update({
+        status: "sent_to_qb",
+        qb_invoice_id: qbInvoice.Id,
+        qb_error: null,
+        sent_at: now(),
+        updated_at: now(),
+      })
+      .eq("id", invoiceId);
+
+    return { ok: true, externalId: qbInvoice.Id };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    await supabaseAdmin
+      .from("marketplace_operator_invoices")
+      .update({
+        status: "failed",
+        qb_error: msg.slice(0, 500),
+        updated_at: now(),
+      })
+      .eq("id", invoiceId);
+    return { ok: false, error: msg };
+  }
+}
+
+export interface DrainSummary {
+  attempted: number;
+  succeeded: number;
+  failed: number;
+  errors: string[];
+}
+
+export async function drainPayouts(limit = 25): Promise<DrainSummary> {
+  const { data: rows } = await supabaseAdmin
+    .from("marketplace_payouts")
+    .select("id")
+    .in("status", ["queued", "failed"])
+    .order("triggered_at", { ascending: true })
+    .limit(limit);
+
+  const summary: DrainSummary = { attempted: 0, succeeded: 0, failed: 0, errors: [] };
+  for (const row of rows || []) {
+    summary.attempted++;
+    const r = await pushPayoutToQb(row.id);
+    if (r.ok) summary.succeeded++;
+    else {
+      summary.failed++;
+      if (r.error) summary.errors.push(r.error);
+    }
+  }
+  return summary;
+}
+
+export async function drainOperatorInvoices(limit = 25): Promise<DrainSummary> {
+  const { data: rows } = await supabaseAdmin
+    .from("marketplace_operator_invoices")
+    .select("id")
+    .in("status", ["queued", "failed"])
+    .order("triggered_at", { ascending: true })
+    .limit(limit);
+
+  const summary: DrainSummary = { attempted: 0, succeeded: 0, failed: 0, errors: [] };
+  for (const row of rows || []) {
+    summary.attempted++;
+    const r = await pushOperatorInvoiceToQb(row.id);
+    if (r.ok) summary.succeeded++;
+    else {
+      summary.failed++;
+      if (r.error) summary.errors.push(r.error);
+    }
+  }
+  return summary;
+}

--- a/src/lib/quickbooks.ts
+++ b/src/lib/quickbooks.ts
@@ -395,6 +395,132 @@ export async function createCharge(params: {
   return res.json();
 }
 
+// ─── Vendor Management (partner payouts) ───
+
+export interface QBVendor {
+  Id: string;
+  DisplayName: string;
+  PrimaryEmailAddr?: { Address: string };
+  SyncToken: string;
+}
+
+export async function findVendorByEmail(email: string): Promise<QBVendor | null> {
+  const query = `SELECT * FROM Vendor WHERE PrimaryEmailAddr = '${email.replace(/'/g, "\\'")}'`;
+  const res = await qbFetch(`/query?query=${encodeURIComponent(query)}`);
+  if (!res.ok) return null;
+  const data = await res.json();
+  return data.QueryResponse?.Vendor?.[0] || null;
+}
+
+export async function findVendorByName(displayName: string): Promise<QBVendor | null> {
+  const query = `SELECT * FROM Vendor WHERE DisplayName = '${displayName.replace(/'/g, "\\'")}'`;
+  const res = await qbFetch(`/query?query=${encodeURIComponent(query)}`);
+  if (!res.ok) return null;
+  const data = await res.json();
+  return data.QueryResponse?.Vendor?.[0] || null;
+}
+
+export async function createVendor(params: {
+  displayName: string;
+  email?: string;
+  phone?: string;
+}): Promise<QBVendor> {
+  const body: Record<string, unknown> = { DisplayName: params.displayName };
+  if (params.email) body.PrimaryEmailAddr = { Address: params.email };
+  if (params.phone) body.PrimaryPhone = { FreeFormNumber: params.phone };
+
+  const res = await qbFetch("/vendor", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    if (text.includes("6240") || text.includes("Duplicate Name")) {
+      const existing = await findVendorByName(params.displayName);
+      if (existing) return existing;
+    }
+    throw new Error(`QB create vendor failed: ${text}`);
+  }
+
+  const data = await res.json();
+  return data.Vendor;
+}
+
+export async function findOrCreateVendor(params: {
+  displayName: string;
+  email?: string;
+  phone?: string;
+}): Promise<QBVendor> {
+  if (params.email) {
+    const byEmail = await findVendorByEmail(params.email);
+    if (byEmail) return byEmail;
+  }
+  const byName = await findVendorByName(params.displayName);
+  if (byName) return byName;
+  return createVendor(params);
+}
+
+// ─── Bill Management (partner payouts owed) ───
+
+export interface QBBill {
+  Id: string;
+  DocNumber?: string;
+  TotalAmt: number;
+  Balance: number;
+  SyncToken: string;
+}
+
+export interface CreateBillParams {
+  vendorId: string;
+  lineItems: { description: string; amount: number }[];
+  memo?: string;
+  dueDate?: string;
+  privateNote?: string;
+}
+
+export async function createBill(params: CreateBillParams): Promise<QBBill> {
+  const lines = params.lineItems.map((item, idx) => ({
+    LineNum: idx + 1,
+    Amount: item.amount,
+    DetailType: "AccountBasedExpenseLineDetail",
+    Description: item.description,
+    AccountBasedExpenseLineDetail: {
+      AccountRef: { value: process.env.QB_PAYOUT_EXPENSE_ACCOUNT_ID || "1" },
+    },
+  }));
+
+  const billBody: Record<string, unknown> = {
+    VendorRef: { value: params.vendorId },
+    Line: lines,
+    DueDate: params.dueDate || new Date().toISOString().split("T")[0],
+    PrivateNote: params.privateNote,
+  };
+
+  const res = await qbFetch("/bill", {
+    method: "POST",
+    body: JSON.stringify(billBody),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`QB create bill failed: ${text}`);
+  }
+
+  const data = await res.json();
+  return data.Bill;
+}
+
+export async function getBill(billId: string): Promise<QBBill> {
+  const res = await qbFetch(`/bill/${billId}`);
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`QB get bill failed: ${text}`);
+  }
+  const data = await res.json();
+  return data.Bill;
+}
+
 // ─── Webhook Verification ───
 
 export function verifyWebhookSignature(payload: string, signature: string): boolean {

--- a/supabase/migrations/100_marketplace_qb_refs.sql
+++ b/supabase/migrations/100_marketplace_qb_refs.sql
@@ -1,0 +1,17 @@
+-- Marketplace Phase 2.4 — QuickBooks Vendor/Customer cache references
+--
+-- We cache the QB Vendor ID on placement_partners and the QB Customer ID on
+-- profiles so the drain worker doesn't need to do a NAME lookup for every
+-- payout / invoice push. All fields nullable + idempotent.
+
+ALTER TABLE placement_partners
+  ADD COLUMN IF NOT EXISTS qb_vendor_id text,
+  ADD COLUMN IF NOT EXISTS qb_vendor_created_at timestamptz;
+
+CREATE INDEX IF NOT EXISTS idx_partners_qb_vendor ON placement_partners(qb_vendor_id);
+
+ALTER TABLE profiles
+  ADD COLUMN IF NOT EXISTS qb_customer_id text,
+  ADD COLUMN IF NOT EXISTS qb_customer_created_at timestamptz;
+
+CREATE INDEX IF NOT EXISTS idx_profiles_qb_customer ON profiles(qb_customer_id);


### PR DESCRIPTION
Drains the marketplace_payouts and marketplace_operator_invoices queues from Phase 2.3 into QuickBooks: PPs become QB Vendors + get Bills for their payouts, operators become QB Customers + get Invoices for placement fees. Webhook flips rows to paid when QB reports the money moved.

Money flow (per submission the operator accepts):
  operator accept → queue Payout + Invoice → drain (auto in accept handler +
  admin button) → QB Bill / QB Invoice created → status sent_to_qb → QB
  webhook (BillPayment / Payment) → status paid.

Data model (migration 100):
- placement_partners: qb_vendor_id + qb_vendor_created_at
- profiles: qb_customer_id + qb_customer_created_at
- Both nullable, both idempotent, indexes for O(1) lookup.

QB helpers (src/lib/quickbooks.ts):
- findVendorByEmail / findVendorByName / createVendor / findOrCreateVendor — mirrors the existing Customer helpers. Handles QB's DisplayName-uniqueness duplicate error (code 6240) by looking up the existing vendor.
- createBill / getBill — creates AccountBasedExpenseLine bills against QB_PAYOUT_EXPENSE_ACCOUNT_ID (env var; defaults to '1' if unset — set this in Vercel).

Drain worker (src/lib/marketplaceQb.ts):
- ensurePartnerVendor / ensureOperatorCustomer — resolve or create the QB Vendor/Customer, cache the ID on partners.qb_vendor_id / profiles.qb_customer_id.
- pushPayoutToQb — creates the QB Bill; on success flips to sent_to_qb + records qb_bill_id + sent_at; on failure flips to failed + records qb_error (500-char truncated). Only acts on queued/failed rows — idempotent.
- pushOperatorInvoiceToQb — same shape for the Invoice side.
- drainPayouts / drainOperatorInvoices — batch drain up to 50 queued/failed rows, returns { attempted, succeeded, failed, errors } summary.

Auto-drain hook:
- Operator accept handler now fires-and-forgets pushPayoutToQb + pushOperatorInvoiceToQb after queueing, so the happy path pushes to QB within milliseconds of the operator clicking Accept. Failures land on the admin queue with an error message.

QB webhook (src/app/api/webhooks/quickbooks/route.ts):
- BillPayment webhook: fetches the payment, walks linked bills, marks matching marketplace_payouts as paid.
- Payment webhook: adds marketplace_operator_invoices to the list of tables checked against qb_invoice_id; marks paid on match.

Admin API (/api/admin/marketplace):
- GET payouts + GET operator-invoices — filterable list with contract + partner
  + submission joins.
- POST payouts/[id]/retry + POST operator-invoices/[id]/retry — manual retry for a single failed row.
- POST payouts/drain + POST operator-invoices/drain — bulk drain (up to 50 rows). Suitable for a cron trigger.

Admin UI:
- New /admin/marketplace/payouts page with two tabs (Partner Payouts / Operator Invoices), status filter, "Drain to QuickBooks" button, per-row retry with QB ref display, error tooltip on failed rows.
- Marketplace shared nav gets a "Payouts" tab.

Set QB_PAYOUT_EXPENSE_ACCOUNT_ID in Vercel to the QB Chart-of-Accounts ID for partner-commission expense (Intuit will accept any expense account).


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2