### PR TITLE
Marketplace Phase 2.5 — Bidirectional ratings + PP team members

### DIFF
--- a/src/app/admin/marketplace/layout.tsx
+++ b/src/app/admin/marketplace/layout.tsx
@@ -2,13 +2,14 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Briefcase, Package, TrendingUp, Users, DollarSign } from "lucide-react";
+import { Briefcase, Package, TrendingUp, Users, DollarSign, Star } from "lucide-react";
 
 const NAV = [
   { href: "/admin/marketplace/contracts", label: "Contracts", icon: Briefcase },
   { href: "/admin/marketplace/submissions", label: "Submissions", icon: Package },
   { href: "/admin/marketplace/tier-proposals", label: "Tier Bumps", icon: TrendingUp },
   { href: "/admin/marketplace/payouts", label: "Payouts", icon: DollarSign },
+  { href: "/admin/marketplace/ratings", label: "Ratings", icon: Star },
   { href: "/admin/marketplace/partners", label: "Partners", icon: Users },
 ];
 

--- a/src/app/admin/marketplace/ratings/page.tsx
+++ b/src/app/admin/marketplace/ratings/page.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Loader2, Star, ArrowLeft, Filter, Lock, Eye } from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
+
+interface Rating {
+  id: string;
+  rater_type: string;
+  rater_profile_id: string;
+  ratee_type: string;
+  ratee_id: string;
+  submission_id: string;
+  contract_id: string;
+  score: number;
+  feedback: string | null;
+  tags: string[] | null;
+  visibility: string;
+  created_at: string;
+  rater: { full_name: string; email: string } | null;
+  submission: { business_name: string; city: string | null; state: string | null } | null;
+  contract: { title: string; tier: number } | null;
+}
+
+const FILTERS = [
+  { key: "all", label: "All" },
+  { key: "partner", label: "About Partners" },
+  { key: "operator", label: "About Operators (admin-only)" },
+];
+
+export default function AdminRatingsPage() {
+  const router = useRouter();
+  const [token, setToken] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [ratings, setRatings] = useState<Rating[]>([]);
+  const [filter, setFilter] = useState("all");
+
+  const load = useCallback(async () => {
+    if (!token) return;
+    setLoading(true);
+    const params = new URLSearchParams();
+    if (filter !== "all") params.set("ratee_type", filter);
+    const res = await fetch(`/api/admin/marketplace/ratings?${params}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.ok) setRatings(await res.json());
+    setLoading(false);
+  }, [token, filter]);
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!session?.access_token) { router.push("/login?redirect=/admin/marketplace/ratings"); return; }
+      setToken(session.access_token);
+    });
+  }, [router]);
+
+  useEffect(() => { load(); }, [load]);
+
+  return (
+    <div className="p-6 max-w-5xl">
+      <Link href="/admin" className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-green-primary mb-4">
+        <ArrowLeft className="h-4 w-4" /> Back to Admin
+      </Link>
+
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
+          <Star className="h-6 w-6 text-green-primary" /> Marketplace Ratings
+        </h1>
+        <p className="text-sm text-gray-500 mt-1">Every rating on every submission — partners rating operators are admin-only.</p>
+      </div>
+
+      <div className="mb-4 flex items-center gap-2 flex-wrap">
+        <Filter className="h-4 w-4 text-gray-400" />
+        {FILTERS.map((f) => (
+          <button
+            key={f.key}
+            onClick={() => setFilter(f.key)}
+            className={`rounded-lg px-3 py-1.5 text-xs font-medium cursor-pointer ${filter === f.key ? "bg-green-100 text-green-700" : "bg-gray-100 text-gray-500 hover:bg-gray-200"}`}
+          >
+            {f.label}
+          </button>
+        ))}
+      </div>
+
+      {loading ? (
+        <div className="flex justify-center py-20"><Loader2 className="h-6 w-6 animate-spin text-green-primary" /></div>
+      ) : ratings.length === 0 ? (
+        <div className="rounded-xl border border-gray-200 bg-white p-12 text-center">
+          <Star className="mx-auto h-12 w-12 text-gray-300 mb-3" />
+          <p className="text-lg font-semibold text-gray-900 mb-1">No ratings yet</p>
+          <p className="text-sm text-gray-500">Ratings appear here as operators accept and partners rate.</p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {ratings.map((r) => (
+            <div key={r.id} className="rounded-2xl border border-gray-100 bg-white p-4">
+              <div className="flex items-start justify-between gap-3 mb-2 flex-wrap">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <div className="flex items-center gap-0.5">
+                      {[1, 2, 3, 4, 5].map((n) => (
+                        <Star key={n} className={`h-4 w-4 ${n <= r.score ? "fill-amber-400 text-amber-400" : "text-gray-200"}`} />
+                      ))}
+                    </div>
+                    <span className="text-sm font-semibold text-gray-900">{r.score}/5</span>
+                    <span className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium ${r.visibility === "admin_only" ? "bg-amber-50 text-amber-700" : "bg-emerald-50 text-emerald-700"}`}>
+                      {r.visibility === "admin_only" ? <Lock className="h-2.5 w-2.5" /> : <Eye className="h-2.5 w-2.5" />}
+                      {r.visibility === "admin_only" ? "Admin-only" : "Visible to ratee"}
+                    </span>
+                  </div>
+                  <p className="text-sm text-gray-700 mt-1">
+                    <span className="text-gray-500">{r.rater_type === "operator" ? "Operator" : "Partner"}:</span>{" "}
+                    <span className="font-medium">{r.rater?.full_name || r.rater?.email || "—"}</span>
+                    <span className="text-gray-400"> → </span>
+                    <span className="text-gray-500">rated {r.ratee_type}</span>
+                  </p>
+                  {r.submission && r.contract && (
+                    <p className="text-xs text-gray-500">
+                      {r.submission.business_name} · {[r.submission.city, r.submission.state].filter(Boolean).join(", ")} · {r.contract.title} (Tier {r.contract.tier})
+                    </p>
+                  )}
+                </div>
+                <span className="text-xs text-gray-400">{new Date(r.created_at).toLocaleDateString()}</span>
+              </div>
+
+              {r.feedback && (
+                <p className="text-sm text-gray-700 whitespace-pre-wrap bg-gray-50 rounded-lg p-2 mt-2">{r.feedback}</p>
+              )}
+              {r.tags && r.tags.length > 0 && (
+                <div className="mt-2 flex flex-wrap gap-1.5">
+                  {r.tags.map((t) => (
+                    <span key={t} className="rounded-full bg-gray-100 text-gray-600 text-[10px] px-2.5 py-0.5">
+                      {t}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/api/admin/marketplace/ratings/route.ts
+++ b/src/app/api/admin/marketplace/ratings/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+
+export async function GET(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const { searchParams } = new URL(req.url);
+  const rateeType = searchParams.get("ratee_type") || "all";
+
+  let query = supabaseAdmin
+    .from("placement_ratings")
+    .select("*, rater:rater_profile_id(full_name, email), submission:submission_id(business_name, city, state), contract:contract_id(title, tier)")
+    .order("created_at", { ascending: false });
+  if (rateeType !== "all") query = query.eq("ratee_type", rateeType);
+
+  const { data, error } = await query;
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json(data || []);
+}

--- a/src/app/api/marketplace/submissions/[id]/rate/route.ts
+++ b/src/app/api/marketplace/submissions/[id]/rate/route.ts
@@ -1,0 +1,84 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getPlacementPartner, forbidden } from "@/lib/marketplaceAuth";
+import { submitRating } from "@/lib/marketplaceRatings";
+
+/**
+ * Partner rates the operator on this submission.
+ * Only allowed once the operator has accepted (operator_status='accepted').
+ */
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const user = await getPlacementPartner(req);
+  if (!user) return forbidden();
+  const { id } = await params;
+
+  const body = await req.json().catch(() => ({}));
+  const score = Number(body.score);
+  const feedback = typeof body.feedback === "string" ? body.feedback : null;
+  const tags = Array.isArray(body.tags) ? body.tags.filter((t: unknown) => typeof t === "string") : [];
+
+  if (!Number.isFinite(score) || score < 1 || score > 5) {
+    return NextResponse.json({ error: "Score must be 1-5" }, { status: 400 });
+  }
+
+  const { data: submission } = await supabaseAdmin
+    .from("placement_submissions")
+    .select("id, contract_id, partner_id, operator_status")
+    .eq("id", id)
+    .maybeSingle();
+  if (!submission || submission.partner_id !== user.id) return forbidden();
+  if (submission.operator_status !== "accepted") {
+    return NextResponse.json({ error: "You can only rate the operator after they accept" }, { status: 400 });
+  }
+
+  const { data: contract } = await supabaseAdmin
+    .from("placement_contracts")
+    .select("id, operator_profile_id")
+    .eq("id", submission.contract_id)
+    .maybeSingle();
+  if (!contract?.operator_profile_id) {
+    return NextResponse.json({ error: "Operator not yet linked to profile — nothing to rate" }, { status: 400 });
+  }
+
+  const result = await submitRating({
+    raterType: "partner",
+    raterProfileId: user.id,
+    rateeType: "operator",
+    rateeId: contract.operator_profile_id,
+    submissionId: submission.id,
+    contractId: contract.id,
+    score,
+    feedback,
+    tags,
+  });
+  if (!result.ok) return NextResponse.json({ error: result.error }, { status: 400 });
+
+  await supabaseAdmin.from("placement_submission_activity").insert({
+    submission_id: id,
+    actor_id: user.id,
+    activity_type: "partner_rated_operator",
+    description: `Partner rated operator (${score}★)`,
+  });
+
+  return NextResponse.json({ ok: true, id: result.ratingId });
+}
+
+/**
+ * GET returns the partner's own rating on this submission (if any) so the UI
+ * can show a "you already rated 5★" state instead of the submit form.
+ */
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const user = await getPlacementPartner(req);
+  if (!user) return forbidden();
+  const { id } = await params;
+
+  const { data } = await supabaseAdmin
+    .from("placement_ratings")
+    .select("id, score, feedback, tags, created_at")
+    .eq("rater_profile_id", user.id)
+    .eq("submission_id", id)
+    .eq("ratee_type", "operator")
+    .maybeSingle();
+
+  return NextResponse.json({ rating: data || null });
+}

--- a/src/app/api/marketplace/team/invite/[token]/route.ts
+++ b/src/app/api/marketplace/team/invite/[token]/route.ts
@@ -1,0 +1,95 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getUserIdFromRequest } from "@/lib/apiAuth";
+
+/**
+ * GET — public preview of the invite (no auth needed) so the accept page
+ * can render "You've been invited to <Company>" before the user signs in.
+ */
+export async function GET(_req: NextRequest, { params }: { params: Promise<{ token: string }> }) {
+  const { token } = await params;
+
+  const { data: invite } = await supabaseAdmin
+    .from("placement_team_invites")
+    .select("id, email, role, expires_at, accepted_at, company:company_id(business_name)")
+    .eq("token", token)
+    .maybeSingle();
+
+  if (!invite) return NextResponse.json({ error: "Invite not found" }, { status: 404 });
+  if (invite.accepted_at) return NextResponse.json({ error: "Already accepted" }, { status: 400 });
+  if (new Date(invite.expires_at).getTime() < Date.now()) {
+    return NextResponse.json({ error: "Invite expired" }, { status: 400 });
+  }
+
+  return NextResponse.json({
+    email: invite.email,
+    role: invite.role,
+    company_name: (Array.isArray(invite.company) ? invite.company[0]?.business_name : (invite.company as { business_name?: string } | null)?.business_name) || "a placement partner",
+  });
+}
+
+/**
+ * POST — accept the invite. Requires the invited email to match the logged-in
+ * profile's email. Upgrades their role to placement_partner and creates the
+ * team_member row.
+ */
+export async function POST(req: NextRequest, { params }: { params: Promise<{ token: string }> }) {
+  const { token } = await params;
+  const userId = await getUserIdFromRequest(req);
+  if (!userId) return NextResponse.json({ error: "Sign in to accept" }, { status: 401 });
+
+  const { data: profile } = await supabaseAdmin
+    .from("profiles")
+    .select("id, email, role")
+    .eq("id", userId)
+    .maybeSingle();
+  if (!profile) return NextResponse.json({ error: "Profile not found" }, { status: 404 });
+
+  const { data: invite } = await supabaseAdmin
+    .from("placement_team_invites")
+    .select("*")
+    .eq("token", token)
+    .maybeSingle();
+  if (!invite) return NextResponse.json({ error: "Invite not found" }, { status: 404 });
+  if (invite.accepted_at) return NextResponse.json({ error: "Already accepted" }, { status: 400 });
+  if (new Date(invite.expires_at).getTime() < Date.now()) {
+    return NextResponse.json({ error: "Invite expired" }, { status: 400 });
+  }
+
+  if (profile.email.trim().toLowerCase() !== invite.email.trim().toLowerCase()) {
+    return NextResponse.json(
+      { error: `This invite is for ${invite.email}. Sign in with that account.` },
+      { status: 400 },
+    );
+  }
+
+  // Upgrade role
+  if (profile.role !== "placement_partner") {
+    await supabaseAdmin.from("profiles").update({ role: "placement_partner" }).eq("id", userId);
+  }
+
+  // Create team membership
+  const now = new Date().toISOString();
+  await supabaseAdmin
+    .from("placement_team_members")
+    .upsert(
+      {
+        company_id: invite.company_id,
+        profile_id: userId,
+        role: invite.role,
+        active: true,
+        invited_by: invite.invited_by,
+        invited_at: invite.created_at,
+        joined_at: now,
+      },
+      { onConflict: "company_id,profile_id" },
+    );
+
+  // Mark invite accepted
+  await supabaseAdmin
+    .from("placement_team_invites")
+    .update({ accepted_at: now })
+    .eq("id", invite.id);
+
+  return NextResponse.json({ ok: true, company_id: invite.company_id });
+}

--- a/src/app/api/marketplace/team/invites/[id]/route.ts
+++ b/src/app/api/marketplace/team/invites/[id]/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getPlacementPartner, forbidden } from "@/lib/marketplaceAuth";
+import { resolveTeamContextForPartner } from "@/lib/marketplaceTeam";
+
+/**
+ * DELETE — revoke a pending invite. Owner/manager only.
+ */
+export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const user = await getPlacementPartner(req);
+  if (!user) return forbidden();
+  const { id } = await params;
+
+  const ctx = await resolveTeamContextForPartner(user.id);
+  if (!ctx) return forbidden();
+  if (ctx.role !== "owner" && ctx.role !== "manager") return forbidden("Owner or manager only");
+
+  await supabaseAdmin
+    .from("placement_team_invites")
+    .delete()
+    .eq("id", id)
+    .eq("company_id", ctx.companyId)
+    .is("accepted_at", null);
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/marketplace/team/members/[id]/route.ts
+++ b/src/app/api/marketplace/team/members/[id]/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getPlacementPartner, forbidden } from "@/lib/marketplaceAuth";
+import { resolveTeamContextForPartner } from "@/lib/marketplaceTeam";
+
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const user = await getPlacementPartner(req);
+  if (!user) return forbidden();
+  const { id } = await params;
+
+  const ctx = await resolveTeamContextForPartner(user.id);
+  if (!ctx || ctx.role !== "owner") return forbidden("Owner only");
+
+  const body = await req.json().catch(() => ({}));
+  const role = body.role;
+  if (!["manager", "agent"].includes(role)) return NextResponse.json({ error: "Invalid role" }, { status: 400 });
+
+  const { data: member } = await supabaseAdmin
+    .from("placement_team_members")
+    .select("id, role, company_id")
+    .eq("id", id)
+    .eq("company_id", ctx.companyId)
+    .maybeSingle();
+  if (!member) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  if (member.role === "owner") return NextResponse.json({ error: "Cannot change owner role" }, { status: 400 });
+
+  await supabaseAdmin
+    .from("placement_team_members")
+    .update({ role })
+    .eq("id", id);
+
+  return NextResponse.json({ ok: true });
+}
+
+export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const user = await getPlacementPartner(req);
+  if (!user) return forbidden();
+  const { id } = await params;
+
+  const ctx = await resolveTeamContextForPartner(user.id);
+  if (!ctx) return forbidden();
+
+  const { data: member } = await supabaseAdmin
+    .from("placement_team_members")
+    .select("id, role, company_id, profile_id")
+    .eq("id", id)
+    .eq("company_id", ctx.companyId)
+    .maybeSingle();
+  if (!member) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  if (member.role === "owner") return NextResponse.json({ error: "Cannot remove owner" }, { status: 400 });
+
+  // Owners can remove anyone; managers can remove agents.
+  if (ctx.role === "agent") return forbidden();
+  if (ctx.role === "manager" && member.role === "manager") return forbidden("Managers cannot remove managers");
+
+  await supabaseAdmin
+    .from("placement_team_members")
+    .update({ active: false })
+    .eq("id", id);
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/marketplace/team/route.ts
+++ b/src/app/api/marketplace/team/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getPlacementPartner, forbidden } from "@/lib/marketplaceAuth";
+import { resolveTeamContextForPartner, generateInviteToken, inviteExpiryDays } from "@/lib/marketplaceTeam";
+import { sendTeamInviteEmail } from "@/lib/marketplaceInviteEmail";
+
+/**
+ * GET — team roster + pending invites for the caller's company.
+ */
+export async function GET(req: NextRequest) {
+  const user = await getPlacementPartner(req);
+  if (!user) return forbidden();
+
+  const ctx = await resolveTeamContextForPartner(user.id);
+  if (!ctx) return NextResponse.json({ error: "No company" }, { status: 404 });
+
+  const [{ data: company }, { data: members }, { data: invites }] = await Promise.all([
+    supabaseAdmin.from("placement_companies").select("*").eq("id", ctx.companyId).maybeSingle(),
+    supabaseAdmin
+      .from("placement_team_members")
+      .select("*, profile:profile_id(full_name, email)")
+      .eq("company_id", ctx.companyId)
+      .order("joined_at", { ascending: true }),
+    supabaseAdmin
+      .from("placement_team_invites")
+      .select("*")
+      .eq("company_id", ctx.companyId)
+      .is("accepted_at", null)
+      .gt("expires_at", new Date().toISOString())
+      .order("created_at", { ascending: false }),
+  ]);
+
+  return NextResponse.json({
+    company,
+    role: ctx.role,
+    members: members || [],
+    invites: invites || [],
+  });
+}
+
+/**
+ * POST — invite a new team member. Owner/manager only. Sends an email
+ * with the accept link.
+ */
+export async function POST(req: NextRequest) {
+  const user = await getPlacementPartner(req);
+  if (!user) return forbidden();
+
+  const ctx = await resolveTeamContextForPartner(user.id);
+  if (!ctx) return NextResponse.json({ error: "No company" }, { status: 404 });
+  if (ctx.role !== "owner" && ctx.role !== "manager") return forbidden("Owner or manager only");
+
+  const body = await req.json().catch(() => ({}));
+  const email = String(body.email || "").trim().toLowerCase();
+  const role = body.role === "manager" ? "manager" : "agent";
+  if (!email || !email.includes("@")) return NextResponse.json({ error: "Valid email required" }, { status: 400 });
+
+  // Managers can only invite agents.
+  if (ctx.role === "manager" && role === "manager") {
+    return NextResponse.json({ error: "Managers can only invite agents" }, { status: 400 });
+  }
+
+  const token = generateInviteToken();
+  const expiresAt = inviteExpiryDays();
+
+  const { data: invite, error } = await supabaseAdmin
+    .from("placement_team_invites")
+    .insert({
+      company_id: ctx.companyId,
+      email,
+      role,
+      invited_by: user.id,
+      token,
+      expires_at: expiresAt,
+    })
+    .select()
+    .single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  // Fire-and-forget email send. Failures don't break invite creation.
+  const { data: company } = await supabaseAdmin
+    .from("placement_companies")
+    .select("business_name")
+    .eq("id", ctx.companyId)
+    .maybeSingle();
+
+  sendTeamInviteEmail({
+    to: email,
+    inviterName: user.full_name || user.email,
+    companyName: company?.business_name || "Your placement partner",
+    role,
+    token,
+  }).catch(() => undefined);
+
+  return NextResponse.json(invite);
+}

--- a/src/app/api/operator/marketplace/submissions/[id]/rate/route.ts
+++ b/src/app/api/operator/marketplace/submissions/[id]/rate/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getOperatorUser, forbidden, getOperatorContractIds } from "@/lib/operatorMarketplaceAuth";
+import { submitRating } from "@/lib/marketplaceRatings";
+
+/**
+ * Operator rates the placement partner for this submission.
+ * Only allowed once the operator has accepted.
+ * Visibility is 'visible_to_ratee' — the PP sees the rating on their own
+ * dashboard aggregate.
+ */
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const user = await getOperatorUser(req);
+  if (!user) return forbidden();
+  const { id } = await params;
+
+  const body = await req.json().catch(() => ({}));
+  const score = Number(body.score);
+  const feedback = typeof body.feedback === "string" ? body.feedback : null;
+  const tags = Array.isArray(body.tags) ? body.tags.filter((t: unknown) => typeof t === "string") : [];
+
+  if (!Number.isFinite(score) || score < 1 || score > 5) {
+    return NextResponse.json({ error: "Score must be 1-5" }, { status: 400 });
+  }
+
+  const contractIds = await getOperatorContractIds(user);
+  if (contractIds.length === 0) return forbidden();
+
+  const { data: submission } = await supabaseAdmin
+    .from("placement_submissions")
+    .select("id, contract_id, partner_id, operator_status")
+    .eq("id", id)
+    .in("contract_id", contractIds)
+    .maybeSingle();
+  if (!submission) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  if (submission.operator_status !== "accepted") {
+    return NextResponse.json({ error: "Only accepted submissions can be rated" }, { status: 400 });
+  }
+
+  const result = await submitRating({
+    raterType: "operator",
+    raterProfileId: user.id,
+    rateeType: "partner",
+    rateeId: submission.partner_id,
+    submissionId: submission.id,
+    contractId: submission.contract_id,
+    score,
+    feedback,
+    tags,
+  });
+  if (!result.ok) return NextResponse.json({ error: result.error }, { status: 400 });
+
+  await supabaseAdmin.from("placement_submission_activity").insert({
+    submission_id: id,
+    actor_id: user.id,
+    activity_type: "operator_rated_partner",
+    description: `Operator rated placement (${score}★)`,
+  });
+
+  return NextResponse.json({ ok: true, id: result.ratingId });
+}
+
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const user = await getOperatorUser(req);
+  if (!user) return forbidden();
+  const { id } = await params;
+
+  const { data } = await supabaseAdmin
+    .from("placement_ratings")
+    .select("id, score, feedback, tags, created_at")
+    .eq("rater_profile_id", user.id)
+    .eq("submission_id", id)
+    .eq("ratee_type", "partner")
+    .maybeSingle();
+
+  return NextResponse.json({ rating: data || null });
+}

--- a/src/app/components/RatingCard.tsx
+++ b/src/app/components/RatingCard.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useState } from "react";
+import { Star, Loader2, CheckCircle2 } from "lucide-react";
+
+export interface ExistingRating {
+  score: number;
+  feedback: string | null;
+  tags: string[];
+  created_at: string;
+}
+
+interface RatingCardProps {
+  title: string;
+  description: string;
+  existing: ExistingRating | null;
+  saving: boolean;
+  error?: string | null;
+  onSubmit: (payload: { score: number; feedback: string; tags: string[] }) => void | Promise<void>;
+  tagOptions?: string[];
+}
+
+export default function RatingCard({
+  title,
+  description,
+  existing,
+  saving,
+  error,
+  onSubmit,
+  tagOptions = [],
+}: RatingCardProps) {
+  const [score, setScore] = useState(existing?.score ?? 5);
+  const [hover, setHover] = useState<number | null>(null);
+  const [feedback, setFeedback] = useState(existing?.feedback ?? "");
+  const [tags, setTags] = useState<string[]>(existing?.tags ?? []);
+
+  if (existing) {
+    return (
+      <div className="rounded-2xl border border-emerald-100 bg-emerald-50 p-5">
+        <div className="flex items-center gap-2 mb-2">
+          <CheckCircle2 className="h-4 w-4 text-emerald-700" />
+          <p className="text-sm font-semibold text-emerald-900">{title} — submitted</p>
+        </div>
+        <div className="flex items-center gap-1 mb-2">
+          {[1, 2, 3, 4, 5].map((n) => (
+            <Star
+              key={n}
+              className={`h-5 w-5 ${n <= existing.score ? "fill-amber-400 text-amber-400" : "text-gray-300"}`}
+            />
+          ))}
+          <span className="text-xs text-gray-500 ml-2">{existing.score}/5</span>
+        </div>
+        {existing.feedback && <p className="text-sm text-gray-700 whitespace-pre-wrap">{existing.feedback}</p>}
+        {existing.tags && existing.tags.length > 0 && (
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {existing.tags.map((t) => (
+              <span key={t} className="rounded-full bg-white text-emerald-700 text-[10px] px-2.5 py-0.5 border border-emerald-200">
+                {t}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  const toggleTag = (t: string) =>
+    setTags((cur) => (cur.includes(t) ? cur.filter((c) => c !== t) : [...cur, t]));
+
+  return (
+    <div className="rounded-2xl border border-gray-100 bg-white p-5">
+      <h3 className="text-sm font-semibold text-gray-900 mb-1">{title}</h3>
+      <p className="text-xs text-gray-500 mb-3">{description}</p>
+
+      <div className="flex items-center gap-1 mb-3">
+        {[1, 2, 3, 4, 5].map((n) => (
+          <button
+            key={n}
+            type="button"
+            onMouseEnter={() => setHover(n)}
+            onMouseLeave={() => setHover(null)}
+            onClick={() => setScore(n)}
+            className="cursor-pointer"
+          >
+            <Star
+              className={`h-7 w-7 transition-colors ${
+                n <= (hover ?? score) ? "fill-amber-400 text-amber-400" : "text-gray-300 hover:text-amber-300"
+              }`}
+            />
+          </button>
+        ))}
+        <span className="text-sm text-gray-500 ml-3">{score}/5</span>
+      </div>
+
+      {tagOptions.length > 0 && (
+        <div className="mb-3">
+          <p className="text-xs text-gray-500 mb-1.5">Quick tags (optional)</p>
+          <div className="flex flex-wrap gap-1.5">
+            {tagOptions.map((t) => (
+              <button
+                key={t}
+                type="button"
+                onClick={() => toggleTag(t)}
+                className={`rounded-full px-2.5 py-1 text-xs font-medium transition-colors cursor-pointer ${
+                  tags.includes(t)
+                    ? "bg-green-primary text-white"
+                    : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+                }`}
+              >
+                {t}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <textarea
+        value={feedback}
+        onChange={(e) => setFeedback(e.target.value)}
+        rows={3}
+        placeholder="Optional feedback…"
+        className="w-full rounded-xl border border-gray-200 px-3 py-2 text-sm focus:border-green-primary focus:outline-none resize-none mb-3"
+      />
+
+      {error && (
+        <p className="text-sm text-red-600 mb-2">{error}</p>
+      )}
+
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={() => onSubmit({ score, feedback, tags })}
+          disabled={saving}
+          className="inline-flex items-center gap-2 rounded-lg bg-green-primary hover:bg-green-hover px-4 py-2 text-sm font-semibold text-white cursor-pointer disabled:opacity-50"
+        >
+          {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Star className="h-4 w-4" />}
+          Submit Rating
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/operator/marketplace/[id]/page.tsx
+++ b/src/app/operator/marketplace/[id]/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useParams } from "next/navigation";
 import Link from "next/link";
 import { Loader2, ArrowLeft, MapPin, Zap, Car, CheckCircle2, XCircle, AlertCircle, Clock } from "lucide-react";
 import { createBrowserClient } from "@/lib/supabase";
+import RatingCard, { ExistingRating } from "@/app/components/RatingCard";
 
 interface Submission {
   id: string;
@@ -54,6 +55,9 @@ export default function OperatorSubmissionDetailPage() {
   const [note, setNote] = useState("");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [rating, setRating] = useState<ExistingRating | null>(null);
+  const [ratingSaving, setRatingSaving] = useState(false);
+  const [ratingError, setRatingError] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     if (!token) return;
@@ -66,8 +70,29 @@ export default function OperatorSubmissionDetailPage() {
       setSubmission(data.submission);
       setPhotos(data.photos);
     }
+    const ratingRes = await fetch(`/api/operator/marketplace/submissions/${id}/rate`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (ratingRes.ok) {
+      const rd = await ratingRes.json();
+      setRating(rd.rating || null);
+    }
     setLoading(false);
   }, [token, id]);
+
+  async function submitRating(payload: { score: number; feedback: string; tags: string[] }) {
+    setRatingError(null);
+    setRatingSaving(true);
+    const res = await fetch(`/api/operator/marketplace/submissions/${id}/rate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify(payload),
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) setRatingError(body.error || "Failed");
+    else await load();
+    setRatingSaving(false);
+  }
 
   useEffect(() => {
     const supabase = createBrowserClient();
@@ -201,6 +226,21 @@ export default function OperatorSubmissionDetailPage() {
           {submission.operator_reviewed_at && (
             <p className="text-xs text-gray-400 mt-1">{new Date(submission.operator_reviewed_at).toLocaleString()}</p>
           )}
+        </div>
+      )}
+
+      {/* Rate the placement partner after accept */}
+      {submission.operator_status === "accepted" && (
+        <div className="mb-4">
+          <RatingCard
+            title="Rate the placement partner"
+            description="How was the placement partner to work with? Your rating helps us prioritize the best partners for you."
+            existing={rating}
+            saving={ratingSaving}
+            error={ratingError}
+            onSubmit={submitRating}
+            tagOptions={["Great location", "Well-researched", "Responsive", "Slow follow-up", "Address wrong"]}
+          />
         </div>
       )}
 

--- a/src/app/placement/page.tsx
+++ b/src/app/placement/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { Loader2, ArrowRight, CheckCircle2, Clock, Building2, Briefcase, Package } from "lucide-react";
+import { Loader2, ArrowRight, CheckCircle2, Clock, Building2, Briefcase, Package, Users, Star } from "lucide-react";
 import { createBrowserClient } from "@/lib/supabase";
 
 interface Partner {
@@ -16,6 +16,8 @@ interface Partner {
   w9_uploaded_at: string | null;
   agreement_signed_at: string | null;
   bank_verified_at: string | null;
+  rating: number | null;
+  rating_count: number | null;
 }
 
 export default function PlacementDashboardPage() {
@@ -109,12 +111,24 @@ export default function PlacementDashboardPage() {
   // Fully verified — dashboard with contracts + submissions cards
   return (
     <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
-      <div className="mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">Placement Partner Dashboard</h1>
-        <p className="text-sm text-gray-500 mt-1">Welcome back{partner.business_name ? `, ${partner.business_name}` : ""}. Pick up a contract or track a submission below.</p>
+      <div className="mb-6 flex items-start justify-between gap-3 flex-wrap">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Placement Partner Dashboard</h1>
+          <p className="text-sm text-gray-500 mt-1">Welcome back{partner.business_name ? `, ${partner.business_name}` : ""}. Pick up a contract or track a submission below.</p>
+        </div>
+        {partner.rating != null && (
+          <div className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-2">
+            <div className="flex items-center gap-1">
+              <Star className="h-4 w-4 fill-amber-400 text-amber-400" />
+              <span className="text-lg font-bold text-amber-900">{Number(partner.rating).toFixed(1)}</span>
+              <span className="text-xs text-amber-700 ml-1">/ 5</span>
+            </div>
+            <p className="text-[10px] text-amber-700">from {partner.rating_count || 0} rating{(partner.rating_count || 0) === 1 ? "" : "s"}</p>
+          </div>
+        )}
       </div>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
         <Link
           href="/placement/contracts"
           className="group rounded-2xl border border-gray-100 bg-white p-6 hover:border-green-200 hover:shadow-sm transition-all"
@@ -141,6 +155,20 @@ export default function PlacementDashboardPage() {
           </div>
           <h2 className="text-lg font-semibold text-gray-900 mb-1">My Submissions</h2>
           <p className="text-sm text-gray-500">Track candidate locations you&apos;ve submitted and see approval status.</p>
+        </Link>
+
+        <Link
+          href="/placement/team"
+          className="group rounded-2xl border border-gray-100 bg-white p-6 hover:border-green-200 hover:shadow-sm transition-all"
+        >
+          <div className="flex items-center justify-between mb-4">
+            <div className="w-12 h-12 rounded-xl bg-purple-50 flex items-center justify-center">
+              <Users className="h-6 w-6 text-purple-600" />
+            </div>
+            <ArrowRight className="h-5 w-5 text-gray-300 group-hover:text-green-primary transition-colors" />
+          </div>
+          <h2 className="text-lg font-semibold text-gray-900 mb-1">Team</h2>
+          <p className="text-sm text-gray-500">Invite locators to your company. They log in with their own account and work under yours.</p>
         </Link>
       </div>
     </div>

--- a/src/app/placement/submissions/[id]/page.tsx
+++ b/src/app/placement/submissions/[id]/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useParams } from "next/navigation";
 import Link from "next/link";
 import { Loader2, ArrowLeft, Upload, CheckCircle2, XCircle, Clock, AlertCircle, MapPin, User, Phone, Mail, Zap, Car, MessageSquare } from "lucide-react";
 import { createBrowserClient } from "@/lib/supabase";
+import RatingCard, { ExistingRating } from "@/app/components/RatingCard";
 
 interface Submission {
   id: string;
@@ -26,6 +27,7 @@ interface Submission {
   notes: string | null;
   admin_status: string;
   operator_status: string;
+  operator_reviewed_at?: string | null;
   admin_review_note: string | null;
   created_at: string;
   placement_contracts: {
@@ -66,6 +68,9 @@ export default function SubmissionDetailPage() {
   const [photos, setPhotos] = useState<Photo[]>([]);
   const [activity, setActivity] = useState<Activity[]>([]);
   const [uploading, setUploading] = useState(false);
+  const [rating, setRating] = useState<ExistingRating | null>(null);
+  const [ratingSaving, setRatingSaving] = useState(false);
+  const [ratingError, setRatingError] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     if (!token) return;
@@ -79,8 +84,29 @@ export default function SubmissionDetailPage() {
       setPhotos(data.photos);
       setActivity(data.activity);
     }
+    const ratingRes = await fetch(`/api/marketplace/submissions/${id}/rate`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (ratingRes.ok) {
+      const rd = await ratingRes.json();
+      setRating(rd.rating || null);
+    }
     setLoading(false);
   }, [token, id]);
+
+  async function submitRating(payload: { score: number; feedback: string; tags: string[] }) {
+    setRatingError(null);
+    setRatingSaving(true);
+    const res = await fetch(`/api/marketplace/submissions/${id}/rate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify(payload),
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) setRatingError(body.error || "Failed");
+    else await load();
+    setRatingSaving(false);
+  }
 
   useEffect(() => {
     const supabase = createBrowserClient();
@@ -243,6 +269,21 @@ export default function SubmissionDetailPage() {
           )}
         </div>
       </div>
+
+      {/* Rating (post-operator-accept) */}
+      {submission.operator_status === "accepted" && (
+        <div className="mb-4">
+          <RatingCard
+            title="Rate this operator"
+            description="How was this operator to work with? Only admin can see this rating — helps us route contracts to partners fairly."
+            existing={rating}
+            saving={ratingSaving}
+            error={ratingError}
+            onSubmit={submitRating}
+            tagOptions={["Responsive", "Clear specs", "Quick to accept", "Slow to respond", "Changed scope"]}
+          />
+        </div>
+      )}
 
       {/* Activity */}
       {activity.length > 0 && (

--- a/src/app/placement/team/invite/[token]/page.tsx
+++ b/src/app/placement/team/invite/[token]/page.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter, useParams } from "next/navigation";
+import Link from "next/link";
+import { Loader2, CheckCircle2, XCircle, Users, AlertCircle } from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
+
+interface InvitePreview {
+  email: string;
+  role: string;
+  company_name: string;
+}
+
+export default function AcceptInvitePage() {
+  const { token } = useParams<{ token: string }>();
+  const router = useRouter();
+  const [loading, setLoading] = useState(true);
+  const [invite, setInvite] = useState<InvitePreview | null>(null);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const [accessToken, setAccessToken] = useState<string | null>(null);
+  const [accepting, setAccepting] = useState(false);
+  const [accepted, setAccepted] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function init() {
+      const res = await fetch(`/api/marketplace/team/invite/${token}`);
+      if (res.ok) setInvite(await res.json());
+      else {
+        const body = await res.json().catch(() => ({}));
+        setPreviewError(body.error || "Invite not found");
+      }
+
+      const supabase = createBrowserClient();
+      const { data: { session } } = await supabase.auth.getSession();
+      setAccessToken(session?.access_token || null);
+
+      setLoading(false);
+    }
+    init();
+  }, [token]);
+
+  async function accept() {
+    if (!accessToken) {
+      router.push(`/login?redirect=/placement/team/invite/${token}`);
+      return;
+    }
+    setError(null);
+    setAccepting(true);
+    const res = await fetch(`/api/marketplace/team/invite/${token}`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) setError(body.error || "Failed to accept");
+    else setAccepted(true);
+    setAccepting(false);
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-[60vh] flex items-center justify-center">
+        <Loader2 className="h-6 w-6 animate-spin text-green-primary" />
+      </div>
+    );
+  }
+
+  if (previewError) {
+    return (
+      <div className="mx-auto max-w-md px-4 py-16 text-center">
+        <div className="mx-auto w-14 h-14 rounded-2xl bg-red-50 flex items-center justify-center mb-4">
+          <XCircle className="h-7 w-7 text-red-500" />
+        </div>
+        <h1 className="text-xl font-bold text-gray-900 mb-1">Invite unavailable</h1>
+        <p className="text-sm text-gray-500 mb-6">{previewError}</p>
+        <Link
+          href="/placement"
+          className="inline-flex items-center rounded-xl border border-gray-200 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 cursor-pointer"
+        >
+          Go to Dashboard
+        </Link>
+      </div>
+    );
+  }
+
+  if (accepted) {
+    return (
+      <div className="mx-auto max-w-md px-4 py-16 text-center">
+        <div className="mx-auto w-14 h-14 rounded-2xl bg-emerald-50 flex items-center justify-center mb-4">
+          <CheckCircle2 className="h-7 w-7 text-emerald-600" />
+        </div>
+        <h1 className="text-xl font-bold text-gray-900 mb-1">You&apos;re in!</h1>
+        <p className="text-sm text-gray-500 mb-6">Welcome to {invite?.company_name}. Let&apos;s find your first placement.</p>
+        <Link
+          href="/placement"
+          className="inline-flex items-center gap-2 rounded-xl bg-green-primary hover:bg-green-hover px-6 py-3 text-sm font-semibold text-white cursor-pointer"
+        >
+          Go to Dashboard
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-md px-4 py-16">
+      <div className="rounded-2xl border border-gray-100 bg-white p-8 text-center">
+        <div className="mx-auto w-14 h-14 rounded-2xl bg-green-50 flex items-center justify-center mb-4">
+          <Users className="h-7 w-7 text-green-primary" />
+        </div>
+        <h1 className="text-xl font-bold text-gray-900 mb-1">Join {invite?.company_name}</h1>
+        <p className="text-sm text-gray-500 mb-6">
+          You&apos;ve been invited to join as a <span className="font-semibold capitalize">{invite?.role}</span>.
+          {invite?.email && (
+            <>
+              <br />
+              <span className="text-xs text-gray-400">Invite for {invite.email}</span>
+            </>
+          )}
+        </p>
+
+        {error && (
+          <div className="mb-4 flex items-start gap-2 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700 text-left">
+            <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
+            <span>{error}</span>
+          </div>
+        )}
+
+        {accessToken ? (
+          <button
+            onClick={accept}
+            disabled={accepting}
+            className="w-full inline-flex items-center justify-center gap-2 rounded-xl bg-green-primary hover:bg-green-hover px-6 py-3 text-sm font-semibold text-white cursor-pointer disabled:opacity-50"
+          >
+            {accepting ? <Loader2 className="h-4 w-4 animate-spin" /> : <CheckCircle2 className="h-4 w-4" />}
+            Accept Invite
+          </button>
+        ) : (
+          <Link
+            href={`/login?redirect=/placement/team/invite/${token}`}
+            className="w-full inline-flex items-center justify-center gap-2 rounded-xl bg-green-primary hover:bg-green-hover px-6 py-3 text-sm font-semibold text-white cursor-pointer"
+          >
+            Sign in to accept
+          </Link>
+        )}
+        <p className="text-[11px] text-gray-400 mt-3">
+          Sign in with the account for {invite?.email} to accept.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/placement/team/page.tsx
+++ b/src/app/placement/team/page.tsx
@@ -1,0 +1,321 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Loader2, Users, UserPlus, ArrowLeft, Mail, X, AlertCircle, Crown, Shield, User, MailPlus } from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
+
+interface Member {
+  id: string;
+  role: string;
+  active: boolean;
+  joined_at: string | null;
+  invited_at: string | null;
+  profile: { full_name: string; email: string } | null;
+}
+
+interface Invite {
+  id: string;
+  email: string;
+  role: string;
+  expires_at: string;
+  created_at: string;
+}
+
+interface TeamData {
+  company: { id: string; business_name: string } | null;
+  role: "owner" | "manager" | "agent";
+  members: Member[];
+  invites: Invite[];
+}
+
+const ROLE_ICONS: Record<string, typeof Crown> = {
+  owner: Crown,
+  manager: Shield,
+  agent: User,
+};
+
+const ROLE_COLORS: Record<string, string> = {
+  owner: "text-amber-600 bg-amber-50",
+  manager: "text-blue-600 bg-blue-50",
+  agent: "text-gray-600 bg-gray-100",
+};
+
+export default function PlacementTeamPage() {
+  const router = useRouter();
+  const [token, setToken] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [data, setData] = useState<TeamData | null>(null);
+  const [showInvite, setShowInvite] = useState(false);
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [inviteRole, setInviteRole] = useState<"manager" | "agent">("agent");
+  const [saving, setSaving] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!token) return;
+    setLoading(true);
+    const res = await fetch("/api/marketplace/team", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.ok) setData(await res.json());
+    setLoading(false);
+  }, [token]);
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!session?.access_token) { router.push("/login?redirect=/placement/team"); return; }
+      setToken(session.access_token);
+    });
+  }, [router]);
+
+  useEffect(() => { load(); }, [load]);
+
+  async function sendInvite() {
+    setError(null);
+    setSaving("invite");
+    const res = await fetch("/api/marketplace/team", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ email: inviteEmail.trim(), role: inviteRole }),
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) setError(body.error || "Failed");
+    else {
+      setMessage(`Invite sent to ${inviteEmail}`);
+      setInviteEmail("");
+      setShowInvite(false);
+      await load();
+    }
+    setSaving(null);
+  }
+
+  async function changeRole(memberId: string, role: "manager" | "agent") {
+    setSaving(`role-${memberId}`);
+    setError(null);
+    const res = await fetch(`/api/marketplace/team/members/${memberId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ role }),
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) setError(body.error || "Failed");
+    else await load();
+    setSaving(null);
+  }
+
+  async function removeMember(memberId: string) {
+    if (!confirm("Remove this member? They'll lose access immediately.")) return;
+    setSaving(`remove-${memberId}`);
+    setError(null);
+    const res = await fetch(`/api/marketplace/team/members/${memberId}`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) setError(body.error || "Failed");
+    else await load();
+    setSaving(null);
+  }
+
+  async function revokeInvite(inviteId: string) {
+    setSaving(`revoke-${inviteId}`);
+    setError(null);
+    const res = await fetch(`/api/marketplace/team/invites/${inviteId}`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.ok) await load();
+    else setError("Failed to revoke");
+    setSaving(null);
+  }
+
+  if (loading || !data) {
+    return <div className="flex justify-center py-20"><Loader2 className="h-6 w-6 animate-spin text-green-primary" /></div>;
+  }
+
+  const canManage = data.role === "owner" || data.role === "manager";
+  const isOwner = data.role === "owner";
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+      <Link href="/placement" className="text-sm text-gray-500 hover:text-green-primary flex items-center gap-1.5 mb-4">
+        <ArrowLeft className="h-4 w-4" /> Back to Dashboard
+      </Link>
+
+      <div className="flex items-center justify-between mb-6 flex-wrap gap-3">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
+            <Users className="h-6 w-6 text-green-primary" /> Team
+          </h1>
+          <p className="text-sm text-gray-500 mt-1">
+            {data.company?.business_name ? `Team members at ${data.company.business_name}.` : "Manage your team."}
+          </p>
+        </div>
+        {canManage && (
+          <button
+            onClick={() => setShowInvite(true)}
+            className="inline-flex items-center gap-1.5 rounded-xl bg-green-primary hover:bg-green-hover px-4 py-2.5 text-sm font-semibold text-white cursor-pointer"
+          >
+            <UserPlus className="h-4 w-4" /> Invite Member
+          </button>
+        )}
+      </div>
+
+      {message && (
+        <div className="mb-4 rounded-xl border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-700">
+          {message}
+        </div>
+      )}
+      {error && (
+        <div className="mb-4 flex items-start gap-2 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {/* Members */}
+      <div className="rounded-2xl border border-gray-100 bg-white overflow-hidden mb-6">
+        <div className="px-5 py-3 border-b border-gray-100 bg-gray-50/50">
+          <h2 className="text-sm font-semibold text-gray-900">Members ({data.members.filter((m) => m.active).length})</h2>
+        </div>
+        <ul>
+          {data.members.filter((m) => m.active).map((m) => {
+            const Icon = ROLE_ICONS[m.role] || User;
+            return (
+              <li key={m.id} className="px-5 py-4 border-b border-gray-50 last:border-b-0 flex items-center justify-between gap-3 flex-wrap">
+                <div className="flex items-center gap-3 flex-1 min-w-0">
+                  <div className={`h-9 w-9 rounded-full flex items-center justify-center ${ROLE_COLORS[m.role] || "bg-gray-100 text-gray-600"}`}>
+                    <Icon className="h-4 w-4" />
+                  </div>
+                  <div className="min-w-0">
+                    <p className="font-medium text-gray-900 truncate">{m.profile?.full_name || m.profile?.email || "—"}</p>
+                    <p className="text-xs text-gray-500 truncate">{m.profile?.email}</p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className={`rounded-full px-2.5 py-0.5 text-xs font-medium capitalize ${ROLE_COLORS[m.role]}`}>
+                    {m.role}
+                  </span>
+                  {isOwner && m.role !== "owner" && (
+                    <select
+                      value={m.role}
+                      onChange={(e) => changeRole(m.id, e.target.value as "manager" | "agent")}
+                      disabled={saving === `role-${m.id}`}
+                      className="rounded-lg border border-gray-200 px-2 py-1 text-xs focus:border-green-primary focus:outline-none"
+                    >
+                      <option value="agent">Agent</option>
+                      <option value="manager">Manager</option>
+                    </select>
+                  )}
+                  {canManage && m.role !== "owner" && (
+                    <button
+                      onClick={() => removeMember(m.id)}
+                      disabled={saving === `remove-${m.id}`}
+                      className="rounded-lg p-1.5 text-gray-400 hover:bg-red-50 hover:text-red-600 cursor-pointer disabled:opacity-50"
+                      title="Remove"
+                    >
+                      <X className="h-4 w-4" />
+                    </button>
+                  )}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+
+      {/* Pending invites */}
+      {data.invites.length > 0 && (
+        <div className="rounded-2xl border border-gray-100 bg-white overflow-hidden">
+          <div className="px-5 py-3 border-b border-gray-100 bg-gray-50/50">
+            <h2 className="text-sm font-semibold text-gray-900">Pending Invites ({data.invites.length})</h2>
+          </div>
+          <ul>
+            {data.invites.map((i) => (
+              <li key={i.id} className="px-5 py-3 border-b border-gray-50 last:border-b-0 flex items-center justify-between gap-3 flex-wrap">
+                <div className="flex items-center gap-3">
+                  <MailPlus className="h-4 w-4 text-gray-400" />
+                  <div>
+                    <p className="text-sm font-medium text-gray-900">{i.email}</p>
+                    <p className="text-xs text-gray-500 capitalize">
+                      {i.role} · expires {new Date(i.expires_at).toLocaleDateString()}
+                    </p>
+                  </div>
+                </div>
+                {canManage && (
+                  <button
+                    onClick={() => revokeInvite(i.id)}
+                    disabled={saving === `revoke-${i.id}`}
+                    className="text-xs text-red-600 hover:underline cursor-pointer disabled:opacity-50"
+                  >
+                    Revoke
+                  </button>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* Invite modal */}
+      {showInvite && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+          <div className="w-full max-w-md rounded-2xl bg-white shadow-xl p-6">
+            <h2 className="text-lg font-bold text-gray-900 mb-1 flex items-center gap-2">
+              <Mail className="h-5 w-5 text-green-primary" /> Invite Team Member
+            </h2>
+            <p className="text-xs text-gray-500 mb-4">They&apos;ll get an email with a link to join.</p>
+
+            <label className="block text-xs font-medium text-gray-600 mb-1">Email</label>
+            <input
+              type="email"
+              value={inviteEmail}
+              onChange={(e) => setInviteEmail(e.target.value)}
+              placeholder="teammate@example.com"
+              className="w-full rounded-xl border border-gray-200 px-3 py-2 text-sm focus:border-green-primary focus:outline-none mb-4"
+            />
+
+            <label className="block text-xs font-medium text-gray-600 mb-1">Role</label>
+            <div className="grid grid-cols-2 gap-2 mb-4">
+              {(isOwner ? (["agent", "manager"] as const) : (["agent"] as const)).map((r) => (
+                <button
+                  key={r}
+                  type="button"
+                  onClick={() => setInviteRole(r)}
+                  className={`rounded-xl border p-3 text-left transition-colors ${inviteRole === r ? "border-green-primary bg-green-50" : "border-gray-200 hover:bg-gray-50"}`}
+                >
+                  <p className="text-sm font-semibold text-gray-900 capitalize">{r}</p>
+                  <p className="text-xs text-gray-500">
+                    {r === "agent" ? "Submits locations. Sees own submissions." : "Invites agents. Sees all company submissions."}
+                  </p>
+                </button>
+              ))}
+            </div>
+
+            {error && <p className="text-sm text-red-600 mb-2">{error}</p>}
+
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() => setShowInvite(false)}
+                className="rounded-lg px-3 py-2 text-sm text-gray-600 hover:bg-gray-100 cursor-pointer"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={sendInvite}
+                disabled={saving === "invite" || !inviteEmail.trim()}
+                className="rounded-lg bg-green-primary hover:bg-green-hover px-4 py-2 text-sm font-semibold text-white cursor-pointer disabled:opacity-50"
+              >
+                {saving === "invite" ? "Sending…" : "Send Invite"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/marketplaceInviteEmail.ts
+++ b/src/lib/marketplaceInviteEmail.ts
@@ -1,0 +1,64 @@
+import { Resend } from "resend";
+
+const FROM_EMAIL = process.env.FROM_EMAIL || "receipts@bytebitevending.com";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://vendingconnector.com";
+
+function getResend() {
+  return new Resend(process.env.RESEND_API_KEY);
+}
+
+interface InviteEmailArgs {
+  to: string;
+  inviterName: string;
+  companyName: string;
+  role: "manager" | "agent";
+  token: string;
+}
+
+export async function sendTeamInviteEmail({
+  to,
+  inviterName,
+  companyName,
+  role,
+  token,
+}: InviteEmailArgs): Promise<void> {
+  if (!process.env.RESEND_API_KEY) return;
+
+  const acceptUrl = `${SITE_URL}/placement/team/invite/${token}`;
+  const roleLabel = role === "manager" ? "Manager" : "Agent";
+
+  await getResend().emails.send({
+    from: FROM_EMAIL,
+    to,
+    subject: `${inviterName} invited you to join ${companyName} on Vending Connector`,
+    html: `
+<div style="max-width:560px;margin:0 auto;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:40px 24px;color:#111827;">
+  <div style="text-align:center;margin-bottom:32px;">
+    <h1 style="color:#16a34a;font-size:24px;margin:0;">Vending Connector</h1>
+    <p style="color:#6b7280;font-size:14px;margin:8px 0 0;">Placement Partner Team Invitation</p>
+  </div>
+
+  <p style="font-size:14px;color:#374151;">Hi there,</p>
+
+  <p style="font-size:14px;color:#374151;line-height:1.6;">
+    <strong>${inviterName}</strong> has invited you to join <strong>${companyName}</strong> as a
+    <strong>${roleLabel}</strong> on the Vending Connector placement partner marketplace.
+  </p>
+
+  <p style="font-size:14px;color:#374151;line-height:1.6;">
+    As a ${roleLabel.toLowerCase()}, you'll be able to browse contracts, submit locations, and earn placement fees on behalf of ${companyName}.
+  </p>
+
+  <div style="text-align:center;margin:32px 0;">
+    <a href="${acceptUrl}" style="display:inline-block;background:#16a34a;color:#ffffff;text-decoration:none;padding:14px 36px;border-radius:8px;font-weight:600;font-size:16px;">Accept Invitation</a>
+  </div>
+
+  <p style="font-size:13px;color:#6b7280;">If the button doesn't work, copy and paste this link into your browser:</p>
+  <p style="font-size:12px;color:#9ca3af;word-break:break-all;">${acceptUrl}</p>
+
+  <p style="font-size:12px;color:#9ca3af;margin-top:32px;">
+    If you didn't expect this invite, you can safely ignore this email — it expires in 14 days.
+  </p>
+</div>`,
+  });
+}

--- a/src/lib/marketplaceRatings.ts
+++ b/src/lib/marketplaceRatings.ts
@@ -1,0 +1,101 @@
+import { supabaseAdmin } from "./supabaseAdmin";
+
+export type RaterType = "partner" | "operator";
+export type RateeType = "partner" | "operator";
+
+export interface SubmitRatingArgs {
+  raterType: RaterType;
+  raterProfileId: string;
+  rateeType: RateeType;
+  rateeId: string;
+  submissionId: string;
+  contractId: string;
+  score: number;
+  feedback?: string | null;
+  tags?: string[];
+}
+
+export interface RatingResult {
+  ok: boolean;
+  error?: string;
+  ratingId?: string;
+}
+
+/**
+ * Rules:
+ * - Partners rating operators → admin_only (protects operator reputation).
+ * - Operators rating partners → visible_to_ratee (PP sees their own aggregate).
+ * - Score 1-5. One rating per rater per submission per ratee_type.
+ */
+export async function submitRating(args: SubmitRatingArgs): Promise<RatingResult> {
+  if (args.score < 1 || args.score > 5) return { ok: false, error: "Score must be 1-5" };
+
+  const visibility = args.rateeType === "operator" ? "admin_only" : "visible_to_ratee";
+
+  const { data, error } = await supabaseAdmin
+    .from("placement_ratings")
+    .insert({
+      rater_type: args.raterType,
+      rater_profile_id: args.raterProfileId,
+      ratee_type: args.rateeType,
+      ratee_id: args.rateeId,
+      submission_id: args.submissionId,
+      contract_id: args.contractId,
+      score: args.score,
+      feedback: args.feedback?.trim() || null,
+      tags: args.tags || [],
+      visibility,
+    })
+    .select("id")
+    .single();
+
+  if (error) {
+    if (error.code === "23505") return { ok: false, error: "Already rated" };
+    return { ok: false, error: error.message };
+  }
+
+  await recomputeAggregate(args.rateeType, args.rateeId);
+  return { ok: true, ratingId: data.id };
+}
+
+/** Recompute + persist the aggregate on the ratee's home table. */
+export async function recomputeAggregate(rateeType: RateeType, rateeId: string): Promise<void> {
+  const { data: rows } = await supabaseAdmin
+    .from("placement_ratings")
+    .select("score")
+    .eq("ratee_type", rateeType)
+    .eq("ratee_id", rateeId);
+
+  const scores = (rows || []).map((r) => Number(r.score)).filter((n) => Number.isFinite(n));
+  const count = scores.length;
+  const avg = count === 0 ? null : Math.round((scores.reduce((a, b) => a + b, 0) / count) * 100) / 100;
+
+  if (rateeType === "partner") {
+    await supabaseAdmin
+      .from("placement_partners")
+      .update({ rating: avg, rating_count: count, updated_at: new Date().toISOString() })
+      .eq("id", rateeId);
+  } else {
+    await supabaseAdmin
+      .from("profiles")
+      .update({
+        operator_marketplace_rating: avg,
+        operator_marketplace_rating_count: count,
+      })
+      .eq("id", rateeId);
+  }
+}
+
+/**
+ * Ratings a partner is allowed to see about themselves (visible_to_ratee only).
+ */
+export async function getPartnerVisibleRatings(partnerId: string) {
+  const { data } = await supabaseAdmin
+    .from("placement_ratings")
+    .select("id, score, feedback, tags, submission_id, contract_id, created_at")
+    .eq("ratee_type", "partner")
+    .eq("ratee_id", partnerId)
+    .eq("visibility", "visible_to_ratee")
+    .order("created_at", { ascending: false });
+  return data || [];
+}

--- a/src/lib/marketplaceTeam.ts
+++ b/src/lib/marketplaceTeam.ts
@@ -1,0 +1,85 @@
+import { supabaseAdmin } from "./supabaseAdmin";
+import { randomBytes } from "crypto";
+
+export interface TeamContext {
+  companyId: string;
+  role: "owner" | "manager" | "agent";
+}
+
+/**
+ * Resolve the partner's team context. Owners without a company yet get one
+ * auto-created (so team management "just works" the first time they open it).
+ * Non-owner team members return their existing membership.
+ */
+export async function resolveTeamContextForPartner(profileId: string): Promise<TeamContext | null> {
+  // Existing membership?
+  const { data: existing } = await supabaseAdmin
+    .from("placement_team_members")
+    .select("company_id, role, active")
+    .eq("profile_id", profileId)
+    .eq("active", true)
+    .maybeSingle();
+  if (existing?.company_id) {
+    return { companyId: existing.company_id, role: existing.role as TeamContext["role"] };
+  }
+
+  // Company they own but no team_members row yet? (early adopters may hit this)
+  const { data: owned } = await supabaseAdmin
+    .from("placement_companies")
+    .select("id")
+    .eq("owner_profile_id", profileId)
+    .eq("active", true)
+    .maybeSingle();
+  if (owned?.id) {
+    await ensureOwnerMembership(owned.id, profileId);
+    return { companyId: owned.id, role: "owner" };
+  }
+
+  // Auto-create a company for the partner from their business_name.
+  const { data: partner } = await supabaseAdmin
+    .from("placement_partners")
+    .select("business_name")
+    .eq("id", profileId)
+    .maybeSingle();
+  if (!partner) return null;
+
+  const { data: profile } = await supabaseAdmin
+    .from("profiles")
+    .select("full_name")
+    .eq("id", profileId)
+    .maybeSingle();
+
+  const businessName = partner.business_name || profile?.full_name || "My Placement Company";
+  const { data: created, error } = await supabaseAdmin
+    .from("placement_companies")
+    .insert({ owner_profile_id: profileId, business_name: businessName })
+    .select("id")
+    .single();
+  if (error || !created) return null;
+
+  await ensureOwnerMembership(created.id, profileId);
+  return { companyId: created.id, role: "owner" };
+}
+
+async function ensureOwnerMembership(companyId: string, profileId: string): Promise<void> {
+  await supabaseAdmin
+    .from("placement_team_members")
+    .upsert(
+      {
+        company_id: companyId,
+        profile_id: profileId,
+        role: "owner",
+        active: true,
+        joined_at: new Date().toISOString(),
+      },
+      { onConflict: "company_id,profile_id" },
+    );
+}
+
+export function generateInviteToken(): string {
+  return randomBytes(24).toString("hex");
+}
+
+export function inviteExpiryDays(days = 14): string {
+  return new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString();
+}

--- a/supabase/migrations/101_marketplace_ratings.sql
+++ b/supabase/migrations/101_marketplace_ratings.sql
@@ -1,0 +1,58 @@
+-- Marketplace Phase 2.5 — Bidirectional ratings + operator rating aggregates.
+--
+-- Ratings for PARTNERS are visible to admins + the partner themselves.
+-- Ratings for OPERATORS are ADMIN-ONLY (never shown to placement partners).
+-- Enforced at the API layer; the raw table stores visibility explicitly so
+-- future admin tooling can audit it directly.
+
+CREATE TABLE IF NOT EXISTS placement_ratings (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- Who wrote it
+  rater_type text NOT NULL CHECK (rater_type IN ('partner', 'operator')),
+  rater_profile_id uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+
+  -- Who it's about
+  ratee_type text NOT NULL CHECK (ratee_type IN ('partner', 'operator')),
+  ratee_id uuid NOT NULL,   -- partner_id when ratee_type=partner, profile_id when operator
+
+  -- Context: always tied to a specific accepted submission
+  submission_id uuid NOT NULL REFERENCES placement_submissions(id) ON DELETE CASCADE,
+  contract_id uuid NOT NULL REFERENCES placement_contracts(id) ON DELETE CASCADE,
+
+  -- Payload
+  score int NOT NULL CHECK (score BETWEEN 1 AND 5),
+  feedback text,
+  tags text[] DEFAULT '{}',
+
+  -- Visibility bucket. Admin-only ratings never leak through partner-facing
+  -- APIs. Recorded on write so future re-eval keeps the original intent.
+  visibility text NOT NULL DEFAULT 'admin_only'
+    CHECK (visibility IN ('admin_only', 'visible_to_ratee')),
+
+  created_at timestamptz DEFAULT now(),
+
+  -- One rating per rater per submission per direction
+  UNIQUE (rater_profile_id, submission_id, ratee_type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ratings_ratee ON placement_ratings(ratee_type, ratee_id);
+CREATE INDEX IF NOT EXISTS idx_ratings_submission ON placement_ratings(submission_id);
+CREATE INDEX IF NOT EXISTS idx_ratings_rater ON placement_ratings(rater_profile_id);
+
+-- Operator aggregate (admin-only surface). Partner aggregate already lives on
+-- placement_partners.rating from Phase 2.1.
+ALTER TABLE profiles
+  ADD COLUMN IF NOT EXISTS operator_marketplace_rating numeric(3,2),
+  ADD COLUMN IF NOT EXISTS operator_marketplace_rating_count int DEFAULT 0;
+
+-- Also add a count on placement_partners so we can show "4.6 (12 ratings)".
+ALTER TABLE placement_partners
+  ADD COLUMN IF NOT EXISTS rating_count int DEFAULT 0;
+
+-- ─── RLS ─────────────────────────────────────────────────────────────────
+ALTER TABLE placement_ratings ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Service role only" ON placement_ratings;
+CREATE POLICY "Service role only" ON placement_ratings
+  FOR ALL TO service_role USING (true) WITH CHECK (true);


### PR DESCRIPTION
Adds trust + scale to the marketplace:
- After every accepted submission, both sides rate each other.
- Placement partner companies can add sub-locators as team members with scoped permissions.

Ratings:
- placement_ratings table (migration 101) — rater/ratee typed, one row per submission per direction, explicit visibility bucket.
- Partners rating operators → admin_only. Operators never see how partners rated them (protects operator reputation).
- Operators rating partners → visible_to_ratee. PPs see their own aggregate on the dashboard (star badge + count).
- profiles.operator_marketplace_rating + _count for the admin-only operator aggregate. placement_partners.rating_count added so we can render "4.6 (12)".
- submitRating helper recomputes and persists the aggregate immediately.
- Rate cards appear on the submission detail page for both sides once operator_status='accepted'. Tag chips + optional feedback.
- Admin /admin/marketplace/ratings inspector — filterable by ratee type, shows visibility badge on every row.

Team members:
- placement_companies + placement_team_members + placement_team_invites tables already existed (scaffolded in Phase 2.1) — this phase builds the API + UI.
- resolveTeamContextForPartner auto-creates a company for an existing partner the first time they open /placement/team, so team management "just works" without a separate onboarding step.
- /placement/team page: roster, pending invites, invite modal, role change (owner only), remove member (owner + manager).
- Role rules: owner → invite + change roles + remove anyone. Manager → invite agents + remove agents. Agent → view roster only.
- Invite acceptance flow at /placement/team/invite/[token]:
  - Public GET preview (no auth needed) shows "Join <Company>" before login.
  - POST accept requires email match — sign-in with the invited email or the accept refuses.
  - Auto-upgrades profile.role to placement_partner on accept.
  - Idempotent (upsert on company_id+profile_id).
- Resend email on invite: branded HTML with 14-day expiring link. Fires-and-forgets — invite creation still succeeds if email hits an error.

Nav + polish:
- /placement dashboard gains a Team card and a star-rating badge.
- Admin marketplace shared nav gains Ratings tab.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2