### PR TITLE
Fix onboarding forbidden — let admins walk through PP wizard

### DIFF
--- a/src/lib/marketplaceAuth.ts
+++ b/src/lib/marketplaceAuth.ts
@@ -30,7 +30,16 @@ export async function getPlacementPartner(req: NextRequest): Promise<PlacementPa
     .select("id, full_name, email, role")
     .eq("id", userId)
     .single();
-  if (!profile || profile.role !== "placement_partner") return null;
+  if (!profile) return null;
+
+  // Accept:
+  //  - placement_partner: normal PPs going through their own dashboard
+  //  - admin: so a Vending Connector admin can walk through the wizard
+  //    (for QA / debugging / supporting a partner over the phone) without
+  //    the "don't clobber elevated roles" guard in POST /partners blocking
+  //    them out of Step 2 onwards.
+  const allowed = profile.role === "placement_partner" || profile.role === "admin";
+  if (!allowed) return null;
 
   const { data: partner } = await supabaseAdmin
     .from("placement_partners")


### PR DESCRIPTION
Reported: clicking "Continue" on the Area of Operation step (Step 2) of /placement/onboarding returns Forbidden. Trace:

- getPlacementPartner requires profile.role === "placement_partner".
- The earlier "don't clobber elevated roles" fix means an admin (or sales_manager, etc.) opening the wizard does NOT get their role flipped to placement_partner on Step 1.
- So on Step 2 the territories POST hits getPlacementPartner, which returns null because the caller's role is still admin, and the endpoint 403s.

Fix: getPlacementPartner now accepts "placement_partner" OR "admin". This lets a Vending Connector admin walk the wizard end-to-end for QA / debugging / phone support without triggering the role-clobber bug we patched earlier. Non-admin/non-partner roles are still rejected.

Sales/director/market-leader/sales-manager remain blocked from PP endpoints by design — if one of them ever needs to test, they should have an admin switch them into the placement_partner role manually first.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2