### PR TITLE
PP docs: driver's license upload + admin viewer signed URLs

### DIFF
--- a/src/app/admin/marketplace/partners/[id]/page.tsx
+++ b/src/app/admin/marketplace/partners/[id]/page.tsx
@@ -97,6 +97,21 @@ export default function AdminPartnerDetailPage() {
     setSaving(null);
   }
 
+  async function viewDocument(docId: string) {
+    // Fetch a fresh 5-minute signed URL, then open it. Direct href would 403
+    // because we can't attach the Authorization header from an <a> click.
+    const res = await fetch(`/api/admin/marketplace/documents/${docId}/download`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      alert(body?.error || "Failed to load document");
+      return;
+    }
+    const { url } = await res.json();
+    if (url) window.open(url, "_blank", "noopener");
+  }
+
   if (loading || !data) {
     return <div className="flex justify-center py-20"><Loader2 className="h-6 w-6 animate-spin text-green-primary" /></div>;
   }
@@ -220,11 +235,12 @@ export default function AdminPartnerDetailPage() {
                       </div>
                     </div>
                     <div className="flex items-center gap-2">
-                      {d.file_url && (
-                        <a href={d.file_url} target="_blank" rel="noopener noreferrer" className="text-xs text-green-primary hover:underline">
-                          View
-                        </a>
-                      )}
+                      <button
+                        onClick={() => viewDocument(d.id)}
+                        className="text-xs text-green-primary hover:underline cursor-pointer"
+                      >
+                        View
+                      </button>
                       <button
                         onClick={() => verifyDocument(d.id, !d.verified_at)}
                         disabled={saving === `doc-${d.id}`}

--- a/src/app/api/admin/marketplace/documents/[id]/download/route.ts
+++ b/src/app/api/admin/marketplace/documents/[id]/download/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+
+/**
+ * GET /api/admin/marketplace/documents/[id]/download
+ *
+ * Returns { url: <signed 5-minute URL> } for the underlying storage object.
+ * The client fetches this with an Authorization header, then window.opens
+ * the URL. Old rows store a public URL that 404s because the private bucket
+ * doesn't serve them — this endpoint sidesteps that with a signed URL.
+ */
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  const { id } = await params;
+
+  const { data: doc } = await supabaseAdmin
+    .from("placement_partner_documents")
+    .select("id, partner_id, document_type, file_url, file_name")
+    .eq("id", id)
+    .maybeSingle();
+  if (!doc) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  // Extract the storage object key from the file_url. Supabase public URLs
+  // look like: https://<project>.supabase.co/storage/v1/object/public/<bucket>/<path>
+  // Signed URLs look like: .../object/sign/<bucket>/<path>?token=...
+  const bucket = "placement-partner-docs";
+  let objectPath: string | null = null;
+  if (doc.file_url) {
+    const marker = `/${bucket}/`;
+    const idx = doc.file_url.indexOf(marker);
+    if (idx >= 0) {
+      objectPath = doc.file_url.slice(idx + marker.length).split("?")[0];
+    }
+  }
+  if (!objectPath) {
+    return NextResponse.json(
+      { error: "Could not resolve storage path for this document" },
+      { status: 500 },
+    );
+  }
+
+  const { data: signed, error: signErr } = await supabaseAdmin.storage
+    .from(bucket)
+    .createSignedUrl(objectPath, 60 * 5);
+  if (signErr || !signed?.signedUrl) {
+    return NextResponse.json(
+      { error: signErr?.message || "Failed to create signed URL" },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({ url: signed.signedUrl, file_name: doc.file_name });
+}

--- a/src/app/placement/onboarding/page.tsx
+++ b/src/app/placement/onboarding/page.tsx
@@ -43,6 +43,8 @@ export default function MarketplaceOnboardingPage() {
   // Step 4
   const [w9File, setW9File] = useState<File | null>(null);
   const [uploadedW9, setUploadedW9] = useState<{ id: string; file_name: string } | null>(null);
+  const [idFile, setIdFile] = useState<File | null>(null);
+  const [uploadedId, setUploadedId] = useState<{ id: string; file_name: string } | null>(null);
 
   // Load existing state
   const load = useCallback(async () => {
@@ -78,6 +80,8 @@ export default function MarketplaceOnboardingPage() {
       }
       const w9 = data.documents?.find((d: { document_type: string }) => d.document_type === "w9");
       if (w9) setUploadedW9({ id: w9.id, file_name: w9.file_name });
+      const idDoc = data.documents?.find((d: { document_type: string }) => d.document_type === "id");
+      if (idDoc) setUploadedId({ id: idDoc.id, file_name: idDoc.file_name });
     } finally {
       setLoading(false);
     }
@@ -166,6 +170,30 @@ export default function MarketplaceOnboardingPage() {
     return true;
   }
 
+  async function uploadIdDoc() {
+    if (!idFile) return true; // Already uploaded previously
+    setSaving(true);
+    setError(null);
+    const fd = new FormData();
+    fd.append("file", idFile);
+    fd.append("type", "id");
+    const res = await fetch("/api/marketplace/partners/documents", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+      body: fd,
+    });
+    setSaving(false);
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      setError(data.error || "Failed to upload driver's license");
+      return false;
+    }
+    const doc = await res.json();
+    setUploadedId({ id: doc.id, file_name: doc.file_name });
+    setIdFile(null);
+    return true;
+  }
+
   async function completeOnboarding() {
     setSaving(true);
     setError(null);
@@ -197,8 +225,12 @@ export default function MarketplaceOnboardingPage() {
       if (ok) setStep(4);
     } else if (step === 4) {
       if (!uploadedW9 && !w9File) { setError("Please upload your W9 to continue"); return; }
-      const uploaded = await uploadW9();
-      if (uploaded) await completeOnboarding();
+      if (!uploadedId && !idFile) { setError("Please upload your driver's license to continue"); return; }
+      const w9Ok = await uploadW9();
+      if (!w9Ok) return;
+      const idOk = await uploadIdDoc();
+      if (!idOk) return;
+      await completeOnboarding();
     }
   }
 
@@ -365,54 +397,93 @@ export default function MarketplaceOnboardingPage() {
           </>
         )}
 
-        {/* STEP 4 — W9 */}
+        {/* STEP 4 — Documents (W-9 + Driver's License) */}
         {step === 4 && (
           <>
             <div className="mb-6 flex items-center gap-3">
               <div className="rounded-lg bg-green-50 p-2"><FileText className="h-5 w-5 text-green-primary" /></div>
               <div>
-                <h2 className="text-lg font-semibold text-gray-900">W-9 tax form</h2>
-                <p className="text-xs text-gray-500">Required so we can pay you. Uploaded securely; only admins can view.</p>
+                <h2 className="text-lg font-semibold text-gray-900">Documents</h2>
+                <p className="text-xs text-gray-500">Required so we can pay you and verify your identity. Uploaded securely; only admins can view.</p>
               </div>
             </div>
 
-            {uploadedW9 ? (
-              <div className="rounded-xl border border-green-200 bg-green-50 p-4 flex items-center gap-3">
-                <CheckCircle2 className="h-5 w-5 text-green-600 shrink-0" />
-                <div className="flex-1">
-                  <p className="text-sm font-medium text-green-900">W-9 uploaded</p>
-                  <p className="text-xs text-green-700">{uploadedW9.file_name}</p>
+            {/* W-9 */}
+            <div className="mb-5">
+              <p className="text-sm font-medium text-gray-900 mb-2">W-9 tax form</p>
+              {uploadedW9 ? (
+                <div className="rounded-xl border border-green-200 bg-green-50 p-4 flex items-center gap-3">
+                  <CheckCircle2 className="h-5 w-5 text-green-600 shrink-0" />
+                  <div className="flex-1">
+                    <p className="text-sm font-medium text-green-900">W-9 uploaded</p>
+                    <p className="text-xs text-green-700">{uploadedW9.file_name}</p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => setUploadedW9(null)}
+                    className="rounded-lg px-2.5 py-1 text-xs font-medium text-green-700 hover:bg-green-100 cursor-pointer"
+                  >
+                    Replace
+                  </button>
                 </div>
-                <button
-                  type="button"
-                  onClick={() => setUploadedW9(null)}
-                  className="rounded-lg px-2.5 py-1 text-xs font-medium text-green-700 hover:bg-green-100 cursor-pointer"
-                >
-                  Replace
-                </button>
-              </div>
-            ) : (
-              <label className="flex flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed border-gray-300 p-8 cursor-pointer hover:bg-gray-50 transition-colors">
-                <Upload className="h-8 w-8 text-gray-400" />
-                <p className="text-sm font-medium text-gray-700">
-                  {w9File ? w9File.name : "Click to upload your W-9"}
-                </p>
-                <p className="text-xs text-gray-400">PDF, PNG, or JPG</p>
-                <input
-                  type="file"
-                  accept=".pdf,.png,.jpg,.jpeg"
-                  onChange={(e) => setW9File(e.target.files?.[0] || null)}
-                  className="hidden"
-                />
-              </label>
-            )}
+              ) : (
+                <label className="flex flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed border-gray-300 p-6 cursor-pointer hover:bg-gray-50 transition-colors">
+                  <Upload className="h-6 w-6 text-gray-400" />
+                  <p className="text-sm font-medium text-gray-700">
+                    {w9File ? w9File.name : "Click to upload your W-9"}
+                  </p>
+                  <p className="text-xs text-gray-400">PDF, PNG, or JPG</p>
+                  <input
+                    type="file"
+                    accept=".pdf,.png,.jpg,.jpeg"
+                    onChange={(e) => setW9File(e.target.files?.[0] || null)}
+                    className="hidden"
+                  />
+                </label>
+              )}
+              <p className="mt-2 text-xs text-gray-500">
+                Don&apos;t have a W-9 handy?{" "}
+                <a href="https://www.irs.gov/pub/irs-pdf/fw9.pdf" target="_blank" rel="noopener noreferrer" className="text-green-primary hover:underline">
+                  Download the IRS blank form here.
+                </a>
+              </p>
+            </div>
 
-            <p className="mt-4 text-xs text-gray-500">
-              Don&apos;t have a W-9 handy?{" "}
-              <a href="https://www.irs.gov/pub/irs-pdf/fw9.pdf" target="_blank" rel="noopener noreferrer" className="text-green-primary hover:underline">
-                Download the IRS blank form here.
-              </a>
-            </p>
+            {/* Driver's License */}
+            <div>
+              <p className="text-sm font-medium text-gray-900 mb-2">Driver&apos;s license</p>
+              {uploadedId ? (
+                <div className="rounded-xl border border-green-200 bg-green-50 p-4 flex items-center gap-3">
+                  <CheckCircle2 className="h-5 w-5 text-green-600 shrink-0" />
+                  <div className="flex-1">
+                    <p className="text-sm font-medium text-green-900">Driver&apos;s license uploaded</p>
+                    <p className="text-xs text-green-700">{uploadedId.file_name}</p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => setUploadedId(null)}
+                    className="rounded-lg px-2.5 py-1 text-xs font-medium text-green-700 hover:bg-green-100 cursor-pointer"
+                  >
+                    Replace
+                  </button>
+                </div>
+              ) : (
+                <label className="flex flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed border-gray-300 p-6 cursor-pointer hover:bg-gray-50 transition-colors">
+                  <Upload className="h-6 w-6 text-gray-400" />
+                  <p className="text-sm font-medium text-gray-700">
+                    {idFile ? idFile.name : "Click to upload your driver's license"}
+                  </p>
+                  <p className="text-xs text-gray-400">PDF, PNG, or JPG</p>
+                  <input
+                    type="file"
+                    accept=".pdf,.png,.jpg,.jpeg"
+                    onChange={(e) => setIdFile(e.target.files?.[0] || null)}
+                    className="hidden"
+                  />
+                </label>
+              )}
+              <p className="mt-2 text-xs text-gray-500">A photo of the front is fine. Used for identity verification only.</p>
+            </div>
           </>
         )}
 


### PR DESCRIPTION
Two bugs in one commit:

1. Admin panel couldn't view uploaded docs — every click returned {"statusCode":"404","error":"Bucket not found"}. The placement-partner-docs bucket is created as PRIVATE in migration 097, but the upload code stored getPublicUrl() results — those URLs only work on public buckets, so unauthenticated GETs get 404'd by Storage. Additionally, if migration 097 was never run in this environment, the bucket itself is missing.

   Fix: new admin-only endpoint that mints a fresh 5-minute signed URL on demand and returns it as JSON. The partner detail page now fetches this endpoint (with Bearer auth) and window.opens the returned URL, sidestepping the direct-href problem where <a> can't send an Auth header.

2. Onboarding wizard collected a W-9 but never a driver's license, even though the /api/marketplace/partners/documents endpoint has always accepted type=id. Reps had no way to capture the ID during signup.

   Fix: step 4 is now titled "Documents" and stacks two upload cards — W-9 (unchanged) and Driver's License (new). Both are required to advance past the step. Existing partners with a W-9 but no ID will be asked for the ID next time they open the wizard.

If the bucket 404 persists after this PR, the bucket doesn't exist yet. Run this one-liner in Supabase SQL Editor to (idempotently) create it:

  INSERT INTO storage.buckets (id, name, public)
  VALUES ('placement-partner-docs', 'placement-partner-docs', false)
  ON CONFLICT (id) DO NOTHING;


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2