### PR TITLE
Marketplace Phase 2.6 — Email notifications + prefs + audit

### DIFF
--- a/src/app/admin/marketplace/layout.tsx
+++ b/src/app/admin/marketplace/layout.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Briefcase, Package, TrendingUp, Users, DollarSign, Star } from "lucide-react";
+import { Briefcase, Package, TrendingUp, Users, DollarSign, Star, Bell } from "lucide-react";
 
 const NAV = [
   { href: "/admin/marketplace/contracts", label: "Contracts", icon: Briefcase },
@@ -10,6 +10,7 @@ const NAV = [
   { href: "/admin/marketplace/tier-proposals", label: "Tier Bumps", icon: TrendingUp },
   { href: "/admin/marketplace/payouts", label: "Payouts", icon: DollarSign },
   { href: "/admin/marketplace/ratings", label: "Ratings", icon: Star },
+  { href: "/admin/marketplace/notifications", label: "Notifications", icon: Bell },
   { href: "/admin/marketplace/partners", label: "Partners", icon: Users },
 ];
 

--- a/src/app/admin/marketplace/notifications/page.tsx
+++ b/src/app/admin/marketplace/notifications/page.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Loader2, Bell, Filter, ArrowLeft, CheckCircle2, XCircle, Clock, Ban } from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
+
+interface Notification {
+  id: string;
+  recipient_profile_id: string | null;
+  recipient_email: string;
+  event_type: string;
+  dedup_key: string | null;
+  subject: string | null;
+  status: string;
+  error: string | null;
+  contract_id: string | null;
+  submission_id: string | null;
+  payout_id: string | null;
+  sent_at: string;
+}
+
+const EVENT_FILTERS = [
+  { key: "all", label: "All events" },
+  { key: "partner_contract_opened", label: "Contract opened" },
+  { key: "admin_submission_created", label: "Submission created" },
+  { key: "operator_submission_ready", label: "Operator ready" },
+  { key: "partner_submission_reviewed", label: "Submission reviewed" },
+  { key: "partner_operator_decided", label: "Operator decision" },
+  { key: "partner_payout_sent", label: "Payout sent" },
+];
+
+const STATUS_FILTERS = [
+  { key: "all", label: "All" },
+  { key: "sent", label: "Sent" },
+  { key: "failed", label: "Failed" },
+  { key: "skipped_preference", label: "Skipped (pref)" },
+  { key: "skipped_rate_limit", label: "Skipped (rate)" },
+];
+
+const STATUS_MAP: Record<string, { color: string; icon: typeof Clock }> = {
+  sent: { color: "bg-emerald-50 text-emerald-700", icon: CheckCircle2 },
+  failed: { color: "bg-red-50 text-red-700", icon: XCircle },
+  skipped_preference: { color: "bg-gray-100 text-gray-600", icon: Ban },
+  skipped_rate_limit: { color: "bg-amber-50 text-amber-700", icon: Clock },
+};
+
+export default function AdminNotificationsPage() {
+  const router = useRouter();
+  const [token, setToken] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+  const [eventType, setEventType] = useState("all");
+  const [status, setStatus] = useState("all");
+
+  const load = useCallback(async () => {
+    if (!token) return;
+    setLoading(true);
+    const params = new URLSearchParams();
+    if (eventType !== "all") params.set("event_type", eventType);
+    if (status !== "all") params.set("status", status);
+    const res = await fetch(`/api/admin/marketplace/notifications?${params}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.ok) setNotifications(await res.json());
+    setLoading(false);
+  }, [token, eventType, status]);
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!session?.access_token) { router.push("/login?redirect=/admin/marketplace/notifications"); return; }
+      setToken(session.access_token);
+    });
+  }, [router]);
+
+  useEffect(() => { load(); }, [load]);
+
+  return (
+    <div className="p-6 max-w-6xl">
+      <Link href="/admin" className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-green-primary mb-4">
+        <ArrowLeft className="h-4 w-4" /> Back to Admin
+      </Link>
+
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
+          <Bell className="h-6 w-6 text-green-primary" /> Notification Log
+        </h1>
+        <p className="text-sm text-gray-500 mt-1">Every marketplace email we&apos;ve sent — successes, skips, and failures.</p>
+      </div>
+
+      <div className="mb-4 flex items-center gap-2 flex-wrap">
+        <Filter className="h-4 w-4 text-gray-400" />
+        <select
+          value={eventType}
+          onChange={(e) => setEventType(e.target.value)}
+          className="rounded-lg border border-gray-200 px-3 py-1.5 text-xs focus:border-green-primary focus:outline-none"
+        >
+          {EVENT_FILTERS.map((f) => <option key={f.key} value={f.key}>{f.label}</option>)}
+        </select>
+        {STATUS_FILTERS.map((f) => (
+          <button
+            key={f.key}
+            onClick={() => setStatus(f.key)}
+            className={`rounded-lg px-3 py-1.5 text-xs font-medium cursor-pointer ${status === f.key ? "bg-green-100 text-green-700" : "bg-gray-100 text-gray-500 hover:bg-gray-200"}`}
+          >
+            {f.label}
+          </button>
+        ))}
+      </div>
+
+      {loading ? (
+        <div className="flex justify-center py-20"><Loader2 className="h-6 w-6 animate-spin text-green-primary" /></div>
+      ) : notifications.length === 0 ? (
+        <div className="rounded-xl border border-gray-200 bg-white p-12 text-center">
+          <Bell className="mx-auto h-12 w-12 text-gray-300 mb-3" />
+          <p className="text-lg font-semibold text-gray-900 mb-1">Nothing here</p>
+          <p className="text-sm text-gray-500">Try a different filter.</p>
+        </div>
+      ) : (
+        <div className="rounded-xl border border-gray-200 bg-white overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="border-b border-gray-100 bg-gray-50/50">
+              <tr>
+                <th className="text-left px-4 py-3 font-medium text-gray-500">Event</th>
+                <th className="text-left px-4 py-3 font-medium text-gray-500">Recipient</th>
+                <th className="text-left px-4 py-3 font-medium text-gray-500">Subject</th>
+                <th className="text-left px-4 py-3 font-medium text-gray-500">Status</th>
+                <th className="text-left px-4 py-3 font-medium text-gray-500">Sent</th>
+              </tr>
+            </thead>
+            <tbody>
+              {notifications.map((n) => {
+                const s = STATUS_MAP[n.status] || STATUS_MAP.sent;
+                const Icon = s.icon;
+                return (
+                  <tr key={n.id} className="border-t border-gray-50">
+                    <td className="px-4 py-3 text-xs text-gray-500 font-mono">{n.event_type}</td>
+                    <td className="px-4 py-3 text-gray-700 text-xs">{n.recipient_email}</td>
+                    <td className="px-4 py-3 text-gray-700 max-w-sm truncate" title={n.subject || ""}>{n.subject || "—"}</td>
+                    <td className="px-4 py-3">
+                      <span className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium capitalize ${s.color}`}>
+                        <Icon className="h-3 w-3" />
+                        {n.status.replace(/_/g, " ")}
+                      </span>
+                      {n.error && <p className="text-[10px] text-red-500 mt-1 max-w-xs truncate" title={n.error}>{n.error}</p>}
+                    </td>
+                    <td className="px-4 py-3 text-xs text-gray-500">{new Date(n.sent_at).toLocaleString()}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/api/admin/marketplace/contracts/[id]/route.ts
+++ b/src/app/api/admin/marketplace/contracts/[id]/route.ts
@@ -80,5 +80,10 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     description: activityDesc,
   });
 
+  if (body.action === "open") {
+    const { notifyPartnerContractOpened } = await import("@/lib/marketplaceNotifications");
+    notifyPartnerContractOpened(id).catch(() => undefined);
+  }
+
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/admin/marketplace/contracts/route.ts
+++ b/src/app/api/admin/marketplace/contracts/route.ts
@@ -83,5 +83,11 @@ export async function POST(req: NextRequest) {
     description: `Contract created — Tier ${tier} · ${insertRow.locations_needed} location(s) in ${insertRow.market_city || insertRow.market_state || "any"}`,
   });
 
+  // Fan out to eligible partners when the contract opens immediately.
+  if (insertRow.status === "open") {
+    const { notifyPartnerContractOpened } = await import("@/lib/marketplaceNotifications");
+    notifyPartnerContractOpened(contract.id).catch(() => undefined);
+  }
+
   return NextResponse.json(contract);
 }

--- a/src/app/api/admin/marketplace/notifications/route.ts
+++ b/src/app/api/admin/marketplace/notifications/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+
+export async function GET(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const { searchParams } = new URL(req.url);
+  const eventType = searchParams.get("event_type") || "all";
+  const status = searchParams.get("status") || "all";
+
+  let query = supabaseAdmin
+    .from("marketplace_notifications")
+    .select("*")
+    .order("sent_at", { ascending: false })
+    .limit(200);
+  if (eventType !== "all") query = query.eq("event_type", eventType);
+  if (status !== "all") query = query.eq("status", status);
+
+  const { data, error } = await query;
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json(data || []);
+}

--- a/src/app/api/admin/marketplace/submissions/[id]/review/route.ts
+++ b/src/app/api/admin/marketplace/submissions/[id]/review/route.ts
@@ -52,5 +52,13 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     // no-op for now; operator acceptance in 2.4 owns the counter
   }
 
+  // Notify the right side (Phase 2.6).
+  const { notifyOperatorSubmissionReady, notifyPartnerSubmissionReviewed } = await import("@/lib/marketplaceNotifications");
+  if (action === "approve") {
+    notifyOperatorSubmissionReady(id).catch(() => undefined);
+  } else {
+    notifyPartnerSubmissionReviewed(id, action as "approve" | "request_changes" | "reject", note || null).catch(() => undefined);
+  }
+
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/marketplace/settings/route.ts
+++ b/src/app/api/marketplace/settings/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getPlacementPartner, forbidden } from "@/lib/marketplaceAuth";
+
+export async function GET(req: NextRequest) {
+  const user = await getPlacementPartner(req);
+  if (!user) return forbidden();
+
+  const { data: profile } = await supabaseAdmin
+    .from("profiles")
+    .select("notification_preferences")
+    .eq("id", user.id)
+    .maybeSingle();
+
+  return NextResponse.json({
+    notification_preferences: (profile?.notification_preferences || {}) as Record<string, boolean>,
+  });
+}
+
+export async function PATCH(req: NextRequest) {
+  const user = await getPlacementPartner(req);
+  if (!user) return forbidden();
+
+  const body = await req.json().catch(() => ({}));
+  const prefs = body.notification_preferences;
+  if (!prefs || typeof prefs !== "object") {
+    return NextResponse.json({ error: "notification_preferences object required" }, { status: 400 });
+  }
+
+  // Whitelist keys — anything else is dropped silently.
+  const allowedKeys = [
+    "partner_contract_opened",
+    "partner_submission_reviewed",
+    "partner_operator_decided",
+    "partner_payout_sent",
+  ];
+  const clean: Record<string, boolean> = {};
+  for (const k of allowedKeys) {
+    if (typeof prefs[k] === "boolean") clean[k] = prefs[k];
+  }
+
+  const { error } = await supabaseAdmin
+    .from("profiles")
+    .update({ notification_preferences: clean })
+    .eq("id", user.id);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  return NextResponse.json({ ok: true, notification_preferences: clean });
+}

--- a/src/app/api/marketplace/submissions/route.ts
+++ b/src/app/api/marketplace/submissions/route.ts
@@ -77,5 +77,8 @@ export async function POST(req: NextRequest) {
     description: `Submitted "${businessName}"`,
   });
 
+  const { notifyAdminSubmissionCreated } = await import("@/lib/marketplaceNotifications");
+  notifyAdminSubmissionCreated(submission.id).catch(() => undefined);
+
   return NextResponse.json(submission);
 }

--- a/src/app/api/operator/marketplace/submissions/[id]/decide/route.ts
+++ b/src/app/api/operator/marketplace/submissions/[id]/decide/route.ts
@@ -56,6 +56,10 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     description: `Operator ${action}ed submission${note ? `: ${note}` : ""}`,
   });
 
+  // Notify partner of the decision (Phase 2.6).
+  const { notifyPartnerOperatorDecided } = await import("@/lib/marketplaceNotifications");
+  notifyPartnerOperatorDecided(id, newStatus as "accepted" | "rejected").catch(() => undefined);
+
   if (action === "accept") {
     // Lock a slot on the contract — fulfilled if this fills the last one.
     const { data: contract } = await supabaseAdmin

--- a/src/app/placement/page.tsx
+++ b/src/app/placement/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { Loader2, ArrowRight, CheckCircle2, Clock, Building2, Briefcase, Package, Users, Star } from "lucide-react";
+import { Loader2, ArrowRight, CheckCircle2, Clock, Building2, Briefcase, Package, Users, Star, Bell } from "lucide-react";
 import { createBrowserClient } from "@/lib/supabase";
 
 interface Partner {
@@ -116,16 +116,24 @@ export default function PlacementDashboardPage() {
           <h1 className="text-2xl font-bold text-gray-900">Placement Partner Dashboard</h1>
           <p className="text-sm text-gray-500 mt-1">Welcome back{partner.business_name ? `, ${partner.business_name}` : ""}. Pick up a contract or track a submission below.</p>
         </div>
-        {partner.rating != null && (
-          <div className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-2">
-            <div className="flex items-center gap-1">
-              <Star className="h-4 w-4 fill-amber-400 text-amber-400" />
-              <span className="text-lg font-bold text-amber-900">{Number(partner.rating).toFixed(1)}</span>
-              <span className="text-xs text-amber-700 ml-1">/ 5</span>
+        <div className="flex items-center gap-2">
+          {partner.rating != null && (
+            <div className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-2">
+              <div className="flex items-center gap-1">
+                <Star className="h-4 w-4 fill-amber-400 text-amber-400" />
+                <span className="text-lg font-bold text-amber-900">{Number(partner.rating).toFixed(1)}</span>
+                <span className="text-xs text-amber-700 ml-1">/ 5</span>
+              </div>
+              <p className="text-[10px] text-amber-700">from {partner.rating_count || 0} rating{(partner.rating_count || 0) === 1 ? "" : "s"}</p>
             </div>
-            <p className="text-[10px] text-amber-700">from {partner.rating_count || 0} rating{(partner.rating_count || 0) === 1 ? "" : "s"}</p>
-          </div>
-        )}
+          )}
+          <Link
+            href="/placement/settings"
+            className="inline-flex items-center gap-1.5 rounded-xl border border-gray-200 bg-white hover:bg-gray-50 px-3 py-2 text-sm font-medium text-gray-700 cursor-pointer"
+          >
+            <Bell className="h-4 w-4" /> Settings
+          </Link>
+        </div>
       </div>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">

--- a/src/app/placement/settings/page.tsx
+++ b/src/app/placement/settings/page.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Loader2, ArrowLeft, Bell, CheckCircle2, AlertCircle } from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
+
+interface Prefs {
+  partner_contract_opened: boolean;
+  partner_submission_reviewed: boolean;
+  partner_operator_decided: boolean;
+  partner_payout_sent: boolean;
+}
+
+const EVENTS: Array<{ key: keyof Prefs; label: string; description: string }> = [
+  {
+    key: "partner_contract_opened",
+    label: "New contracts",
+    description: "Email me when a contract that matches my territory + industries opens.",
+  },
+  {
+    key: "partner_submission_reviewed",
+    label: "Submission review updates",
+    description: "Email me when admin requests changes or rejects a submission.",
+  },
+  {
+    key: "partner_operator_decided",
+    label: "Operator decisions",
+    description: "Email me when the operator accepts or rejects a submission.",
+  },
+  {
+    key: "partner_payout_sent",
+    label: "Payout confirmations",
+    description: "Email me when a payout is queued for QuickBooks.",
+  },
+];
+
+function defaultPrefs(saved: Partial<Prefs>): Prefs {
+  return {
+    partner_contract_opened: saved.partner_contract_opened !== false,
+    partner_submission_reviewed: saved.partner_submission_reviewed !== false,
+    partner_operator_decided: saved.partner_operator_decided !== false,
+    partner_payout_sent: saved.partner_payout_sent !== false,
+  };
+}
+
+export default function PlacementSettingsPage() {
+  const router = useRouter();
+  const [token, setToken] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [prefs, setPrefs] = useState<Prefs>(defaultPrefs({}));
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!token) return;
+    setLoading(true);
+    const res = await fetch("/api/marketplace/settings", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setPrefs(defaultPrefs(data.notification_preferences || {}));
+    }
+    setLoading(false);
+  }, [token]);
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!session?.access_token) { router.push("/login?redirect=/placement/settings"); return; }
+      setToken(session.access_token);
+    });
+  }, [router]);
+
+  useEffect(() => { load(); }, [load]);
+
+  async function save() {
+    setError(null);
+    setMessage(null);
+    setSaving(true);
+    const res = await fetch("/api/marketplace/settings", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ notification_preferences: prefs }),
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) setError(body.error || "Failed");
+    else setMessage("Preferences saved");
+    setSaving(false);
+  }
+
+  if (loading) {
+    return <div className="flex justify-center py-20"><Loader2 className="h-6 w-6 animate-spin text-green-primary" /></div>;
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-8 sm:px-6">
+      <Link href="/placement" className="text-sm text-gray-500 hover:text-green-primary flex items-center gap-1.5 mb-4">
+        <ArrowLeft className="h-4 w-4" /> Back to Dashboard
+      </Link>
+
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
+          <Bell className="h-6 w-6 text-green-primary" /> Notification Settings
+        </h1>
+        <p className="text-sm text-gray-500 mt-1">Choose which marketplace emails you want to receive.</p>
+      </div>
+
+      {message && (
+        <div className="mb-4 flex items-start gap-2 rounded-xl border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-700">
+          <CheckCircle2 className="h-4 w-4 mt-0.5 shrink-0" />
+          <span>{message}</span>
+        </div>
+      )}
+      {error && (
+        <div className="mb-4 flex items-start gap-2 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      <div className="rounded-2xl border border-gray-100 bg-white p-5 space-y-4">
+        {EVENTS.map((e) => (
+          <label key={e.key} className="flex items-start gap-3 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={prefs[e.key]}
+              onChange={(ev) => setPrefs((p) => ({ ...p, [e.key]: ev.target.checked }))}
+              className="mt-1 h-4 w-4 rounded border-gray-300 text-green-600 focus:ring-green-500"
+            />
+            <div>
+              <p className="text-sm font-medium text-gray-900">{e.label}</p>
+              <p className="text-xs text-gray-500">{e.description}</p>
+            </div>
+          </label>
+        ))}
+      </div>
+
+      <div className="mt-4 flex justify-end">
+        <button
+          onClick={save}
+          disabled={saving}
+          className="inline-flex items-center gap-2 rounded-xl bg-green-primary hover:bg-green-hover px-6 py-2.5 text-sm font-semibold text-white cursor-pointer disabled:opacity-50"
+        >
+          {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+          Save Preferences
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/marketplaceHandoff.ts
+++ b/src/lib/marketplaceHandoff.ts
@@ -101,6 +101,14 @@ export async function createContractFromAgreement(agreementId: string): Promise<
     description: `Contract auto-created from signed agreement ${ag.id.slice(0, 8)} — ${locationsNeeded} location(s) at Tier 1`,
   });
 
+  // Contract is opened immediately — notify eligible partners.
+  try {
+    const { notifyPartnerContractOpened } = await import("./marketplaceNotifications");
+    notifyPartnerContractOpened(contract.id).catch(() => undefined);
+  } catch {
+    /* non-critical */
+  }
+
   return contract.id;
 }
 

--- a/src/lib/marketplaceNotifications.ts
+++ b/src/lib/marketplaceNotifications.ts
@@ -1,0 +1,566 @@
+/**
+ * Phase 2.6 — Marketplace email notifications.
+ *
+ * All email-sends flow through sendNotification, which:
+ *   1. Skips if the recipient turned off this event type.
+ *   2. Skips if we already sent this dedup_key within RATE_LIMIT_MINUTES.
+ *   3. Sends via Resend + records a marketplace_notifications row.
+ *
+ * Per-event helpers (notifyPartnerContractOpened, etc.) resolve the recipients,
+ * render the HTML, and delegate to sendNotification.
+ */
+
+import { Resend } from "resend";
+import { supabaseAdmin } from "./supabaseAdmin";
+import { isPartnerEligibleForContract } from "./marketplaceEligibility";
+
+const FROM_EMAIL = process.env.FROM_EMAIL || "receipts@bytebitevending.com";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://vendingconnector.com";
+const ADMIN_NOTIFICATIONS_EMAIL =
+  process.env.MARKETPLACE_ADMIN_NOTIFICATIONS_EMAIL || "james@apexaivending.com";
+const RATE_LIMIT_MINUTES = 15;
+
+function getResend(): Resend | null {
+  const key = process.env.RESEND_API_KEY;
+  return key ? new Resend(key) : null;
+}
+
+export type EventType =
+  | "partner_contract_opened"
+  | "admin_submission_created"
+  | "operator_submission_ready"
+  | "partner_submission_reviewed"
+  | "partner_operator_decided"
+  | "partner_payout_sent";
+
+/** Every event defaults to on unless the recipient explicitly turns it off. */
+function isEventEnabled(prefs: Record<string, boolean> | null, event: EventType): boolean {
+  if (!prefs) return true;
+  const v = prefs[event];
+  return v !== false;
+}
+
+interface SendArgs {
+  event: EventType;
+  recipientEmail: string;
+  recipientProfileId: string | null;
+  subject: string;
+  html: string;
+  dedupKey: string;
+  contractId?: string | null;
+  submissionId?: string | null;
+  payoutId?: string | null;
+  invoiceId?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+async function loadPreferences(profileId: string | null): Promise<Record<string, boolean> | null> {
+  if (!profileId) return null;
+  const { data } = await supabaseAdmin
+    .from("profiles")
+    .select("notification_preferences")
+    .eq("id", profileId)
+    .maybeSingle();
+  return (data?.notification_preferences || {}) as Record<string, boolean>;
+}
+
+async function alreadySentRecently(dedupKey: string): Promise<boolean> {
+  const cutoff = new Date(Date.now() - RATE_LIMIT_MINUTES * 60 * 1000).toISOString();
+  const { data } = await supabaseAdmin
+    .from("marketplace_notifications")
+    .select("id")
+    .eq("dedup_key", dedupKey)
+    .eq("status", "sent")
+    .gte("sent_at", cutoff)
+    .limit(1)
+    .maybeSingle();
+  return !!data;
+}
+
+async function recordNotification(row: {
+  recipient_profile_id: string | null;
+  recipient_email: string;
+  event_type: EventType;
+  dedup_key: string;
+  subject: string;
+  status: "sent" | "skipped_preference" | "skipped_rate_limit" | "failed";
+  error?: string;
+  contract_id?: string | null;
+  submission_id?: string | null;
+  payout_id?: string | null;
+  invoice_id?: string | null;
+  metadata?: Record<string, unknown>;
+}) {
+  await supabaseAdmin.from("marketplace_notifications").insert({
+    ...row,
+    error: row.error?.slice(0, 500),
+    metadata: row.metadata || null,
+  });
+}
+
+export async function sendNotification(args: SendArgs): Promise<{ status: string; error?: string }> {
+  // 1. Preferences
+  const prefs = await loadPreferences(args.recipientProfileId);
+  if (!isEventEnabled(prefs, args.event)) {
+    await recordNotification({
+      recipient_profile_id: args.recipientProfileId,
+      recipient_email: args.recipientEmail,
+      event_type: args.event,
+      dedup_key: args.dedupKey,
+      subject: args.subject,
+      status: "skipped_preference",
+      contract_id: args.contractId,
+      submission_id: args.submissionId,
+      payout_id: args.payoutId,
+      invoice_id: args.invoiceId,
+      metadata: args.metadata,
+    });
+    return { status: "skipped_preference" };
+  }
+
+  // 2. Rate limit
+  if (await alreadySentRecently(args.dedupKey)) {
+    await recordNotification({
+      recipient_profile_id: args.recipientProfileId,
+      recipient_email: args.recipientEmail,
+      event_type: args.event,
+      dedup_key: args.dedupKey,
+      subject: args.subject,
+      status: "skipped_rate_limit",
+      contract_id: args.contractId,
+      submission_id: args.submissionId,
+      payout_id: args.payoutId,
+      invoice_id: args.invoiceId,
+      metadata: args.metadata,
+    });
+    return { status: "skipped_rate_limit" };
+  }
+
+  // 3. Send
+  const resend = getResend();
+  if (!resend) {
+    await recordNotification({
+      recipient_profile_id: args.recipientProfileId,
+      recipient_email: args.recipientEmail,
+      event_type: args.event,
+      dedup_key: args.dedupKey,
+      subject: args.subject,
+      status: "failed",
+      error: "RESEND_API_KEY not configured",
+      contract_id: args.contractId,
+      submission_id: args.submissionId,
+      payout_id: args.payoutId,
+      invoice_id: args.invoiceId,
+      metadata: args.metadata,
+    });
+    return { status: "failed", error: "RESEND_API_KEY not configured" };
+  }
+
+  try {
+    await resend.emails.send({
+      from: FROM_EMAIL,
+      to: args.recipientEmail,
+      subject: args.subject,
+      html: args.html,
+    });
+    await recordNotification({
+      recipient_profile_id: args.recipientProfileId,
+      recipient_email: args.recipientEmail,
+      event_type: args.event,
+      dedup_key: args.dedupKey,
+      subject: args.subject,
+      status: "sent",
+      contract_id: args.contractId,
+      submission_id: args.submissionId,
+      payout_id: args.payoutId,
+      invoice_id: args.invoiceId,
+      metadata: args.metadata,
+    });
+    return { status: "sent" };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    await recordNotification({
+      recipient_profile_id: args.recipientProfileId,
+      recipient_email: args.recipientEmail,
+      event_type: args.event,
+      dedup_key: args.dedupKey,
+      subject: args.subject,
+      status: "failed",
+      error: msg,
+      contract_id: args.contractId,
+      submission_id: args.submissionId,
+      payout_id: args.payoutId,
+      invoice_id: args.invoiceId,
+      metadata: args.metadata,
+    });
+    return { status: "failed", error: msg };
+  }
+}
+
+// ─── HTML shell ──────────────────────────────────────────────────────────
+
+function renderShell({
+  heading,
+  intro,
+  ctaLabel,
+  ctaHref,
+  facts,
+  footer,
+}: {
+  heading: string;
+  intro: string;
+  ctaLabel?: string;
+  ctaHref?: string;
+  facts?: Array<[string, string]>;
+  footer?: string;
+}): string {
+  const factsHtml = (facts || [])
+    .map(
+      ([k, v]) => `
+      <tr>
+        <td style="padding:8px 12px;border:1px solid #e5e7eb;color:#6b7280;font-size:13px;">${k}</td>
+        <td style="padding:8px 12px;border:1px solid #e5e7eb;color:#111;font-size:13px;font-weight:600;">${v}</td>
+      </tr>`,
+    )
+    .join("");
+  const cta = ctaLabel && ctaHref
+    ? `<div style="text-align:center;margin:32px 0;">
+        <a href="${ctaHref}" style="display:inline-block;background:#16a34a;color:#ffffff;text-decoration:none;padding:14px 36px;border-radius:8px;font-weight:600;font-size:16px;">${ctaLabel}</a>
+      </div>`
+    : "";
+  return `
+<div style="max-width:560px;margin:0 auto;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:40px 24px;color:#111827;">
+  <div style="text-align:center;margin-bottom:32px;">
+    <h1 style="color:#16a34a;font-size:24px;margin:0;">Vending Connector</h1>
+    <p style="color:#6b7280;font-size:14px;margin:8px 0 0;">Placement Marketplace</p>
+  </div>
+  <h2 style="color:#111;font-size:18px;margin-bottom:12px;">${heading}</h2>
+  <p style="font-size:14px;color:#374151;line-height:1.6;">${intro}</p>
+  ${factsHtml ? `<table style="width:100%;border-collapse:collapse;margin:20px 0;">${factsHtml}</table>` : ""}
+  ${cta}
+  ${footer ? `<p style="font-size:12px;color:#9ca3af;margin-top:24px;">${footer}</p>` : ""}
+</div>`;
+}
+
+// ─── Per-event helpers ───────────────────────────────────────────────────
+
+interface ContractCore {
+  id: string;
+  title: string;
+  tier: number;
+  partner_payout: number;
+  market_state: string | null;
+  market_city: string | null;
+  machine_type: string | null;
+  locations_needed: number;
+  deadline_at: string | null;
+  status: string;
+}
+
+/**
+ * Fan out to every eligible partner when a contract opens. Called on both
+ * "create-and-publish" and "PATCH action=open" flows. Idempotent per
+ * (contract, partner) via dedup key.
+ */
+export async function notifyPartnerContractOpened(contractId: string): Promise<void> {
+  const { data: contract } = await supabaseAdmin
+    .from("placement_contracts")
+    .select("id, title, tier, partner_payout, market_state, market_city, machine_type, locations_needed, deadline_at, status")
+    .eq("id", contractId)
+    .maybeSingle<ContractCore>();
+  if (!contract || contract.status !== "open") return;
+
+  const { data: partners } = await supabaseAdmin
+    .from("placement_partners")
+    .select("id")
+    .eq("active", true)
+    .eq("onboarding_complete", true);
+
+  for (const p of partners || []) {
+    const eligibility = await isPartnerEligibleForContract(p.id, contract.id);
+    if (!eligibility.eligible) continue;
+
+    const { data: profile } = await supabaseAdmin
+      .from("profiles")
+      .select("id, full_name, email")
+      .eq("id", p.id)
+      .maybeSingle();
+    if (!profile?.email) continue;
+
+    const facts: Array<[string, string]> = [
+      ["Payout", `$${Number(contract.partner_payout).toLocaleString()}/location`],
+      ["Market", [contract.market_city, contract.market_state].filter(Boolean).join(", ") || "Any"],
+      ["Machine", contract.machine_type || "VendEra AI Machine"],
+      ["Slots", String(contract.locations_needed)],
+    ];
+    if (contract.deadline_at) {
+      facts.push(["Deadline", new Date(contract.deadline_at).toLocaleDateString()]);
+    }
+
+    const html = renderShell({
+      heading: `New contract for you: ${contract.title}`,
+      intro: `A new Tier ${contract.tier} contract just opened that matches your territory and industries. First to submit qualified locations gets paid — grab it before someone else does.`,
+      ctaLabel: "View Contract",
+      ctaHref: `${SITE_URL}/placement/contracts/${contract.id}`,
+      facts,
+      footer: "You can turn off contract alerts in your placement settings.",
+    });
+
+    await sendNotification({
+      event: "partner_contract_opened",
+      recipientEmail: profile.email,
+      recipientProfileId: profile.id,
+      subject: `New Tier ${contract.tier} contract available — $${Number(contract.partner_payout).toLocaleString()}/location`,
+      html,
+      dedupKey: `partner_contract_opened:${contract.id}:${profile.id}`,
+      contractId: contract.id,
+    });
+  }
+}
+
+/** Admin alert when a partner submits a candidate location. */
+export async function notifyAdminSubmissionCreated(submissionId: string): Promise<void> {
+  const { data: submission } = await supabaseAdmin
+    .from("placement_submissions")
+    .select("id, business_name, city, state, contract_id")
+    .eq("id", submissionId)
+    .maybeSingle();
+  if (!submission) return;
+
+  const { data: contract } = await supabaseAdmin
+    .from("placement_contracts")
+    .select("title, tier")
+    .eq("id", submission.contract_id)
+    .maybeSingle();
+
+  const html = renderShell({
+    heading: "New submission awaiting review",
+    intro: "A placement partner just submitted a candidate location. Approve or request changes to move it into the operator's inbox.",
+    ctaLabel: "Review Submission",
+    ctaHref: `${SITE_URL}/admin/marketplace/submissions/${submission.id}`,
+    facts: [
+      ["Business", submission.business_name],
+      ["Location", [submission.city, submission.state].filter(Boolean).join(", ") || "—"],
+      ["Contract", contract?.title || "—"],
+      ["Tier", `Tier ${contract?.tier || "?"}`],
+    ],
+    footer: "You're receiving this because you're the marketplace admin contact.",
+  });
+
+  await sendNotification({
+    event: "admin_submission_created",
+    recipientEmail: ADMIN_NOTIFICATIONS_EMAIL,
+    recipientProfileId: null,
+    subject: `New submission: ${submission.business_name}`,
+    html,
+    dedupKey: `admin_submission_created:${submission.id}`,
+    submissionId: submission.id,
+    contractId: submission.contract_id,
+  });
+}
+
+/** Operator alert once admin approves. This is the "location ready to review" ping. */
+export async function notifyOperatorSubmissionReady(submissionId: string): Promise<void> {
+  const { data: submission } = await supabaseAdmin
+    .from("placement_submissions")
+    .select("id, business_name, city, state, contract_id")
+    .eq("id", submissionId)
+    .maybeSingle();
+  if (!submission) return;
+
+  const { data: contract } = await supabaseAdmin
+    .from("placement_contracts")
+    .select("title, tier, operator_profile_id, source_agreement_id")
+    .eq("id", submission.contract_id)
+    .maybeSingle();
+  if (!contract) return;
+
+  // Resolve operator email — profile first, then agreement fallback.
+  let operatorEmail: string | null = null;
+  let operatorProfileId: string | null = contract.operator_profile_id || null;
+  if (operatorProfileId) {
+    const { data: profile } = await supabaseAdmin
+      .from("profiles")
+      .select("email")
+      .eq("id", operatorProfileId)
+      .maybeSingle();
+    operatorEmail = profile?.email || null;
+  }
+  if (!operatorEmail && contract.source_agreement_id) {
+    const { data: ag } = await supabaseAdmin
+      .from("purchase_agreements")
+      .select("operator_email")
+      .eq("id", contract.source_agreement_id)
+      .maybeSingle();
+    operatorEmail = ag?.operator_email || null;
+  }
+  if (!operatorEmail) return;
+
+  const html = renderShell({
+    heading: "A new location is ready for your review",
+    intro: "Our placement network sourced a candidate location for you. Accept to lock the slot and start install, or reject to pass.",
+    ctaLabel: "Review Location",
+    ctaHref: `${SITE_URL}/operator/marketplace/${submission.id}`,
+    facts: [
+      ["Business", submission.business_name],
+      ["Location", [submission.city, submission.state].filter(Boolean).join(", ") || "—"],
+      ["Contract", contract.title],
+    ],
+    footer: "You'll only see location content — never the partner's identity.",
+  });
+
+  await sendNotification({
+    event: "operator_submission_ready",
+    recipientEmail: operatorEmail,
+    recipientProfileId: operatorProfileId,
+    subject: `Location ready to review — ${submission.business_name}`,
+    html,
+    dedupKey: `operator_submission_ready:${submission.id}`,
+    submissionId: submission.id,
+    contractId: submission.contract_id,
+  });
+}
+
+/**
+ * Partner update after admin review action (approve / request_changes / reject).
+ * Only used for non-approve outcomes — approve triggers the operator ping (the
+ * partner sees it via the operator decision hook instead).
+ */
+export async function notifyPartnerSubmissionReviewed(
+  submissionId: string,
+  action: "approve" | "request_changes" | "reject",
+  note: string | null,
+): Promise<void> {
+  const { data: submission } = await supabaseAdmin
+    .from("placement_submissions")
+    .select("id, business_name, partner_id, contract_id")
+    .eq("id", submissionId)
+    .maybeSingle();
+  if (!submission) return;
+
+  const { data: profile } = await supabaseAdmin
+    .from("profiles")
+    .select("id, email")
+    .eq("id", submission.partner_id)
+    .maybeSingle();
+  if (!profile?.email) return;
+
+  const outcome =
+    action === "approve"
+      ? "was approved and is now with the operator"
+      : action === "reject"
+        ? "was rejected"
+        : "needs changes before it can move forward";
+
+  const html = renderShell({
+    heading: `Your submission ${outcome}`,
+    intro:
+      action === "approve"
+        ? "Nice work — the operator can accept or reject from here. We'll email you when they decide."
+        : action === "request_changes"
+          ? "Admin has left feedback for you. Update the submission and it goes back into review."
+          : "Admin has closed this submission. You can submit another location on the same contract if you like.",
+    ctaLabel: "Open Submission",
+    ctaHref: `${SITE_URL}/placement/submissions/${submission.id}`,
+    facts: note ? [["Admin note", note]] : undefined,
+  });
+
+  await sendNotification({
+    event: "partner_submission_reviewed",
+    recipientEmail: profile.email,
+    recipientProfileId: profile.id,
+    subject: `Submission update — ${submission.business_name}`,
+    html,
+    dedupKey: `partner_submission_reviewed:${submission.id}:${action}`,
+    submissionId: submission.id,
+    contractId: submission.contract_id,
+    metadata: { action, note },
+  });
+}
+
+/** Partner alert when the operator accepts or rejects. */
+export async function notifyPartnerOperatorDecided(
+  submissionId: string,
+  decision: "accepted" | "rejected",
+): Promise<void> {
+  const { data: submission } = await supabaseAdmin
+    .from("placement_submissions")
+    .select("id, business_name, partner_id, contract_id")
+    .eq("id", submissionId)
+    .maybeSingle();
+  if (!submission) return;
+
+  const { data: profile } = await supabaseAdmin
+    .from("profiles")
+    .select("id, email")
+    .eq("id", submission.partner_id)
+    .maybeSingle();
+  if (!profile?.email) return;
+
+  const { data: contract } = await supabaseAdmin
+    .from("placement_contracts")
+    .select("partner_payout")
+    .eq("id", submission.contract_id)
+    .maybeSingle();
+
+  const heading = decision === "accepted" ? "Operator accepted your location!" : "Operator passed on this one";
+  const intro =
+    decision === "accepted"
+      ? `Great work. Your $${Number(contract?.partner_payout || 0).toLocaleString()} payout is being queued to QuickBooks. Keep an eye out for a Bill in the next few minutes.`
+      : "The operator passed on this location. If the contract still has open slots, you can submit another candidate.";
+
+  const html = renderShell({
+    heading,
+    intro,
+    ctaLabel: "Open Submission",
+    ctaHref: `${SITE_URL}/placement/submissions/${submission.id}`,
+  });
+
+  await sendNotification({
+    event: "partner_operator_decided",
+    recipientEmail: profile.email,
+    recipientProfileId: profile.id,
+    subject: decision === "accepted" ? `Accepted — ${submission.business_name}` : `Not this one — ${submission.business_name}`,
+    html,
+    dedupKey: `partner_operator_decided:${submission.id}:${decision}`,
+    submissionId: submission.id,
+    contractId: submission.contract_id,
+  });
+}
+
+/** Partner confirmation once the payout Bill lands in QB. */
+export async function notifyPartnerPayoutSent(payoutId: string): Promise<void> {
+  const { data: payout } = await supabaseAdmin
+    .from("marketplace_payouts")
+    .select("id, partner_id, amount, qb_bill_id, submission_id, contract_id")
+    .eq("id", payoutId)
+    .maybeSingle();
+  if (!payout) return;
+
+  const { data: profile } = await supabaseAdmin
+    .from("profiles")
+    .select("id, email")
+    .eq("id", payout.partner_id)
+    .maybeSingle();
+  if (!profile?.email) return;
+
+  const html = renderShell({
+    heading: `Payout on its way — $${Number(payout.amount).toLocaleString()}`,
+    intro: "Your placement payout was pushed to QuickBooks as a Bill. It'll be paid on our normal payment cycle. You'll get a second email once we mark it paid.",
+    ctaLabel: "View Submissions",
+    ctaHref: `${SITE_URL}/placement/submissions`,
+    facts: payout.qb_bill_id ? [["QuickBooks Bill", payout.qb_bill_id]] : undefined,
+  });
+
+  await sendNotification({
+    event: "partner_payout_sent",
+    recipientEmail: profile.email,
+    recipientProfileId: profile.id,
+    subject: `Payout queued — $${Number(payout.amount).toLocaleString()}`,
+    html,
+    dedupKey: `partner_payout_sent:${payout.id}`,
+    payoutId: payout.id,
+    submissionId: payout.submission_id,
+    contractId: payout.contract_id,
+  });
+}

--- a/src/lib/marketplaceQb.ts
+++ b/src/lib/marketplaceQb.ts
@@ -153,6 +153,14 @@ export async function pushPayoutToQb(payoutId: string): Promise<QbPushResult> {
       })
       .eq("id", payoutId);
 
+    // Fire-and-forget partner payout email (Phase 2.6).
+    try {
+      const { notifyPartnerPayoutSent } = await import("./marketplaceNotifications");
+      notifyPartnerPayoutSent(payoutId).catch(() => undefined);
+    } catch {
+      /* non-critical */
+    }
+
     return { ok: true, externalId: bill.Id };
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);

--- a/supabase/migrations/102_marketplace_notifications.sql
+++ b/supabase/migrations/102_marketplace_notifications.sql
@@ -1,0 +1,55 @@
+-- Marketplace Phase 2.6 — Email notification audit log + per-user preferences.
+--
+-- Every marketplace email we send goes through the same pipeline:
+--   1. Check the recipient's notification_preferences (JSONB on profiles) —
+--      each event type gets an explicit on/off switch. Missing keys = default on.
+--   2. Check the audit log to dedup within the event's rate-limit window
+--      (currently 15 minutes per recipient per key).
+--   3. Send via Resend + insert a marketplace_notifications row for the audit.
+
+CREATE TABLE IF NOT EXISTS marketplace_notifications (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  recipient_profile_id uuid REFERENCES profiles(id) ON DELETE CASCADE,
+  recipient_email text NOT NULL,
+
+  -- Event bucket — one of the well-known strings from marketplaceNotifications.ts
+  event_type text NOT NULL,
+  -- Machine-friendly dedup key (usually "<event>:<entity_id>:<recipient>")
+  dedup_key text,
+
+  subject text,
+
+  -- Best-effort references (set as many as apply)
+  contract_id uuid REFERENCES placement_contracts(id) ON DELETE SET NULL,
+  submission_id uuid REFERENCES placement_submissions(id) ON DELETE SET NULL,
+  payout_id uuid REFERENCES marketplace_payouts(id) ON DELETE SET NULL,
+  invoice_id uuid REFERENCES marketplace_operator_invoices(id) ON DELETE SET NULL,
+
+  status text NOT NULL DEFAULT 'sent'
+    CHECK (status IN ('sent', 'skipped_preference', 'skipped_rate_limit', 'failed')),
+  error text,
+
+  metadata jsonb,
+  sent_at timestamptz DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_notifications_event ON marketplace_notifications(event_type, sent_at DESC);
+CREATE INDEX IF NOT EXISTS idx_notifications_recipient ON marketplace_notifications(recipient_profile_id, sent_at DESC);
+CREATE INDEX IF NOT EXISTS idx_notifications_dedup ON marketplace_notifications(dedup_key);
+
+-- Notification preferences on profiles (nullable JSONB defaulting to on).
+ALTER TABLE profiles
+  ADD COLUMN IF NOT EXISTS notification_preferences jsonb DEFAULT '{}'::jsonb;
+
+-- Also on placement_partners for partner-facing bulk defaults (mirror if we
+-- need them independent of profile-level prefs). Nullable — profile takes
+-- precedence when non-null.
+ALTER TABLE placement_partners
+  ADD COLUMN IF NOT EXISTS notification_preferences jsonb DEFAULT '{}'::jsonb;
+
+-- RLS
+ALTER TABLE marketplace_notifications ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "Service role only" ON marketplace_notifications;
+CREATE POLICY "Service role only" ON marketplace_notifications
+  FOR ALL TO service_role USING (true) WITH CHECK (true);


### PR DESCRIPTION
Every marketplace state change now emails the right person. Six event types all flow through one pipeline with preferences, dedup rate-limiting, Resend delivery, and a persistent audit log.

Pipeline (src/lib/marketplaceNotifications.ts):
- sendNotification is the single entry point. Every call:
  1. Loads the recipient's notification_preferences (JSONB on profiles). Missing keys default to on so we never silently drop delivery.
  2. Checks marketplace_notifications for the same dedup_key in the last 15 minutes; if found, records a skipped_rate_limit row and returns.
  3. Sends via Resend and records a sent (or failed) row.
- Every send lands in marketplace_notifications with contract_id, submission_id, payout_id, invoice_id references so the audit page can pivot on any entity.
- One shared HTML shell (renderShell) so all templates look the same.

Events wired:
- partner_contract_opened → fires from admin contract POST (when status=open), PATCH action=open, and marketplaceHandoff.createContractFromAgreement (the auto-contract from a signed agreement). Walks every active+onboarded partner, runs isPartnerEligibleForContract, and emails matches only. Dedup key includes the partner id so it's safe to re-run.
- admin_submission_created → partner submission POST. Delivers to MARKETPLACE_ADMIN_NOTIFICATIONS_EMAIL (falls back to james@apexaivending.com).
- operator_submission_ready → admin submissions/[id]/review action=approve. Resolves the operator email via placement_contracts.operator_profile_id or the source purchase agreement.
- partner_submission_reviewed → admin submissions/[id]/review action= request_changes | reject. Includes the admin note.
- partner_operator_decided → operator submissions/[id]/decide accept | reject.
- partner_payout_sent → marketplaceQb.pushPayoutToQb on successful QB Bill push. Confirms the payout amount + QB Bill id.

Data model (migration 102):
- marketplace_notifications: full send log, indexed by (event_type, sent_at), (recipient_profile_id, sent_at), and (dedup_key) for cheap dedup lookups.
- profiles.notification_preferences JSONB (partner opt-out).
- placement_partners.notification_preferences JSONB (reserved for future partner-wide defaults).

UI:
- /placement/settings — partner-facing toggle per event. Whitelist the four events partners can opt out of; the admin/operator events are business- critical and can't be muted.
- /admin/marketplace/notifications — audit inspector with event type + status filters. Failed sends show the error inline; skips show why (preference vs rate limit).
- Bell "Settings" button on the placement dashboard header.
- Notifications tab added to the admin marketplace shared nav.

Env:
- MARKETPLACE_ADMIN_NOTIFICATIONS_EMAIL (optional) — override the admin submission-created recipient. Defaults to james@apexaivending.com.
- Reuses RESEND_API_KEY, FROM_EMAIL, NEXT_PUBLIC_SITE_URL already set.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2