### PR TITLE
Add "Send to Operator" option for location placement agreements

### DIFF
--- a/src/app/api/sales/agreements/[id]/send/route.ts
+++ b/src/app/api/sales/agreements/[id]/send/route.ts
@@ -31,6 +31,13 @@ export async function POST(
     );
   }
 
+  // Optional body: { target: "location" | "operator" }. Location-placement
+  // agreements let the rep choose between the two — some locations don't
+  // sign (letter of authorization, verbal approval, etc.) and the operator
+  // is the party who signs on the deal.
+  const body = await req.json().catch(() => ({}));
+  const targetChoice = body.target === "operator" ? "operator" : "location";
+
   // Fetch agreement
   const { data: agreement, error: agErr } = await supabaseAdmin
     .from("purchase_agreements")
@@ -43,9 +50,18 @@ export async function POST(
 
   const isLocationPlacement = agreement.agreement_type === "location_placement";
   const includeEquipment = agreement.include_equipment !== false;
+  const sendToOperator = isLocationPlacement && targetChoice === "operator";
 
   let requiredFields: Array<{ key: string; label: string }>;
-  if (isLocationPlacement) {
+  if (isLocationPlacement && sendToOperator) {
+    // Sending directly to the operator — no location contact info required.
+    requiredFields = [
+      { key: "location_business_name", label: "Location business name" },
+      { key: "placement_operator_company", label: "Operator company name" },
+      { key: "placement_operator_email", label: "Operator email" },
+      { key: "effective_date", label: "Effective date" },
+    ];
+  } else if (isLocationPlacement) {
     requiredFields = [
       { key: "location_business_name", label: "Location business name" },
       { key: "location_contact_name", label: "Location contact name" },
@@ -92,17 +108,31 @@ export async function POST(
     process.env.NEXT_PUBLIC_SITE_URL || "https://vendingconnector.com";
   const signingUrl = `${siteUrl}/sign/${agreement.sign_token}`;
 
-  // Determine recipient and CCs based on agreement type
-  const recipientEmail = isLocationPlacement
-    ? agreement.location_contact_email
-    : agreement.operator_email;
+  // Determine recipient and CCs based on agreement type + target choice.
+  let recipientEmail: string | null;
+  if (sendToOperator) {
+    recipientEmail = agreement.placement_operator_email;
+  } else if (isLocationPlacement) {
+    recipientEmail = agreement.location_contact_email;
+  } else {
+    recipientEmail = agreement.operator_email;
+  }
 
   const ccEmails: string[] = [];
   if (isLocationPlacement) {
-    // For location placement: rep gets CC during initial send (NOT operator —
-    // they get the fully signed copy later)
+    // Rep always gets CC during initial send (they're the sales owner).
     if (agreement.rep_email && agreement.rep_email !== recipientEmail) {
       ccEmails.push(agreement.rep_email);
+    }
+    // When sending to operator, also CC the location contact if we have one —
+    // keeps everyone in the loop even though the location isn't the signer.
+    if (
+      sendToOperator &&
+      agreement.location_contact_email &&
+      agreement.location_contact_email !== recipientEmail &&
+      !ccEmails.includes(agreement.location_contact_email)
+    ) {
+      ccEmails.push(agreement.location_contact_email);
     }
   } else {
     if (
@@ -119,6 +149,13 @@ export async function POST(
   }
 
   // Build email HTML
+  const placementGreetingName = sendToOperator
+    ? (agreement.placement_operator_contact_name || agreement.placement_operator_company || "there")
+    : (agreement.location_contact_name || agreement.location_business_name);
+  const placementIntro = sendToOperator
+    ? `Please review and sign the location placement agreement below. This agreement covers placement of ${agreement.placement_machine_count || 1} ${agreement.placement_machine_type || "VendEra AI Machine"}${(agreement.placement_machine_count || 1) === 1 ? "" : "s"} at <strong>${agreement.location_business_name}</strong>.`
+    : `Please review and sign the location placement agreement below. This agreement covers placement of ${agreement.placement_machine_count || 1} ${agreement.placement_machine_type || "VendEra AI Machine"}${(agreement.placement_machine_count || 1) === 1 ? "" : "s"} at <strong>${agreement.location_business_name}</strong>.`;
+
   const html = isLocationPlacement ? `
 <!DOCTYPE html>
 <html>
@@ -129,9 +166,9 @@ export async function POST(
     <p style="color:#6b7280;font-size:14px;margin:8px 0 0;">Location Placement Agreement</p>
   </div>
 
-  <p>Hi ${agreement.location_contact_name || agreement.location_business_name},</p>
+  <p>Hi ${placementGreetingName},</p>
 
-  <p>Please review and sign the location placement agreement below. This agreement covers placement of ${agreement.placement_machine_count || 1} ${agreement.placement_machine_type || "VendEra AI Machine"}${(agreement.placement_machine_count || 1) === 1 ? "" : "s"} at <strong>${agreement.location_business_name}</strong>.</p>
+  <p>${placementIntro}</p>
 
   <p>This agreement covers:</p>
   <ul style="color:#374151;line-height:1.8;">
@@ -193,10 +230,12 @@ export async function POST(
 </html>`.trim();
 
   if (!recipientEmail) {
-    return NextResponse.json(
-      { error: isLocationPlacement ? "Location contact email is required" : "Operator email is required" },
-      { status: 400 },
-    );
+    const missingLabel = sendToOperator
+      ? "Operator email is required"
+      : isLocationPlacement
+        ? "Location contact email is required"
+        : "Operator email is required";
+    return NextResponse.json({ error: missingLabel }, { status: 400 });
   }
 
   const subject = isLocationPlacement
@@ -235,11 +274,12 @@ export async function POST(
     .eq("id", id);
 
   // Log activity
+  const audience = sendToOperator ? "operator" : isLocationPlacement ? "location" : "operator";
   await supabaseAdmin.from("agreement_activity_log").insert({
     agreement_id: id,
     user_id: user.id,
     activity_type: "sent",
-    description: `Agreement emailed to ${recipientEmail}${ccEmails.length > 0 ? ` (CC: ${ccEmails.join(", ")})` : ""}`,
+    description: `Agreement emailed to ${audience} at ${recipientEmail}${ccEmails.length > 0 ? ` (CC: ${ccEmails.join(", ")})` : ""}`,
   });
 
   return NextResponse.json({ ok: true, emailSent: true });

--- a/src/app/sales/agreements/[id]/page.tsx
+++ b/src/app/sales/agreements/[id]/page.tsx
@@ -506,12 +506,28 @@ function StandaloneAgreementEditor() {
     setSaving(false);
   }
 
-  async function handleSend() {
+  async function handleSend(target: "location" | "operator" = "location") {
     if (!agreement) return;
 
     const isLocationPlacement = agreement.agreement_type === "location_placement";
+    const sendToOperator = isLocationPlacement && target === "operator";
 
-    if (isLocationPlacement) {
+    if (sendToOperator) {
+      // Location contact fields skipped — some deals don't require the
+      // location to sign; operator is the sole signer.
+      if (!form?.placement_operator_email?.trim()) {
+        showToast("Operator email is required to send", "error");
+        return;
+      }
+      if (!form?.placement_operator_company?.trim()) {
+        showToast("Operator company name is required to send", "error");
+        return;
+      }
+      if (!form?.location_business_name?.trim()) {
+        showToast("Location business name is required to send", "error");
+        return;
+      }
+    } else if (isLocationPlacement) {
       if (!form?.location_contact_email?.trim()) {
         showToast("Location contact email is required to send", "error");
         return;
@@ -548,19 +564,32 @@ function StandaloneAgreementEditor() {
       return;
     }
 
-    const confirmMsg = isLocationPlacement
-      ? `Send this agreement to ${form?.location_contact_email}? They will receive an email with a signing link.`
-      : "Send this agreement to the operator? They will receive an email with a signing link.";
+    const targetEmail = sendToOperator
+      ? form?.placement_operator_email
+      : isLocationPlacement
+        ? form?.location_contact_email
+        : form?.operator_email;
+    const confirmMsg = sendToOperator
+      ? `Send this agreement to the operator at ${targetEmail}? They will receive an email with a signing link.`
+      : isLocationPlacement
+        ? `Send this agreement to ${targetEmail}? They will receive an email with a signing link.`
+        : "Send this agreement to the operator? They will receive an email with a signing link.";
     if (!confirm(confirmMsg)) return;
 
     setSending(true);
     const res = await fetch(`/api/sales/agreements/${agreement.id}/send`, {
       method: "POST",
       headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ target }),
     });
 
     if (res.ok) {
-      showToast(isLocationPlacement ? "Agreement sent to location" : "Agreement sent to operator");
+      const msg = sendToOperator
+        ? "Agreement sent to operator"
+        : isLocationPlacement
+          ? "Agreement sent to location"
+          : "Agreement sent to operator";
+      showToast(msg);
       await fetchAgreement();
     } else {
       const err = await res.json().catch(() => ({ error: "Send failed" }));
@@ -844,7 +873,7 @@ function StandaloneAgreementEditor() {
           )}
           {!isReadOnly && (
             <button
-              onClick={handleSend}
+              onClick={() => handleSend("location")}
               disabled={sending || dirty}
               className="rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white hover:bg-indigo-700 disabled:opacity-50 cursor-pointer inline-flex items-center gap-2"
               title={dirty ? "Save changes first" : ""}
@@ -1216,13 +1245,24 @@ function StandaloneAgreementEditor() {
               )}
               {!isReadOnly && (
                 <button
-                  onClick={handleSend}
+                  onClick={() => handleSend("location")}
                   disabled={sending || dirty}
                   className="w-full rounded-lg bg-indigo-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50 cursor-pointer inline-flex items-center justify-center gap-2"
                   title={dirty ? "Save changes first" : ""}
                 >
                   {sending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
                   {agreement.agreement_type === "location_placement" ? "Send to Location" : "Send to Operator"}
+                </button>
+              )}
+              {!isReadOnly && agreement.agreement_type === "location_placement" && (
+                <button
+                  onClick={() => handleSend("operator")}
+                  disabled={sending || dirty}
+                  className="w-full rounded-lg border border-indigo-200 bg-white px-4 py-2.5 text-sm font-medium text-indigo-700 hover:bg-indigo-50 disabled:opacity-50 cursor-pointer inline-flex items-center justify-center gap-2"
+                  title={dirty ? "Save changes first" : "Skip location signature — operator signs directly"}
+                >
+                  {sending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
+                  Send to Operator
                 </button>
               )}
               <button


### PR DESCRIPTION
Some deals close without a location signature — verbal approval, an existing letter of authorization, an owner acting through the operator — but until now the only send option on a location placement agreement was to email the location contact. Reps had to either fake a location contact record or send the PDF out of band. This adds a first-class "Send to Operator" button that sits alongside "Send to Location" on the agreement editor.

UI (src/app/sales/agreements/[id]/page.tsx):
- handleSend now takes a "location" | "operator" target. Validation is branched per target — operator-target skips the location_contact_name / _email checks and only requires placement_operator_email + placement_operator_company + location_business_name + effective_date.
- The sidebar now shows two buttons for location placement agreements:
    - Primary indigo: "Send to Location" (unchanged look, explicit label)
    - Secondary outlined: "Send to Operator" — hover tooltip explains the flow (skips location signature, operator signs directly).
- Toolbar send button pins to "location" as the default target for backwards compatibility.

API (src/app/api/sales/agreements/[id]/send/route.ts):
- POST body accepts { target?: "location" | "operator" }. Non-string or missing → treated as "location" so existing callers keep working.
- Required-field list branches: operator-target drops the location contact name/email; keeps operator email + operator company + location business name + effective date.
- Recipient resolution: operator-target emails placement_operator_email.
- CCs: rep still gets CC. When sending to operator, the location contact email (if present) also gets CC'd so nobody's out of the loop.
- Email body: greeting uses the operator's contact name / company when the target is operator instead of the location contact name.
- 400 missing-recipient error now names the right field per target.
- Activity log records "emailed to operator at …" vs "emailed to location at …" so history shows which flow was used.

Non-location-placement agreements are untouched — the second button only renders for location placement.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2