### PR TITLE
Unstick /complete-profile Continue — three fixes stacked

### DIFF
--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -105,11 +105,29 @@ export async function PATCH(req: NextRequest) {
     ];
     // Privileged roles can ONLY be set by an admin via /api/admin/users.
     // Self-service signup must never grant admin/sales access.
-    const PRIVILEGED_ROLES = new Set(["admin", "sales", "director_of_sales", "market_leader"]);
+    const PRIVILEGED_ROLES = new Set(["admin", "sales", "director_of_sales", "market_leader", "sales_manager"]);
+
+    // Fetch the current role so we can also protect elevated users from
+    // accidentally demoting themselves (e.g. an admin filling out
+    // /complete-profile picking accountType=operator would otherwise land
+    // as role=operator and lose CRM access).
+    const { data: currentProfile } = await supabaseAdmin
+      .from("profiles")
+      .select("role")
+      .eq("id", user.id)
+      .maybeSingle();
+    const currentRole = currentProfile?.role || "";
+    const currentIsPrivileged = PRIVILEGED_ROLES.has(currentRole);
+
     const updates: Partial<Record<string, string | null>> = {};
     for (const field of allowedFields) {
       if (field in body) {
-        if (field === "role" && PRIVILEGED_ROLES.has(body.role)) continue;
+        if (field === "role") {
+          // Reject setting privileged roles from this endpoint.
+          if (PRIVILEGED_ROLES.has(body.role)) continue;
+          // Reject downgrading a privileged user via self-service.
+          if (currentIsPrivileged) continue;
+        }
         updates[field] = body[field];
       }
     }

--- a/src/app/complete-profile/page.tsx
+++ b/src/app/complete-profile/page.tsx
@@ -22,6 +22,7 @@ export default function CompleteProfilePage() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
   const [accountType, setAccountType] = useState<AccountType | "">("");
+  const [elevatedRole, setElevatedRole] = useState(false);
   const [form, setForm] = useState({
     full_name: "",
     company_name: "",
@@ -56,6 +57,13 @@ export default function CompleteProfilePage() {
           if (profile.role && ["operator", "locator", "location_manager", "employee", "sales"].includes(profile.role)) {
             setAccountType(profile.role === "sales" ? "employee" : profile.role);
           }
+          // Elevated roles (admin, sales_manager, director_of_sales,
+          // market_leader) don't fit the four account-type buttons; skip the
+          // picker for them so they can save phone/address without being
+          // trapped on "Please select an account type".
+          if (profile.role && ["admin", "sales_manager", "director_of_sales", "market_leader"].includes(profile.role)) {
+            setElevatedRole(true);
+          }
           setForm({
             full_name: profile.full_name || "",
             company_name: profile.company_name || "",
@@ -74,18 +82,23 @@ export default function CompleteProfilePage() {
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    if (!accountType) { setError("Please select an account type"); return; }
-    if (!form.full_name.trim()) { setError("Full name is required"); return; }
-    if (!form.phone.trim()) { setError("Phone number is required"); return; }
-    if (!form.address.trim()) { setError("Address is required"); return; }
-    if (!form.city.trim()) { setError("City is required"); return; }
-    if (!form.state.trim()) { setError("State is required"); return; }
-    if (!form.zip.trim()) { setError("Zip code is required"); return; }
+    if (!elevatedRole && !accountType) { setError("Please select an account type"); window.scrollTo({ top: 0, behavior: "smooth" }); return; }
+    if (!form.full_name.trim()) { setError("Full name is required"); window.scrollTo({ top: 0, behavior: "smooth" }); return; }
+    if (!form.phone.trim()) { setError("Phone number is required"); window.scrollTo({ top: 0, behavior: "smooth" }); return; }
+    if (!form.address.trim()) { setError("Address is required"); window.scrollTo({ top: 0, behavior: "smooth" }); return; }
+    if (!form.city.trim()) { setError("City is required"); window.scrollTo({ top: 0, behavior: "smooth" }); return; }
+    if (!form.state.trim()) { setError("State is required"); window.scrollTo({ top: 0, behavior: "smooth" }); return; }
+    if (!form.zip.trim()) { setError("Zip code is required"); window.scrollTo({ top: 0, behavior: "smooth" }); return; }
 
     setSaving(true);
     setError("");
 
-    const role = accountType === "employee" ? "sales" : accountType;
+    // Elevated roles keep their existing role (PATCH endpoint also enforces
+    // this server-side). Non-elevated users pick from the four options.
+    const payload: Record<string, unknown> = { ...form };
+    if (!elevatedRole && accountType) {
+      payload.role = accountType === "employee" ? "sales" : accountType;
+    }
 
     try {
       const res = await fetch("/api/auth/me", {
@@ -94,17 +107,19 @@ export default function CompleteProfilePage() {
           "Content-Type": "application/json",
           Authorization: `Bearer ${token}`,
         },
-        body: JSON.stringify({ ...form, role }),
+        body: JSON.stringify(payload),
       });
 
       if (res.ok) {
         router.push("/dashboard");
       } else {
-        const data = await res.json();
+        const data = await res.json().catch(() => ({ error: "Failed to save" }));
         setError(data.error || "Failed to save");
+        window.scrollTo({ top: 0, behavior: "smooth" });
       }
     } catch {
       setError("Failed to save. Please try again.");
+      window.scrollTo({ top: 0, behavior: "smooth" });
     } finally {
       setSaving(false);
     }
@@ -136,31 +151,33 @@ export default function CompleteProfilePage() {
           )}
 
           <form onSubmit={handleSubmit} className="space-y-4">
-            <div>
-              <label className="block text-xs font-medium text-gray-500 mb-2">Account Type <span className="text-red-500">*</span></label>
-              <div className="grid grid-cols-2 gap-2">
-                {ACCOUNT_TYPES.map((t) => {
-                  const Icon = t.icon;
-                  const selected = accountType === t.value;
-                  return (
-                    <button
-                      key={t.value}
-                      type="button"
-                      onClick={() => setAccountType(t.value)}
-                      className={`flex flex-col items-center gap-1 p-3 rounded-xl border-2 transition-all text-center cursor-pointer ${
-                        selected
-                          ? "border-green-600 bg-green-50 text-green-700"
-                          : "border-gray-200 hover:border-gray-300 text-gray-600"
-                      }`}
-                    >
-                      <Icon className="h-5 w-5" />
-                      <span className="text-xs font-semibold">{t.label}</span>
-                      <span className="text-[10px] leading-tight opacity-70">{t.description}</span>
-                    </button>
-                  );
-                })}
+            {!elevatedRole && (
+              <div>
+                <label className="block text-xs font-medium text-gray-500 mb-2">Account Type <span className="text-red-500">*</span></label>
+                <div className="grid grid-cols-2 gap-2">
+                  {ACCOUNT_TYPES.map((t) => {
+                    const Icon = t.icon;
+                    const selected = accountType === t.value;
+                    return (
+                      <button
+                        key={t.value}
+                        type="button"
+                        onClick={() => setAccountType(t.value)}
+                        className={`flex flex-col items-center gap-1 p-3 rounded-xl border-2 transition-all text-center cursor-pointer ${
+                          selected
+                            ? "border-green-600 bg-green-50 text-green-700"
+                            : "border-gray-200 hover:border-gray-300 text-gray-600"
+                        }`}
+                      >
+                        <Icon className="h-5 w-5" />
+                        <span className="text-xs font-semibold">{t.label}</span>
+                        <span className="text-[10px] leading-tight opacity-70">{t.description}</span>
+                      </button>
+                    );
+                  })}
+                </div>
               </div>
-            </div>
+            )}
             <div>
               <label className="block text-xs font-medium text-gray-500 mb-1">Full Name <span className="text-red-500">*</span></label>
               <input

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createServerClient } from "@supabase/ssr";
+import { createClient } from "@supabase/supabase-js";
 
 /**
  * Routes that require an authenticated session.
@@ -122,7 +123,17 @@ export async function proxy(req: NextRequest) {
     const meta = { ...(user.user_metadata || {}), ...(user.app_metadata || {}) } as Record<string, unknown>;
     let phone = typeof meta.phone === "string" ? meta.phone.trim() : "";
     if (!phone) {
-      const { data: profile } = await supabase
+      // Fallback uses service role — the user's own session may or may not
+      // have a SELECT policy on profiles depending on project setup, and a
+      // missing policy would silently return no rows and trap the user in a
+      // /complete-profile ↔ /dashboard redirect loop even after they saved a
+      // phone. Service role bypasses RLS so this is reliable.
+      const admin = createClient(
+        process.env.NEXT_PUBLIC_SUPABASE_URL!,
+        process.env.SUPABASE_SERVICE_ROLE_KEY!,
+        { auth: { autoRefreshToken: false, persistSession: false } },
+      );
+      const { data: profile } = await admin
         .from("profiles")
         .select("phone")
         .eq("id", user.id)


### PR DESCRIPTION
Reported: hitting "Continue" on /complete-profile does nothing visible. Traced to three separate issues that lined up to strand the user:

1. Middleware redirect loop for legacy users The phone-on-file gate in src/proxy.ts falls back to reading profiles.phone when user_metadata.phone is empty. That fallback used the request's own Supabase client (anon key + user session), which is gated by RLS. This repo doesn't have an explicit "SELECT WHERE auth.uid() = id" policy on profiles — most Supabase projects set that up in the dashboard, but nothing forces it — so the read could silently return zero rows even though the profile row is right there. Result: middleware couldn't see the just-saved phone, redirected the user back to /complete-profile, which auto-redirected to /dashboard (because the page's own check hits /api/auth/me which uses service role and DID see the phone), which redirected back to /complete-profile — an infinite ping-pong.

   Fix: middleware now uses the service role client for the profiles.phone fallback. RLS gaps can no longer cause the loop.

2. Role clobber via /complete-profile PATCH /api/auth/me only blocked promoting to a privileged role (admin/sales/director/market_leader). It didn't stop an already-privileged user from downgrading themselves — so an admin filling out /complete-profile with accountType="operator" would silently become an operator and lose CRM access on the next request.

   Fix: server now fetches the caller's current role. If they're already privileged, any incoming role change from this endpoint is ignored. Also added sales_manager to the privileged set (was missing).

3. Elevated users stuck on "Please select an account type" The four account-type buttons don't include admin / sales_manager / director_of_sales / market_leader. When one of those users landed on /complete-profile (because their phone metadata was empty), the useEffect never pre-selected a type, so hitting Continue would fail the "select an account type" validation — with the error text rendered at the top of the form, above the fold. If they were scrolled to the button, they just saw nothing happen.

   Fix: detect elevated roles, hide the account-type picker for them, and skip that field in the validation and payload. Also: on every validation failure or fetch error, smooth-scroll the page to top so the error is visible.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2