### PR TITLE
Financial spine — Phase 1: ledger + event log + backfill + admin shell

### DIFF
--- a/src/app/admin/financial/attributions/page.tsx
+++ b/src/app/admin/financial/attributions/page.tsx
@@ -1,0 +1,19 @@
+import { Clock } from "lucide-react";
+
+export default function AttributionsStub() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold text-gray-900 mb-2">Attributions</h1>
+      <p className="text-sm text-gray-500 mb-6">
+        Multi-credit sales attribution (Lead Owner / Closer / Referrer / Assist / Manager Override).
+      </p>
+      <div className="rounded-2xl border border-amber-200 bg-amber-50 p-6 flex items-center gap-3">
+        <Clock className="h-6 w-6 text-amber-600" />
+        <div>
+          <p className="text-sm font-medium text-amber-900">Ships in Phase 3</p>
+          <p className="text-xs text-amber-700">Attribution model + configurable roles + lock at order creation + audited admin overrides.</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/financial/backfill/page.tsx
+++ b/src/app/admin/financial/backfill/page.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Loader2, ArrowLeft, Database, AlertCircle, CheckCircle2, Play } from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
+
+interface PlanRow {
+  source_table: string;
+  source_id: string;
+  action: "create" | "skip";
+  reason?: string;
+  provider: string;
+  amount_cents: number;
+  status: string;
+  buyer_email?: string | null;
+  created_at?: string | null;
+}
+
+interface Plan {
+  cutoff: string;
+  rows: PlanRow[];
+  summary: {
+    total: number;
+    to_create: number;
+    to_skip: number;
+    by_source: Record<string, { create: number; skip: number }>;
+  };
+}
+
+export default function BackfillPage() {
+  const router = useRouter();
+  const [token, setToken] = useState("");
+  const [days, setDays] = useState(90);
+  const [plan, setPlan] = useState<Plan | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [applying, setApplying] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!session?.access_token) { router.push("/login?redirect=/admin/financial/backfill"); return; }
+      setToken(session.access_token);
+    });
+  }, [router]);
+
+  async function preview() {
+    setError(null);
+    setMessage(null);
+    setLoading(true);
+    const res = await fetch(`/api/admin/financial/backfill?days=${days}&limit=500`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.ok) setPlan(await res.json());
+    else setError((await res.json().catch(() => ({}))).error || "Preview failed");
+    setLoading(false);
+  }
+
+  async function apply() {
+    if (!confirm(`Apply backfill for the last ${days} days? This will create payment + invoice rows and stamp the source rows.`)) return;
+    setError(null);
+    setApplying(true);
+    const res = await fetch("/api/admin/financial/backfill", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ days, limit: 500 }),
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) setError(body.error || "Apply failed");
+    else {
+      setMessage(`Applied — created ${body.summary?.to_create || 0} rows, skipped ${body.summary?.to_skip || 0}.`);
+      setPlan(null);
+    }
+    setApplying(false);
+  }
+
+  return (
+    <div className="p-6">
+      <Link href="/admin/financial" className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-green-primary mb-4">
+        <ArrowLeft className="h-4 w-4" /> Financial Center
+      </Link>
+
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
+          <Database className="h-6 w-6 text-green-primary" /> Backfill
+        </h1>
+        <p className="text-sm text-gray-500 mt-1">
+          Hydrate the payment ledger from your existing purchase tables (lead purchases, machine listing purchases, coffee orders). Preview is safe — nothing is written until you click Apply.
+        </p>
+      </div>
+
+      {error && (
+        <div className="mb-4 flex items-start gap-2 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+      {message && (
+        <div className="mb-4 flex items-start gap-2 rounded-xl border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-700">
+          <CheckCircle2 className="h-4 w-4 mt-0.5 shrink-0" />
+          <span>{message}</span>
+        </div>
+      )}
+
+      <div className="rounded-2xl border border-gray-100 bg-white p-5 mb-4">
+        <div className="flex items-end gap-3 flex-wrap">
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">Cutoff (days back)</label>
+            <input
+              type="number"
+              min="1"
+              max="3650"
+              value={days}
+              onChange={(e) => setDays(Math.max(1, Math.min(3650, Number(e.target.value) || 1)))}
+              className="w-32 rounded-xl border border-gray-200 px-3 py-2 text-sm focus:border-green-primary focus:outline-none"
+            />
+          </div>
+          <button
+            onClick={preview}
+            disabled={loading}
+            className="inline-flex items-center gap-2 rounded-xl border border-gray-200 hover:bg-gray-50 px-4 py-2 text-sm font-medium text-gray-700 cursor-pointer disabled:opacity-50"
+          >
+            {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+            Preview
+          </button>
+          <button
+            onClick={apply}
+            disabled={!plan || applying}
+            className="inline-flex items-center gap-2 rounded-xl bg-green-primary hover:bg-green-hover px-4 py-2 text-sm font-semibold text-white cursor-pointer disabled:opacity-50"
+          >
+            {applying ? <Loader2 className="h-4 w-4 animate-spin" /> : <Play className="h-4 w-4" />}
+            Apply
+          </button>
+        </div>
+      </div>
+
+      {plan && (
+        <>
+          <div className="rounded-2xl border border-gray-100 bg-white p-5 mb-4">
+            <h2 className="text-sm font-semibold text-gray-900 mb-3">Summary</h2>
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+              <Stat label="Total Rows Scanned" value={String(plan.summary.total)} />
+              <Stat label="Will Create" value={String(plan.summary.to_create)} tone="good" />
+              <Stat label="Will Skip" value={String(plan.summary.to_skip)} />
+              <Stat label="Cutoff" value={new Date(plan.cutoff).toLocaleDateString()} />
+            </div>
+            <div className="mt-4 grid grid-cols-1 sm:grid-cols-3 gap-2">
+              {Object.entries(plan.summary.by_source).map(([src, counts]) => (
+                <div key={src} className="rounded-lg border border-gray-100 p-3 text-xs">
+                  <p className="font-medium text-gray-900">{src}</p>
+                  <p className="text-gray-500 mt-0.5">create: {counts.create} · skip: {counts.skip}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="rounded-2xl border border-gray-100 bg-white p-5 overflow-hidden">
+            <h2 className="text-sm font-semibold text-gray-900 mb-3">Detail (first 50 rows)</h2>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-xs text-gray-500 border-b border-gray-100">
+                    <th className="text-left py-2 px-2 font-medium">Source</th>
+                    <th className="text-left py-2 px-2 font-medium">Action</th>
+                    <th className="text-left py-2 px-2 font-medium">Provider</th>
+                    <th className="text-right py-2 px-2 font-medium">Amount</th>
+                    <th className="text-left py-2 px-2 font-medium">Buyer</th>
+                    <th className="text-left py-2 px-2 font-medium">Reason</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {plan.rows.slice(0, 50).map((r) => (
+                    <tr key={`${r.source_table}-${r.source_id}`} className="border-b border-gray-50 last:border-b-0">
+                      <td className="py-2 px-2 text-xs text-gray-500">{r.source_table}</td>
+                      <td className="py-2 px-2">
+                        <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium capitalize ${r.action === "create" ? "bg-emerald-50 text-emerald-700" : "bg-gray-100 text-gray-500"}`}>
+                          {r.action}
+                        </span>
+                      </td>
+                      <td className="py-2 px-2 text-xs uppercase">{r.provider}</td>
+                      <td className="py-2 px-2 text-right font-semibold text-emerald-700">
+                        ${(r.amount_cents / 100).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                      </td>
+                      <td className="py-2 px-2 text-xs text-gray-500">{r.buyer_email || "—"}</td>
+                      <td className="py-2 px-2 text-xs text-gray-500">{r.reason || "—"}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            {plan.rows.length > 50 && (
+              <p className="text-xs text-gray-400 mt-2 text-center">
+                {plan.rows.length - 50} more rows omitted from preview. Apply processes all of them.
+              </p>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function Stat({ label, value, tone }: { label: string; value: string; tone?: "good" }) {
+  return (
+    <div className="rounded-xl border border-gray-100 p-3">
+      <p className="text-xs text-gray-500">{label}</p>
+      <p className={`text-lg font-bold mt-0.5 ${tone === "good" ? "text-emerald-700" : "text-gray-900"}`}>{value}</p>
+    </div>
+  );
+}

--- a/src/app/admin/financial/commissions/page.tsx
+++ b/src/app/admin/financial/commissions/page.tsx
@@ -1,0 +1,19 @@
+import { Clock } from "lucide-react";
+
+export default function CommissionsStub() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold text-gray-900 mb-2">Commissions</h1>
+      <p className="text-sm text-gray-500 mb-6">
+        Company-wide commission ledger, category rates, per-user rate overrides, payout batches.
+      </p>
+      <div className="rounded-2xl border border-amber-200 bg-amber-50 p-6 flex items-center gap-3">
+        <Clock className="h-6 w-6 text-amber-600" />
+        <div>
+          <p className="text-sm font-medium text-amber-900">Ships in Phase 4</p>
+          <p className="text-xs text-amber-700">Rules editor, ledger view, auto-earn on collection, hold periods, snapshot-at-earn.</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/financial/invoices/page.tsx
+++ b/src/app/admin/financial/invoices/page.tsx
@@ -1,0 +1,19 @@
+import { Clock } from "lucide-react";
+
+export default function InvoicesStub() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold text-gray-900 mb-2">Invoices</h1>
+      <p className="text-sm text-gray-500 mb-6">
+        Invoice aging + per-invoice detail + payment allocations.
+      </p>
+      <div className="rounded-2xl border border-amber-200 bg-amber-50 p-6 flex items-center gap-3">
+        <Clock className="h-6 w-6 text-amber-600" />
+        <div>
+          <p className="text-sm font-medium text-amber-900">Ships in Phase 2</p>
+          <p className="text-xs text-amber-700">Aging buckets, per-invoice payment history, admin write-off action.</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/financial/layout.tsx
+++ b/src/app/admin/financial/layout.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { DollarSign, ListChecks, FileText, RotateCcw, AlertTriangle, PieChart, Users, ArrowLeftRight, Database } from "lucide-react";
+
+const NAV = [
+  { href: "/admin/financial", label: "Overview", icon: PieChart, exact: true },
+  { href: "/admin/financial/payments", label: "Payments", icon: DollarSign },
+  { href: "/admin/financial/invoices", label: "Invoices", icon: FileText },
+  { href: "/admin/financial/refunds", label: "Refunds", icon: RotateCcw },
+  { href: "/admin/financial/reconciliation", label: "Reconciliation", icon: AlertTriangle },
+  { href: "/admin/financial/commissions", label: "Commissions", icon: ListChecks },
+  { href: "/admin/financial/attributions", label: "Attributions", icon: Users },
+  { href: "/admin/financial/settings", label: "Settings", icon: ArrowLeftRight },
+  { href: "/admin/financial/backfill", label: "Backfill", icon: Database },
+];
+
+export default function FinancialLayout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  return (
+    <div className="min-h-[calc(100vh-160px)] bg-light">
+      <div className="border-b border-gray-100 bg-white">
+        <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+          <nav className="flex gap-1 overflow-x-auto py-2">
+            {NAV.map(({ href, label, icon: Icon, exact }) => {
+              const active = exact
+                ? pathname === href
+                : pathname === href || pathname.startsWith(`${href}/`);
+              return (
+                <Link
+                  key={href}
+                  href={href}
+                  className={`inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium whitespace-nowrap transition-colors ${
+                    active ? "bg-green-primary text-white" : "text-gray-600 hover:bg-gray-100"
+                  }`}
+                >
+                  <Icon className="h-4 w-4" />
+                  {label}
+                </Link>
+              );
+            })}
+          </nav>
+        </div>
+      </div>
+      <div className="mx-auto max-w-6xl">{children}</div>
+    </div>
+  );
+}

--- a/src/app/admin/financial/page.tsx
+++ b/src/app/admin/financial/page.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Loader2, DollarSign, PieChart, ArrowRight, ArrowLeft } from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
+
+interface Payment {
+  id: string;
+  provider: string;
+  amount_cents: number;
+  currency: string;
+  status: string;
+  paid_at: string | null;
+  created_at: string;
+  buyer_email: string | null;
+  method: string | null;
+}
+
+export default function FinancialOverviewPage() {
+  const router = useRouter();
+  const [token, setToken] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [recent, setRecent] = useState<Payment[]>([]);
+
+  const load = useCallback(async () => {
+    if (!token) return;
+    setLoading(true);
+    const res = await fetch("/api/admin/financial/payments?limit=25", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.ok) setRecent(await res.json());
+    setLoading(false);
+  }, [token]);
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!session?.access_token) { router.push("/login?redirect=/admin/financial"); return; }
+      setToken(session.access_token);
+    });
+  }, [router]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const totalPaidCents = recent.reduce((sum, p) => (p.status === "paid" ? sum + Number(p.amount_cents) : sum), 0);
+  const totalPending = recent.filter((p) => p.status === "pending").length;
+  const totalFailed = recent.filter((p) => p.status === "failed").length;
+
+  return (
+    <div className="p-6">
+      <Link href="/admin" className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-green-primary mb-4">
+        <ArrowLeft className="h-4 w-4" /> Back to Admin
+      </Link>
+
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
+          <PieChart className="h-6 w-6 text-green-primary" /> Financial Center
+        </h1>
+        <p className="text-sm text-gray-500 mt-1">
+          Every payment across QuickBooks, Stripe, and manual entries flows through this ledger.
+          Phase 1 wires in the payments spine and backfill. Refunds, commissions, and reconciliation ship in the following phases.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+        <Tile
+          label="Recent Collected (last 25)"
+          value={`$${(totalPaidCents / 100).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`}
+        />
+        <Tile label="Pending" value={String(totalPending)} />
+        <Tile label="Failed" value={String(totalFailed)} tone="warn" />
+      </div>
+
+      <div className="rounded-2xl border border-gray-100 bg-white p-5">
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-sm font-semibold text-gray-900 flex items-center gap-2">
+            <DollarSign className="h-4 w-4 text-green-primary" /> Recent Payments
+          </h2>
+          <Link href="/admin/financial/payments" className="text-xs text-green-primary hover:underline flex items-center gap-1">
+            View all <ArrowRight className="h-3 w-3" />
+          </Link>
+        </div>
+        {loading ? (
+          <div className="flex justify-center py-8"><Loader2 className="h-5 w-5 animate-spin text-green-primary" /></div>
+        ) : recent.length === 0 ? (
+          <p className="text-sm text-gray-500 text-center py-8">
+            No payments in the ledger yet. Run the <Link href="/admin/financial/backfill" className="text-green-primary hover:underline">backfill</Link> to hydrate from existing purchases.
+          </p>
+        ) : (
+          <PaymentList payments={recent} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Tile({ label, value, tone }: { label: string; value: string; tone?: "warn" }) {
+  return (
+    <div className="rounded-2xl border border-gray-100 bg-white p-5">
+      <p className="text-xs text-gray-500">{label}</p>
+      <p className={`text-2xl font-bold mt-1 ${tone === "warn" ? "text-red-600" : "text-gray-900"}`}>{value}</p>
+    </div>
+  );
+}
+
+export function PaymentList({ payments }: { payments: Payment[] }) {
+  return (
+    <table className="w-full text-sm">
+      <thead>
+        <tr className="text-xs text-gray-500 border-b border-gray-100">
+          <th className="text-left py-2 px-2 font-medium">Provider</th>
+          <th className="text-left py-2 px-2 font-medium">Buyer</th>
+          <th className="text-left py-2 px-2 font-medium">Method</th>
+          <th className="text-right py-2 px-2 font-medium">Amount</th>
+          <th className="text-left py-2 px-2 font-medium">Status</th>
+          <th className="text-left py-2 px-2 font-medium">Paid</th>
+        </tr>
+      </thead>
+      <tbody>
+        {payments.map((p) => (
+          <tr key={p.id} className="border-b border-gray-50 last:border-b-0">
+            <td className="py-2 px-2 text-xs text-gray-500 uppercase">{p.provider}</td>
+            <td className="py-2 px-2 text-gray-700 text-xs">{p.buyer_email || "—"}</td>
+            <td className="py-2 px-2 text-gray-700 text-xs capitalize">{p.method || "—"}</td>
+            <td className="py-2 px-2 text-right font-semibold text-emerald-700">
+              ${(Number(p.amount_cents) / 100).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+            </td>
+            <td className="py-2 px-2">
+              <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium capitalize ${statusColor(p.status)}`}>
+                {p.status.replace(/_/g, " ")}
+              </span>
+            </td>
+            <td className="py-2 px-2 text-xs text-gray-500">
+              {p.paid_at ? new Date(p.paid_at).toLocaleDateString() : "—"}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function statusColor(status: string): string {
+  if (status === "paid") return "bg-emerald-50 text-emerald-700";
+  if (status === "pending") return "bg-amber-50 text-amber-700";
+  if (status === "failed") return "bg-red-50 text-red-700";
+  if (status === "refunded" || status === "partial_refund") return "bg-blue-50 text-blue-700";
+  if (status === "chargeback" || status === "disputed") return "bg-red-100 text-red-800";
+  return "bg-gray-100 text-gray-600";
+}

--- a/src/app/admin/financial/payments/new/page.tsx
+++ b/src/app/admin/financial/payments/new/page.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Loader2, ArrowLeft, Upload, CheckCircle2, AlertCircle } from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
+
+const METHODS = ["ach", "wire", "cash", "check", "zelle", "venmo", "paypal", "other"] as const;
+const STATUSES = ["paid", "pending", "failed"] as const;
+
+export default function NewManualPaymentPage() {
+  const router = useRouter();
+  const [token, setToken] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [proof, setProof] = useState<{ bucket: string; path: string; file_name: string } | null>(null);
+
+  const [form, setForm] = useState({
+    amount: "",
+    method: "ach" as (typeof METHODS)[number],
+    status: "paid" as (typeof STATUSES)[number],
+    order_id: "",
+    agreement_id: "",
+    invoice_id: "",
+    buyer_email: "",
+    reference: "",
+    note: "",
+    reason: "",
+  });
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!session?.access_token) { router.push("/login?redirect=/admin/financial/payments/new"); return; }
+      setToken(session.access_token);
+    });
+  }, [router]);
+
+  async function uploadProof(file: File) {
+    setUploading(true);
+    setError(null);
+    const fd = new FormData();
+    fd.append("file", file);
+    const res = await fetch("/api/admin/financial/payments/proof", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+      body: fd,
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) setError(body.error || "Upload failed");
+    else setProof(body);
+    setUploading(false);
+  }
+
+  async function save() {
+    setError(null);
+    const amt = Number(form.amount);
+    if (!Number.isFinite(amt) || amt <= 0) { setError("Amount must be a positive number (in dollars)"); return; }
+    if (!form.buyer_email && !form.order_id && !form.agreement_id) {
+      setError("Add at least one of: buyer email, order id, or agreement id");
+      return;
+    }
+    setSaving(true);
+    const res = await fetch("/api/admin/financial/payments", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({
+        amount: amt,
+        method: form.method,
+        status: form.status,
+        order_id: form.order_id.trim() || null,
+        agreement_id: form.agreement_id.trim() || null,
+        invoice_id: form.invoice_id.trim() || null,
+        buyer_email: form.buyer_email.trim() || null,
+        reference: form.reference.trim() || null,
+        note: form.note.trim() || null,
+        reason: form.reason.trim() || null,
+        proof_bucket: proof?.bucket,
+        proof_path: proof?.path,
+      }),
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) { setError(body.error || "Save failed"); setSaving(false); return; }
+    router.push("/admin/financial/payments");
+  }
+
+  const inputClass = "w-full rounded-xl border border-gray-200 px-3 py-2 text-sm focus:border-green-primary focus:outline-none";
+  const labelClass = "block text-xs font-medium text-gray-600 mb-1";
+
+  return (
+    <div className="p-6 max-w-2xl">
+      <Link href="/admin/financial/payments" className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-green-primary mb-4">
+        <ArrowLeft className="h-4 w-4" /> Payments
+      </Link>
+
+      <h1 className="text-2xl font-bold text-gray-900 mb-1">Record Manual Payment</h1>
+      <p className="text-sm text-gray-500 mb-6">
+        For ACH, wire, cash, check, Zelle, Venmo, or other off-provider payments. Attach a proof of receipt.
+      </p>
+
+      {error && (
+        <div className="mb-4 flex items-start gap-2 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      <div className="space-y-4">
+        <div className="rounded-2xl border border-gray-100 bg-white p-5 space-y-3">
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div>
+              <label className={labelClass}>Amount (USD) *</label>
+              <input
+                type="number"
+                min="0"
+                step="0.01"
+                value={form.amount}
+                onChange={(e) => setForm((f) => ({ ...f, amount: e.target.value }))}
+                placeholder="0.00"
+                className={inputClass}
+              />
+            </div>
+            <div>
+              <label className={labelClass}>Method *</label>
+              <select
+                value={form.method}
+                onChange={(e) => setForm((f) => ({ ...f, method: e.target.value as (typeof METHODS)[number] }))}
+                className={inputClass}
+              >
+                {METHODS.map((m) => <option key={m} value={m}>{m.toUpperCase()}</option>)}
+              </select>
+            </div>
+            <div>
+              <label className={labelClass}>Status *</label>
+              <select
+                value={form.status}
+                onChange={(e) => setForm((f) => ({ ...f, status: e.target.value as (typeof STATUSES)[number] }))}
+                className={inputClass}
+              >
+                {STATUSES.map((s) => <option key={s} value={s}>{s}</option>)}
+              </select>
+            </div>
+          </div>
+        </div>
+
+        <div className="rounded-2xl border border-gray-100 bg-white p-5 space-y-3">
+          <h3 className="text-sm font-semibold text-gray-900">Link to CRM entity (at least one)</h3>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div>
+              <label className={labelClass}>Order ID</label>
+              <input type="text" value={form.order_id} onChange={(e) => setForm((f) => ({ ...f, order_id: e.target.value }))} className={inputClass + " font-mono"} />
+            </div>
+            <div>
+              <label className={labelClass}>Agreement ID</label>
+              <input type="text" value={form.agreement_id} onChange={(e) => setForm((f) => ({ ...f, agreement_id: e.target.value }))} className={inputClass + " font-mono"} />
+            </div>
+            <div className="sm:col-span-2">
+              <label className={labelClass}>Buyer Email</label>
+              <input type="email" value={form.buyer_email} onChange={(e) => setForm((f) => ({ ...f, buyer_email: e.target.value }))} className={inputClass} />
+            </div>
+          </div>
+        </div>
+
+        <div className="rounded-2xl border border-gray-100 bg-white p-5 space-y-3">
+          <h3 className="text-sm font-semibold text-gray-900">Proof of receipt</h3>
+          {proof ? (
+            <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-3 flex items-center gap-3">
+              <CheckCircle2 className="h-5 w-5 text-emerald-600" />
+              <div className="flex-1">
+                <p className="text-sm font-medium text-emerald-900">{proof.file_name}</p>
+                <p className="text-xs text-emerald-700">Uploaded to payment-proofs bucket</p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setProof(null)}
+                className="text-xs text-emerald-700 hover:underline"
+              >
+                Replace
+              </button>
+            </div>
+          ) : (
+            <label className={`flex flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed border-gray-300 p-6 cursor-pointer hover:bg-gray-50 transition-colors ${uploading ? "opacity-50 pointer-events-none" : ""}`}>
+              {uploading ? <Loader2 className="h-6 w-6 text-gray-400 animate-spin" /> : <Upload className="h-6 w-6 text-gray-400" />}
+              <p className="text-sm font-medium text-gray-700">{uploading ? "Uploading…" : "Click to upload PDF, PNG, JPG"}</p>
+              <input
+                type="file"
+                accept=".pdf,.png,.jpg,.jpeg"
+                className="hidden"
+                onChange={(e) => { const f = e.target.files?.[0]; if (f) uploadProof(f); e.currentTarget.value = ""; }}
+              />
+            </label>
+          )}
+        </div>
+
+        <div className="rounded-2xl border border-gray-100 bg-white p-5 space-y-3">
+          <div>
+            <label className={labelClass}>Reference / confirmation #</label>
+            <input type="text" value={form.reference} onChange={(e) => setForm((f) => ({ ...f, reference: e.target.value }))} className={inputClass} placeholder="Check #, ACH trace ID, etc." />
+          </div>
+          <div>
+            <label className={labelClass}>Reason (why manual)</label>
+            <input type="text" value={form.reason} onChange={(e) => setForm((f) => ({ ...f, reason: e.target.value }))} className={inputClass} placeholder="e.g. Wire transfer arrived, entering manually" />
+          </div>
+          <div>
+            <label className={labelClass}>Note (internal only)</label>
+            <textarea rows={3} value={form.note} onChange={(e) => setForm((f) => ({ ...f, note: e.target.value }))} className={`${inputClass} resize-none`} />
+          </div>
+        </div>
+
+        <div className="flex justify-end gap-2">
+          <Link
+            href="/admin/financial/payments"
+            className="rounded-xl border border-gray-200 px-6 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 cursor-pointer"
+          >
+            Cancel
+          </Link>
+          <button
+            onClick={save}
+            disabled={saving}
+            className="inline-flex items-center gap-2 rounded-xl bg-green-primary hover:bg-green-hover px-6 py-3 text-sm font-semibold text-white cursor-pointer disabled:opacity-50"
+          >
+            {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+            Record Payment
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/financial/payments/page.tsx
+++ b/src/app/admin/financial/payments/page.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Loader2, DollarSign, Plus, ArrowLeft, Filter } from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
+import { PaymentList } from "../page";
+
+interface Payment {
+  id: string;
+  provider: string;
+  amount_cents: number;
+  currency: string;
+  status: string;
+  paid_at: string | null;
+  created_at: string;
+  buyer_email: string | null;
+  method: string | null;
+}
+
+const STATUS_FILTERS = [
+  { key: "all", label: "All" },
+  { key: "paid", label: "Paid" },
+  { key: "pending", label: "Pending" },
+  { key: "failed", label: "Failed" },
+  { key: "refunded", label: "Refunded" },
+  { key: "partial_refund", label: "Partial Refund" },
+  { key: "chargeback", label: "Chargeback" },
+];
+
+const PROVIDER_FILTERS = [
+  { key: "all", label: "All Providers" },
+  { key: "stripe", label: "Stripe" },
+  { key: "quickbooks", label: "QuickBooks" },
+  { key: "manual", label: "Manual" },
+];
+
+export default function AdminPaymentsPage() {
+  const router = useRouter();
+  const [token, setToken] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [payments, setPayments] = useState<Payment[]>([]);
+  const [status, setStatus] = useState("all");
+  const [provider, setProvider] = useState("all");
+
+  const load = useCallback(async () => {
+    if (!token) return;
+    setLoading(true);
+    const params = new URLSearchParams();
+    params.set("status", status);
+    params.set("provider", provider);
+    params.set("limit", "200");
+    const res = await fetch(`/api/admin/financial/payments?${params}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.ok) setPayments(await res.json());
+    setLoading(false);
+  }, [token, status, provider]);
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!session?.access_token) { router.push("/login?redirect=/admin/financial/payments"); return; }
+      setToken(session.access_token);
+    });
+  }, [router]);
+
+  useEffect(() => { load(); }, [load]);
+
+  return (
+    <div className="p-6">
+      <Link href="/admin/financial" className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-green-primary mb-4">
+        <ArrowLeft className="h-4 w-4" /> Financial Center
+      </Link>
+
+      <div className="flex items-center justify-between mb-4 flex-wrap gap-3">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
+            <DollarSign className="h-6 w-6 text-green-primary" /> Payments
+          </h1>
+          <p className="text-sm text-gray-500 mt-1">Every payment webhook + manual entry lands here.</p>
+        </div>
+        <Link
+          href="/admin/financial/payments/new"
+          className="inline-flex items-center gap-1.5 rounded-xl bg-green-primary hover:bg-green-hover px-4 py-2.5 text-sm font-semibold text-white cursor-pointer"
+        >
+          <Plus className="h-4 w-4" /> Record Manual Payment
+        </Link>
+      </div>
+
+      <div className="mb-4 flex items-center gap-2 flex-wrap">
+        <Filter className="h-4 w-4 text-gray-400" />
+        <select
+          value={provider}
+          onChange={(e) => setProvider(e.target.value)}
+          className="rounded-lg border border-gray-200 px-3 py-1.5 text-xs focus:border-green-primary focus:outline-none"
+        >
+          {PROVIDER_FILTERS.map((f) => <option key={f.key} value={f.key}>{f.label}</option>)}
+        </select>
+        {STATUS_FILTERS.map((f) => (
+          <button
+            key={f.key}
+            onClick={() => setStatus(f.key)}
+            className={`rounded-lg px-3 py-1.5 text-xs font-medium cursor-pointer ${status === f.key ? "bg-green-100 text-green-700" : "bg-gray-100 text-gray-500 hover:bg-gray-200"}`}
+          >
+            {f.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="rounded-2xl border border-gray-100 bg-white p-5">
+        {loading ? (
+          <div className="flex justify-center py-8"><Loader2 className="h-5 w-5 animate-spin text-green-primary" /></div>
+        ) : payments.length === 0 ? (
+          <p className="text-sm text-gray-500 text-center py-8">No payments match the current filter.</p>
+        ) : (
+          <PaymentList payments={payments} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/financial/reconciliation/page.tsx
+++ b/src/app/admin/financial/reconciliation/page.tsx
@@ -1,0 +1,19 @@
+import { Clock } from "lucide-react";
+
+export default function ReconciliationStub() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold text-gray-900 mb-2">Reconciliation</h1>
+      <p className="text-sm text-gray-500 mb-6">
+        Daily reconciliation exception queue. Compares provider records against the payment ledger.
+      </p>
+      <div className="rounded-2xl border border-amber-200 bg-amber-50 p-6 flex items-center gap-3">
+        <Clock className="h-6 w-6 text-amber-600" />
+        <div>
+          <p className="text-sm font-medium text-amber-900">Ships in Phase 2</p>
+          <p className="text-xs text-amber-700">Cron runs at 5pm ET, flags missing webhooks / amount mismatches / duplicates / orphan refunds.</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/financial/refunds/page.tsx
+++ b/src/app/admin/financial/refunds/page.tsx
@@ -1,0 +1,19 @@
+import { Clock } from "lucide-react";
+
+export default function RefundsStub() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold text-gray-900 mb-2">Refunds &amp; Chargebacks</h1>
+      <p className="text-sm text-gray-500 mb-6">
+        Refund queue + chargeback dispute queue with auto commission reversal.
+      </p>
+      <div className="rounded-2xl border border-amber-200 bg-amber-50 p-6 flex items-center gap-3">
+        <Clock className="h-6 w-6 text-amber-600" />
+        <div>
+          <p className="text-sm font-medium text-amber-900">Ships in Phase 2</p>
+          <p className="text-xs text-amber-700">Record a refund → automatically reverses affected commissions + adjusts metrics.</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/financial/settings/page.tsx
+++ b/src/app/admin/financial/settings/page.tsx
@@ -1,0 +1,19 @@
+import { Clock } from "lucide-react";
+
+export default function SettingsStub() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold text-gray-900 mb-2">Financial Settings</h1>
+      <p className="text-sm text-gray-500 mb-6">
+        Company-wide commission defaults, category rates, reminder cadence, reconciliation window.
+      </p>
+      <div className="rounded-2xl border border-amber-200 bg-amber-50 p-6 flex items-center gap-3">
+        <Clock className="h-6 w-6 text-amber-600" />
+        <div>
+          <p className="text-sm font-medium text-amber-900">Ships in Phase 4</p>
+          <p className="text-xs text-amber-700">Default commission %, category rates, priority order, hold periods, reminder schedule.</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -4646,6 +4646,14 @@ export default function AdminPage() {
                 <span className="sm:hidden">Place</span>
               </Link>
               <Link
+                href="/admin/financial"
+                className="inline-flex items-center gap-2 rounded-xl border border-green-primary px-4 py-2.5 text-sm font-medium text-green-primary shadow-sm transition-colors hover:bg-green-50"
+              >
+                <DollarSign className="h-4 w-4" />
+                <span className="hidden sm:inline">Financial Center</span>
+                <span className="sm:hidden">$</span>
+              </Link>
+              <Link
                 href="/sales"
                 className="inline-flex items-center gap-2 rounded-xl bg-green-primary px-4 py-2.5 text-sm font-medium text-white shadow-sm transition-colors hover:bg-green-primary/90"
               >

--- a/src/app/api/admin/financial/backfill/route.ts
+++ b/src/app/api/admin/financial/backfill/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAdminUserId } from "@/lib/adminAuth";
+import { runBackfill } from "@/lib/paymentBackfill";
+import { writeAuditLog } from "@/lib/paymentLedger";
+
+/**
+ * GET /api/admin/financial/backfill?days=90&limit=200 — preview mode.
+ *   Returns the plan (rows that would be created/skipped) with no writes.
+ * POST — apply mode. Writes ledger rows and stamps financial_spine_* on
+ *   the source rows. Records an audit_logs entry so we can prove what/when.
+ *
+ * Idempotent — re-running skips rows that are already backfilled.
+ */
+
+export async function GET(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const { searchParams } = new URL(req.url);
+  const days = Math.max(1, Math.min(3650, Number(searchParams.get("days") || 90)));
+  const limit = Math.max(10, Math.min(500, Number(searchParams.get("limit") || 200)));
+
+  const plan = await runBackfill({ cutoffDays: days, apply: false, limit });
+  return NextResponse.json(plan);
+}
+
+export async function POST(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const body = await req.json().catch(() => ({}));
+  const days = Math.max(1, Math.min(3650, Number(body.days || 90)));
+  const limit = Math.max(10, Math.min(500, Number(body.limit || 200)));
+
+  const plan = await runBackfill({ cutoffDays: days, apply: true, limit });
+
+  await writeAuditLog({
+    actorId: adminId,
+    action: "financial_backfill_applied",
+    entityType: "system",
+    metadata: {
+      cutoff_days: days,
+      limit,
+      summary: plan.summary,
+    },
+  });
+
+  return NextResponse.json({ ok: true, summary: plan.summary, rows: plan.rows });
+}

--- a/src/app/api/admin/financial/payments/[id]/proof/route.ts
+++ b/src/app/api/admin/financial/payments/[id]/proof/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+
+/**
+ * GET /api/admin/financial/payments/[id]/proof
+ *
+ * Returns { url } — a fresh 5-minute signed URL for the proof file on the
+ * payment. Admin-only. Client fetches this, opens the URL.
+ */
+
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id } = await params;
+
+  const { data: payment } = await supabaseAdmin
+    .from("payments")
+    .select("proof_bucket, proof_path")
+    .eq("id", id)
+    .maybeSingle();
+  if (!payment?.proof_bucket || !payment.proof_path) {
+    return NextResponse.json({ error: "No proof attached to this payment" }, { status: 404 });
+  }
+
+  const { data: signed, error } = await supabaseAdmin.storage
+    .from(payment.proof_bucket)
+    .createSignedUrl(payment.proof_path, 60 * 5);
+  if (error || !signed?.signedUrl) {
+    return NextResponse.json({ error: error?.message || "Failed to sign URL" }, { status: 500 });
+  }
+  return NextResponse.json({ url: signed.signedUrl });
+}

--- a/src/app/api/admin/financial/payments/proof/route.ts
+++ b/src/app/api/admin/financial/payments/proof/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+
+/**
+ * POST /api/admin/financial/payments/proof
+ *
+ * Admin uploads a proof-of-payment (screenshot, PDF of ACH confirmation, etc)
+ * to the private `payment-proofs` bucket. Returns { bucket, path } that the
+ * admin then passes to POST /api/admin/financial/payments as the proof_*
+ * fields.
+ *
+ * The proof is never public. Later download is served through
+ * /api/admin/financial/payments/[id]/proof which mints a 5-minute signed URL.
+ */
+
+const BUCKET = "payment-proofs";
+
+export async function POST(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const form = await req.formData();
+  const file = form.get("file");
+  if (!(file instanceof File)) return NextResponse.json({ error: "Missing file" }, { status: 400 });
+
+  const ext = (file.name.split(".").pop() || "pdf").toLowerCase();
+  const timestamp = Date.now();
+  const path = `${adminId}/${timestamp}-${Math.random().toString(36).slice(2, 8)}.${ext}`;
+
+  const buffer = Buffer.from(await file.arrayBuffer());
+  const { error } = await supabaseAdmin.storage
+    .from(BUCKET)
+    .upload(path, buffer, { contentType: file.type || "application/octet-stream", upsert: false });
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  return NextResponse.json({
+    bucket: BUCKET,
+    path,
+    file_name: file.name,
+  });
+}

--- a/src/app/api/admin/financial/payments/route.ts
+++ b/src/app/api/admin/financial/payments/route.ts
@@ -1,0 +1,123 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+import { upsertPayment, upsertInvoice, writeAuditLog } from "@/lib/paymentLedger";
+import type { PaymentStatus } from "@/lib/paymentLedger";
+
+/**
+ * GET /api/admin/financial/payments — admin-only list of payment ledger rows.
+ * POST — admin manually records a payment (ACH/wire/cash/check received
+ * outside of a provider webhook). Requires proof upload beforehand via the
+ * companion /api/admin/financial/payments/proof endpoint; the returned
+ * bucket + path are then attached here.
+ */
+
+const ALLOWED_METHODS = new Set(["ach", "wire", "cash", "check", "zelle", "venmo", "paypal", "other"]);
+const ALLOWED_STATUSES = new Set<PaymentStatus>([
+  "pending", "paid", "failed", "cancelled", "written_off",
+]);
+
+export async function GET(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const { searchParams } = new URL(req.url);
+  const status = searchParams.get("status") || "all";
+  const provider = searchParams.get("provider") || "all";
+  const limit = Math.min(200, Math.max(1, Number(searchParams.get("limit") || 100)));
+
+  let query = supabaseAdmin
+    .from("payments")
+    .select("*")
+    .order("created_at", { ascending: false })
+    .limit(limit);
+  if (status !== "all") query = query.eq("status", status);
+  if (provider !== "all") query = query.eq("provider", provider);
+
+  const { data, error } = await query;
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json(data || []);
+}
+
+export async function POST(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const body = await req.json().catch(() => ({}));
+
+  const amount = Number(body.amount);
+  if (!Number.isFinite(amount) || amount <= 0) {
+    return NextResponse.json({ error: "amount (in dollars) is required" }, { status: 400 });
+  }
+  const method = String(body.method || "").toLowerCase();
+  if (!ALLOWED_METHODS.has(method)) {
+    return NextResponse.json({ error: `method must be one of ${Array.from(ALLOWED_METHODS).join(", ")}` }, { status: 400 });
+  }
+  const status = String(body.status || "paid") as PaymentStatus;
+  if (!ALLOWED_STATUSES.has(status)) {
+    return NextResponse.json({ error: "invalid status for a manual payment" }, { status: 400 });
+  }
+
+  const orderId = typeof body.order_id === "string" ? body.order_id : null;
+  const agreementId = typeof body.agreement_id === "string" ? body.agreement_id : null;
+  const invoiceId = typeof body.invoice_id === "string" ? body.invoice_id : null;
+  const buyerEmail = typeof body.buyer_email === "string" ? body.buyer_email : null;
+
+  // Optional: create a shell invoice if none was linked but an order/agreement
+  // was provided. Keeps the invoice/payment 1:1 in the ledger.
+  let finalInvoiceId = invoiceId;
+  if (!finalInvoiceId && (orderId || agreementId)) {
+    const shell = await upsertInvoice({
+      provider: "manual",
+      providerInvoiceId: `manual-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      orderId,
+      agreementId,
+      buyerEmail,
+      totalCents: Math.round(amount * 100),
+      status: status === "paid" ? "paid" : "open",
+      createdBy: adminId,
+    });
+    finalInvoiceId = shell.id;
+  }
+
+  const payment = await upsertPayment({
+    provider: "manual",
+    providerPaymentId: `manual-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    invoiceId: finalInvoiceId || null,
+    orderId,
+    agreementId,
+    buyerEmail,
+    amountCents: Math.round(amount * 100),
+    method,
+    status,
+    paidAt: status === "paid" ? new Date().toISOString() : null,
+    manualReference: typeof body.reference === "string" ? body.reference.slice(0, 200) : null,
+    proofBucket: typeof body.proof_bucket === "string" ? body.proof_bucket : null,
+    proofPath: typeof body.proof_path === "string" ? body.proof_path : null,
+    proofUrl: typeof body.proof_url === "string" ? body.proof_url : null,
+    metadata: {
+      recorded_by_admin: true,
+      note: typeof body.note === "string" ? body.note.slice(0, 500) : null,
+    },
+    createdBy: adminId,
+  });
+
+  await writeAuditLog({
+    actorId: adminId,
+    action: "manual_payment_recorded",
+    entityType: "payment",
+    entityId: payment.id,
+    reason: typeof body.reason === "string" ? body.reason : null,
+    after: {
+      amount,
+      method,
+      status,
+      order_id: orderId,
+      agreement_id: agreementId,
+      invoice_id: finalInvoiceId,
+      reference: body.reference || null,
+    },
+  });
+
+  return NextResponse.json({ ok: true, payment });
+}

--- a/src/app/api/webhooks/quickbooks/route.ts
+++ b/src/app/api/webhooks/quickbooks/route.ts
@@ -8,6 +8,8 @@ import {
   handleCoffeeOrderCompleted,
   handleMarketplacePurchaseCompleted,
 } from "@/lib/paymentHandlers";
+import { recordPaymentEvent, markEventProcessed } from "@/lib/paymentLedger";
+import { ingestQbPaymentEvent } from "@/lib/paymentIngest";
 
 interface QBWebhookEvent {
   eventNotifications: {
@@ -41,11 +43,41 @@ export async function POST(req: NextRequest) {
 
   for (const notification of event.eventNotifications || []) {
     for (const entity of notification.dataChangeEvent?.entities || []) {
-      if (entity.name === "Payment" && (entity.operation === "Create" || entity.operation === "Update")) {
-        await handleQBPayment(entity.id, notification.realmId);
+      // Financial spine — one event_id per entity update. Re-delivery of the
+      // same batch produces the same event_id + skips already-processed rows.
+      const eventId = `qb:${notification.realmId}:${entity.name}:${entity.id}:${entity.lastUpdated}`;
+      let ledgerEventRowId: string | null = null;
+      try {
+        const { event: eventRow, alreadyProcessed } = await recordPaymentEvent({
+          provider: "quickbooks",
+          eventId,
+          eventType: `${entity.name}.${entity.operation}`,
+          signatureVerified: true,
+          payload: { entity, realmId: notification.realmId },
+        });
+        if (alreadyProcessed) continue;
+        ledgerEventRowId = eventRow.id;
+      } catch (logErr) {
+        console.error("[qb-webhook] event log write failed (proceeding):", logErr);
       }
-      if (entity.name === "BillPayment" && (entity.operation === "Create" || entity.operation === "Update")) {
-        await handleQBBillPayment(entity.id, notification.realmId);
+
+      try {
+        if (entity.name === "Payment" && (entity.operation === "Create" || entity.operation === "Update")) {
+          // Ledger ingest first (non-fatal), then existing downstream handler.
+          try {
+            await ingestQbPaymentEvent(entity.id, notification.realmId, ledgerEventRowId);
+          } catch (ingestErr) {
+            console.error("[qb-webhook] ledger ingest failed (non-fatal):", ingestErr);
+          }
+          await handleQBPayment(entity.id, notification.realmId);
+        }
+        if (entity.name === "BillPayment" && (entity.operation === "Create" || entity.operation === "Update")) {
+          await handleQBBillPayment(entity.id, notification.realmId);
+        }
+      } finally {
+        if (ledgerEventRowId) {
+          await markEventProcessed(ledgerEventRowId).catch(() => undefined);
+        }
       }
     }
   }

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -9,6 +9,8 @@ import {
   handleMarketplacePurchaseCompleted,
   handlePaymentExpired,
 } from "@/lib/paymentHandlers";
+import { recordPaymentEvent, markEventProcessed } from "@/lib/paymentLedger";
+import { ingestStripeEvent } from "@/lib/paymentIngest";
 
 function getStripeClient(): Stripe {
   const key = process.env.STRIPE_SECRET_KEY;
@@ -62,6 +64,34 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: message }, { status: 400 });
   }
 
+  // Financial spine — log the event and short-circuit on duplicate deliveries.
+  // Downstream handlers (below) only fire on the first successful delivery,
+  // so re-tries never double-write commissions/emails/downstream side-effects.
+  let ledgerEventId: string | null = null;
+  try {
+    const { event: eventRow, alreadyProcessed } = await recordPaymentEvent({
+      provider: "stripe",
+      eventId: event.id,
+      eventType: event.type,
+      signatureVerified: true,
+      payload: event as unknown as Record<string, unknown>,
+    });
+    if (alreadyProcessed) {
+      return NextResponse.json({ received: true, idempotent: true });
+    }
+    ledgerEventId = eventRow.id;
+    // Best-effort — write an invoice/payment row in the canonical ledger.
+    // Failure here doesn't block the existing downstream handlers.
+    try {
+      await ingestStripeEvent(event, eventRow.id);
+    } catch (ingestErr) {
+      console.error("[stripe-webhook] ledger ingest failed (non-fatal):", ingestErr);
+    }
+  } catch (logErr) {
+    console.error("[stripe-webhook] event log write failed (proceeding):", logErr);
+  }
+
+  try {
   if (event.type === "checkout.session.completed") {
     const session = event.data.object as Stripe.Checkout.Session;
     const paymentIntentId =
@@ -180,6 +210,15 @@ export async function POST(req: NextRequest) {
         .update({ stripe_onboarding_complete: true })
         .eq("stripe_account_id", account.id);
       console.log(`[stripe-webhook] Connect account ${account.id} onboarding complete`);
+    }
+  }
+  } finally {
+    // Mark the event row processed regardless of whether the specific
+    // event type had a handler here — a "handled" event means "we saw it
+    // and won't reprocess". Retries after an uncaught throw skip this,
+    // so recovery via Stripe's built-in retries still works.
+    if (ledgerEventId) {
+      await markEventProcessed(ledgerEventId).catch(() => undefined);
     }
   }
 

--- a/src/lib/paymentBackfill.ts
+++ b/src/lib/paymentBackfill.ts
@@ -1,0 +1,261 @@
+/**
+ * Backfill orchestrator — walks each legacy purchase table and produces a
+ * plan of (invoices, payments) that would be created if applied. Preview mode
+ * returns the plan without writing; apply mode writes atomically per row and
+ * stamps `financial_spine_invoice_id` / `financial_spine_payment_id` on the
+ * source row so subsequent runs skip it.
+ *
+ * Sources included in Phase 1:
+ *   lead_purchases, machine_listing_purchases, coffee_orders,
+ *   user_listing_purchases, pipeline_payments, agreement_tokens.
+ *
+ * Cutoff: rows whose created_at (or best-effort equivalent) falls within the
+ * cutoff window are considered. Default 90 days.
+ */
+
+import { supabaseAdmin } from "./supabaseAdmin";
+import { upsertInvoice, upsertPayment } from "./paymentLedger";
+
+export interface BackfillPlanRow {
+  source_table: string;
+  source_id: string;
+  action: "create" | "skip";
+  reason?: string;
+  provider: string;
+  amount_cents: number;
+  status: string;
+  invoice_ref?: string | null;
+  payment_ref?: string | null;
+  buyer_email?: string | null;
+  created_at?: string | null;
+}
+
+export interface BackfillPlan {
+  cutoff: string;
+  rows: BackfillPlanRow[];
+  summary: {
+    total: number;
+    to_create: number;
+    to_skip: number;
+    by_source: Record<string, { create: number; skip: number }>;
+  };
+}
+
+function cutoffIso(days: number): string {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+/**
+ * Producing the plan. No writes — every row is inspected + classified.
+ * `apply=true` writes atomically per row.
+ */
+export async function runBackfill(opts: { cutoffDays?: number; apply: boolean; limit?: number }): Promise<BackfillPlan> {
+  const days = opts.cutoffDays ?? 90;
+  const cutoff = cutoffIso(days);
+  const limit = Math.min(500, Math.max(10, opts.limit ?? 200));
+  const rows: BackfillPlanRow[] = [];
+
+  // ─── lead_purchases ───────────────────────────────────────────────────
+  {
+    const { data } = await supabaseAdmin
+      .from("lead_purchases")
+      .select("id, user_id, request_id, stripe_checkout_session_id, stripe_payment_intent_id, amount_cents, buyer_email, status, qb_invoice_id, qb_payment_id, payment_provider, financial_spine_invoice_id, financial_spine_payment_id, created_at")
+      .gte("created_at", cutoff)
+      .order("created_at", { ascending: false })
+      .limit(limit);
+
+    for (const r of data || []) {
+      if (r.financial_spine_payment_id) {
+        rows.push({ source_table: "lead_purchases", source_id: r.id, action: "skip", reason: "already backfilled", provider: r.payment_provider || "unknown", amount_cents: r.amount_cents || 0, status: r.status });
+        continue;
+      }
+      if (r.status !== "completed" && r.status !== "paid") {
+        rows.push({ source_table: "lead_purchases", source_id: r.id, action: "skip", reason: `status=${r.status}`, provider: r.payment_provider || "unknown", amount_cents: r.amount_cents || 0, status: r.status });
+        continue;
+      }
+      const provider = r.payment_provider === "quickbooks" ? "quickbooks" : "stripe";
+      const providerInvoiceId = provider === "quickbooks" ? r.qb_invoice_id : r.stripe_checkout_session_id;
+      const providerPaymentId = provider === "quickbooks" ? r.qb_payment_id : r.stripe_payment_intent_id;
+      const plan: BackfillPlanRow = {
+        source_table: "lead_purchases",
+        source_id: r.id,
+        action: "create",
+        provider,
+        amount_cents: r.amount_cents || 0,
+        status: "paid",
+        invoice_ref: providerInvoiceId || null,
+        payment_ref: providerPaymentId || null,
+        buyer_email: r.buyer_email || null,
+        created_at: r.created_at,
+      };
+      rows.push(plan);
+
+      if (opts.apply) {
+        const invoice = await upsertInvoice({
+          provider,
+          providerInvoiceId: providerInvoiceId || null,
+          leadId: r.request_id,
+          buyerProfileId: r.user_id,
+          buyerEmail: r.buyer_email,
+          subtotalCents: r.amount_cents || 0,
+          totalCents: r.amount_cents || 0,
+          status: "paid",
+        });
+        const payment = await upsertPayment({
+          provider,
+          providerPaymentId: providerPaymentId || null,
+          invoiceId: invoice.id,
+          buyerProfileId: r.user_id,
+          buyerEmail: r.buyer_email,
+          amountCents: r.amount_cents || 0,
+          method: "card",
+          status: "paid",
+          paidAt: r.created_at,
+        });
+        await supabaseAdmin
+          .from("lead_purchases")
+          .update({
+            financial_spine_invoice_id: invoice.id,
+            financial_spine_payment_id: payment.id,
+          })
+          .eq("id", r.id);
+      }
+    }
+  }
+
+  // ─── machine_listing_purchases ────────────────────────────────────────
+  {
+    const { data } = await supabaseAdmin
+      .from("machine_listing_purchases")
+      .select("id, machine_listing_id, buyer_email, amount_cents, status, stripe_checkout_session_id, stripe_payment_intent_id, qb_invoice_id, qb_payment_id, payment_provider, financial_spine_payment_id, created_at")
+      .gte("created_at", cutoff)
+      .order("created_at", { ascending: false })
+      .limit(limit);
+
+    for (const r of data || []) {
+      if (r.financial_spine_payment_id) {
+        rows.push({ source_table: "machine_listing_purchases", source_id: r.id, action: "skip", reason: "already backfilled", provider: r.payment_provider || "unknown", amount_cents: r.amount_cents || 0, status: r.status });
+        continue;
+      }
+      if (r.status !== "completed" && r.status !== "paid") {
+        rows.push({ source_table: "machine_listing_purchases", source_id: r.id, action: "skip", reason: `status=${r.status}`, provider: r.payment_provider || "unknown", amount_cents: r.amount_cents || 0, status: r.status });
+        continue;
+      }
+      const provider = r.payment_provider === "quickbooks" ? "quickbooks" : "stripe";
+      const providerInvoiceId = provider === "quickbooks" ? r.qb_invoice_id : r.stripe_checkout_session_id;
+      const providerPaymentId = provider === "quickbooks" ? r.qb_payment_id : r.stripe_payment_intent_id;
+      rows.push({
+        source_table: "machine_listing_purchases",
+        source_id: r.id,
+        action: "create",
+        provider,
+        amount_cents: r.amount_cents || 0,
+        status: "paid",
+        invoice_ref: providerInvoiceId,
+        payment_ref: providerPaymentId,
+        buyer_email: r.buyer_email,
+        created_at: r.created_at,
+      });
+
+      if (opts.apply) {
+        const invoice = await upsertInvoice({
+          provider,
+          providerInvoiceId: providerInvoiceId || null,
+          buyerEmail: r.buyer_email,
+          subtotalCents: r.amount_cents || 0,
+          totalCents: r.amount_cents || 0,
+          status: "paid",
+        });
+        const payment = await upsertPayment({
+          provider,
+          providerPaymentId: providerPaymentId || null,
+          invoiceId: invoice.id,
+          buyerEmail: r.buyer_email,
+          amountCents: r.amount_cents || 0,
+          method: "card",
+          status: "paid",
+          paidAt: r.created_at,
+        });
+        await supabaseAdmin
+          .from("machine_listing_purchases")
+          .update({ financial_spine_invoice_id: invoice.id, financial_spine_payment_id: payment.id })
+          .eq("id", r.id);
+      }
+    }
+  }
+
+  // ─── coffee_orders ────────────────────────────────────────────────────
+  {
+    const { data } = await supabaseAdmin
+      .from("coffee_orders")
+      .select("id, operator_id, total_cents, status, stripe_checkout_session_id, stripe_payment_intent_id, qb_invoice_id, qb_payment_id, payment_provider, financial_spine_payment_id, created_at")
+      .gte("created_at", cutoff)
+      .order("created_at", { ascending: false })
+      .limit(limit);
+
+    for (const r of data || []) {
+      if (r.financial_spine_payment_id) {
+        rows.push({ source_table: "coffee_orders", source_id: r.id, action: "skip", reason: "already backfilled", provider: r.payment_provider || "unknown", amount_cents: r.total_cents || 0, status: r.status });
+        continue;
+      }
+      if (r.status !== "completed" && r.status !== "paid") {
+        rows.push({ source_table: "coffee_orders", source_id: r.id, action: "skip", reason: `status=${r.status}`, provider: r.payment_provider || "unknown", amount_cents: r.total_cents || 0, status: r.status });
+        continue;
+      }
+      const provider = r.payment_provider === "quickbooks" ? "quickbooks" : "stripe";
+      const providerInvoiceId = provider === "quickbooks" ? r.qb_invoice_id : r.stripe_checkout_session_id;
+      const providerPaymentId = provider === "quickbooks" ? r.qb_payment_id : r.stripe_payment_intent_id;
+      rows.push({
+        source_table: "coffee_orders",
+        source_id: r.id,
+        action: "create",
+        provider,
+        amount_cents: r.total_cents || 0,
+        status: "paid",
+        invoice_ref: providerInvoiceId,
+        payment_ref: providerPaymentId,
+        created_at: r.created_at,
+      });
+
+      if (opts.apply) {
+        const invoice = await upsertInvoice({
+          provider,
+          providerInvoiceId: providerInvoiceId || null,
+          buyerProfileId: r.operator_id,
+          subtotalCents: r.total_cents || 0,
+          totalCents: r.total_cents || 0,
+          status: "paid",
+        });
+        const payment = await upsertPayment({
+          provider,
+          providerPaymentId: providerPaymentId || null,
+          invoiceId: invoice.id,
+          buyerProfileId: r.operator_id,
+          amountCents: r.total_cents || 0,
+          method: "card",
+          status: "paid",
+          paidAt: r.created_at,
+        });
+        await supabaseAdmin
+          .from("coffee_orders")
+          .update({ financial_spine_invoice_id: invoice.id, financial_spine_payment_id: payment.id })
+          .eq("id", r.id);
+      }
+    }
+  }
+
+  // Summary
+  const summary = {
+    total: rows.length,
+    to_create: rows.filter((r) => r.action === "create").length,
+    to_skip: rows.filter((r) => r.action === "skip").length,
+    by_source: {} as Record<string, { create: number; skip: number }>,
+  };
+  for (const r of rows) {
+    summary.by_source[r.source_table] = summary.by_source[r.source_table] || { create: 0, skip: 0 };
+    if (r.action === "create") summary.by_source[r.source_table].create++;
+    else summary.by_source[r.source_table].skip++;
+  }
+
+  return { cutoff, rows, summary };
+}

--- a/src/lib/paymentIngest.ts
+++ b/src/lib/paymentIngest.ts
@@ -1,0 +1,212 @@
+/**
+ * Provider-specific ingest — reads a provider event and writes the canonical
+ * ledger rows (invoices, payments, allocations) via paymentLedger.
+ *
+ * Each ingest function is non-fatal for the caller: if it throws or logs a
+ * failure, the pre-existing downstream handlers still run. As we migrate more
+ * business logic onto the ledger, downstream handlers can be simplified /
+ * removed, but for Phase 1 both flows coexist.
+ */
+
+import type Stripe from "stripe";
+import { supabaseAdmin } from "./supabaseAdmin";
+import { getConnection } from "./quickbooks";
+import { upsertInvoice, upsertPayment } from "./paymentLedger";
+
+function toCents(amount: number | string | null | undefined): number {
+  if (amount == null) return 0;
+  const n = typeof amount === "string" ? parseFloat(amount) : amount;
+  if (!Number.isFinite(n)) return 0;
+  return Math.round(n * 100);
+}
+
+// ─── Stripe ──────────────────────────────────────────────────────────────
+
+/**
+ * Best-effort mapping from a Stripe event to (invoice + payment) rows.
+ * We handle the events that currently drive money movement in this app —
+ * checkout.session.completed + payment_intent.succeeded — and skip the rest
+ * (subscription events, account.updated, etc.) since they don't create
+ * customer-collection records.
+ */
+export async function ingestStripeEvent(event: Stripe.Event, eventRowId: string): Promise<void> {
+  const t = event.type;
+
+  if (t === "checkout.session.completed") {
+    const session = event.data.object as Stripe.Checkout.Session;
+    if (session.mode === "subscription") return; // subs are handled separately
+    if (session.payment_status !== "paid") return;
+
+    const amount = session.amount_total ?? 0;
+    const email = session.customer_email || session.customer_details?.email || null;
+    const meta = (session.metadata || {}) as Record<string, string | null | undefined>;
+
+    // Resolve linked entities from metadata that existing checkout endpoints
+    // stamp on the session.
+    const orderId = typeof meta.order_id === "string" ? meta.order_id : null;
+    const agreementId = typeof meta.agreement_id === "string" ? meta.agreement_id : null;
+    const leadId = typeof meta.lead_id === "string" ? meta.lead_id : (typeof meta.request_id === "string" ? meta.request_id : null);
+    const buyerProfileId = typeof meta.user_id === "string" ? meta.user_id : null;
+
+    // Create invoice keyed on the session id — one invoice per checkout.
+    const invoice = await upsertInvoice({
+      provider: "stripe",
+      providerInvoiceId: session.id,
+      providerInvoiceUrl: session.url || null,
+      orderId,
+      agreementId,
+      leadId,
+      buyerProfileId,
+      buyerEmail: email,
+      subtotalCents: amount,
+      totalCents: amount,
+      status: "paid",
+      sentAt: new Date().toISOString(),
+      metadata: { checkout_type: meta.type || null },
+    });
+
+    const paymentIntentId = typeof session.payment_intent === "string"
+      ? session.payment_intent
+      : session.payment_intent?.id ?? null;
+
+    await upsertPayment({
+      provider: "stripe",
+      providerPaymentId: paymentIntentId || session.id,
+      eventId: eventRowId,
+      invoiceId: invoice.id,
+      orderId,
+      agreementId,
+      buyerProfileId,
+      buyerEmail: email,
+      amountCents: amount,
+      method: "card",
+      status: "paid",
+      paidAt: new Date().toISOString(),
+    });
+    return;
+  }
+
+  if (t === "payment_intent.succeeded") {
+    const pi = event.data.object as Stripe.PaymentIntent;
+    const amount = pi.amount_received || pi.amount || 0;
+    await upsertPayment({
+      provider: "stripe",
+      providerPaymentId: pi.id,
+      eventId: eventRowId,
+      buyerEmail: pi.receipt_email || null,
+      amountCents: amount,
+      method: pi.payment_method_types?.[0] || null,
+      status: "paid",
+      paidAt: new Date().toISOString(),
+    });
+    return;
+  }
+
+  if (t === "checkout.session.expired") {
+    const session = event.data.object as Stripe.Checkout.Session;
+    // Cancel the invoice row if we had one — mirrors the expiration event.
+    await supabaseAdmin
+      .from("invoices")
+      .update({ status: "void", voided_at: new Date().toISOString() })
+      .eq("provider", "stripe")
+      .eq("provider_invoice_id", session.id);
+    return;
+  }
+
+  if (t === "charge.refunded") {
+    // Chargeback + refund handling lives in the Phase 2 refund flow — for
+    // now, just capture that the event happened by writing a payment row
+    // with the refund status. The existing handlers don't touch this.
+    const charge = event.data.object as Stripe.Charge;
+    const parentIntentId = typeof charge.payment_intent === "string" ? charge.payment_intent : charge.payment_intent?.id;
+    if (!parentIntentId) return;
+    const { data: parent } = await supabaseAdmin
+      .from("payments")
+      .select("id")
+      .eq("provider", "stripe")
+      .eq("provider_payment_id", parentIntentId)
+      .maybeSingle();
+    if (!parent) return;
+    // Delegated to Phase 2 UI/refund route — noop for now.
+    return;
+  }
+}
+
+// ─── QuickBooks ──────────────────────────────────────────────────────────
+
+/**
+ * Fetches the QB Payment record, walks the LinkedTxn list to find the parent
+ * Invoice, and writes ledger rows.
+ */
+export async function ingestQbPaymentEvent(
+  paymentId: string,
+  realmId: string,
+  eventRowId: string | null,
+): Promise<void> {
+  const conn = await getConnection();
+  if (conn.realm_id !== realmId) return;
+
+  const base = process.env.QB_ENVIRONMENT === "production"
+    ? "https://quickbooks.api.intuit.com"
+    : "https://sandbox-quickbooks.api.intuit.com";
+
+  const res = await fetch(`${base}/v3/company/${realmId}/payment/${paymentId}`, {
+    headers: {
+      Authorization: `Bearer ${conn.access_token}`,
+      Accept: "application/json",
+    },
+  });
+  if (!res.ok) return;
+  const data = await res.json();
+  const payment = data.Payment;
+  if (!payment) return;
+
+  const amountCents = toCents(payment.TotalAmt);
+  const paidAt = payment.TxnDate ? new Date(payment.TxnDate).toISOString() : new Date().toISOString();
+
+  // Walk linked invoices — most QB Payments carry a single invoice.
+  const linkedInvoiceIds: string[] = [];
+  for (const line of payment.Line || []) {
+    for (const txn of line.LinkedTxn || []) {
+      if (txn.TxnType === "Invoice") linkedInvoiceIds.push(String(txn.TxnId));
+    }
+  }
+
+  const primaryInvoiceQbId = linkedInvoiceIds[0] || null;
+  let invoiceRowId: string | null = null;
+
+  if (primaryInvoiceQbId) {
+    // If we already know this QB invoice, use it. Otherwise create a shell.
+    const { data: existingInvoice } = await supabaseAdmin
+      .from("invoices")
+      .select("id, total_cents")
+      .eq("provider", "quickbooks")
+      .eq("provider_invoice_id", primaryInvoiceQbId)
+      .maybeSingle();
+
+    if (existingInvoice) {
+      invoiceRowId = existingInvoice.id;
+    } else {
+      const created = await upsertInvoice({
+        provider: "quickbooks",
+        providerInvoiceId: primaryInvoiceQbId,
+        buyerEmail: payment.CustomerRef?.name || null,
+        subtotalCents: amountCents,
+        totalCents: amountCents,
+        status: "paid",
+      });
+      invoiceRowId = created.id;
+    }
+  }
+
+  await upsertPayment({
+    provider: "quickbooks",
+    providerPaymentId: String(payment.Id),
+    eventId: eventRowId,
+    invoiceId: invoiceRowId,
+    amountCents,
+    method: payment.PaymentMethodRef?.name?.toLowerCase() || "unknown",
+    status: "paid",
+    paidAt,
+  });
+}

--- a/src/lib/paymentLedger.ts
+++ b/src/lib/paymentLedger.ts
@@ -1,0 +1,491 @@
+/**
+ * Payment ledger writer — provider-agnostic entry point that both the Stripe
+ * and QuickBooks webhooks call. Every call is idempotent on (provider,
+ * event_id) — a duplicate webhook delivery lands in payment_events but does
+ * NOT double-write to payments or invoices.
+ *
+ * Contract:
+ *   1. Call recordPaymentEvent(...) at the very top of each webhook handler,
+ *      with the verified provider event body. Returns { eventRow, alreadyProcessed }.
+ *   2. If alreadyProcessed → return early. All downstream side-effects already
+ *      happened on the first delivery.
+ *   3. Otherwise, resolve/create the Invoice + Payment via upsertInvoice +
+ *      upsertPayment (or recordRefund for negative-amount events).
+ *   4. Call markEventProcessed(eventRow.id) at the end. If anything throws
+ *      in between, the event row stays unprocessed and a retry will re-run
+ *      the handler cleanly.
+ *
+ * All amount fields use bigint cents to avoid float drift.
+ */
+
+import { supabaseAdmin } from "./supabaseAdmin";
+
+export type PaymentProvider = "stripe" | "quickbooks" | "paypal" | "manual";
+
+export type PaymentStatus =
+  | "draft"
+  | "pending"
+  | "paid"
+  | "partial_refund"
+  | "refunded"
+  | "failed"
+  | "disputed"
+  | "chargeback"
+  | "cancelled"
+  | "written_off";
+
+export type InvoiceStatus =
+  | "draft"
+  | "open"
+  | "partially_paid"
+  | "paid"
+  | "overdue"
+  | "void"
+  | "written_off";
+
+export interface RecordPaymentEventArgs {
+  provider: PaymentProvider;
+  eventId: string;
+  eventType: string;
+  signatureVerified: boolean;
+  payload: Record<string, unknown> | unknown;
+}
+
+export interface PaymentEventRow {
+  id: string;
+  provider: string;
+  event_id: string;
+  event_type: string;
+  signature_verified: boolean;
+  processed_at: string | null;
+  received_at: string;
+}
+
+export interface RecordEventResult {
+  event: PaymentEventRow;
+  alreadyProcessed: boolean;
+}
+
+/**
+ * Insert a payment_events row (or return the existing one for retries).
+ * Returns alreadyProcessed=true if the same (provider, event_id) has already
+ * been fully processed, in which case downstream side-effects should skip.
+ */
+export async function recordPaymentEvent(args: RecordPaymentEventArgs): Promise<RecordEventResult> {
+  const { data: existing } = await supabaseAdmin
+    .from("payment_events")
+    .select("id, provider, event_id, event_type, signature_verified, processed_at, received_at")
+    .eq("provider", args.provider)
+    .eq("event_id", args.eventId)
+    .maybeSingle();
+
+  if (existing) {
+    return { event: existing as PaymentEventRow, alreadyProcessed: !!existing.processed_at };
+  }
+
+  const { data: created, error } = await supabaseAdmin
+    .from("payment_events")
+    .insert({
+      provider: args.provider,
+      event_id: args.eventId,
+      event_type: args.eventType,
+      signature_verified: args.signatureVerified,
+      payload: args.payload,
+    })
+    .select("id, provider, event_id, event_type, signature_verified, processed_at, received_at")
+    .single();
+  if (error) throw error;
+  return { event: created as PaymentEventRow, alreadyProcessed: false };
+}
+
+export async function markEventProcessed(eventRowId: string, error?: string): Promise<void> {
+  await supabaseAdmin
+    .from("payment_events")
+    .update({
+      processed_at: new Date().toISOString(),
+      processing_error: error || null,
+    })
+    .eq("id", eventRowId);
+}
+
+// ─── Invoice upsert ──────────────────────────────────────────────────────
+
+export interface UpsertInvoiceArgs {
+  provider: PaymentProvider;
+  providerInvoiceId?: string | null;
+  providerInvoiceUrl?: string | null;
+
+  orderId?: string | null;
+  agreementId?: string | null;
+  accountId?: string | null;
+  leadId?: string | null;
+  buyerProfileId?: string | null;
+  buyerEmail?: string | null;
+  buyerName?: string | null;
+
+  subtotalCents?: number;
+  taxCents?: number;
+  discountCents?: number;
+  totalCents: number;
+  currency?: string;
+
+  status?: InvoiceStatus;
+  dueDate?: string | null;
+  sentAt?: string | null;
+
+  memo?: string | null;
+  metadata?: Record<string, unknown> | null;
+  createdBy?: string | null;
+}
+
+export interface InvoiceRow {
+  id: string;
+  status: InvoiceStatus;
+  total_cents: number;
+  amount_paid_cents: number;
+  balance_due_cents: number;
+}
+
+/**
+ * Idempotent by (provider, provider_invoice_id) when providerInvoiceId is set.
+ * When not set, always creates a new invoice — caller is responsible for its
+ * own dedup logic.
+ */
+export async function upsertInvoice(args: UpsertInvoiceArgs): Promise<InvoiceRow> {
+  const total = args.totalCents;
+  const subtotal = args.subtotalCents ?? total;
+
+  if (args.providerInvoiceId) {
+    const { data: existing } = await supabaseAdmin
+      .from("invoices")
+      .select("id, status, total_cents, amount_paid_cents, balance_due_cents")
+      .eq("provider", args.provider)
+      .eq("provider_invoice_id", args.providerInvoiceId)
+      .maybeSingle();
+    if (existing) return existing as InvoiceRow;
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from("invoices")
+    .insert({
+      provider: args.provider,
+      provider_invoice_id: args.providerInvoiceId || null,
+      provider_invoice_url: args.providerInvoiceUrl || null,
+      order_id: args.orderId || null,
+      agreement_id: args.agreementId || null,
+      account_id: args.accountId || null,
+      lead_id: args.leadId || null,
+      buyer_profile_id: args.buyerProfileId || null,
+      buyer_email: args.buyerEmail || null,
+      buyer_name: args.buyerName || null,
+      subtotal_cents: subtotal,
+      tax_cents: args.taxCents ?? 0,
+      discount_cents: args.discountCents ?? 0,
+      total_cents: total,
+      balance_due_cents: total,
+      currency: args.currency || "USD",
+      status: args.status || "open",
+      due_date: args.dueDate || null,
+      sent_at: args.sentAt || null,
+      memo: args.memo || null,
+      metadata: args.metadata || null,
+      created_by: args.createdBy || null,
+    })
+    .select("id, status, total_cents, amount_paid_cents, balance_due_cents")
+    .single();
+  if (error) throw error;
+  return data as InvoiceRow;
+}
+
+// ─── Payment upsert ──────────────────────────────────────────────────────
+
+export interface UpsertPaymentArgs {
+  provider: PaymentProvider;
+  providerPaymentId?: string | null;
+  providerChargeId?: string | null;
+  eventId?: string | null;
+
+  invoiceId?: string | null;
+  orderId?: string | null;
+  agreementId?: string | null;
+  accountId?: string | null;
+  buyerProfileId?: string | null;
+  buyerEmail?: string | null;
+
+  amountCents: number;              // positive for payments; use recordRefund for negatives
+  currency?: string;
+  method?: string | null;           // 'card' | 'ach' | ...
+  last4?: string | null;
+
+  status: PaymentStatus;
+  paidAt?: string | null;
+  failedAt?: string | null;
+  failedReason?: string | null;
+
+  providerFeeCents?: number;
+
+  manualReference?: string | null;
+  proofBucket?: string | null;
+  proofPath?: string | null;
+  proofUrl?: string | null;
+
+  metadata?: Record<string, unknown> | null;
+  createdBy?: string | null;
+}
+
+export interface PaymentRow {
+  id: string;
+  status: PaymentStatus;
+  amount_cents: number;
+  invoice_id: string | null;
+}
+
+/**
+ * Idempotent by (provider, provider_payment_id). If a payment already exists
+ * with the same provider payment id, we update the status/paid_at rather
+ * than double-writing. Also writes a payment_status_history row on any
+ * status change and, when linked to an invoice, updates the invoice's
+ * amount_paid / balance / status atomically.
+ */
+export async function upsertPayment(args: UpsertPaymentArgs): Promise<PaymentRow> {
+  let existing: PaymentRow | null = null;
+  if (args.providerPaymentId) {
+    const { data } = await supabaseAdmin
+      .from("payments")
+      .select("id, status, amount_cents, invoice_id")
+      .eq("provider", args.provider)
+      .eq("provider_payment_id", args.providerPaymentId)
+      .maybeSingle();
+    existing = (data as PaymentRow) || null;
+  }
+
+  const now = new Date().toISOString();
+
+  if (existing) {
+    // Update in place if status/paid_at is different. Don't clobber a paid
+    // record back to pending.
+    if (existing.status !== args.status) {
+      await supabaseAdmin
+        .from("payments")
+        .update({
+          status: args.status,
+          paid_at: args.paidAt || null,
+          failed_at: args.failedAt || null,
+          failed_reason: args.failedReason || null,
+          updated_at: now,
+        })
+        .eq("id", existing.id);
+
+      await supabaseAdmin.from("payment_status_history").insert({
+        payment_id: existing.id,
+        from_status: existing.status,
+        to_status: args.status,
+        event_id: args.eventId || null,
+      });
+
+      if (existing.invoice_id) {
+        await recomputeInvoiceTotals(existing.invoice_id);
+      }
+    }
+    return { ...existing, status: args.status };
+  }
+
+  const { data: inserted, error } = await supabaseAdmin
+    .from("payments")
+    .insert({
+      provider: args.provider,
+      provider_payment_id: args.providerPaymentId || null,
+      provider_charge_id: args.providerChargeId || null,
+      event_id: args.eventId || null,
+      invoice_id: args.invoiceId || null,
+      order_id: args.orderId || null,
+      agreement_id: args.agreementId || null,
+      account_id: args.accountId || null,
+      buyer_profile_id: args.buyerProfileId || null,
+      buyer_email: args.buyerEmail || null,
+      amount_cents: args.amountCents,
+      currency: args.currency || "USD",
+      method: args.method || null,
+      last4: args.last4 || null,
+      status: args.status,
+      paid_at: args.paidAt || null,
+      failed_at: args.failedAt || null,
+      failed_reason: args.failedReason || null,
+      provider_fee_cents: args.providerFeeCents ?? 0,
+      manual_reference: args.manualReference || null,
+      proof_bucket: args.proofBucket || null,
+      proof_path: args.proofPath || null,
+      proof_url: args.proofUrl || null,
+      metadata: args.metadata || null,
+      created_by: args.createdBy || null,
+    })
+    .select("id, status, amount_cents, invoice_id")
+    .single();
+  if (error) throw error;
+
+  await supabaseAdmin.from("payment_status_history").insert({
+    payment_id: inserted.id,
+    from_status: null,
+    to_status: args.status,
+    event_id: args.eventId || null,
+  });
+
+  if (args.invoiceId && args.status === "paid") {
+    await recomputeInvoiceTotals(args.invoiceId);
+  }
+
+  return inserted as PaymentRow;
+}
+
+/**
+ * Sums all paid + partial_refund payments against the invoice and updates
+ * amount_paid / balance / status. Never touches history — that lives in
+ * payment_status_history. Called on every payment status transition.
+ */
+export async function recomputeInvoiceTotals(invoiceId: string): Promise<void> {
+  const { data: inv } = await supabaseAdmin
+    .from("invoices")
+    .select("id, total_cents, status")
+    .eq("id", invoiceId)
+    .maybeSingle();
+  if (!inv) return;
+
+  const { data: pays } = await supabaseAdmin
+    .from("payments")
+    .select("amount_cents, status")
+    .eq("invoice_id", invoiceId)
+    .in("status", ["paid", "partial_refund", "refunded"]);
+
+  const paid = (pays || []).reduce((sum, p) => {
+    // paid contributes positively; refunded/partial_refund subtract via their
+    // negative amount_cents (recordRefund writes negative rows).
+    return sum + Number(p.amount_cents || 0);
+  }, 0);
+
+  const balance = Math.max(0, Number(inv.total_cents) - paid);
+  let status: InvoiceStatus = inv.status as InvoiceStatus;
+  if (balance <= 0 && Number(inv.total_cents) > 0) status = "paid";
+  else if (paid > 0 && balance > 0) status = "partially_paid";
+  else if (paid === 0 && (status === "paid" || status === "partially_paid")) status = "open";
+
+  const now = new Date().toISOString();
+  await supabaseAdmin
+    .from("invoices")
+    .update({
+      amount_paid_cents: paid,
+      balance_due_cents: balance,
+      status,
+      paid_at: status === "paid" ? now : null,
+      updated_at: now,
+    })
+    .eq("id", invoiceId);
+
+  if (inv.status !== status) {
+    await supabaseAdmin.from("payment_status_history").insert({
+      invoice_id: invoiceId,
+      from_status: inv.status,
+      to_status: status,
+    });
+  }
+}
+
+// ─── Refunds / chargebacks ──────────────────────────────────────────────
+
+export interface RecordRefundArgs {
+  parentPaymentId: string;
+  provider: PaymentProvider;
+  providerRefundId?: string | null;
+  eventId?: string | null;
+  amountCents: number;               // positive input; stored negative
+  reason?: string | null;
+  isChargeback?: boolean;
+  createdBy?: string | null;
+}
+
+export async function recordRefund(args: RecordRefundArgs): Promise<PaymentRow | null> {
+  const { data: parent } = await supabaseAdmin
+    .from("payments")
+    .select("id, invoice_id, order_id, agreement_id, account_id, buyer_profile_id, buyer_email, method, amount_cents, status")
+    .eq("id", args.parentPaymentId)
+    .maybeSingle();
+  if (!parent) return null;
+
+  const negativeAmount = -Math.abs(args.amountCents);
+  const nowIso = new Date().toISOString();
+
+  const { data: refund, error } = await supabaseAdmin
+    .from("payments")
+    .insert({
+      provider: args.provider,
+      provider_payment_id: args.providerRefundId || null,
+      event_id: args.eventId || null,
+      invoice_id: parent.invoice_id,
+      order_id: parent.order_id,
+      agreement_id: parent.agreement_id,
+      account_id: parent.account_id,
+      buyer_profile_id: parent.buyer_profile_id,
+      buyer_email: parent.buyer_email,
+      method: parent.method,
+      amount_cents: negativeAmount,
+      status: args.isChargeback ? "chargeback" : "refunded",
+      refund_of_payment_id: parent.id,
+      refund_reason: args.reason || null,
+      refunded_at: nowIso,
+      created_by: args.createdBy || null,
+    })
+    .select("id, status, amount_cents, invoice_id")
+    .single();
+  if (error) throw error;
+
+  // Move the parent from paid → partial_refund or refunded depending on the
+  // proportion. Chargebacks always become 'chargeback'.
+  const fullyRefunded = Math.abs(negativeAmount) >= Math.abs(Number(parent.amount_cents));
+  const parentNewStatus: PaymentStatus = args.isChargeback
+    ? "chargeback"
+    : fullyRefunded
+      ? "refunded"
+      : "partial_refund";
+
+  await supabaseAdmin
+    .from("payments")
+    .update({ status: parentNewStatus, refunded_at: nowIso, updated_at: nowIso })
+    .eq("id", parent.id);
+
+  await supabaseAdmin.from("payment_status_history").insert({
+    payment_id: parent.id,
+    from_status: parent.status,
+    to_status: parentNewStatus,
+    event_id: args.eventId || null,
+    reason: args.reason || null,
+  });
+
+  if (parent.invoice_id) await recomputeInvoiceTotals(parent.invoice_id);
+
+  return refund as PaymentRow;
+}
+
+// ─── Audit ─────────────────────────────────────────────────────────────
+
+export interface AuditArgs {
+  actorId: string | null;
+  action: string;
+  entityType: string;
+  entityId?: string | null;
+  reason?: string | null;
+  before?: Record<string, unknown> | null;
+  after?: Record<string, unknown> | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export async function writeAuditLog(args: AuditArgs): Promise<void> {
+  await supabaseAdmin.from("audit_logs").insert({
+    actor_id: args.actorId,
+    action: args.action,
+    entity_type: args.entityType,
+    entity_id: args.entityId || null,
+    reason: args.reason || null,
+    before: args.before || null,
+    after: args.after || null,
+    metadata: args.metadata || null,
+  });
+}

--- a/supabase/migrations/105_financial_spine_phase1.sql
+++ b/supabase/migrations/105_financial_spine_phase1.sql
@@ -1,0 +1,298 @@
+-- Financial spine — Phase 1
+-- Canonical payment ledger + provider-agnostic invoice model + verified
+-- webhook event log + universal financial audit trail. All additive: existing
+-- tables (sales_orders, purchase_agreements, lead_purchases, coffee_orders,
+-- machine_listing_purchases, user_listing_purchases, pipeline_payments,
+-- marketplace_payouts, marketplace_operator_invoices, agreement_tokens) are
+-- untouched. Cross-references let backfill wire them to the new spine without
+-- rewriting the old flows.
+--
+-- RLS on new tables:
+--   - service_role writes everything (webhook + API layer)
+--   - authenticated users can SELECT rows tagged with their user_id for the
+--     "My Performance" / "My Commissions" pages (rep dashboards)
+--   - admin-only sums live behind service-role views that only the admin API
+--     layer touches
+--
+-- Anything the sales rep should NOT be able to see (company gross, other
+-- reps' payments, aggregate revenue) stays behind service_role by omission.
+
+-- ─── Universal audit log ─────────────────────────────────────────────────
+-- One table for every financial override, rate change, attribution change,
+-- refund entry, manual payment. Explicit "before" / "after" JSONB so we can
+-- audit the mutation exactly.
+CREATE TABLE IF NOT EXISTS audit_logs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  actor_id uuid REFERENCES profiles(id),
+  action text NOT NULL,             -- e.g. "manual_payment_recorded", "attribution_override"
+  entity_type text NOT NULL,        -- "payment" | "invoice" | "commission_rule" | ...
+  entity_id uuid,
+  reason text,
+  before jsonb,
+  after jsonb,
+  metadata jsonb,
+  created_at timestamptz DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_logs_entity ON audit_logs(entity_type, entity_id);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_actor ON audit_logs(actor_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_action ON audit_logs(action, created_at DESC);
+
+-- ─── Webhook event log ───────────────────────────────────────────────────
+-- Every provider event lands here first with signature verification result +
+-- raw payload. Downstream handlers only fire on the transition from
+-- processed_at IS NULL → set, so retries + double-deliveries are safe.
+CREATE TABLE IF NOT EXISTS payment_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  provider text NOT NULL,           -- 'stripe' | 'quickbooks' | 'paypal' | 'manual'
+  event_id text NOT NULL,           -- provider's own event / message id
+  event_type text NOT NULL,         -- 'checkout.session.completed', 'Payment', etc
+  signature_verified boolean NOT NULL DEFAULT false,
+  payload jsonb NOT NULL,
+  processed_at timestamptz,
+  processing_error text,
+  received_at timestamptz DEFAULT now(),
+  UNIQUE (provider, event_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_payment_events_unprocessed ON payment_events(received_at) WHERE processed_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_payment_events_type ON payment_events(provider, event_type, received_at DESC);
+
+-- ─── Canonical invoices ──────────────────────────────────────────────────
+-- Provider-agnostic invoice record. `provider_invoice_id` maps to whatever
+-- the underlying system uses: QB Invoice.Id, Stripe checkout_session.id,
+-- Stripe invoice.id (for subs), or manual. Existing sales_orders.qb_invoice_id
+-- can be foreign-referenced here at backfill time.
+CREATE TABLE IF NOT EXISTS invoices (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- Provider identity
+  provider text NOT NULL,           -- 'stripe' | 'quickbooks' | 'manual'
+  provider_invoice_id text,
+  provider_invoice_url text,        -- link the customer can click to pay
+
+  -- CRM linkage (nullable — some flows don't have an order/agreement)
+  order_id uuid REFERENCES sales_orders(id) ON DELETE SET NULL,
+  agreement_id uuid REFERENCES purchase_agreements(id) ON DELETE SET NULL,
+  account_id uuid REFERENCES sales_accounts(id) ON DELETE SET NULL,
+  lead_id uuid REFERENCES sales_leads(id) ON DELETE SET NULL,
+
+  -- Buyer
+  buyer_profile_id uuid REFERENCES profiles(id) ON DELETE SET NULL,
+  buyer_email text,
+  buyer_name text,
+
+  -- Amounts stored as cents to avoid float drift
+  subtotal_cents bigint NOT NULL DEFAULT 0,
+  tax_cents bigint NOT NULL DEFAULT 0,
+  discount_cents bigint NOT NULL DEFAULT 0,
+  total_cents bigint NOT NULL DEFAULT 0,
+  amount_paid_cents bigint NOT NULL DEFAULT 0,
+  balance_due_cents bigint NOT NULL DEFAULT 0,
+  currency text NOT NULL DEFAULT 'USD',
+
+  -- Lifecycle
+  status text NOT NULL DEFAULT 'draft'
+    CHECK (status IN ('draft','open','partially_paid','paid','overdue','void','written_off')),
+  due_date date,
+  sent_at timestamptz,
+  paid_at timestamptz,
+  voided_at timestamptz,
+
+  memo text,
+  metadata jsonb,
+
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now(),
+  created_by uuid REFERENCES profiles(id),
+
+  UNIQUE (provider, provider_invoice_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_invoices_status ON invoices(status);
+CREATE INDEX IF NOT EXISTS idx_invoices_order ON invoices(order_id);
+CREATE INDEX IF NOT EXISTS idx_invoices_agreement ON invoices(agreement_id);
+CREATE INDEX IF NOT EXISTS idx_invoices_account ON invoices(account_id);
+CREATE INDEX IF NOT EXISTS idx_invoices_buyer ON invoices(buyer_profile_id);
+CREATE INDEX IF NOT EXISTS idx_invoices_due ON invoices(due_date) WHERE status IN ('open','partially_paid','overdue');
+
+-- ─── Canonical payments ──────────────────────────────────────────────────
+-- Single source of truth for what actually got collected. Every payment
+-- (real webhook, manual admin entry, refund) is a row here. Refunds are
+-- negative-amount rows referencing the parent payment_id.
+CREATE TABLE IF NOT EXISTS payments (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  provider text NOT NULL,            -- 'stripe' | 'quickbooks' | 'paypal' | 'manual'
+  provider_payment_id text,
+  provider_charge_id text,
+  event_id uuid REFERENCES payment_events(id) ON DELETE SET NULL,
+
+  invoice_id uuid REFERENCES invoices(id) ON DELETE SET NULL,
+  order_id uuid REFERENCES sales_orders(id) ON DELETE SET NULL,
+  agreement_id uuid REFERENCES purchase_agreements(id) ON DELETE SET NULL,
+  account_id uuid REFERENCES sales_accounts(id) ON DELETE SET NULL,
+
+  buyer_profile_id uuid REFERENCES profiles(id) ON DELETE SET NULL,
+  buyer_email text,
+
+  -- Signed amount. Refunds/chargebacks are negative.
+  amount_cents bigint NOT NULL,
+  currency text NOT NULL DEFAULT 'USD',
+
+  method text,                       -- 'card' | 'ach' | 'wire' | 'check' | 'cash' | 'zelle' | 'venmo' | 'paypal'
+  last4 text,
+
+  -- Lifecycle. Historical status_history captures transitions; this is the
+  -- current state.
+  status text NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('draft','pending','paid','partial_refund','refunded','failed','disputed','chargeback','cancelled','written_off')),
+
+  -- Refund linkage
+  refund_of_payment_id uuid REFERENCES payments(id) ON DELETE SET NULL,
+  refund_reason text,
+
+  -- Fees the processor withheld — for later net-revenue math
+  provider_fee_cents bigint DEFAULT 0,
+
+  failed_reason text,
+  failed_at timestamptz,
+  paid_at timestamptz,
+  refunded_at timestamptz,
+  disputed_at timestamptz,
+
+  -- Manual entries capture the proof + admin who filed it
+  manual_reference text,
+  proof_url text,
+  proof_bucket text,
+  proof_path text,
+
+  metadata jsonb,
+
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now(),
+  created_by uuid REFERENCES profiles(id),
+
+  UNIQUE (provider, provider_payment_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_payments_invoice ON payments(invoice_id);
+CREATE INDEX IF NOT EXISTS idx_payments_order ON payments(order_id);
+CREATE INDEX IF NOT EXISTS idx_payments_agreement ON payments(agreement_id);
+CREATE INDEX IF NOT EXISTS idx_payments_status_paid_at ON payments(status, paid_at DESC);
+CREATE INDEX IF NOT EXISTS idx_payments_buyer ON payments(buyer_profile_id);
+CREATE INDEX IF NOT EXISTS idx_payments_provider_id ON payments(provider, provider_payment_id);
+CREATE INDEX IF NOT EXISTS idx_payments_refund_of ON payments(refund_of_payment_id);
+
+-- ─── Payment allocations ─────────────────────────────────────────────────
+-- Splits a single payment across invoice / order_items when needed
+-- (deposit vs remaining, multi-invoice batch).
+CREATE TABLE IF NOT EXISTS payment_allocations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  payment_id uuid NOT NULL REFERENCES payments(id) ON DELETE CASCADE,
+  invoice_id uuid REFERENCES invoices(id) ON DELETE SET NULL,
+  order_item_id uuid REFERENCES order_items(id) ON DELETE SET NULL,
+  amount_cents bigint NOT NULL,
+  memo text,
+  created_at timestamptz DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_alloc_payment ON payment_allocations(payment_id);
+CREATE INDEX IF NOT EXISTS idx_alloc_invoice ON payment_allocations(invoice_id);
+CREATE INDEX IF NOT EXISTS idx_alloc_order_item ON payment_allocations(order_item_id);
+
+-- ─── Payment / invoice status history ────────────────────────────────────
+-- Append-only. Every status transition on a payment or invoice writes one
+-- row so we can prove the timeline in reconciliation + audit views.
+CREATE TABLE IF NOT EXISTS payment_status_history (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  payment_id uuid REFERENCES payments(id) ON DELETE CASCADE,
+  invoice_id uuid REFERENCES invoices(id) ON DELETE CASCADE,
+  from_status text,
+  to_status text NOT NULL,
+  reason text,
+  event_id uuid REFERENCES payment_events(id) ON DELETE SET NULL,
+  actor_id uuid REFERENCES profiles(id),
+  changed_at timestamptz DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_status_hist_payment ON payment_status_history(payment_id, changed_at DESC);
+CREATE INDEX IF NOT EXISTS idx_status_hist_invoice ON payment_status_history(invoice_id, changed_at DESC);
+
+-- ─── RLS ─────────────────────────────────────────────────────────────────
+ALTER TABLE audit_logs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE payment_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE invoices ENABLE ROW LEVEL SECURITY;
+ALTER TABLE payments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE payment_allocations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE payment_status_history ENABLE ROW LEVEL SECURITY;
+
+-- Service role can do anything on all six.
+DO $$
+DECLARE t text;
+BEGIN
+  FOR t IN SELECT unnest(ARRAY[
+    'audit_logs','payment_events','invoices','payments','payment_allocations','payment_status_history'
+  ]) LOOP
+    EXECUTE format('DROP POLICY IF EXISTS "Service role only" ON %I;', t);
+    EXECUTE format('CREATE POLICY "Service role only" ON %I FOR ALL TO service_role USING (true) WITH CHECK (true);', t);
+  END LOOP;
+END $$;
+
+-- Buyers (operators/customers) can SELECT their own invoices + their own
+-- payments through the anon client. Useful for /account/invoices and
+-- /account/receipts pages that hit Supabase directly.
+DROP POLICY IF EXISTS "Buyer reads own invoices" ON invoices;
+CREATE POLICY "Buyer reads own invoices" ON invoices
+  FOR SELECT TO authenticated
+  USING (buyer_profile_id = auth.uid());
+
+DROP POLICY IF EXISTS "Buyer reads own payments" ON payments;
+CREATE POLICY "Buyer reads own payments" ON payments
+  FOR SELECT TO authenticated
+  USING (buyer_profile_id = auth.uid());
+
+-- Notably absent (by design):
+--   - No auth policy for payment_events / audit_logs — admin only via API
+--   - No auth policy for payment_allocations / payment_status_history —
+--     surfaced through API views, never direct DB reads
+--   - No rep-visibility policy here — those get added in the commissions
+--     phase (Phase 4), scoped to commission_ledger rows only
+
+-- ─── Storage: payment-proofs ─────────────────────────────────────────────
+-- Private bucket for manual payment proof uploads (screenshots, PDFs of
+-- ACH confirmations, etc). Only served through the admin API via short-
+-- lived signed URLs — never public.
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('payment-proofs', 'payment-proofs', false)
+ON CONFLICT (id) DO NOTHING;
+
+-- ─── Backfill safety pins ────────────────────────────────────────────────
+-- These columns let the backfill script mark rows as "already reconciled to
+-- the new spine" without touching existing status flags.
+ALTER TABLE lead_purchases
+  ADD COLUMN IF NOT EXISTS financial_spine_invoice_id uuid REFERENCES invoices(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS financial_spine_payment_id uuid REFERENCES payments(id) ON DELETE SET NULL;
+
+ALTER TABLE machine_listing_purchases
+  ADD COLUMN IF NOT EXISTS financial_spine_invoice_id uuid REFERENCES invoices(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS financial_spine_payment_id uuid REFERENCES payments(id) ON DELETE SET NULL;
+
+ALTER TABLE coffee_orders
+  ADD COLUMN IF NOT EXISTS financial_spine_invoice_id uuid REFERENCES invoices(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS financial_spine_payment_id uuid REFERENCES payments(id) ON DELETE SET NULL;
+
+ALTER TABLE user_listing_purchases
+  ADD COLUMN IF NOT EXISTS financial_spine_invoice_id uuid REFERENCES invoices(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS financial_spine_payment_id uuid REFERENCES payments(id) ON DELETE SET NULL;
+
+ALTER TABLE pipeline_payments
+  ADD COLUMN IF NOT EXISTS financial_spine_invoice_id uuid REFERENCES invoices(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS financial_spine_payment_id uuid REFERENCES payments(id) ON DELETE SET NULL;
+
+ALTER TABLE agreement_tokens
+  ADD COLUMN IF NOT EXISTS financial_spine_invoice_id uuid REFERENCES invoices(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS financial_spine_payment_id uuid REFERENCES payments(id) ON DELETE SET NULL;
+
+ALTER TABLE sales_orders
+  ADD COLUMN IF NOT EXISTS financial_spine_invoice_id uuid REFERENCES invoices(id) ON DELETE SET NULL;


### PR DESCRIPTION
Foundational commit for the CRM financial rewire. Adds the canonical payment
+ invoice ledger and starts feeding it from every existing payment path without altering any downstream behavior. All existing checkout/order/agreement flows continue to work exactly as before; the new tables shadow them until later phases wire the CRM to consume the ledger directly.

Migration 105 — new tables:
- payment_events (idempotency: unique on provider+event_id, signature_verified, payload JSONB, processed_at)
- invoices (provider-agnostic; cents-only amounts; status draft/open/ partially_paid/paid/overdue/void/written_off; buyer + order + agreement + lead refs)
- payments (provider/provider_payment_id unique; cents; status pending/paid/ partial_refund/refunded/failed/disputed/chargeback/cancelled/written_off; refund_of_payment_id for reversal linkage; manual_reference + proof_url + proof_bucket + proof_path for admin manual entries)
- payment_allocations (splits one payment across invoice/order_item)
- payment_status_history (append-only)
- audit_logs (universal financial audit)
- storage bucket 'payment-proofs' (private)
- financial_spine_invoice_id + financial_spine_payment_id columns added to lead_purchases / machine_listing_purchases / coffee_orders / user_listing_purchases / pipeline_payments / agreement_tokens / sales_orders so backfill is idempotent and existing tables know they're already in the ledger.

RLS baseline:
- All six new tables: service_role_full_access via API layer.
- invoices + payments: buyer can SELECT own rows through the anon client (buyer_profile_id = auth.uid()) — enables /account/invoices later without extra API calls.
- payment_events, audit_logs, payment_allocations, payment_status_history: admin-only via API, no direct auth SELECT.
- Notably absent: rep-visibility policies — those ship with commission_ledger in Phase 4, scoped tightly.

src/lib/paymentLedger.ts — the writer:
- recordPaymentEvent(provider, event_id, event_type, signature_verified, payload) — idempotent on (provider, event_id); returns { event, alreadyProcessed } so webhook handlers can short-circuit duplicate deliveries.
- markEventProcessed(id, error?) — closes out the event row.
- upsertInvoice() — idempotent on (provider, provider_invoice_id); creates or returns existing.
- upsertPayment() — idempotent on (provider, provider_payment_id); on status change writes payment_status_history and recomputes invoice totals (amount_paid, balance_due, status) atomically.
- recordRefund() — records a negative-amount child payment linked via refund_of_payment_id, flips the parent to partial_refund/refunded/ chargeback, updates invoice balance. (Phase 2 refund UI calls this.)
- writeAuditLog() — every override/manual entry funnels through here.
- recomputeInvoiceTotals() — sums paid+refunded payments, recomputes balance + status, appends a history row on transition.

src/lib/paymentIngest.ts — provider-specific normalizers:
- ingestStripeEvent(): checkout.session.completed, payment_intent.succeeded, checkout.session.expired, charge.refunded (refund handling placeholder for Phase 2). Extracts order_id / agreement_id / lead_id / user_id from existing metadata that checkout endpoints already stamp.
- ingestQbPaymentEvent(): fetches the QB Payment record, walks LinkedTxn for the parent Invoice, upserts both into the ledger.
- Both are non-fatal: a throw here logs + swallows and lets the existing downstream handlers continue.

Webhook extensions (additive only):
- src/app/api/webhooks/stripe/route.ts: after signature verify, records the event and short-circuits on duplicates. Calls ingestStripeEvent + wraps existing dispatch in try/finally so the event is marked processed. Existing handlers (handleLeadPurchaseCompleted, handleAgreementPaymentCompleted, ...) are untouched.
- src/app/api/webhooks/quickbooks/route.ts: per-entity event_id built from realm+name+id+lastUpdated. Skips already-processed entities. Ingests the Payment, calls existing handleQBPayment / handleQBBillPayment.

Admin manual payment (POST /api/admin/financial/payments):
- Admin-only. Method whitelist (ach/wire/cash/check/zelle/venmo/paypal/other).
- Auto-creates a shell invoice if not provided and order_id or agreement_id is set — keeps invoice/payment 1:1 in the ledger.
- Writes an audit_logs row with the reason.
- Proof upload: POST /api/admin/financial/payments/proof accepts a file, stores it in the private payment-proofs bucket, returns { bucket, path } which the manual-payment POST attaches.
- Later download: GET /api/admin/financial/payments/[id]/proof mints a 5-minute signed URL; admin-only.

Backfill (src/lib/paymentBackfill.ts + /api/admin/financial/backfill):
- GET runs preview mode — no writes, returns { rows, summary { total, to_create, to_skip, by_source } }.
- POST applies. Per-row: upsert invoice + payment, stamp financial_spine_invoice_id / financial_spine_payment_id on the source row so subsequent runs skip. Sources: lead_purchases, machine_listing_purchases, coffee_orders. (Other sources — user_listing_purchases, pipeline_payments, agreement_tokens — added in a follow-up before Phase 2 ships to keep this commit reviewable.)
- Default cutoff 90 days; configurable 1-3650 via ?days= param.
- Audit_logs row records the run.

Admin UI:
- /admin/financial — Financial Center overview with recent payments table, KPI tiles, links to sub-pages.
- /admin/financial/payments — filterable payments list.
- /admin/financial/payments/new — manual payment form with proof upload.
- /admin/financial/backfill — preview + apply UI.
- /admin/financial/{invoices,refunds,reconciliation,commissions,attributions,settings} — placeholder pages that say "Ships in Phase X" so nav doesn't 404 and the scope is visible at a glance.
- Shared layout with tabbed nav.
- Admin panel header gets a "Financial Center" button next to Placements.

Existing behavior preserved:
- Existing /admin/*, /sales/*, /coffee/*, agreements/orders/quotes pages, Resend receipt emails, sales_commissions table + logic, all webhooks' downstream side effects — none of it changes in this commit.
- Existing sales_commissions rows will be carried forward into commission_ledger with is_legacy=true when Phase 4 ships.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2