### PR TITLE
PP payout structure: partner-side collection, admin one-click ACH, QB…

### DIFF
--- a/src/app/admin/marketplace/payouts/page.tsx
+++ b/src/app/admin/marketplace/payouts/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { Loader2, DollarSign, Filter, ArrowLeft, RefreshCw, Send, AlertCircle, CheckCircle2 } from "lucide-react";
+import { Loader2, DollarSign, Filter, ArrowLeft, RefreshCw, Send, AlertCircle, CheckCircle2, Eye, EyeOff, ClipboardCheck } from "lucide-react";
 import { createBrowserClient } from "@/lib/supabase";
 
 interface Payout {
@@ -73,6 +73,7 @@ export default function AdminPayoutsPage() {
   const [saving, setSaving] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [revealed, setRevealed] = useState<Record<string, { method: string; bank_name: string | null; account_holder: string | null; account_type: string | null; routing_number: string | null; account_number: string | null; notes: string | null; verified_at: string | null } | null>>({});
 
   const load = useCallback(async () => {
     if (!token) return;
@@ -114,6 +115,39 @@ export default function AdminPayoutsPage() {
     const body = await res.json().catch(() => ({}));
     if (!res.ok) setError(body.error || "Drain failed");
     else setMessage(`Drained: ${body.succeeded} succeeded, ${body.failed} failed of ${body.attempted} attempted`);
+    await load();
+    setSaving(null);
+  }
+
+  async function toggleReveal(id: string) {
+    if (revealed[id] !== undefined) {
+      setRevealed((r) => { const c = { ...r }; delete c[id]; return c; });
+      return;
+    }
+    setSaving(`reveal-${id}`);
+    const res = await fetch(`/api/admin/marketplace/payouts/${id}/bank-info`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.ok) {
+      const body = await res.json();
+      setRevealed((r) => ({ ...r, [id]: body.bank_account || null }));
+    }
+    setSaving(null);
+  }
+
+  async function markPaid(id: string) {
+    const methodInput = prompt("Payment method used (ACH, Zelle, Check, etc.)?", "ACH");
+    if (methodInput === null) return;
+    const ref = prompt("Reference / confirmation # (optional)?", "");
+    setSaving(`mark-paid-${id}`);
+    const res = await fetch(`/api/admin/marketplace/payouts/${id}/mark-paid`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ method: methodInput, reference: ref }),
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) setError(body.error || "Failed to mark paid");
+    else setMessage("Payout marked paid");
     await load();
     setSaving(null);
   }
@@ -223,34 +257,105 @@ export default function AdminPayoutsPage() {
               </tr>
             </thead>
             <tbody>
-              {tab === "payouts" && payouts.map((p) => (
-                <tr key={p.id} className="border-t border-gray-50">
-                  <td className="px-4 py-3 text-gray-700">{p.partner?.business_name || `Partner #${p.partner_id.slice(0, 8)}`}</td>
-                  <td className="px-4 py-3 text-gray-700 text-xs">{p.contract?.title || "—"}</td>
-                  <td className="px-4 py-3 text-gray-700 text-xs">{p.submission ? `${p.submission.business_name} · ${[p.submission.city, p.submission.state].filter(Boolean).join(", ")}` : "—"}</td>
-                  <td className="px-4 py-3 text-right font-semibold text-emerald-700">${Number(p.amount).toLocaleString()}</td>
-                  <td className="px-4 py-3">
-                    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium capitalize ${STATUS_COLORS[p.status] || "bg-gray-100 text-gray-600"}`}>
-                      {p.status.replace(/_/g, " ")}
-                    </span>
-                    {p.qb_error && <p className="text-[10px] text-red-500 mt-1 max-w-xs truncate" title={p.qb_error}>{p.qb_error}</p>}
-                  </td>
-                  <td className="px-4 py-3 text-xs text-gray-500 font-mono">{p.qb_bill_id || "—"}</td>
-                  <td className="px-4 py-3 text-xs text-gray-500">{new Date(p.triggered_at).toLocaleDateString()}</td>
-                  <td className="px-4 py-3">
-                    {(p.status === "queued" || p.status === "failed") && (
-                      <button
-                        onClick={() => retry(p.id)}
-                        disabled={saving === `retry-${p.id}`}
-                        className="inline-flex items-center gap-1 rounded-lg border border-gray-200 hover:bg-gray-50 px-2 py-1 text-xs font-medium text-gray-700 cursor-pointer disabled:opacity-50"
-                      >
-                        {saving === `retry-${p.id}` ? <Loader2 className="h-3 w-3 animate-spin" /> : <RefreshCw className="h-3 w-3" />}
-                        Send
-                      </button>
-                    )}
-                  </td>
-                </tr>
-              ))}
+              {tab === "payouts" && payouts.flatMap((p) => {
+                const info = revealed[p.id];
+                const showPanel = info !== undefined;
+                const rows = [
+                  <tr key={p.id} className="border-t border-gray-50">
+                    <td className="px-4 py-3 text-gray-700">{p.partner?.business_name || `Partner #${p.partner_id.slice(0, 8)}`}</td>
+                    <td className="px-4 py-3 text-gray-700 text-xs">{p.contract?.title || "—"}</td>
+                    <td className="px-4 py-3 text-gray-700 text-xs">{p.submission ? `${p.submission.business_name} · ${[p.submission.city, p.submission.state].filter(Boolean).join(", ")}` : "—"}</td>
+                    <td className="px-4 py-3 text-right font-semibold text-emerald-700">${Number(p.amount).toLocaleString()}</td>
+                    <td className="px-4 py-3">
+                      <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium capitalize ${STATUS_COLORS[p.status] || "bg-gray-100 text-gray-600"}`}>
+                        {p.status.replace(/_/g, " ")}
+                      </span>
+                      {p.qb_error && <p className="text-[10px] text-red-500 mt-1 max-w-xs truncate" title={p.qb_error}>{p.qb_error}</p>}
+                    </td>
+                    <td className="px-4 py-3 text-xs text-gray-500 font-mono">{p.qb_bill_id || "—"}</td>
+                    <td className="px-4 py-3 text-xs text-gray-500">{new Date(p.triggered_at).toLocaleDateString()}</td>
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-1 flex-wrap justify-end">
+                        {(p.status === "queued" || p.status === "failed") && (
+                          <button
+                            onClick={() => retry(p.id)}
+                            disabled={saving === `retry-${p.id}`}
+                            className="inline-flex items-center gap-1 rounded-lg border border-gray-200 hover:bg-gray-50 px-2 py-1 text-xs font-medium text-gray-700 cursor-pointer disabled:opacity-50"
+                          >
+                            {saving === `retry-${p.id}` ? <Loader2 className="h-3 w-3 animate-spin" /> : <RefreshCw className="h-3 w-3" />}
+                            Send
+                          </button>
+                        )}
+                        {p.status !== "paid" && p.status !== "cancelled" && (
+                          <button
+                            onClick={() => toggleReveal(p.id)}
+                            disabled={saving === `reveal-${p.id}`}
+                            className="inline-flex items-center gap-1 rounded-lg border border-gray-200 hover:bg-gray-50 px-2 py-1 text-xs font-medium text-gray-700 cursor-pointer disabled:opacity-50"
+                          >
+                            {saving === `reveal-${p.id}` ? <Loader2 className="h-3 w-3 animate-spin" /> : (showPanel ? <EyeOff className="h-3 w-3" /> : <Eye className="h-3 w-3" />)}
+                            Bank
+                          </button>
+                        )}
+                        {p.status !== "paid" && (
+                          <button
+                            onClick={() => markPaid(p.id)}
+                            disabled={saving === `mark-paid-${p.id}`}
+                            className="inline-flex items-center gap-1 rounded-lg bg-emerald-600 hover:bg-emerald-700 px-2 py-1 text-xs font-medium text-white cursor-pointer disabled:opacity-50"
+                          >
+                            {saving === `mark-paid-${p.id}` ? <Loader2 className="h-3 w-3 animate-spin" /> : <ClipboardCheck className="h-3 w-3" />}
+                            Mark Paid
+                          </button>
+                        )}
+                      </div>
+                    </td>
+                  </tr>,
+                ];
+                if (showPanel) {
+                  rows.push(
+                    <tr key={`${p.id}-bank`} className="bg-amber-50/40">
+                      <td colSpan={8} className="px-4 py-3">
+                        {info ? (
+                          <div className="text-xs text-gray-700 grid grid-cols-1 sm:grid-cols-3 gap-3">
+                            <div>
+                              <p className="text-gray-500">Method</p>
+                              <p className="font-medium capitalize">{info.method.replace("_", " ")}</p>
+                            </div>
+                            <div>
+                              <p className="text-gray-500">Payee / Holder</p>
+                              <p className="font-medium">{info.account_holder || "—"}</p>
+                            </div>
+                            <div>
+                              <p className="text-gray-500">Bank</p>
+                              <p className="font-medium">{info.bank_name || "—"} <span className="text-gray-400">({info.account_type || "—"})</span></p>
+                            </div>
+                            <div>
+                              <p className="text-gray-500">Routing #</p>
+                              <p className="font-mono select-all">{info.routing_number || "—"}</p>
+                            </div>
+                            <div>
+                              <p className="text-gray-500">Account #</p>
+                              <p className="font-mono select-all">{info.account_number || "—"}</p>
+                            </div>
+                            <div>
+                              <p className="text-gray-500">Verified</p>
+                              <p className="font-medium">{info.verified_at ? new Date(info.verified_at).toLocaleDateString() : "Unverified"}</p>
+                            </div>
+                            {info.notes && (
+                              <div className="sm:col-span-3">
+                                <p className="text-gray-500">Partner notes</p>
+                                <p className="text-sm text-gray-700 whitespace-pre-wrap">{info.notes}</p>
+                              </div>
+                            )}
+                          </div>
+                        ) : (
+                          <p className="text-xs text-red-600">No payout details on file — reach out to the partner to submit them via /placement/payouts.</p>
+                        )}
+                      </td>
+                    </tr>,
+                  );
+                }
+                return rows;
+              })}
               {tab === "invoices" && invoices.map((i) => (
                 <tr key={i.id} className="border-t border-gray-50">
                   <td className="px-4 py-3 text-gray-700">{i.operator_business_name || "—"}<div className="text-xs text-gray-400">{i.operator_email}</div></td>

--- a/src/app/api/admin/marketplace/payouts/[id]/bank-info/route.ts
+++ b/src/app/api/admin/marketplace/payouts/[id]/bank-info/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+
+/**
+ * Reveals the full ACH details for a payout so admin can run the transfer.
+ * Explicitly admin-only. Fetched on demand (not embedded in the list) so
+ * the full account/routing numbers only cross the wire when the admin
+ * actually clicks the reveal button.
+ */
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id } = await params;
+
+  const { data: payout } = await supabaseAdmin
+    .from("marketplace_payouts")
+    .select("id, partner_id, amount")
+    .eq("id", id)
+    .maybeSingle();
+  if (!payout) return NextResponse.json({ error: "Payout not found" }, { status: 404 });
+
+  const { data: bank } = await supabaseAdmin
+    .from("placement_bank_accounts")
+    .select("method, bank_name, account_holder, account_type, routing_number, account_number, notes, verified_at")
+    .eq("partner_id", payout.partner_id)
+    .eq("active", true)
+    .maybeSingle();
+
+  if (!bank) return NextResponse.json({ bank_account: null });
+  return NextResponse.json({ bank_account: bank });
+}

--- a/src/app/api/admin/marketplace/payouts/[id]/mark-paid/route.ts
+++ b/src/app/api/admin/marketplace/payouts/[id]/mark-paid/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+
+/**
+ * Manually flip a payout to "paid" after admin runs the ACH / cuts the check.
+ * Records who marked it, when, how, and an optional reference (check number,
+ * ACH batch id, transaction id, etc.). Also fires the partner_payout_sent
+ * notification if it wasn't already sent (to catch payouts that were paid
+ * without ever going through QB).
+ */
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id } = await params;
+
+  const body = await req.json().catch(() => ({}));
+  const method = typeof body.method === "string" ? body.method.trim().slice(0, 40) : null;
+  const reference = typeof body.reference === "string" ? body.reference.trim().slice(0, 120) : null;
+
+  const now = new Date().toISOString();
+  const { data: updated, error } = await supabaseAdmin
+    .from("marketplace_payouts")
+    .update({
+      status: "paid",
+      paid_at: now,
+      paid_method: method,
+      paid_reference: reference,
+      paid_by: adminId,
+      updated_at: now,
+    })
+    .eq("id", id)
+    .select("id, partner_id")
+    .single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  // Fire-and-forget partner notification — no-op if already sent recently.
+  try {
+    const { notifyPartnerPayoutSent } = await import("@/lib/marketplaceNotifications");
+    notifyPartnerPayoutSent(updated.id).catch(() => undefined);
+  } catch { /* non-critical */ }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/marketplace/partners/bank-accounts/route.ts
+++ b/src/app/api/marketplace/partners/bank-accounts/route.ts
@@ -1,0 +1,102 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getPlacementPartner, forbidden } from "@/lib/marketplaceAuth";
+
+/**
+ * GET — return the partner's active bank account. Full numbers are omitted;
+ * only display-safe fields (last4, holder, method) come back.
+ * POST — create/replace the partner's active bank account (upsert; sets the
+ * previous one inactive first).
+ *
+ * routing_number + account_number never appear in responses. They live in DB
+ * for service-role code paths only (QB sync, admin payouts page).
+ */
+
+function last4(s: string | null | undefined): string | null {
+  if (!s) return null;
+  const digits = String(s).replace(/\D/g, "");
+  if (digits.length < 4) return null;
+  return digits.slice(-4);
+}
+
+export async function GET(req: NextRequest) {
+  const user = await getPlacementPartner(req);
+  if (!user) return forbidden();
+
+  const { data } = await supabaseAdmin
+    .from("placement_bank_accounts")
+    .select("id, method, bank_name, account_holder, account_type, routing_last4, account_last4, verified_at, notes, created_at")
+    .eq("partner_id", user.id)
+    .eq("active", true)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  return NextResponse.json({ bank_account: data || null });
+}
+
+export async function POST(req: NextRequest) {
+  const user = await getPlacementPartner(req);
+  if (!user) return forbidden();
+
+  const body = await req.json().catch(() => ({}));
+  const method = ["ach", "manual_check", "zelle", "venmo", "wire"].includes(body.method) ? body.method : "ach";
+  const bankName = String(body.bank_name || "").trim();
+  const accountHolder = String(body.account_holder || "").trim();
+  const accountType = ["checking", "savings"].includes(body.account_type) ? body.account_type : null;
+  const routingNumber = String(body.routing_number || "").trim();
+  const accountNumber = String(body.account_number || "").trim();
+  const notes = String(body.notes || "").trim();
+
+  if (method === "ach" || method === "wire") {
+    if (!bankName) return NextResponse.json({ error: "Bank name is required" }, { status: 400 });
+    if (!accountHolder) return NextResponse.json({ error: "Account holder name is required" }, { status: 400 });
+    const routingDigits = routingNumber.replace(/\D/g, "");
+    const accountDigits = accountNumber.replace(/\D/g, "");
+    if (routingDigits.length !== 9) return NextResponse.json({ error: "Routing number must be 9 digits" }, { status: 400 });
+    if (accountDigits.length < 4 || accountDigits.length > 17) {
+      return NextResponse.json({ error: "Account number must be 4-17 digits" }, { status: 400 });
+    }
+  } else {
+    if (!accountHolder) return NextResponse.json({ error: "Account holder / payee name is required" }, { status: 400 });
+  }
+
+  // Retire the current active account (audit-preserving — we don't delete).
+  await supabaseAdmin
+    .from("placement_bank_accounts")
+    .update({ active: false })
+    .eq("partner_id", user.id)
+    .eq("active", true);
+
+  const insertRow = {
+    partner_id: user.id,
+    method,
+    bank_name: bankName || null,
+    account_holder: accountHolder || null,
+    account_type: accountType,
+    routing_number: routingNumber.replace(/\D/g, "") || null,
+    account_number: accountNumber.replace(/\D/g, "") || null,
+    routing_last4: last4(routingNumber),
+    account_last4: last4(accountNumber),
+    notes: notes || null,
+    active: true,
+    verified_at: null,
+    qb_vendor_synced_at: null,
+  };
+
+  const { data: newRow, error } = await supabaseAdmin
+    .from("placement_bank_accounts")
+    .insert(insertRow)
+    .select("id, method, bank_name, account_holder, account_type, routing_last4, account_last4, notes, created_at")
+    .single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  await supabaseAdmin.from("placement_partner_activity").insert({
+    partner_id: user.id,
+    actor_id: user.id,
+    activity_type: "bank_updated",
+    description: `Payout details updated (${method})${insertRow.account_last4 ? ` — ****${insertRow.account_last4}` : ""}`,
+  });
+
+  return NextResponse.json({ bank_account: newRow });
+}

--- a/src/app/placement/onboarding/page.tsx
+++ b/src/app/placement/onboarding/page.tsx
@@ -15,7 +15,10 @@ interface Territory {
   travel_radius_miles?: number;
 }
 
-type Step = 1 | 2 | 3 | 4 | 5;
+type Step = 1 | 2 | 3 | 4 | 5 | 6;
+
+type PayoutMethod = "ach" | "manual_check" | "zelle" | "venmo" | "wire";
+type AccountType = "checking" | "savings";
 
 export default function MarketplaceOnboardingPage() {
   const router = useRouter();
@@ -45,6 +48,16 @@ export default function MarketplaceOnboardingPage() {
   const [uploadedW9, setUploadedW9] = useState<{ id: string; file_name: string } | null>(null);
   const [idFile, setIdFile] = useState<File | null>(null);
   const [uploadedId, setUploadedId] = useState<{ id: string; file_name: string } | null>(null);
+
+  // Step 5 — payout details
+  const [payoutMethod, setPayoutMethod] = useState<PayoutMethod>("ach");
+  const [bankName, setBankName] = useState("");
+  const [accountHolder, setAccountHolder] = useState("");
+  const [accountType, setAccountType] = useState<AccountType>("checking");
+  const [routingNumber, setRoutingNumber] = useState("");
+  const [accountNumber, setAccountNumber] = useState("");
+  const [payoutNotes, setPayoutNotes] = useState("");
+  const [savedBank, setSavedBank] = useState<{ method: string; account_last4: string | null } | null>(null);
 
   // Load existing state
   const load = useCallback(async () => {
@@ -82,6 +95,23 @@ export default function MarketplaceOnboardingPage() {
       if (w9) setUploadedW9({ id: w9.id, file_name: w9.file_name });
       const idDoc = data.documents?.find((d: { document_type: string }) => d.document_type === "id");
       if (idDoc) setUploadedId({ id: idDoc.id, file_name: idDoc.file_name });
+
+      // Load existing bank account (last4 only — full numbers never come back)
+      const bankRes = await fetch("/api/marketplace/partners/bank-accounts", {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      });
+      if (bankRes.ok) {
+        const bankData = await bankRes.json();
+        const b = bankData.bank_account;
+        if (b) {
+          setSavedBank({ method: b.method, account_last4: b.account_last4 || null });
+          setPayoutMethod(b.method || "ach");
+          setBankName(b.bank_name || "");
+          setAccountHolder(b.account_holder || "");
+          if (b.account_type) setAccountType(b.account_type);
+          setPayoutNotes(b.notes || "");
+        }
+      }
     } finally {
       setLoading(false);
     }
@@ -194,6 +224,52 @@ export default function MarketplaceOnboardingPage() {
     return true;
   }
 
+  async function saveBankAccount() {
+    // Skip write if user hasn't changed anything and already has one on file
+    // (full number fields blank means they're keeping the existing one).
+    const routingDigits = routingNumber.replace(/\D/g, "");
+    const accountDigits = accountNumber.replace(/\D/g, "");
+    if (savedBank && !routingDigits && !accountDigits) return true;
+
+    if (payoutMethod === "ach" || payoutMethod === "wire") {
+      if (!bankName.trim()) { setError("Bank name is required"); return false; }
+      if (!accountHolder.trim()) { setError("Account holder name is required"); return false; }
+      if (routingDigits.length !== 9) { setError("Routing number must be 9 digits"); return false; }
+      if (accountDigits.length < 4 || accountDigits.length > 17) { setError("Account number must be 4-17 digits"); return false; }
+    } else {
+      if (!accountHolder.trim()) { setError("Payee name is required"); return false; }
+    }
+
+    setSaving(true);
+    setError(null);
+    const res = await fetch("/api/marketplace/partners/bank-accounts", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({
+        method: payoutMethod,
+        bank_name: bankName.trim() || null,
+        account_holder: accountHolder.trim(),
+        account_type: accountType,
+        routing_number: routingDigits || null,
+        account_number: accountDigits || null,
+        notes: payoutNotes.trim() || null,
+      }),
+    });
+    setSaving(false);
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      setError(data.error || "Failed to save payout details");
+      return false;
+    }
+    const body = await res.json();
+    if (body.bank_account) {
+      setSavedBank({ method: body.bank_account.method, account_last4: body.bank_account.account_last4 || null });
+      setRoutingNumber("");
+      setAccountNumber("");
+    }
+    return true;
+  }
+
   async function completeOnboarding() {
     setSaving(true);
     setError(null);
@@ -208,7 +284,7 @@ export default function MarketplaceOnboardingPage() {
       return;
     }
     setSuccess("You're all set — your profile is now under review.");
-    setStep(5);
+    setStep(6);
   }
 
   async function nextStep() {
@@ -230,6 +306,10 @@ export default function MarketplaceOnboardingPage() {
       if (!w9Ok) return;
       const idOk = await uploadIdDoc();
       if (!idOk) return;
+      setStep(5);
+    } else if (step === 5) {
+      const ok = await saveBankAccount();
+      if (!ok) return;
       await completeOnboarding();
     }
   }
@@ -258,7 +338,7 @@ export default function MarketplaceOnboardingPage() {
 
       {/* Step indicator */}
       <div className="mb-6 flex items-center gap-2">
-        {[1, 2, 3, 4].map((n) => (
+        {[1, 2, 3, 4, 5].map((n) => (
           <div key={n} className="flex-1">
             <div className={`h-1.5 rounded-full ${step >= n ? "bg-green-600" : "bg-gray-200"}`} />
             <div className={`mt-1 text-xs font-medium ${step === n ? "text-green-700" : step > n ? "text-green-600" : "text-gray-400"}`}>
@@ -487,8 +567,126 @@ export default function MarketplaceOnboardingPage() {
           </>
         )}
 
-        {/* STEP 5 — Success */}
+        {/* STEP 5 — Payout details */}
         {step === 5 && (
+          <>
+            <div className="mb-6 flex items-center gap-3">
+              <div className="rounded-lg bg-green-50 p-2"><Briefcase className="h-5 w-5 text-green-primary" /></div>
+              <div>
+                <h2 className="text-lg font-semibold text-gray-900">Payout details</h2>
+                <p className="text-xs text-gray-500">How should we pay you out? You can change this later from your dashboard.</p>
+              </div>
+            </div>
+
+            {savedBank && (
+              <div className="mb-4 rounded-xl border border-green-200 bg-green-50 p-3 text-sm">
+                <p className="font-medium text-green-900">Current: {savedBank.method.replace("_", " ")}{savedBank.account_last4 ? ` — ****${savedBank.account_last4}` : ""}</p>
+                <p className="text-xs text-green-700 mt-0.5">Leave routing / account fields blank below to keep this on file, or enter new values to replace it.</p>
+              </div>
+            )}
+
+            <label className="block text-xs font-medium text-gray-600 mb-1">Payout method</label>
+            <div className="grid grid-cols-2 sm:grid-cols-5 gap-2 mb-4">
+              {(["ach", "wire", "manual_check", "zelle", "venmo"] as const).map((m) => (
+                <button
+                  key={m}
+                  type="button"
+                  onClick={() => setPayoutMethod(m)}
+                  className={`rounded-xl border px-2 py-2 text-xs font-medium transition-colors cursor-pointer capitalize ${payoutMethod === m ? "border-green-primary bg-green-50 text-green-700" : "border-gray-200 text-gray-600 hover:bg-gray-50"}`}
+                >
+                  {m.replace("_", " ")}
+                </button>
+              ))}
+            </div>
+
+            <div className="space-y-3">
+              <div>
+                <label className="block text-xs font-medium text-gray-600 mb-1">
+                  {payoutMethod === "ach" || payoutMethod === "wire" ? "Account holder (name on the account)" : "Payee name"} *
+                </label>
+                <input
+                  type="text"
+                  value={accountHolder}
+                  onChange={(e) => setAccountHolder(e.target.value)}
+                  placeholder={payoutMethod === "ach" || payoutMethod === "wire" ? "Jane Doe" : "Payee name for the check / Zelle / Venmo"}
+                  className="w-full rounded-xl border border-gray-200 px-3 py-2.5 text-sm focus:border-green-primary focus:outline-none"
+                />
+              </div>
+
+              {(payoutMethod === "ach" || payoutMethod === "wire") && (
+                <>
+                  <div>
+                    <label className="block text-xs font-medium text-gray-600 mb-1">Bank name *</label>
+                    <input
+                      type="text"
+                      value={bankName}
+                      onChange={(e) => setBankName(e.target.value)}
+                      placeholder="Chase, Wells Fargo, etc."
+                      className="w-full rounded-xl border border-gray-200 px-3 py-2.5 text-sm focus:border-green-primary focus:outline-none"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs font-medium text-gray-600 mb-1">Account type</label>
+                    <div className="flex gap-2">
+                      {(["checking", "savings"] as const).map((t) => (
+                        <button
+                          key={t}
+                          type="button"
+                          onClick={() => setAccountType(t)}
+                          className={`flex-1 rounded-xl border px-3 py-2 text-sm font-medium transition-colors cursor-pointer capitalize ${accountType === t ? "border-green-primary bg-green-50 text-green-700" : "border-gray-200 text-gray-600 hover:bg-gray-50"}`}
+                        >
+                          {t}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                    <div>
+                      <label className="block text-xs font-medium text-gray-600 mb-1">Routing number *</label>
+                      <input
+                        type="text"
+                        value={routingNumber}
+                        onChange={(e) => setRoutingNumber(e.target.value.replace(/\D/g, "").slice(0, 9))}
+                        placeholder="9 digits"
+                        inputMode="numeric"
+                        className="w-full rounded-xl border border-gray-200 px-3 py-2.5 text-sm focus:border-green-primary focus:outline-none font-mono"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-xs font-medium text-gray-600 mb-1">Account number *</label>
+                      <input
+                        type="text"
+                        value={accountNumber}
+                        onChange={(e) => setAccountNumber(e.target.value.replace(/\D/g, "").slice(0, 17))}
+                        placeholder="4-17 digits"
+                        inputMode="numeric"
+                        className="w-full rounded-xl border border-gray-200 px-3 py-2.5 text-sm focus:border-green-primary focus:outline-none font-mono"
+                      />
+                    </div>
+                  </div>
+                </>
+              )}
+
+              <div>
+                <label className="block text-xs font-medium text-gray-600 mb-1">Notes (optional)</label>
+                <textarea
+                  value={payoutNotes}
+                  onChange={(e) => setPayoutNotes(e.target.value)}
+                  rows={2}
+                  placeholder={payoutMethod === "zelle" ? "Zelle email or phone" : payoutMethod === "venmo" ? "Venmo handle (@username)" : payoutMethod === "manual_check" ? "Mailing address for check" : "Anything we should know about your account"}
+                  className="w-full rounded-xl border border-gray-200 px-3 py-2 text-sm focus:border-green-primary focus:outline-none resize-none"
+                />
+              </div>
+            </div>
+
+            <p className="mt-4 text-xs text-gray-500">
+              🔒 Routing and account numbers are stored securely and only viewable by our finance team when processing your payout. We&apos;ll show you only the last 4 digits on your dashboard.
+            </p>
+          </>
+        )}
+
+        {/* STEP 6 — Success */}
+        {step === 6 && (
           <div className="text-center py-6">
             <div className="mx-auto w-16 h-16 rounded-full bg-green-50 flex items-center justify-center mb-4">
               <CheckCircle2 className="w-8 h-8 text-green-primary" />
@@ -513,7 +711,7 @@ export default function MarketplaceOnboardingPage() {
         )}
 
         {/* Navigation */}
-        {step < 5 && (
+        {step < 6 && (
           <div className="mt-8 flex items-center justify-between">
             <button
               type="button"
@@ -535,7 +733,7 @@ export default function MarketplaceOnboardingPage() {
                 </>
               ) : (
                 <>
-                  {step === 4 ? "Finish" : "Continue"} <ArrowRight className="h-4 w-4" />
+                  {step === 5 ? "Finish" : "Continue"} <ArrowRight className="h-4 w-4" />
                 </>
               )}
             </button>

--- a/src/app/placement/page.tsx
+++ b/src/app/placement/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { Loader2, ArrowRight, CheckCircle2, Clock, Building2, Briefcase, Package, Users, Star, Bell } from "lucide-react";
+import { Loader2, ArrowRight, CheckCircle2, Clock, Building2, Briefcase, Package, Users, Star, Bell, DollarSign } from "lucide-react";
 import { createBrowserClient } from "@/lib/supabase";
 
 interface Partner {
@@ -197,6 +197,20 @@ export default function PlacementDashboardPage() {
           </div>
           <h2 className="text-lg font-semibold text-gray-900 mb-1">Team</h2>
           <p className="text-sm text-gray-500">Invite locators to your company. They log in with their own account and work under yours.</p>
+        </Link>
+
+        <Link
+          href="/placement/payouts"
+          className="group rounded-2xl border border-gray-100 bg-white p-6 hover:border-green-200 hover:shadow-sm transition-all"
+        >
+          <div className="flex items-center justify-between mb-4">
+            <div className="w-12 h-12 rounded-xl bg-emerald-50 flex items-center justify-center">
+              <DollarSign className="h-6 w-6 text-emerald-600" />
+            </div>
+            <ArrowRight className="h-5 w-5 text-gray-300 group-hover:text-green-primary transition-colors" />
+          </div>
+          <h2 className="text-lg font-semibold text-gray-900 mb-1">Payout Details</h2>
+          <p className="text-sm text-gray-500">How we pay you when the operator accepts a location. ACH, Zelle, Venmo, or check.</p>
         </Link>
       </div>
     </div>

--- a/src/app/placement/payouts/page.tsx
+++ b/src/app/placement/payouts/page.tsx
@@ -1,0 +1,269 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Loader2, ArrowLeft, DollarSign, Lock, CheckCircle2, AlertCircle } from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
+
+type Method = "ach" | "manual_check" | "zelle" | "venmo" | "wire";
+type AccountType = "checking" | "savings";
+
+interface SavedBank {
+  method: string;
+  bank_name: string | null;
+  account_holder: string | null;
+  account_type: string | null;
+  routing_last4: string | null;
+  account_last4: string | null;
+  verified_at: string | null;
+  notes: string | null;
+}
+
+export default function PlacementPayoutsPage() {
+  const router = useRouter();
+  const [token, setToken] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const [savedBank, setSavedBank] = useState<SavedBank | null>(null);
+  const [method, setMethod] = useState<Method>("ach");
+  const [bankName, setBankName] = useState("");
+  const [accountHolder, setAccountHolder] = useState("");
+  const [accountType, setAccountType] = useState<AccountType>("checking");
+  const [routingNumber, setRoutingNumber] = useState("");
+  const [accountNumber, setAccountNumber] = useState("");
+  const [notes, setNotes] = useState("");
+
+  const load = useCallback(async () => {
+    if (!token) return;
+    setLoading(true);
+    const res = await fetch("/api/marketplace/partners/bank-accounts", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.ok) {
+      const data = await res.json();
+      const b: SavedBank | null = data.bank_account;
+      setSavedBank(b);
+      if (b) {
+        setMethod((b.method as Method) || "ach");
+        setBankName(b.bank_name || "");
+        setAccountHolder(b.account_holder || "");
+        if (b.account_type === "checking" || b.account_type === "savings") setAccountType(b.account_type);
+        setNotes(b.notes || "");
+      }
+    }
+    setLoading(false);
+  }, [token]);
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!session?.access_token) { router.push("/login?redirect=/placement/payouts"); return; }
+      setToken(session.access_token);
+    });
+  }, [router]);
+
+  useEffect(() => { load(); }, [load]);
+
+  async function save() {
+    setError(null);
+    setMessage(null);
+    const routingDigits = routingNumber.replace(/\D/g, "");
+    const accountDigits = accountNumber.replace(/\D/g, "");
+    if (method === "ach" || method === "wire") {
+      if (!bankName.trim()) { setError("Bank name is required"); return; }
+      if (!accountHolder.trim()) { setError("Account holder name is required"); return; }
+      if (routingDigits.length !== 9) { setError("Routing number must be 9 digits"); return; }
+      if (accountDigits.length < 4 || accountDigits.length > 17) { setError("Account number must be 4-17 digits"); return; }
+    } else {
+      if (!accountHolder.trim()) { setError("Payee name is required"); return; }
+    }
+
+    setSaving(true);
+    const res = await fetch("/api/marketplace/partners/bank-accounts", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({
+        method,
+        bank_name: bankName.trim() || null,
+        account_holder: accountHolder.trim(),
+        account_type: accountType,
+        routing_number: routingDigits || null,
+        account_number: accountDigits || null,
+        notes: notes.trim() || null,
+      }),
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      setError(body.error || "Failed to save");
+    } else {
+      setMessage("Payout details saved");
+      setRoutingNumber("");
+      setAccountNumber("");
+      await load();
+    }
+    setSaving(false);
+  }
+
+  if (loading) {
+    return <div className="flex justify-center py-20"><Loader2 className="h-6 w-6 animate-spin text-green-primary" /></div>;
+  }
+
+  const inputClass = "w-full rounded-xl border border-gray-200 px-3 py-2.5 text-sm focus:border-green-primary focus:outline-none";
+  const monoInputClass = inputClass + " font-mono";
+
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-8 sm:px-6">
+      <Link href="/placement" className="text-sm text-gray-500 hover:text-green-primary flex items-center gap-1.5 mb-4">
+        <ArrowLeft className="h-4 w-4" /> Back to Dashboard
+      </Link>
+
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
+          <DollarSign className="h-6 w-6 text-green-primary" /> Payout Details
+        </h1>
+        <p className="text-sm text-gray-500 mt-1">How we pay you when the operator accepts a location you sourced.</p>
+      </div>
+
+      {savedBank && (
+        <div className="mb-4 rounded-xl border border-green-200 bg-green-50 p-3 text-sm">
+          <p className="font-medium text-green-900">
+            Current on file: {savedBank.method.replace("_", " ")}
+            {savedBank.account_last4 ? ` — ****${savedBank.account_last4}` : ""}
+            {savedBank.verified_at ? " (verified)" : " (unverified)"}
+          </p>
+          <p className="text-xs text-green-700 mt-0.5">
+            Leave routing / account fields blank to keep this on file, or enter new values to replace it.
+          </p>
+        </div>
+      )}
+
+      {message && (
+        <div className="mb-4 flex items-start gap-2 rounded-xl border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-700">
+          <CheckCircle2 className="h-4 w-4 mt-0.5 shrink-0" />
+          <span>{message}</span>
+        </div>
+      )}
+      {error && (
+        <div className="mb-4 flex items-start gap-2 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      <div className="rounded-2xl border border-gray-100 bg-white p-5">
+        <label className="block text-xs font-medium text-gray-600 mb-1">Payout method</label>
+        <div className="grid grid-cols-2 sm:grid-cols-5 gap-2 mb-5">
+          {(["ach", "wire", "manual_check", "zelle", "venmo"] as const).map((m) => (
+            <button
+              key={m}
+              type="button"
+              onClick={() => setMethod(m)}
+              className={`rounded-xl border px-2 py-2 text-xs font-medium transition-colors cursor-pointer capitalize ${method === m ? "border-green-primary bg-green-50 text-green-700" : "border-gray-200 text-gray-600 hover:bg-gray-50"}`}
+            >
+              {m.replace("_", " ")}
+            </button>
+          ))}
+        </div>
+
+        <div className="space-y-3">
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">
+              {method === "ach" || method === "wire" ? "Account holder (name on the account)" : "Payee name"} *
+            </label>
+            <input
+              type="text"
+              value={accountHolder}
+              onChange={(e) => setAccountHolder(e.target.value)}
+              className={inputClass}
+            />
+          </div>
+
+          {(method === "ach" || method === "wire") && (
+            <>
+              <div>
+                <label className="block text-xs font-medium text-gray-600 mb-1">Bank name *</label>
+                <input
+                  type="text"
+                  value={bankName}
+                  onChange={(e) => setBankName(e.target.value)}
+                  placeholder="Chase, Wells Fargo, etc."
+                  className={inputClass}
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-gray-600 mb-1">Account type</label>
+                <div className="flex gap-2">
+                  {(["checking", "savings"] as const).map((t) => (
+                    <button
+                      key={t}
+                      type="button"
+                      onClick={() => setAccountType(t)}
+                      className={`flex-1 rounded-xl border px-3 py-2 text-sm font-medium transition-colors cursor-pointer capitalize ${accountType === t ? "border-green-primary bg-green-50 text-green-700" : "border-gray-200 text-gray-600 hover:bg-gray-50"}`}
+                    >
+                      {t}
+                    </button>
+                  ))}
+                </div>
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <div>
+                  <label className="block text-xs font-medium text-gray-600 mb-1">Routing number *</label>
+                  <input
+                    type="text"
+                    value={routingNumber}
+                    onChange={(e) => setRoutingNumber(e.target.value.replace(/\D/g, "").slice(0, 9))}
+                    placeholder="9 digits"
+                    inputMode="numeric"
+                    className={monoInputClass}
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs font-medium text-gray-600 mb-1">Account number *</label>
+                  <input
+                    type="text"
+                    value={accountNumber}
+                    onChange={(e) => setAccountNumber(e.target.value.replace(/\D/g, "").slice(0, 17))}
+                    placeholder="4-17 digits"
+                    inputMode="numeric"
+                    className={monoInputClass}
+                  />
+                </div>
+              </div>
+            </>
+          )}
+
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">Notes (optional)</label>
+            <textarea
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              rows={2}
+              placeholder={method === "zelle" ? "Zelle email or phone" : method === "venmo" ? "Venmo handle (@username)" : method === "manual_check" ? "Mailing address for check" : "Anything we should know"}
+              className={`${inputClass} resize-none`}
+            />
+          </div>
+        </div>
+
+        <div className="mt-5 flex items-start gap-2 rounded-xl bg-gray-50 p-3 text-xs text-gray-600">
+          <Lock className="h-3.5 w-3.5 mt-0.5 shrink-0 text-gray-500" />
+          <span>Routing and account numbers are encrypted at rest and only accessible to our finance team when processing your payout. Your dashboard shows only the last 4 digits.</span>
+        </div>
+
+        <div className="mt-4 flex justify-end">
+          <button
+            onClick={save}
+            disabled={saving}
+            className="inline-flex items-center gap-2 rounded-xl bg-green-primary hover:bg-green-hover px-6 py-2.5 text-sm font-semibold text-white cursor-pointer disabled:opacity-50"
+          >
+            {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+            Save Payout Details
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/marketplaceQb.ts
+++ b/src/lib/marketplaceQb.ts
@@ -17,12 +17,34 @@ import {
   findOrCreateCustomer,
   createBill,
   createInvoice,
+  updateVendorNotes,
 } from "./quickbooks";
 
 const now = () => new Date().toISOString();
 
 interface EnsureVendorArgs {
   partnerId: string;
+}
+
+function buildBankNotes(bank: {
+  method: string;
+  bank_name: string | null;
+  account_holder: string | null;
+  account_type: string | null;
+  routing_number: string | null;
+  account_number: string | null;
+  notes: string | null;
+} | null): string | undefined {
+  if (!bank) return undefined;
+  const lines: string[] = [];
+  lines.push(`Payout method: ${bank.method}`);
+  if (bank.account_holder) lines.push(`Payee: ${bank.account_holder}`);
+  if (bank.bank_name) lines.push(`Bank: ${bank.bank_name}`);
+  if (bank.account_type) lines.push(`Account type: ${bank.account_type}`);
+  if (bank.routing_number) lines.push(`Routing: ${bank.routing_number}`);
+  if (bank.account_number) lines.push(`Account: ${bank.account_number}`);
+  if (bank.notes) lines.push(`Notes: ${bank.notes}`);
+  return lines.join("\n");
 }
 
 async function ensurePartnerVendor({ partnerId }: EnsureVendorArgs): Promise<string | null> {
@@ -32,7 +54,6 @@ async function ensurePartnerVendor({ partnerId }: EnsureVendorArgs): Promise<str
     .eq("id", partnerId)
     .maybeSingle();
   if (!partner) return null;
-  if (partner.qb_vendor_id) return partner.qb_vendor_id;
 
   const { data: profile } = await supabaseAdmin
     .from("profiles")
@@ -40,11 +61,36 @@ async function ensurePartnerVendor({ partnerId }: EnsureVendorArgs): Promise<str
     .eq("id", partnerId)
     .maybeSingle();
 
+  const { data: bank } = await supabaseAdmin
+    .from("placement_bank_accounts")
+    .select("id, method, bank_name, account_holder, account_type, routing_number, account_number, notes, qb_vendor_synced_at")
+    .eq("partner_id", partnerId)
+    .eq("active", true)
+    .maybeSingle();
+
+  const notes = buildBankNotes(bank);
   const displayName = partner.business_name || profile?.full_name || `Partner ${partnerId.slice(0, 8)}`;
+
+  // Existing vendor: sync bank notes if we haven't already, then return the id.
+  if (partner.qb_vendor_id) {
+    if (bank && !bank.qb_vendor_synced_at && notes) {
+      try {
+        await updateVendorNotes(partner.qb_vendor_id, notes);
+        await supabaseAdmin
+          .from("placement_bank_accounts")
+          .update({ qb_vendor_synced_at: now() })
+          .eq("id", bank.id);
+      } catch { /* non-critical — Bill still gets created */ }
+    }
+    return partner.qb_vendor_id;
+  }
+
+  // New vendor path — attach bank notes at creation.
   const vendor = await findOrCreateVendor({
     displayName,
     email: profile?.email || undefined,
     phone: profile?.phone || undefined,
+    notes,
   });
 
   await supabaseAdmin
@@ -55,6 +101,13 @@ async function ensurePartnerVendor({ partnerId }: EnsureVendorArgs): Promise<str
       updated_at: now(),
     })
     .eq("id", partnerId);
+
+  if (bank && notes) {
+    await supabaseAdmin
+      .from("placement_bank_accounts")
+      .update({ qb_vendor_synced_at: now() })
+      .eq("id", bank.id);
+  }
 
   return vendor.Id;
 }

--- a/src/lib/quickbooks.ts
+++ b/src/lib/quickbooks.ts
@@ -424,10 +424,13 @@ export async function createVendor(params: {
   displayName: string;
   email?: string;
   phone?: string;
+  notes?: string;
 }): Promise<QBVendor> {
   const body: Record<string, unknown> = { DisplayName: params.displayName };
   if (params.email) body.PrimaryEmailAddr = { Address: params.email };
   if (params.phone) body.PrimaryPhone = { FreeFormNumber: params.phone };
+  if (params.notes) body.PrintOnCheckName = params.displayName; // used on printed checks
+  if (params.notes) body.Notes = params.notes;
 
   const res = await qbFetch("/vendor", {
     method: "POST",
@@ -451,6 +454,7 @@ export async function findOrCreateVendor(params: {
   displayName: string;
   email?: string;
   phone?: string;
+  notes?: string;
 }): Promise<QBVendor> {
   if (params.email) {
     const byEmail = await findVendorByEmail(params.email);
@@ -459,6 +463,32 @@ export async function findOrCreateVendor(params: {
   const byName = await findVendorByName(params.displayName);
   if (byName) return byName;
   return createVendor(params);
+}
+
+/**
+ * Update an existing vendor's Notes field (used to attach ACH info later
+ * once the partner adds it, when the vendor was created without it).
+ * Requires the current SyncToken — we fetch a fresh copy first.
+ */
+export async function updateVendorNotes(vendorId: string, notes: string): Promise<void> {
+  const getRes = await qbFetch(`/vendor/${vendorId}`);
+  if (!getRes.ok) {
+    throw new Error(`QB get vendor failed: ${await getRes.text()}`);
+  }
+  const current = (await getRes.json()).Vendor;
+  const res = await qbFetch("/vendor", {
+    method: "POST",
+    body: JSON.stringify({
+      Id: current.Id,
+      SyncToken: current.SyncToken,
+      DisplayName: current.DisplayName,
+      Notes: notes,
+      sparse: true,
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`QB update vendor failed: ${await res.text()}`);
+  }
 }
 
 // ─── Bill Management (partner payouts owed) ───

--- a/supabase/migrations/104_marketplace_payout_details.sql
+++ b/supabase/migrations/104_marketplace_payout_details.sql
@@ -1,0 +1,29 @@
+-- Marketplace payout structure: capture bank info from placement partners so
+-- payouts can be executed without an admin-vs-PP email round-trip. The
+-- routing/account numbers are only ever accessed via service-role code paths
+-- (see the "Service role only" RLS policy from migration 097) and Supabase
+-- disk-at-rest encryption applies at the storage layer.
+
+ALTER TABLE placement_bank_accounts
+  ADD COLUMN IF NOT EXISTS routing_number text,
+  ADD COLUMN IF NOT EXISTS account_number text,
+  ADD COLUMN IF NOT EXISTS account_type text
+    CHECK (account_type IS NULL OR account_type IN ('checking', 'savings')),
+  ADD COLUMN IF NOT EXISTS notes text,
+  ADD COLUMN IF NOT EXISTS qb_vendor_synced_at timestamptz;
+
+-- payout method labels expanded — some partners may prefer paper checks or
+-- want us to Zelle/Venmo them until their bank profile is ready.
+ALTER TABLE placement_bank_accounts
+  DROP CONSTRAINT IF EXISTS placement_bank_accounts_method_check;
+
+ALTER TABLE placement_bank_accounts
+  ADD CONSTRAINT placement_bank_accounts_method_check
+  CHECK (method IN ('ach', 'manual_check', 'zelle', 'venmo', 'wire'));
+
+-- Mark on the payout row when + how it was actually settled (independent of
+-- QB Bill status). "paid_at" already exists; add human context.
+ALTER TABLE marketplace_payouts
+  ADD COLUMN IF NOT EXISTS paid_method text,
+  ADD COLUMN IF NOT EXISTS paid_reference text,
+  ADD COLUMN IF NOT EXISTS paid_by uuid REFERENCES profiles(id);


### PR DESCRIPTION
… sync

Audit found the payout loop had a huge gap: placement_bank_accounts existed in schema but there was no PP-facing API or onboarding step to populate it, no admin surface to consume it, and the QB Vendor sync only carried name + email + phone — leaving admin to email each partner for their ACH info before every payment.

This commit closes the loop end-to-end without leaving the "QuickBooks for now" constraint set earlier in the marketplace phases:

Data (migration 104):
- placement_bank_accounts gains routing_number, account_number, account_type, notes, and qb_vendor_synced_at columns. Full numbers are only accessed via service-role code paths (RLS from migration 097 is unchanged). Method CHECK is broadened to ach | wire | manual_check | zelle | venmo.
- marketplace_payouts gains paid_method, paid_reference, paid_by so the admin dashboard can record how / who settled a payout independently of the QB Bill lifecycle.

Partner side (/placement/*):
- New API: GET / POST /api/marketplace/partners/bank-accounts. Idempotent upsert semantics — POST retires the previous active row and creates a new one, so history is preserved. GET only returns display-safe fields (last4, method, holder); full numbers never round-trip to the browser.
- Onboarding wizard adds Step 5 "Payout details" — payout method picker, bank name, account holder, account type, routing #, account #, notes. Progress bar and Continue button label updated. Success step renumbered to 6.
- Standalone editable page at /placement/payouts with the same form so partners can update payout info any time without re-running onboarding.
- Placement dashboard gains a "Payout Details" card.

QuickBooks side (src/lib/quickbooks.ts + marketplaceQb.ts):
- createVendor / findOrCreateVendor accept an optional notes param and now populate PrintOnCheckName + Notes on new Vendors so admins running QB Bill Pay see the ACH details right on the Vendor record.
- New updateVendorNotes helper for backfilling Notes on existing vendors.
- ensurePartnerVendor pulls the active bank row on every call. New vendors get notes attached at creation. Existing vendors that haven't been synced yet get their Notes patched via updateVendorNotes and the qb_vendor_synced_at timestamp recorded.

Admin side (/admin/marketplace/payouts):
- New endpoints: GET  /api/admin/marketplace/payouts/[id]/bank-info — reveals ACH details on demand (kept out of the list response so full numbers only cross the wire when admin clicks Bank). POST /api/admin/marketplace/payouts/[id]/mark-paid — sets status=paid + paid_at/paid_method/paid_reference/paid_by. Fires the partner payout notification (no-op if the email already went out).
- Payouts table gains "Bank" (reveal/hide) and "Mark Paid" buttons per row. Revealed rows expand a panel showing method, payee, bank name, account type, routing #, account #, verification status, and partner notes — everything admin needs to run ACH inside their bank or QB Bill Pay without any back-and-forth.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2