### PR TITLE
Fix CRM redirect — stop marketplace onboarding from clobbering elevat…

### DIFF
--- a/src/app/api/marketplace/partners/route.ts
+++ b/src/app/api/marketplace/partners/route.ts
@@ -51,11 +51,23 @@ export async function POST(req: NextRequest) {
   const businessName = String(body.business_name || "").trim();
   const bio = String(body.bio || "").trim();
 
-  // Upgrade profile role (safe: existing roles are unaffected)
-  await supabaseAdmin
+  // Only upgrade the profile role if the caller has a "no role assigned yet"
+  // role. Admins, sales, and other CRM roles keep their existing role — they
+  // may be poking at the marketplace onboarding for testing purposes and
+  // should never lose access to their real tools. If they truly need to
+  // become a placement partner, admin can flip the role manually.
+  const { data: currentProfile } = await supabaseAdmin
     .from("profiles")
-    .update({ role: "placement_partner" })
-    .eq("id", userId);
+    .select("role")
+    .eq("id", userId)
+    .maybeSingle();
+  const upgradableRoles = ["requestor", "operator", "locator", "location_manager"];
+  if (!currentProfile?.role || upgradableRoles.includes(currentProfile.role)) {
+    await supabaseAdmin
+      .from("profiles")
+      .update({ role: "placement_partner" })
+      .eq("id", userId);
+  }
 
   // Upsert partner
   const { data: partner, error } = await supabaseAdmin

--- a/src/app/api/marketplace/team/invite/[token]/route.ts
+++ b/src/app/api/marketplace/team/invite/[token]/route.ts
@@ -63,8 +63,11 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ tok
     );
   }
 
-  // Upgrade role
-  if (profile.role !== "placement_partner") {
+  // Upgrade role — but preserve elevated CRM roles. An admin, sales manager,
+  // etc. accepting an invite still gets the team_members row (so they can
+  // work under the company) without losing their existing tools.
+  const upgradableRoles = ["requestor", "operator", "locator", "location_manager"];
+  if (!profile.role || upgradableRoles.includes(profile.role)) {
     await supabaseAdmin.from("profiles").update({ role: "placement_partner" }).eq("id", userId);
   }
 


### PR DESCRIPTION
…ed roles

POST /api/marketplace/partners was unconditionally rewriting profiles.role to 'placement_partner' every time it was called. If an admin, director, market leader, sales manager, or sales rep hit /placement and clicked "Get Started" — even to look at the wizard — their role would silently be downgraded.

Once their role was placement_partner:
- /sales/layout calls /api/sales/users, doesn't find them (they're not in the sales roles list), and does router.push("/")
- The root landing page auto-redirects any authenticated user to /dashboard

Net effect: clicking "CRM" or "Open Sales CRM" bounced them to /dashboard. The middleware placement_partner isolation wasn't in play — it reads user_metadata.role, not profiles.role — this was pure DB corruption from the code path.

Fix:
- POST /api/marketplace/partners now only upgrades role when the current role is empty or in an "upgradable" set (requestor, operator, locator, location_manager). Everything else is preserved, so admins et al can poke at the wizard without losing their tools. If someone genuinely needs to become a placement partner from an elevated role, admin can flip the role manually via /admin.
- POST /api/marketplace/team/invite/[token] gets the same guard for symmetry — an admin accepting a team invite still gets the team_members row but keeps their admin role.

Restoring a clobbered account is a single SQL update in Supabase — see the PR body for the runbook.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2