### PR TITLE
Include sales_manager in the /api/sales/users list

### DIFF
--- a/src/app/api/sales/users/route.ts
+++ b/src/app/api/sales/users/route.ts
@@ -10,7 +10,7 @@ export async function GET(req: NextRequest) {
   const { data, error } = await supabaseAdmin
     .from("profiles")
     .select("id, full_name, email, role")
-    .in("role", ["admin", "sales", "director_of_sales", "market_leader"])
+    .in("role", ["admin", "sales", "director_of_sales", "market_leader", "sales_manager"])
     .order("full_name");
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });


### PR DESCRIPTION
salesAuth.getSalesUser already allows sales_manager to authenticate against the CRM, but /api/sales/users was filtering the returned list to just the older four roles (admin, sales, director_of_sales, market_leader). As a result the /sales layout's "am I in the list?" self-check would silently fail for a sales_manager and bounce them to / → /dashboard, even though their profile was correctly configured. Adding sales_manager to the .in() list closes the gap.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2