### PR TITLE
Add Placement Providers nav tab; combine Locations + Routes browse

### DIFF
--- a/src/app/browse-requests/page.tsx
+++ b/src/app/browse-requests/page.tsx
@@ -636,11 +636,22 @@ export default function BrowseRequestsPage() {
         <div className="mx-auto max-w-7xl px-4 pb-8 pt-12 sm:px-6 lg:px-8">
           <div className="text-center">
             <h1 className="text-3xl font-bold tracking-tight text-black-primary sm:text-4xl">
-              Browse Vending Requests
+              Locations and Routes For Sale
             </h1>
             <p className="mx-auto mt-3 max-w-2xl text-base text-gray-600 sm:text-lg">
-              Find locations looking for vending machines and grow your route
+              Find open location requests and browse vending routes for sale.
             </p>
+            <div className="mx-auto mt-5 inline-flex rounded-xl border border-gray-200 bg-white p-1 shadow-sm">
+              <span className="rounded-lg bg-green-primary px-4 py-1.5 text-sm font-semibold text-white">
+                Locations
+              </span>
+              <Link
+                href="/routes-for-sale"
+                className="rounded-lg px-4 py-1.5 text-sm font-medium text-gray-600 hover:bg-gray-50"
+              >
+                Routes
+              </Link>
+            </div>
           </div>
 
           {/* Search bar */}

--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -3,27 +3,27 @@
 import { useState, useEffect } from "react";
 import Link from "next/link";
 import { useRouter, usePathname } from "next/navigation";
-import { Menu, X, ChevronRight, LogOut, LayoutDashboard, User, Shield, Route, ShoppingBag, ScrollText, Heart, Briefcase, Zap, Coffee } from "lucide-react";
+import { Menu, X, ChevronRight, LogOut, LayoutDashboard, User, Shield, ShoppingBag, ScrollText, Heart, Briefcase, Zap, Coffee } from "lucide-react";
 import { createBrowserClient } from "@/lib/supabase";
 import type { Profile } from "@/lib/types";
 import Tooltip from "@/app/components/Tooltip";
 import { TOOLTIP_COPY } from "@/lib/tooltipCopy";
 
 const navLinks = [
-  { label: "Locations for Sale", href: "/signup?redirect=/browse-requests" },
+  { label: "Locations and Routes For Sale", href: "/signup?redirect=/browse-requests" },
   { label: "Sell a Location", href: "/signup?role=locator&redirect=/marketplace" },
   { label: "Machines for Sale", href: "/signup?redirect=/machines-for-sale" },
-  { label: "Routes for Sale", href: "/signup?redirect=/routes-for-sale" },
+  { label: "Placement Providers", href: "/signup?redirect=/placement" },
   { label: "Browse Operators", href: "/signup?redirect=/browse-operators" },
   { label: "Financing", href: "/signup?redirect=/financing" },
 ];
 
 const authNavLinks = [
-  { label: "Locations for Sale", href: "/browse-requests" },
+  { label: "Locations and Routes For Sale", href: "/browse-requests" },
   { label: "Sell a Location", href: "/marketplace" },
   { label: "Your Leads", href: "/your-leads" },
   { label: "Machines for Sale", href: "/machines-for-sale" },
-  { label: "Routes for Sale", href: "/routes-for-sale" },
+  { label: "Placement Providers", href: "/placement" },
   { label: "Browse Operators", href: "/browse-operators" },
   { label: "Coffee", href: "/coffee" },
   { label: "Financing", href: "/financing" },
@@ -324,14 +324,14 @@ export default function Navbar() {
                       Profile
                     </Link>
                     <Link
-                      href="/routes-for-sale"
+                      href="/placement"
                       onClick={() => setUserMenuOpen(false)}
                       className="flex items-center gap-2 px-4 py-2.5 text-sm text-black-primary transition-colors hover:bg-gray-50"
-                      title={TOOLTIP_COPY["Routes for Sale"]}
-                      aria-label={TOOLTIP_COPY["Routes for Sale"]}
+                      title={TOOLTIP_COPY["Placement Providers"]}
+                      aria-label={TOOLTIP_COPY["Placement Providers"]}
                     >
-                      <Route className="h-4 w-4 text-black-primary/50" />
-                      Routes for Sale
+                      <Briefcase className="h-4 w-4 text-black-primary/50" />
+                      Placement Providers
                     </Link>
                     {profile?.coffee_access_enabled && (
                       <Link
@@ -538,14 +538,14 @@ export default function Navbar() {
                 </li>
                 <li>
                   <Link
-                    href="/routes-for-sale"
+                    href="/placement"
                     onClick={() => setMobileOpen(false)}
                     className="flex items-center justify-between rounded-lg px-4 py-3 text-[15px] font-medium text-white transition-colors hover:bg-white/15"
-                    aria-label={TOOLTIP_COPY["Routes for Sale"]}
+                    aria-label={TOOLTIP_COPY["Placement Providers"]}
                   >
                     <span className="flex items-center gap-2.5">
-                      <Route className="h-4 w-4" />
-                      Routes for Sale
+                      <Briefcase className="h-4 w-4" />
+                      Placement Providers
                     </span>
                     <ChevronRight className="h-4 w-4 text-white/40" />
                   </Link>

--- a/src/app/routes-for-sale/page.tsx
+++ b/src/app/routes-for-sale/page.tsx
@@ -205,12 +205,23 @@ export default function RoutesForSalePage() {
         <div className="mx-auto max-w-7xl px-4 pb-8 pt-12 sm:px-6 lg:px-8">
           <div className="text-center">
             <h1 className="text-2xl font-bold tracking-tight text-black-primary sm:text-3xl md:text-4xl">
-              Routes for Sale
+              Locations and Routes For Sale
             </h1>
             <p className="mx-auto mt-3 max-w-2xl text-base text-gray-600 sm:text-lg">
-              Browse vending routes and businesses available for purchase
+              Browse vending routes and businesses available for purchase.
             </p>
-            <div className="mt-5">
+            <div className="mx-auto mt-5 inline-flex rounded-xl border border-gray-200 bg-white p-1 shadow-sm">
+              <Link
+                href="/browse-requests"
+                className="rounded-lg px-4 py-1.5 text-sm font-medium text-gray-600 hover:bg-gray-50"
+              >
+                Locations
+              </Link>
+              <span className="rounded-lg bg-green-primary px-4 py-1.5 text-sm font-semibold text-white">
+                Routes
+              </span>
+            </div>
+            <div className="mt-4">
               <Link
                 href="/post-route"
                 className="inline-flex w-full sm:w-auto items-center justify-center gap-2 rounded-xl bg-green-primary px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-green-hover"

--- a/src/lib/tooltipCopy.ts
+++ b/src/lib/tooltipCopy.ts
@@ -9,8 +9,12 @@
 export const TOOLTIP_COPY: Record<string, string> = {
   "Locations for Sale":
     "Browse available locations requesting services for vending, coffee, ATM, AI vending, and more.",
+  "Locations and Routes For Sale":
+    "Browse open location requests and vending routes for sale in one place.",
   "Routes for Sale":
     "Explore vending routes and machine portfolios currently available for purchase.",
+  "Placement Providers":
+    "Hire vetted placement partners to secure vending locations in your territory — or apply to become one.",
   "Browse Operators":
     "Find operators by service type, market, and capability for your location.",
   "How It Works":


### PR DESCRIPTION
Placement Partner onboarding was hidden — the /placement page existed but nothing in the primary nav pointed to it, so prospective PPs couldn't find it without a direct link. This surfaces it in the main navigation.

Nav changes (Navbar.tsx):
- navLinks (logged-out) and authNavLinks (logged-in):
  - "Locations for Sale" → "Locations and Routes For Sale"
  - "Routes for Sale" removed as a separate entry
  - "Placement Providers" → /placement inserted in the Routes slot
- Desktop user dropdown: "Routes for Sale" entry replaced with "Placement Providers" → /placement, icon swapped Route → Briefcase
- Mobile drawer: same swap
- Removed the now-unused `Route` lucide import

Combined browse UX (browse-requests + routes-for-sale):
- Both pages get a matching hero title "Locations and Routes For Sale"
- Both get a segmented Locations | Routes pill that cross-links to the other page — Locations is highlighted on /browse-requests, Routes is highlighted on /routes-for-sale
- Routes-for-sale hero subtitle simplified; "Post a Route for Sale" CTA preserved

Copy (tooltipCopy.ts):
- Added "Locations and Routes For Sale" and "Placement Providers" entries
- Kept the old "Locations for Sale" and "Routes for Sale" keys in place so any lingering references don't break


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2