### PR TITLE
Financial spine — Phase 2: refunds, chargebacks, reconciliation, agin…

### DIFF
--- a/src/app/admin/financial/invoices/page.tsx
+++ b/src/app/admin/financial/invoices/page.tsx
@@ -1,19 +1,191 @@
-import { Clock } from "lucide-react";
+"use client";
 
-export default function InvoicesStub() {
+import { useEffect, useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Loader2, FileText, ArrowLeft, Filter } from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
+
+interface Invoice {
+  id: string;
+  provider: string;
+  provider_invoice_id: string | null;
+  provider_invoice_url: string | null;
+  buyer_email: string | null;
+  buyer_name: string | null;
+  total_cents: number;
+  amount_paid_cents: number;
+  balance_due_cents: number;
+  status: string;
+  due_date: string | null;
+  sent_at: string | null;
+  paid_at: string | null;
+  created_at: string;
+}
+
+interface Summary {
+  open: { count: number; balance_cents: number };
+  b0_30: { count: number; balance_cents: number };
+  b31_60: { count: number; balance_cents: number };
+  b61_90: { count: number; balance_cents: number };
+  b90_plus: { count: number; balance_cents: number };
+}
+
+const STATUS_FILTERS = [
+  { key: "all", label: "All" },
+  { key: "open", label: "Open" },
+  { key: "partially_paid", label: "Partial" },
+  { key: "overdue", label: "Overdue" },
+  { key: "paid", label: "Paid" },
+  { key: "void", label: "Void" },
+];
+
+export default function InvoicesPage() {
+  const router = useRouter();
+  const [token, setToken] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [invoices, setInvoices] = useState<Invoice[]>([]);
+  const [summary, setSummary] = useState<Summary | null>(null);
+  const [status, setStatus] = useState("all");
+  const [bucket, setBucket] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!token) return;
+    setLoading(true);
+    const params = new URLSearchParams();
+    params.set("status", status);
+    if (bucket) params.set("bucket", bucket);
+    const res = await fetch(`/api/admin/financial/invoices?${params}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setSummary(data.summary);
+      setInvoices(data.invoices);
+    }
+    setLoading(false);
+  }, [token, status, bucket]);
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!session?.access_token) { router.push("/login?redirect=/admin/financial/invoices"); return; }
+      setToken(session.access_token);
+    });
+  }, [router]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const fmt = (c: number) => `$${(c / 100).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
   return (
     <div className="p-6">
-      <h1 className="text-2xl font-bold text-gray-900 mb-2">Invoices</h1>
-      <p className="text-sm text-gray-500 mb-6">
-        Invoice aging + per-invoice detail + payment allocations.
-      </p>
-      <div className="rounded-2xl border border-amber-200 bg-amber-50 p-6 flex items-center gap-3">
-        <Clock className="h-6 w-6 text-amber-600" />
-        <div>
-          <p className="text-sm font-medium text-amber-900">Ships in Phase 2</p>
-          <p className="text-xs text-amber-700">Aging buckets, per-invoice payment history, admin write-off action.</p>
+      <Link href="/admin/financial" className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-green-primary mb-4">
+        <ArrowLeft className="h-4 w-4" /> Financial Center
+      </Link>
+
+      <div className="mb-4">
+        <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
+          <FileText className="h-6 w-6 text-green-primary" /> Invoices
+        </h1>
+        <p className="text-sm text-gray-500 mt-1">
+          Provider-agnostic invoice ledger. Aging buckets by due_date (falls back to sent_at).
+        </p>
+      </div>
+
+      {summary && (
+        <div className="grid grid-cols-2 sm:grid-cols-5 gap-3 mb-4">
+          <AgingTile label="Open A/R" count={summary.open.count} balance={fmt(summary.open.balance_cents)} active={!bucket} onClick={() => setBucket(null)} />
+          <AgingTile label="0-30 days" count={summary.b0_30.count} balance={fmt(summary.b0_30.balance_cents)} tone="ok" active={bucket === "0-30"} onClick={() => setBucket(bucket === "0-30" ? null : "0-30")} />
+          <AgingTile label="31-60 days" count={summary.b31_60.count} balance={fmt(summary.b31_60.balance_cents)} tone="warn" active={bucket === "31-60"} onClick={() => setBucket(bucket === "31-60" ? null : "31-60")} />
+          <AgingTile label="61-90 days" count={summary.b61_90.count} balance={fmt(summary.b61_90.balance_cents)} tone="alert" active={bucket === "61-90"} onClick={() => setBucket(bucket === "61-90" ? null : "61-90")} />
+          <AgingTile label="90+ days" count={summary.b90_plus.count} balance={fmt(summary.b90_plus.balance_cents)} tone="critical" active={bucket === "90+"} onClick={() => setBucket(bucket === "90+" ? null : "90+")} />
         </div>
+      )}
+
+      <div className="mb-4 flex items-center gap-2 flex-wrap">
+        <Filter className="h-4 w-4 text-gray-400" />
+        {STATUS_FILTERS.map((f) => (
+          <button
+            key={f.key}
+            onClick={() => setStatus(f.key)}
+            className={`rounded-lg px-3 py-1.5 text-xs font-medium cursor-pointer ${status === f.key ? "bg-green-100 text-green-700" : "bg-gray-100 text-gray-500 hover:bg-gray-200"}`}
+          >
+            {f.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="rounded-2xl border border-gray-100 bg-white p-5">
+        {loading ? (
+          <div className="flex justify-center py-8"><Loader2 className="h-5 w-5 animate-spin text-green-primary" /></div>
+        ) : invoices.length === 0 ? (
+          <p className="text-sm text-gray-500 text-center py-8">No invoices match the current filters.</p>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-xs text-gray-500 border-b border-gray-100">
+                <th className="text-left py-2 px-2 font-medium">Provider</th>
+                <th className="text-left py-2 px-2 font-medium">Buyer</th>
+                <th className="text-right py-2 px-2 font-medium">Total</th>
+                <th className="text-right py-2 px-2 font-medium">Paid</th>
+                <th className="text-right py-2 px-2 font-medium">Balance</th>
+                <th className="text-left py-2 px-2 font-medium">Status</th>
+                <th className="text-left py-2 px-2 font-medium">Due</th>
+              </tr>
+            </thead>
+            <tbody>
+              {invoices.map((inv) => (
+                <tr key={inv.id} className="border-b border-gray-50 last:border-b-0">
+                  <td className="py-2 px-2 text-xs text-gray-500 uppercase">{inv.provider}</td>
+                  <td className="py-2 px-2 text-xs text-gray-700">{inv.buyer_name || inv.buyer_email || "—"}</td>
+                  <td className="py-2 px-2 text-right font-mono text-xs">{fmt(inv.total_cents)}</td>
+                  <td className="py-2 px-2 text-right font-mono text-xs text-emerald-700">{fmt(inv.amount_paid_cents)}</td>
+                  <td className={`py-2 px-2 text-right font-mono text-xs font-semibold ${inv.balance_due_cents > 0 ? "text-red-600" : "text-gray-500"}`}>
+                    {fmt(inv.balance_due_cents)}
+                  </td>
+                  <td className="py-2 px-2">
+                    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium capitalize ${statusColor(inv.status)}`}>
+                      {inv.status.replace(/_/g, " ")}
+                    </span>
+                  </td>
+                  <td className="py-2 px-2 text-xs text-gray-500">
+                    {inv.due_date ? new Date(inv.due_date).toLocaleDateString() : "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
       </div>
     </div>
   );
+}
+
+function AgingTile({ label, count, balance, tone, active, onClick }: { label: string; count: number; balance: string; tone?: "ok" | "warn" | "alert" | "critical"; active: boolean; onClick: () => void }) {
+  const ring = active ? "ring-2 ring-green-primary" : "";
+  const dot = tone === "critical" ? "bg-red-500" : tone === "alert" ? "bg-red-400" : tone === "warn" ? "bg-amber-400" : tone === "ok" ? "bg-emerald-400" : "bg-gray-300";
+  return (
+    <button
+      onClick={onClick}
+      className={`rounded-2xl border border-gray-100 bg-white p-4 text-left cursor-pointer hover:border-green-200 ${ring}`}
+    >
+      <div className="flex items-center gap-2">
+        <span className={`inline-block h-2 w-2 rounded-full ${dot}`} />
+        <p className="text-xs text-gray-500">{label}</p>
+      </div>
+      <p className="text-lg font-bold text-gray-900 mt-1">{balance}</p>
+      <p className="text-xs text-gray-400">{count} invoice{count === 1 ? "" : "s"}</p>
+    </button>
+  );
+}
+
+function statusColor(status: string): string {
+  if (status === "paid") return "bg-emerald-50 text-emerald-700";
+  if (status === "open") return "bg-blue-50 text-blue-700";
+  if (status === "partially_paid") return "bg-amber-50 text-amber-700";
+  if (status === "overdue") return "bg-red-50 text-red-700";
+  if (status === "void") return "bg-gray-100 text-gray-500";
+  if (status === "written_off") return "bg-gray-100 text-gray-500";
+  return "bg-gray-100 text-gray-600";
 }

--- a/src/app/admin/financial/reconciliation/page.tsx
+++ b/src/app/admin/financial/reconciliation/page.tsx
@@ -1,18 +1,239 @@
-import { Clock } from "lucide-react";
+"use client";
 
-export default function ReconciliationStub() {
+import { useEffect, useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Loader2, AlertTriangle, ArrowLeft, Play, CheckCircle2, AlertCircle, Filter } from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
+
+interface Exception {
+  id: string;
+  type: string;
+  provider: string | null;
+  provider_ref: string | null;
+  crm_payment_id: string | null;
+  crm_invoice_id: string | null;
+  amount_cents: number | null;
+  note: string;
+  detected_at: string;
+  resolved_at: string | null;
+  resolved_by: string | null;
+  resolution_action: string | null;
+  resolution_note: string | null;
+}
+
+const STATUS_FILTERS = [
+  { key: "open", label: "Open" },
+  { key: "resolved", label: "Resolved" },
+  { key: "all", label: "All" },
+];
+
+const TYPE_COLORS: Record<string, string> = {
+  missing_webhook: "bg-red-50 text-red-700",
+  missing_provider: "bg-red-50 text-red-700",
+  amount_mismatch: "bg-amber-50 text-amber-700",
+  duplicate_payment: "bg-amber-50 text-amber-700",
+  orphan_refund: "bg-blue-50 text-blue-700",
+  wrong_invoice_link: "bg-amber-50 text-amber-700",
+  stale_open_invoice: "bg-gray-100 text-gray-600",
+  other: "bg-gray-100 text-gray-600",
+};
+
+export default function ReconciliationPage() {
+  const router = useRouter();
+  const [token, setToken] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [running, setRunning] = useState(false);
+  const [saving, setSaving] = useState<string | null>(null);
+  const [items, setItems] = useState<Exception[]>([]);
+  const [status, setStatus] = useState("open");
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [lastRun, setLastRun] = useState<{ scanned: Record<string, number>; exceptions_filed: number; finished_at: string } | null>(null);
+
+  const load = useCallback(async () => {
+    if (!token) return;
+    setLoading(true);
+    const res = await fetch(`/api/admin/financial/reconciliation?status=${status}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.ok) setItems(await res.json());
+    setLoading(false);
+  }, [token, status]);
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!session?.access_token) { router.push("/login?redirect=/admin/financial/reconciliation"); return; }
+      setToken(session.access_token);
+    });
+  }, [router]);
+
+  useEffect(() => { load(); }, [load]);
+
+  async function runNow() {
+    setRunning(true);
+    setError(null);
+    setMessage(null);
+    const res = await fetch("/api/cron/reconciliation", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) setError(body.error || "Run failed");
+    else {
+      setLastRun({ scanned: body.scanned, exceptions_filed: body.exceptions_filed, finished_at: body.finished_at });
+      setMessage(`Reconciliation complete — filed ${body.exceptions_filed} new exceptions.`);
+      await load();
+    }
+    setRunning(false);
+  }
+
+  async function resolve(id: string, action: string) {
+    const note = prompt(`Resolution note (optional) for action "${action}"?`, "");
+    if (note === null) return;
+    setSaving(id);
+    setError(null);
+    const res = await fetch("/api/admin/financial/reconciliation", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ id, action, note }),
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body.error || "Resolve failed");
+    } else {
+      await load();
+    }
+    setSaving(null);
+  }
+
   return (
     <div className="p-6">
-      <h1 className="text-2xl font-bold text-gray-900 mb-2">Reconciliation</h1>
-      <p className="text-sm text-gray-500 mb-6">
-        Daily reconciliation exception queue. Compares provider records against the payment ledger.
-      </p>
-      <div className="rounded-2xl border border-amber-200 bg-amber-50 p-6 flex items-center gap-3">
-        <Clock className="h-6 w-6 text-amber-600" />
+      <Link href="/admin/financial" className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-green-primary mb-4">
+        <ArrowLeft className="h-4 w-4" /> Financial Center
+      </Link>
+
+      <div className="flex items-center justify-between mb-4 flex-wrap gap-3">
         <div>
-          <p className="text-sm font-medium text-amber-900">Ships in Phase 2</p>
-          <p className="text-xs text-amber-700">Cron runs at 5pm ET, flags missing webhooks / amount mismatches / duplicates / orphan refunds.</p>
+          <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
+            <AlertTriangle className="h-6 w-6 text-green-primary" /> Reconciliation
+          </h1>
+          <p className="text-sm text-gray-500 mt-1">
+            Runs daily at 5pm ET. Flags stale open invoices, missing webhook events, and duplicate payments.
+          </p>
         </div>
+        <button
+          onClick={runNow}
+          disabled={running}
+          className="inline-flex items-center gap-1.5 rounded-xl bg-green-primary hover:bg-green-hover px-4 py-2.5 text-sm font-semibold text-white cursor-pointer disabled:opacity-50"
+        >
+          {running ? <Loader2 className="h-4 w-4 animate-spin" /> : <Play className="h-4 w-4" />}
+          Run Now
+        </button>
+      </div>
+
+      {message && (
+        <div className="mb-4 flex items-start gap-2 rounded-xl border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-700">
+          <CheckCircle2 className="h-4 w-4 mt-0.5 shrink-0" />
+          <span>{message}</span>
+        </div>
+      )}
+      {error && (
+        <div className="mb-4 flex items-start gap-2 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {lastRun && (
+        <div className="mb-4 rounded-xl border border-gray-100 bg-white p-3 text-xs text-gray-700 flex flex-wrap items-center gap-4">
+          <span><strong>Last manual run:</strong> {new Date(lastRun.finished_at).toLocaleString()}</span>
+          <span>Scanned: {lastRun.scanned.crm_payments || 0} payments, {lastRun.scanned.crm_invoices || 0} invoices</span>
+          <span className={lastRun.exceptions_filed > 0 ? "text-red-600 font-semibold" : "text-emerald-700 font-semibold"}>
+            Filed {lastRun.exceptions_filed} exceptions
+          </span>
+        </div>
+      )}
+
+      <div className="mb-4 flex items-center gap-2 flex-wrap">
+        <Filter className="h-4 w-4 text-gray-400" />
+        {STATUS_FILTERS.map((f) => (
+          <button
+            key={f.key}
+            onClick={() => setStatus(f.key)}
+            className={`rounded-lg px-3 py-1.5 text-xs font-medium cursor-pointer ${status === f.key ? "bg-green-100 text-green-700" : "bg-gray-100 text-gray-500 hover:bg-gray-200"}`}
+          >
+            {f.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="rounded-2xl border border-gray-100 bg-white p-5">
+        {loading ? (
+          <div className="flex justify-center py-8"><Loader2 className="h-5 w-5 animate-spin text-green-primary" /></div>
+        ) : items.length === 0 ? (
+          <div className="text-center py-8">
+            <CheckCircle2 className="mx-auto h-10 w-10 text-emerald-400 mb-2" />
+            <p className="text-sm text-gray-500">Nothing to review — the ledger reconciles cleanly.</p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {items.map((x) => (
+              <div key={x.id} className={`rounded-xl border p-4 ${x.resolved_at ? "border-gray-100 bg-gray-50" : "border-amber-200 bg-white"}`}>
+                <div className="flex items-start justify-between gap-3 mb-2 flex-wrap">
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 mb-1 flex-wrap">
+                      <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium capitalize ${TYPE_COLORS[x.type] || "bg-gray-100 text-gray-600"}`}>
+                        {x.type.replace(/_/g, " ")}
+                      </span>
+                      {x.provider && <span className="text-xs text-gray-500 uppercase">{x.provider}</span>}
+                      {x.amount_cents != null && (
+                        <span className="text-xs font-semibold text-gray-700">
+                          ${(Math.abs(Number(x.amount_cents)) / 100).toLocaleString(undefined, { minimumFractionDigits: 2 })}
+                        </span>
+                      )}
+                    </div>
+                    <p className="text-sm text-gray-700">{x.note}</p>
+                    <div className="mt-1 flex items-center gap-3 text-xs text-gray-500 flex-wrap">
+                      <span>Detected {new Date(x.detected_at).toLocaleString()}</span>
+                      {x.provider_ref && <span className="font-mono">{x.provider_ref}</span>}
+                      {x.crm_payment_id && <span>payment {x.crm_payment_id.slice(0, 8)}</span>}
+                      {x.crm_invoice_id && <span>invoice {x.crm_invoice_id.slice(0, 8)}</span>}
+                    </div>
+                  </div>
+                  {!x.resolved_at && (
+                    <div className="flex flex-wrap gap-1.5">
+                      <button
+                        onClick={() => resolve(x.id, "reconciled")}
+                        disabled={saving === x.id}
+                        className="rounded-lg bg-emerald-600 hover:bg-emerald-700 px-3 py-1.5 text-xs font-semibold text-white cursor-pointer disabled:opacity-50"
+                      >
+                        Reconciled
+                      </button>
+                      <button
+                        onClick={() => resolve(x.id, "ignored")}
+                        disabled={saving === x.id}
+                        className="rounded-lg border border-gray-200 hover:bg-gray-50 px-3 py-1.5 text-xs font-medium text-gray-700 cursor-pointer disabled:opacity-50"
+                      >
+                        Ignore
+                      </button>
+                    </div>
+                  )}
+                  {x.resolved_at && (
+                    <div className="text-xs text-gray-500 text-right">
+                      <p className="font-medium capitalize">{x.resolution_action?.replace(/_/g, " ")}</p>
+                      <p>{new Date(x.resolved_at).toLocaleDateString()}</p>
+                    </div>
+                  )}
+                </div>
+                {x.resolution_note && (
+                  <p className="text-xs text-gray-600 bg-gray-50 rounded p-2 mt-1">{x.resolution_note}</p>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/app/admin/financial/refunds/page.tsx
+++ b/src/app/admin/financial/refunds/page.tsx
@@ -1,18 +1,229 @@
-import { Clock } from "lucide-react";
+"use client";
 
-export default function RefundsStub() {
+import { useEffect, useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Loader2, RotateCcw, ArrowLeft, Plus, AlertCircle, CheckCircle2 } from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
+import { REFUND_REASONS, type RefundReasonCode } from "@/lib/refundReasons";
+
+interface Refund {
+  id: string;
+  provider: string;
+  amount_cents: number;
+  status: string;
+  refund_reason: string | null;
+  refunded_at: string | null;
+  created_at: string;
+  refund_of_payment_id: string | null;
+  parent: {
+    id: string;
+    amount_cents: number;
+    buyer_email: string | null;
+    provider: string;
+    method: string | null;
+    paid_at: string | null;
+  } | null;
+}
+
+export default function RefundsPage() {
+  const router = useRouter();
+  const [token, setToken] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [refunds, setRefunds] = useState<Refund[]>([]);
+  const [showForm, setShowForm] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const [form, setForm] = useState({
+    parent_payment_id: "",
+    amount: "",
+    reason_code: "customer_request" as RefundReasonCode,
+    notes: "",
+    is_chargeback: false,
+    provider_refund_id: "",
+  });
+
+  const load = useCallback(async () => {
+    if (!token) return;
+    setLoading(true);
+    const res = await fetch("/api/admin/financial/refunds", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.ok) setRefunds(await res.json());
+    setLoading(false);
+  }, [token]);
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!session?.access_token) { router.push("/login?redirect=/admin/financial/refunds"); return; }
+      setToken(session.access_token);
+    });
+  }, [router]);
+
+  useEffect(() => { load(); }, [load]);
+
+  async function save() {
+    setError(null);
+    setMessage(null);
+    setSaving(true);
+    const res = await fetch("/api/admin/financial/refunds", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({
+        parent_payment_id: form.parent_payment_id.trim(),
+        amount: Number(form.amount),
+        reason_code: form.reason_code,
+        notes: form.notes.trim() || null,
+        is_chargeback: form.is_chargeback,
+        provider_refund_id: form.provider_refund_id.trim() || null,
+      }),
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) setError(body.error || "Failed to record refund");
+    else {
+      setMessage(form.is_chargeback ? "Chargeback recorded" : "Refund recorded");
+      setForm({ parent_payment_id: "", amount: "", reason_code: "customer_request", notes: "", is_chargeback: false, provider_refund_id: "" });
+      setShowForm(false);
+      await load();
+    }
+    setSaving(false);
+  }
+
+  const inputClass = "w-full rounded-xl border border-gray-200 px-3 py-2 text-sm focus:border-green-primary focus:outline-none";
+  const labelClass = "block text-xs font-medium text-gray-600 mb-1";
+
   return (
     <div className="p-6">
-      <h1 className="text-2xl font-bold text-gray-900 mb-2">Refunds &amp; Chargebacks</h1>
-      <p className="text-sm text-gray-500 mb-6">
-        Refund queue + chargeback dispute queue with auto commission reversal.
-      </p>
-      <div className="rounded-2xl border border-amber-200 bg-amber-50 p-6 flex items-center gap-3">
-        <Clock className="h-6 w-6 text-amber-600" />
+      <Link href="/admin/financial" className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-green-primary mb-4">
+        <ArrowLeft className="h-4 w-4" /> Financial Center
+      </Link>
+
+      <div className="flex items-center justify-between mb-4 flex-wrap gap-3">
         <div>
-          <p className="text-sm font-medium text-amber-900">Ships in Phase 2</p>
-          <p className="text-xs text-amber-700">Record a refund → automatically reverses affected commissions + adjusts metrics.</p>
+          <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
+            <RotateCcw className="h-6 w-6 text-green-primary" /> Refunds &amp; Chargebacks
+          </h1>
+          <p className="text-sm text-gray-500 mt-1">
+            Record a refund or chargeback. Parent payment status updates automatically; commission reversal wires in Phase 4.
+          </p>
         </div>
+        <button
+          onClick={() => setShowForm((s) => !s)}
+          className="inline-flex items-center gap-1.5 rounded-xl bg-green-primary hover:bg-green-hover px-4 py-2.5 text-sm font-semibold text-white cursor-pointer"
+        >
+          <Plus className="h-4 w-4" /> Record Refund
+        </button>
+      </div>
+
+      {message && (
+        <div className="mb-4 flex items-start gap-2 rounded-xl border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-700">
+          <CheckCircle2 className="h-4 w-4 mt-0.5 shrink-0" />
+          <span>{message}</span>
+        </div>
+      )}
+      {error && (
+        <div className="mb-4 flex items-start gap-2 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {showForm && (
+        <div className="rounded-2xl border border-gray-100 bg-white p-5 mb-4 space-y-3">
+          <h2 className="text-sm font-semibold text-gray-900">New refund</h2>
+          <div>
+            <label className={labelClass}>Parent payment ID (from Payments list) *</label>
+            <input type="text" value={form.parent_payment_id} onChange={(e) => setForm((f) => ({ ...f, parent_payment_id: e.target.value }))} className={inputClass + " font-mono"} />
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div>
+              <label className={labelClass}>Amount (USD) *</label>
+              <input type="number" min="0" step="0.01" value={form.amount} onChange={(e) => setForm((f) => ({ ...f, amount: e.target.value }))} className={inputClass} />
+            </div>
+            <div>
+              <label className={labelClass}>Reason *</label>
+              <select value={form.reason_code} onChange={(e) => setForm((f) => ({ ...f, reason_code: e.target.value as RefundReasonCode }))} className={inputClass}>
+                {REFUND_REASONS.map((r) => <option key={r.code} value={r.code}>{r.label}</option>)}
+              </select>
+            </div>
+          </div>
+          <div>
+            <label className={labelClass}>Notes (optional)</label>
+            <textarea rows={2} value={form.notes} onChange={(e) => setForm((f) => ({ ...f, notes: e.target.value }))} className={`${inputClass} resize-none`} placeholder="Free-form context for the finance team." />
+          </div>
+          <div>
+            <label className={labelClass}>Provider refund ID (optional)</label>
+            <input type="text" value={form.provider_refund_id} onChange={(e) => setForm((f) => ({ ...f, provider_refund_id: e.target.value }))} className={inputClass + " font-mono"} placeholder="Stripe re_..., QB refund id, etc." />
+          </div>
+          <label className="flex items-center gap-2 text-sm text-gray-700 cursor-pointer">
+            <input type="checkbox" checked={form.is_chargeback} onChange={(e) => setForm((f) => ({ ...f, is_chargeback: e.target.checked }))} className="h-4 w-4 rounded border-gray-300" />
+            This is a chargeback (dispute lost), not a voluntary refund
+          </label>
+          <div className="flex justify-end gap-2 pt-2">
+            <button onClick={() => setShowForm(false)} className="rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 cursor-pointer">
+              Cancel
+            </button>
+            <button
+              onClick={save}
+              disabled={saving || !form.parent_payment_id.trim() || !Number(form.amount)}
+              className="inline-flex items-center gap-2 rounded-xl bg-green-primary hover:bg-green-hover px-6 py-2 text-sm font-semibold text-white cursor-pointer disabled:opacity-50"
+            >
+              {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+              Record {form.is_chargeback ? "Chargeback" : "Refund"}
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className="rounded-2xl border border-gray-100 bg-white p-5">
+        {loading ? (
+          <div className="flex justify-center py-8"><Loader2 className="h-5 w-5 animate-spin text-green-primary" /></div>
+        ) : refunds.length === 0 ? (
+          <p className="text-sm text-gray-500 text-center py-8">No refunds or chargebacks recorded yet.</p>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-xs text-gray-500 border-b border-gray-100">
+                <th className="text-left py-2 px-2 font-medium">Type</th>
+                <th className="text-left py-2 px-2 font-medium">Parent</th>
+                <th className="text-right py-2 px-2 font-medium">Amount</th>
+                <th className="text-left py-2 px-2 font-medium">Reason</th>
+                <th className="text-left py-2 px-2 font-medium">When</th>
+              </tr>
+            </thead>
+            <tbody>
+              {refunds.map((r) => (
+                <tr key={r.id} className="border-b border-gray-50 last:border-b-0">
+                  <td className="py-2 px-2">
+                    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium capitalize ${r.status === "chargeback" ? "bg-red-100 text-red-800" : "bg-blue-50 text-blue-700"}`}>
+                      {r.status.replace(/_/g, " ")}
+                    </span>
+                  </td>
+                  <td className="py-2 px-2 text-xs text-gray-700">
+                    {r.parent ? (
+                      <>
+                        <p className="font-mono text-[10px]">{r.parent.id.slice(0, 8)}…</p>
+                        <p className="text-gray-500">{r.parent.buyer_email || "—"}</p>
+                      </>
+                    ) : "—"}
+                  </td>
+                  <td className="py-2 px-2 text-right font-semibold text-red-700">
+                    ${(Math.abs(Number(r.amount_cents)) / 100).toLocaleString(undefined, { minimumFractionDigits: 2 })}
+                  </td>
+                  <td className="py-2 px-2 text-xs text-gray-700 max-w-xs truncate" title={r.refund_reason || ""}>
+                    {r.refund_reason || "—"}
+                  </td>
+                  <td className="py-2 px-2 text-xs text-gray-500">
+                    {r.refunded_at ? new Date(r.refunded_at).toLocaleDateString() : new Date(r.created_at).toLocaleDateString()}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
       </div>
     </div>
   );

--- a/src/app/api/admin/financial/invoices/route.ts
+++ b/src/app/api/admin/financial/invoices/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+
+/**
+ * GET /api/admin/financial/invoices
+ *   status filter: draft | open | partially_paid | paid | overdue | void | written_off | all
+ *   bucket filter: 0-30 | 31-60 | 61-90 | 90+
+ * Returns aging summary + rows.
+ */
+
+export async function GET(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const { searchParams } = new URL(req.url);
+  const status = searchParams.get("status") || "all";
+  const bucket = searchParams.get("bucket");
+  const limit = Math.min(500, Math.max(1, Number(searchParams.get("limit") || 200)));
+
+  // Aging summary (all invoices with balance)
+  const { data: aging } = await supabaseAdmin
+    .from("invoices")
+    .select("id, total_cents, balance_due_cents, due_date, sent_at, status")
+    .in("status", ["open", "partially_paid", "overdue"])
+    .limit(2000);
+
+  const today = new Date();
+  const summary = {
+    open: { count: 0, balance_cents: 0 },
+    b0_30: { count: 0, balance_cents: 0 },
+    b31_60: { count: 0, balance_cents: 0 },
+    b61_90: { count: 0, balance_cents: 0 },
+    b90_plus: { count: 0, balance_cents: 0 },
+  };
+
+  for (const inv of aging || []) {
+    const bal = Number(inv.balance_due_cents || 0);
+    summary.open.count++;
+    summary.open.balance_cents += bal;
+    const anchor = inv.due_date ? new Date(inv.due_date) : inv.sent_at ? new Date(inv.sent_at) : today;
+    const daysOld = Math.floor((today.getTime() - anchor.getTime()) / (1000 * 60 * 60 * 24));
+    if (daysOld < 30) { summary.b0_30.count++; summary.b0_30.balance_cents += bal; }
+    else if (daysOld < 60) { summary.b31_60.count++; summary.b31_60.balance_cents += bal; }
+    else if (daysOld < 90) { summary.b61_90.count++; summary.b61_90.balance_cents += bal; }
+    else { summary.b90_plus.count++; summary.b90_plus.balance_cents += bal; }
+  }
+
+  // Detail rows
+  let query = supabaseAdmin
+    .from("invoices")
+    .select("*")
+    .order("due_date", { ascending: true, nullsFirst: false })
+    .limit(limit);
+  if (status !== "all") query = query.eq("status", status);
+  const { data: rows, error } = await query;
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  let filtered = rows || [];
+  if (bucket) {
+    filtered = filtered.filter((inv) => {
+      const anchor = inv.due_date ? new Date(inv.due_date) : inv.sent_at ? new Date(inv.sent_at) : today;
+      const daysOld = Math.floor((today.getTime() - anchor.getTime()) / (1000 * 60 * 60 * 24));
+      if (bucket === "0-30") return daysOld < 30;
+      if (bucket === "31-60") return daysOld >= 30 && daysOld < 60;
+      if (bucket === "61-90") return daysOld >= 60 && daysOld < 90;
+      if (bucket === "90+") return daysOld >= 90;
+      return true;
+    });
+  }
+
+  return NextResponse.json({ summary, invoices: filtered });
+}

--- a/src/app/api/admin/financial/reconciliation/route.ts
+++ b/src/app/api/admin/financial/reconciliation/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+import { writeAuditLog } from "@/lib/paymentLedger";
+
+/**
+ * GET /api/admin/financial/reconciliation?status=open|resolved|all
+ *   List reconciliation exceptions.
+ * PATCH /api/admin/financial/reconciliation/[id] is a separate route.
+ */
+
+export async function GET(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const { searchParams } = new URL(req.url);
+  const status = searchParams.get("status") || "open";
+
+  let query = supabaseAdmin
+    .from("payment_reconciliation_exceptions")
+    .select("*")
+    .order("detected_at", { ascending: false })
+    .limit(500);
+  if (status === "open") query = query.is("resolved_at", null);
+  else if (status === "resolved") query = query.not("resolved_at", "is", null);
+
+  const { data, error } = await query;
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json(data || []);
+}
+
+/**
+ * Resolve/dismiss an exception. Called from the queue UI.
+ */
+export async function PATCH(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const body = await req.json().catch(() => ({}));
+  const id = String(body.id || "").trim();
+  if (!id) return NextResponse.json({ error: "id required" }, { status: 400 });
+
+  const action = ["ignored", "reconciled", "refunded", "manual_entry", "other"].includes(body.action)
+    ? body.action
+    : null;
+  if (!action) return NextResponse.json({ error: "invalid action" }, { status: 400 });
+
+  const note = String(body.note || "").trim();
+
+  const now = new Date().toISOString();
+  await supabaseAdmin
+    .from("payment_reconciliation_exceptions")
+    .update({
+      resolved_at: now,
+      resolved_by: adminId,
+      resolution_action: action,
+      resolution_note: note || null,
+    })
+    .eq("id", id);
+
+  await writeAuditLog({
+    actorId: adminId,
+    action: "reconciliation_exception_resolved",
+    entityType: "reconciliation_exception",
+    entityId: id,
+    metadata: { resolution_action: action, note },
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/admin/financial/refunds/route.ts
+++ b/src/app/api/admin/financial/refunds/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+import { recordRefund, writeAuditLog } from "@/lib/paymentLedger";
+import { isValidRefundReason } from "@/lib/refundReasons";
+
+/**
+ * GET /api/admin/financial/refunds — list refund + chargeback rows
+ *   (negative-amount payments) plus their parent payment info.
+ * POST — admin records a refund against a parent payment.
+ *
+ * Refunds recorded here are additive to the ledger:
+ *   - Parent payment moves paid → partial_refund / refunded / chargeback
+ *   - A negative-amount payment row is created linked via refund_of_payment_id
+ *   - Invoice totals are recomputed
+ *   - Once Phase 4 lands, affected commission rows will auto-reverse via the
+ *     refund_of_payment_id trace.
+ */
+
+export async function GET(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const { data, error } = await supabaseAdmin
+    .from("payments")
+    .select("*, parent:refund_of_payment_id(id, amount_cents, buyer_email, provider, method, paid_at)")
+    .in("status", ["refunded", "partial_refund", "chargeback"])
+    .order("refunded_at", { ascending: false, nullsFirst: false })
+    .limit(200);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json(data || []);
+}
+
+export async function POST(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const body = await req.json().catch(() => ({}));
+  const parentPaymentId = String(body.parent_payment_id || "").trim();
+  const amount = Number(body.amount);
+  const reasonCode = String(body.reason_code || "").trim();
+  const notes = String(body.notes || "").trim();
+  const isChargeback = body.is_chargeback === true;
+
+  if (!parentPaymentId) return NextResponse.json({ error: "parent_payment_id is required" }, { status: 400 });
+  if (!Number.isFinite(amount) || amount <= 0) return NextResponse.json({ error: "amount must be > 0 (in dollars)" }, { status: 400 });
+  if (!isValidRefundReason(reasonCode)) return NextResponse.json({ error: "invalid reason_code" }, { status: 400 });
+
+  // Load parent to validate it's refundable and get provider info
+  const { data: parent } = await supabaseAdmin
+    .from("payments")
+    .select("id, provider, status, amount_cents, buyer_email, invoice_id, order_id, agreement_id")
+    .eq("id", parentPaymentId)
+    .maybeSingle();
+  if (!parent) return NextResponse.json({ error: "parent payment not found" }, { status: 404 });
+  if (!["paid", "partial_refund"].includes(parent.status)) {
+    return NextResponse.json({ error: `parent payment status is ${parent.status} — must be paid or partial_refund to record a refund` }, { status: 400 });
+  }
+  if (Math.round(amount * 100) > Number(parent.amount_cents)) {
+    return NextResponse.json({ error: "refund amount exceeds parent payment amount" }, { status: 400 });
+  }
+
+  const refund = await recordRefund({
+    parentPaymentId: parent.id,
+    provider: parent.provider as "stripe" | "quickbooks" | "paypal" | "manual",
+    providerRefundId: typeof body.provider_refund_id === "string" ? body.provider_refund_id : null,
+    amountCents: Math.round(amount * 100),
+    reason: notes ? `${reasonCode}: ${notes}` : reasonCode,
+    isChargeback,
+    createdBy: adminId,
+  });
+
+  await writeAuditLog({
+    actorId: adminId,
+    action: isChargeback ? "chargeback_recorded" : "refund_recorded",
+    entityType: "payment",
+    entityId: parent.id,
+    reason: reasonCode,
+    metadata: {
+      amount,
+      is_chargeback: isChargeback,
+      reason_code: reasonCode,
+      notes,
+      refund_payment_id: refund?.id,
+      provider_refund_id: body.provider_refund_id || null,
+    },
+  });
+
+  return NextResponse.json({ ok: true, refund });
+}

--- a/src/app/api/cron/reconciliation/route.ts
+++ b/src/app/api/cron/reconciliation/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server";
+import { runReconciliation } from "@/lib/paymentReconciliation";
+import { writeAuditLog } from "@/lib/paymentLedger";
+
+/**
+ * Daily Vercel Cron entry point. Wired at 22:00 UTC (5pm ET) in vercel.json.
+ * Also accepts admin-token calls so we can trigger from the reconciliation UI.
+ *
+ * Auth:
+ *   - Vercel Cron sends a "authorization: Bearer $CRON_SECRET" header. We
+ *     accept that when CRON_SECRET is configured.
+ *   - Otherwise falls back to admin auth (the /admin/financial/reconciliation
+ *     page calls this endpoint with an admin's session token).
+ */
+
+function isCronAuthorized(req: NextRequest): boolean {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) return false;
+  const auth = req.headers.get("authorization") || "";
+  return auth === `Bearer ${secret}`;
+}
+
+async function isAdminAuthorized(req: NextRequest): Promise<boolean> {
+  const { getAdminUserId } = await import("@/lib/adminAuth");
+  const adminId = await getAdminUserId(req);
+  return !!adminId;
+}
+
+async function handle(req: NextRequest): Promise<NextResponse> {
+  const cronOk = isCronAuthorized(req);
+  const adminOk = cronOk ? true : await isAdminAuthorized(req);
+  if (!cronOk && !adminOk) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const summary = await runReconciliation();
+
+  await writeAuditLog({
+    actorId: null,
+    action: cronOk ? "reconciliation_cron_ran" : "reconciliation_manual_ran",
+    entityType: "system",
+    metadata: summary as unknown as Record<string, unknown>,
+  });
+
+  return NextResponse.json(summary);
+}
+
+// Vercel Cron dispatches GET requests
+export async function GET(req: NextRequest) { return handle(req); }
+// UI "Run now" button uses POST
+export async function POST(req: NextRequest) { return handle(req); }

--- a/src/app/api/cron/reminders/route.ts
+++ b/src/app/api/cron/reminders/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server";
+import { runPaymentReminders } from "@/lib/paymentReminders";
+import { writeAuditLog } from "@/lib/paymentLedger";
+
+/**
+ * Hourly Vercel Cron entry point for invoice reminder emails.
+ * Wired in vercel.json. Auth via CRON_SECRET (same as reconciliation).
+ */
+
+function isCronAuthorized(req: NextRequest): boolean {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) return false;
+  const auth = req.headers.get("authorization") || "";
+  return auth === `Bearer ${secret}`;
+}
+
+async function isAdminAuthorized(req: NextRequest): Promise<boolean> {
+  const { getAdminUserId } = await import("@/lib/adminAuth");
+  const adminId = await getAdminUserId(req);
+  return !!adminId;
+}
+
+async function handle(req: NextRequest): Promise<NextResponse> {
+  const cronOk = isCronAuthorized(req);
+  const adminOk = cronOk ? true : await isAdminAuthorized(req);
+  if (!cronOk && !adminOk) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const summary = await runPaymentReminders();
+
+  await writeAuditLog({
+    actorId: null,
+    action: cronOk ? "reminders_cron_ran" : "reminders_manual_ran",
+    entityType: "system",
+    metadata: summary as unknown as Record<string, unknown>,
+  });
+
+  return NextResponse.json(summary);
+}
+
+export async function GET(req: NextRequest) { return handle(req); }
+export async function POST(req: NextRequest) { return handle(req); }

--- a/src/lib/paymentIngest.ts
+++ b/src/lib/paymentIngest.ts
@@ -11,7 +11,7 @@
 import type Stripe from "stripe";
 import { supabaseAdmin } from "./supabaseAdmin";
 import { getConnection } from "./quickbooks";
-import { upsertInvoice, upsertPayment } from "./paymentLedger";
+import { upsertInvoice, upsertPayment, recordRefund } from "./paymentLedger";
 
 function toCents(amount: number | string | null | undefined): number {
   if (amount == null) return 0;
@@ -114,20 +114,122 @@ export async function ingestStripeEvent(event: Stripe.Event, eventRowId: string)
   }
 
   if (t === "charge.refunded") {
-    // Chargeback + refund handling lives in the Phase 2 refund flow — for
-    // now, just capture that the event happened by writing a payment row
-    // with the refund status. The existing handlers don't touch this.
     const charge = event.data.object as Stripe.Charge;
     const parentIntentId = typeof charge.payment_intent === "string" ? charge.payment_intent : charge.payment_intent?.id;
     if (!parentIntentId) return;
     const { data: parent } = await supabaseAdmin
       .from("payments")
-      .select("id")
+      .select("id, amount_cents, refund_of_payment_id")
       .eq("provider", "stripe")
       .eq("provider_payment_id", parentIntentId)
       .maybeSingle();
     if (!parent) return;
-    // Delegated to Phase 2 UI/refund route — noop for now.
+
+    // Iterate the actual refund objects on the charge — Stripe fires this
+    // event once per new/updated refund. We upsert each by providerRefundId
+    // via recordRefund's parent update logic (idempotent per event).
+    for (const refund of charge.refunds?.data || []) {
+      const alreadyRecorded = await supabaseAdmin
+        .from("payments")
+        .select("id")
+        .eq("provider", "stripe")
+        .eq("provider_payment_id", refund.id)
+        .maybeSingle();
+      if (alreadyRecorded.data) continue;
+
+      await recordRefund({
+        parentPaymentId: parent.id,
+        provider: "stripe",
+        providerRefundId: refund.id,
+        eventId: eventRowId,
+        amountCents: refund.amount,
+        reason: refund.reason || "webhook_refund",
+      });
+    }
+    return;
+  }
+
+  if (t === "charge.dispute.created") {
+    const dispute = event.data.object as Stripe.Dispute;
+    const chargeId = typeof dispute.charge === "string" ? dispute.charge : dispute.charge?.id;
+    if (!chargeId) return;
+    const { data: parent } = await supabaseAdmin
+      .from("payments")
+      .select("id, status")
+      .eq("provider", "stripe")
+      .eq("provider_charge_id", chargeId)
+      .maybeSingle();
+    if (!parent) return;
+    // Flip to disputed without recording a negative-amount row yet — that
+    // happens if the dispute is lost (closed status = 'lost').
+    await supabaseAdmin
+      .from("payments")
+      .update({ status: "disputed", disputed_at: new Date().toISOString() })
+      .eq("id", parent.id);
+    await supabaseAdmin.from("payment_status_history").insert({
+      payment_id: parent.id,
+      from_status: parent.status,
+      to_status: "disputed",
+      event_id: eventRowId,
+      reason: `Stripe dispute opened: ${dispute.reason || "unknown"}`,
+    });
+    return;
+  }
+
+  if (t === "charge.dispute.closed") {
+    const dispute = event.data.object as Stripe.Dispute;
+    const chargeId = typeof dispute.charge === "string" ? dispute.charge : dispute.charge?.id;
+    if (!chargeId) return;
+    const { data: parent } = await supabaseAdmin
+      .from("payments")
+      .select("id, status, amount_cents")
+      .eq("provider", "stripe")
+      .eq("provider_charge_id", chargeId)
+      .maybeSingle();
+    if (!parent) return;
+
+    if (dispute.status === "lost") {
+      // Merchant lost — treat as chargeback: negative-amount row + parent
+      // status flips to chargeback (paid → chargeback via recordRefund).
+      await recordRefund({
+        parentPaymentId: parent.id,
+        provider: "stripe",
+        providerRefundId: `dispute-${dispute.id}`,
+        eventId: eventRowId,
+        amountCents: dispute.amount,
+        reason: `chargeback_lost: ${dispute.reason || ""}`,
+        isChargeback: true,
+      });
+    } else if (dispute.status === "won" || dispute.status === "warning_closed") {
+      // Merchant won — return the parent to paid so metrics recover.
+      await supabaseAdmin
+        .from("payments")
+        .update({ status: "paid", disputed_at: null })
+        .eq("id", parent.id);
+      await supabaseAdmin.from("payment_status_history").insert({
+        payment_id: parent.id,
+        from_status: parent.status,
+        to_status: "paid",
+        event_id: eventRowId,
+        reason: `Stripe dispute closed as ${dispute.status}`,
+      });
+    }
+    return;
+  }
+
+  if (t === "payment_intent.payment_failed") {
+    const pi = event.data.object as Stripe.PaymentIntent;
+    await upsertPayment({
+      provider: "stripe",
+      providerPaymentId: pi.id,
+      eventId: eventRowId,
+      buyerEmail: pi.receipt_email || null,
+      amountCents: pi.amount || 0,
+      method: pi.payment_method_types?.[0] || null,
+      status: "failed",
+      failedAt: new Date().toISOString(),
+      failedReason: pi.last_payment_error?.message || pi.last_payment_error?.code || "unknown",
+    });
     return;
   }
 }

--- a/src/lib/paymentReconciliation.ts
+++ b/src/lib/paymentReconciliation.ts
@@ -1,0 +1,221 @@
+/**
+ * Daily reconciliation — walks the last 30 days of provider records and files
+ * an exception for anything that doesn't match the CRM payment ledger.
+ *
+ * We keep this deliberately conservative: only "we have proof of a diff" flags
+ * an exception. False negatives are safer than false positives here — a real
+ * duplicate/missing/mismatch will show up in multiple daily runs anyway.
+ */
+
+import { supabaseAdmin } from "./supabaseAdmin";
+
+const WINDOW_DAYS = 30;
+
+export interface ReconciliationRun {
+  started_at: string;
+  finished_at: string;
+  windows: {
+    from: string;
+    to: string;
+  };
+  scanned: {
+    stripe_charges: number;
+    qb_payments: number;
+    crm_payments: number;
+    crm_invoices: number;
+  };
+  exceptions_filed: number;
+  errors: string[];
+}
+
+function daysAgoIso(days: number): string {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+async function fileException(row: {
+  type: "missing_webhook" | "missing_provider" | "amount_mismatch" | "duplicate_payment" | "orphan_refund" | "wrong_invoice_link" | "stale_open_invoice" | "other";
+  provider?: string | null;
+  provider_ref?: string | null;
+  crm_payment_id?: string | null;
+  crm_invoice_id?: string | null;
+  amount_cents?: number | null;
+  note: string;
+}) {
+  // Dedup: don't file another exception for the same (type, provider,
+  // provider_ref) if there's already an unresolved one.
+  const query = supabaseAdmin
+    .from("payment_reconciliation_exceptions")
+    .select("id")
+    .eq("type", row.type)
+    .is("resolved_at", null);
+  if (row.provider) query.eq("provider", row.provider);
+  if (row.provider_ref) query.eq("provider_ref", row.provider_ref);
+  const { data: existing } = await query.limit(1).maybeSingle();
+  if (existing) return false;
+
+  await supabaseAdmin.from("payment_reconciliation_exceptions").insert(row);
+  return true;
+}
+
+/**
+ * Sweep 1: stale open invoices past due_date.
+ * Runs against our own DB — no provider round-trip needed.
+ */
+async function sweepStaleOpenInvoices(): Promise<number> {
+  const today = new Date().toISOString().slice(0, 10);
+  const { data } = await supabaseAdmin
+    .from("invoices")
+    .select("id, provider, provider_invoice_id, due_date, total_cents, balance_due_cents, status")
+    .in("status", ["open", "partially_paid"])
+    .lt("due_date", today)
+    .limit(500);
+
+  let filed = 0;
+  for (const inv of data || []) {
+    // Mark overdue if not already
+    if (inv.status !== "overdue") {
+      await supabaseAdmin
+        .from("invoices")
+        .update({ status: "overdue" })
+        .eq("id", inv.id);
+      await supabaseAdmin.from("payment_status_history").insert({
+        invoice_id: inv.id,
+        from_status: inv.status,
+        to_status: "overdue",
+        reason: "reconciliation: past due_date",
+      });
+    }
+
+    // File exception only if it's been overdue for more than 7 days
+    const overdueSevenPlus = inv.due_date && (Date.now() - new Date(inv.due_date).getTime()) > 7 * 24 * 60 * 60 * 1000;
+    if (overdueSevenPlus) {
+      const ok = await fileException({
+        type: "stale_open_invoice",
+        provider: inv.provider,
+        provider_ref: inv.provider_invoice_id,
+        crm_invoice_id: inv.id,
+        amount_cents: inv.balance_due_cents,
+        note: `Invoice past due since ${inv.due_date} with balance $${(Number(inv.balance_due_cents) / 100).toFixed(2)}.`,
+      });
+      if (ok) filed++;
+    }
+  }
+  return filed;
+}
+
+/**
+ * Sweep 2: CRM payments in the last 30 days with no corresponding provider
+ * event log entry.
+ *
+ * Uses payment_events as the source of truth for "did we see a webhook".
+ * Manual entries are exempt (they have provider='manual' and no event log
+ * row is expected).
+ */
+async function sweepMissingProviderEvents(): Promise<number> {
+  const cutoff = daysAgoIso(WINDOW_DAYS);
+  const { data } = await supabaseAdmin
+    .from("payments")
+    .select("id, provider, provider_payment_id, amount_cents, event_id, created_at")
+    .in("provider", ["stripe", "quickbooks", "paypal"])
+    .in("status", ["paid", "partial_refund", "refunded", "chargeback"])
+    .gte("created_at", cutoff)
+    .is("event_id", null)
+    .limit(500);
+
+  let filed = 0;
+  for (const p of data || []) {
+    // Manual entries can legitimately have no event_id — they're recorded by
+    // the admin. Anything else is suspicious.
+    const ok = await fileException({
+      type: "missing_webhook",
+      provider: p.provider,
+      provider_ref: p.provider_payment_id,
+      crm_payment_id: p.id,
+      amount_cents: p.amount_cents,
+      note: `Payment recorded without a linked provider event. Was the webhook delivered?`,
+    });
+    if (ok) filed++;
+  }
+  return filed;
+}
+
+/**
+ * Sweep 3: duplicate payments in the last 30 days.
+ * Groups by (provider, provider_payment_id) and flags any group with count > 1.
+ * The UNIQUE constraint on payments (provider, provider_payment_id) should
+ * make this impossible, but nulls in provider_payment_id (manual entries)
+ * can still stack.
+ */
+async function sweepDuplicatePayments(): Promise<number> {
+  const cutoff = daysAgoIso(WINDOW_DAYS);
+  const { data } = await supabaseAdmin
+    .from("payments")
+    .select("id, provider, provider_payment_id, amount_cents, order_id, buyer_email")
+    .in("status", ["paid", "partial_refund"])
+    .gte("created_at", cutoff)
+    .limit(1000);
+
+  // Group by (buyer_email, amount_cents, order_id) — manual entry duplicates
+  // usually share those three even without provider_payment_id.
+  const groups = new Map<string, typeof data>();
+  for (const p of data || []) {
+    const key = `${p.buyer_email || ""}|${p.amount_cents}|${p.order_id || ""}`;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key)!.push(p);
+  }
+
+  let filed = 0;
+  for (const [, group] of groups) {
+    if (!group || group.length < 2) continue;
+    // File one exception per group (dedup only flags the first) — points to
+    // both payment ids in the note.
+    const ok = await fileException({
+      type: "duplicate_payment",
+      crm_payment_id: group[0].id,
+      amount_cents: group[0].amount_cents,
+      note: `Duplicate candidate: ${group.length} payments for ${group[0].buyer_email || "(unknown buyer)"} with same amount + order. Payment IDs: ${group.map((g) => g.id.slice(0, 8)).join(", ")}`,
+    });
+    if (ok) filed++;
+  }
+  return filed;
+}
+
+export async function runReconciliation(): Promise<ReconciliationRun> {
+  const started = new Date().toISOString();
+  const errors: string[] = [];
+  const scanned = { stripe_charges: 0, qb_payments: 0, crm_payments: 0, crm_invoices: 0 };
+  let filed = 0;
+
+  try {
+    filed += await sweepStaleOpenInvoices();
+  } catch (e) {
+    errors.push(`stale_open_invoices: ${e instanceof Error ? e.message : String(e)}`);
+  }
+  try {
+    filed += await sweepMissingProviderEvents();
+  } catch (e) {
+    errors.push(`missing_provider_events: ${e instanceof Error ? e.message : String(e)}`);
+  }
+  try {
+    filed += await sweepDuplicatePayments();
+  } catch (e) {
+    errors.push(`duplicate_payments: ${e instanceof Error ? e.message : String(e)}`);
+  }
+
+  // Count scan totals
+  const [{ count: crmPayments }, { count: crmInvoices }] = await Promise.all([
+    supabaseAdmin.from("payments").select("*", { count: "exact", head: true }).gte("created_at", daysAgoIso(WINDOW_DAYS)),
+    supabaseAdmin.from("invoices").select("*", { count: "exact", head: true }).gte("created_at", daysAgoIso(WINDOW_DAYS)),
+  ]);
+  scanned.crm_payments = crmPayments || 0;
+  scanned.crm_invoices = crmInvoices || 0;
+
+  return {
+    started_at: started,
+    finished_at: new Date().toISOString(),
+    windows: { from: daysAgoIso(WINDOW_DAYS), to: new Date().toISOString() },
+    scanned,
+    exceptions_filed: filed,
+    errors,
+  };
+}

--- a/src/lib/paymentReminders.ts
+++ b/src/lib/paymentReminders.ts
@@ -1,0 +1,211 @@
+/**
+ * Payment reminder engine — walks open + partially_paid + overdue invoices
+ * and figures out the next reminder stage to send. Idempotent per invoice per
+ * stage — we track `last_reminder_stage` + `last_reminder_at` and never
+ * repeat a stage.
+ *
+ * Stages, keyed off invoice.due_date (or invoice.sent_at as fallback):
+ *   sent              — 0 hours after invoice send confirmation
+ *   pre_due_3         — 3 days before due date
+ *   due_today         — day of due date
+ *   overdue_3         — 3 days past due
+ *   overdue_7         — 7 days past due
+ *   admin_escalation  — 14 days past due
+ *
+ * A single hourly cron pass runs this. Each stage's guard requires the
+ * previous stage to have fired (so a fresh invoice doesn't jump straight to
+ * overdue_7 if it was inserted late).
+ */
+
+import { Resend } from "resend";
+import { supabaseAdmin } from "./supabaseAdmin";
+import { writeAuditLog } from "./paymentLedger";
+
+const FROM_EMAIL = process.env.FROM_EMAIL || "receipts@bytebitevending.com";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://vendingconnector.com";
+const ADMIN_ESCALATION_EMAIL = process.env.MARKETPLACE_ADMIN_NOTIFICATIONS_EMAIL || "james@apexaivending.com";
+
+type Stage = "sent" | "pre_due_3" | "due_today" | "overdue_3" | "overdue_7" | "admin_escalation";
+
+interface InvoiceRow {
+  id: string;
+  buyer_email: string | null;
+  buyer_name: string | null;
+  total_cents: number;
+  balance_due_cents: number;
+  currency: string;
+  due_date: string | null;
+  sent_at: string | null;
+  status: string;
+  provider: string;
+  provider_invoice_url: string | null;
+  memo: string | null;
+  last_reminder_stage: string | null;
+  last_reminder_at: string | null;
+}
+
+function daysBetween(a: Date, b: Date): number {
+  return Math.floor((b.getTime() - a.getTime()) / (1000 * 60 * 60 * 24));
+}
+
+/**
+ * Decide the next stage for an invoice, or null if nothing to send now.
+ */
+export function nextStageFor(inv: InvoiceRow, now: Date): Stage | null {
+  const due = inv.due_date ? new Date(inv.due_date) : null;
+  const sent = inv.sent_at ? new Date(inv.sent_at) : null;
+  const anchor = due || sent;
+  if (!anchor) return null;
+  const daysToDue = due ? daysBetween(now, due) : null; // positive = future
+  const daysPastDue = due ? -daysBetween(now, due) : null;
+
+  const already = new Set<string>();
+  if (inv.last_reminder_stage) already.add(inv.last_reminder_stage);
+
+  // Stages fire in order — each one requires the previous to have fired
+  // (or the previous stage's window to have passed).
+  if (!already.has("sent") && sent) return "sent";
+  if (!already.has("pre_due_3") && daysToDue !== null && daysToDue <= 3 && daysToDue > 0) return "pre_due_3";
+  if (!already.has("due_today") && daysToDue !== null && daysToDue <= 0 && daysPastDue !== null && daysPastDue <= 0) return "due_today";
+  if (!already.has("overdue_3") && daysPastDue !== null && daysPastDue >= 3 && daysPastDue < 7) return "overdue_3";
+  if (!already.has("overdue_7") && daysPastDue !== null && daysPastDue >= 7 && daysPastDue < 14) return "overdue_7";
+  if (!already.has("admin_escalation") && daysPastDue !== null && daysPastDue >= 14) return "admin_escalation";
+
+  return null;
+}
+
+function renderShell({ heading, intro, cta, invoice, footer }: { heading: string; intro: string; cta?: { label: string; href: string }; invoice: InvoiceRow; footer?: string }): string {
+  const balance = (Number(invoice.balance_due_cents) / 100).toLocaleString(undefined, { style: "currency", currency: invoice.currency || "USD" });
+  const total = (Number(invoice.total_cents) / 100).toLocaleString(undefined, { style: "currency", currency: invoice.currency || "USD" });
+  return `<div style="max-width:560px;margin:0 auto;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:40px 24px;color:#111827;">
+  <div style="text-align:center;margin-bottom:24px;"><h1 style="color:#16a34a;font-size:22px;margin:0;">Vending Connector</h1></div>
+  <h2 style="font-size:18px;margin:0 0 12px;">${heading}</h2>
+  <p style="font-size:14px;color:#374151;line-height:1.6;">${intro}</p>
+  <table style="width:100%;border-collapse:collapse;margin:16px 0;">
+    <tr><td style="padding:6px 8px;border:1px solid #e5e7eb;color:#6b7280;font-size:12px;">Total</td><td style="padding:6px 8px;border:1px solid #e5e7eb;font-size:12px;text-align:right;">${total}</td></tr>
+    <tr><td style="padding:6px 8px;border:1px solid #e5e7eb;color:#6b7280;font-size:12px;">Balance due</td><td style="padding:6px 8px;border:1px solid #e5e7eb;font-size:12px;text-align:right;font-weight:600;color:${invoice.balance_due_cents > 0 ? "#dc2626" : "#16a34a"};">${balance}</td></tr>
+    ${invoice.due_date ? `<tr><td style="padding:6px 8px;border:1px solid #e5e7eb;color:#6b7280;font-size:12px;">Due date</td><td style="padding:6px 8px;border:1px solid #e5e7eb;font-size:12px;text-align:right;">${new Date(invoice.due_date).toLocaleDateString()}</td></tr>` : ""}
+  </table>
+  ${cta ? `<div style="text-align:center;margin:24px 0;"><a href="${cta.href}" style="display:inline-block;background:#16a34a;color:#fff;padding:12px 28px;border-radius:8px;text-decoration:none;font-weight:600;font-size:14px;">${cta.label}</a></div>` : ""}
+  ${footer ? `<p style="font-size:12px;color:#9ca3af;margin-top:16px;">${footer}</p>` : ""}
+</div>`;
+}
+
+function stageContent(stage: Stage, inv: InvoiceRow): { subject: string; heading: string; intro: string; recipient: string; cta?: { label: string; href: string } } {
+  const payLink = inv.provider_invoice_url || `${SITE_URL}/account/invoices`;
+  const cta = { label: "Pay invoice", href: payLink };
+  switch (stage) {
+    case "sent":
+      return {
+        subject: "Your invoice from Vending Connector",
+        heading: "Your invoice is ready",
+        intro: "Thanks for your business. You can review and pay at your convenience using the button below.",
+        recipient: inv.buyer_email || "",
+        cta,
+      };
+    case "pre_due_3":
+      return {
+        subject: "Reminder: invoice due in 3 days",
+        heading: "Reminder — payment due soon",
+        intro: "A friendly reminder that your invoice is due in 3 days.",
+        recipient: inv.buyer_email || "",
+        cta,
+      };
+    case "due_today":
+      return {
+        subject: "Reminder: invoice due today",
+        heading: "Reminder — payment due today",
+        intro: "Your invoice is due today. Please complete payment when convenient.",
+        recipient: inv.buyer_email || "",
+        cta,
+      };
+    case "overdue_3":
+      return {
+        subject: "Past due: invoice 3 days overdue",
+        heading: "Your invoice is now past due",
+        intro: "We haven't received payment yet. Please pay as soon as possible to avoid interruptions.",
+        recipient: inv.buyer_email || "",
+        cta,
+      };
+    case "overdue_7":
+      return {
+        subject: "Past due: invoice 7 days overdue",
+        heading: "Invoice significantly past due",
+        intro: "Your invoice is now more than 7 days past due. Please pay immediately, or reply to this email to discuss.",
+        recipient: inv.buyer_email || "",
+        cta,
+      };
+    case "admin_escalation":
+      return {
+        subject: `Admin escalation: invoice past due 14+ days (${inv.buyer_email || "(no email)"})`,
+        heading: "Invoice escalation",
+        intro: `Invoice ${inv.id.slice(0, 8)} for ${inv.buyer_email || "(no email)"} is past due by 14+ days with balance ${(Number(inv.balance_due_cents) / 100).toLocaleString()}. Human follow-up needed.`,
+        recipient: ADMIN_ESCALATION_EMAIL,
+      };
+  }
+}
+
+export interface ReminderRun {
+  scanned: number;
+  sent: number;
+  skipped_no_email: number;
+  errors: string[];
+}
+
+export async function runPaymentReminders(): Promise<ReminderRun> {
+  const summary: ReminderRun = { scanned: 0, sent: 0, skipped_no_email: 0, errors: [] };
+  const resendKey = process.env.RESEND_API_KEY;
+  if (!resendKey) {
+    summary.errors.push("RESEND_API_KEY not configured");
+    return summary;
+  }
+  const resend = new Resend(resendKey);
+  const now = new Date();
+
+  const { data: invoices } = await supabaseAdmin
+    .from("invoices")
+    .select("id, buyer_email, buyer_name, total_cents, balance_due_cents, currency, due_date, sent_at, status, provider, provider_invoice_url, memo, last_reminder_stage, last_reminder_at")
+    .in("status", ["open", "partially_paid", "overdue"])
+    .gt("balance_due_cents", 0)
+    .limit(500);
+
+  for (const inv of (invoices || []) as InvoiceRow[]) {
+    summary.scanned++;
+    const stage = nextStageFor(inv, now);
+    if (!stage) continue;
+    const content = stageContent(stage, inv);
+    if (!content.recipient) {
+      summary.skipped_no_email++;
+      continue;
+    }
+    const html = renderShell({ heading: content.heading, intro: content.intro, cta: content.cta, invoice: inv });
+
+    try {
+      await resend.emails.send({
+        from: FROM_EMAIL,
+        to: content.recipient,
+        subject: content.subject,
+        html,
+      });
+      await supabaseAdmin
+        .from("invoices")
+        .update({
+          last_reminder_stage: stage,
+          last_reminder_at: now.toISOString(),
+        })
+        .eq("id", inv.id);
+      await writeAuditLog({
+        actorId: null,
+        action: "invoice_reminder_sent",
+        entityType: "invoice",
+        entityId: inv.id,
+        metadata: { stage, recipient: content.recipient },
+      });
+      summary.sent++;
+    } catch (e) {
+      summary.errors.push(`${inv.id.slice(0, 8)}: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  return summary;
+}

--- a/src/lib/refundReasons.ts
+++ b/src/lib/refundReasons.ts
@@ -1,0 +1,20 @@
+/**
+ * Structured refund reason codes — one hardcoded list keeps reporting clean,
+ * a free-text "notes" field on the payment captures the rest.
+ */
+
+export const REFUND_REASONS = [
+  { code: "customer_request", label: "Customer request" },
+  { code: "duplicate_payment", label: "Duplicate payment" },
+  { code: "service_not_delivered", label: "Service not delivered" },
+  { code: "fraud", label: "Fraud" },
+  { code: "chargeback_response", label: "Chargeback response" },
+  { code: "admin_correction", label: "Admin correction" },
+  { code: "other", label: "Other" },
+] as const;
+
+export type RefundReasonCode = (typeof REFUND_REASONS)[number]["code"];
+
+export function isValidRefundReason(code: unknown): code is RefundReasonCode {
+  return typeof code === "string" && REFUND_REASONS.some((r) => r.code === code);
+}

--- a/supabase/migrations/106_financial_spine_phase2.sql
+++ b/supabase/migrations/106_financial_spine_phase2.sql
@@ -1,0 +1,58 @@
+-- Financial spine — Phase 2: reconciliation exceptions + reminder tracking.
+--
+-- Adds two small additive tables — no changes to Phase 1 tables. Once these
+-- exist, the daily reconciliation cron can file discrepancies and the hourly
+-- reminder cron can track when each invoice was last poked so we don't
+-- double-email.
+
+CREATE TABLE IF NOT EXISTS payment_reconciliation_exceptions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- Bucket for the queue view
+  type text NOT NULL CHECK (type IN (
+    'missing_webhook',       -- provider says paid, we have no payment row
+    'missing_provider',      -- we have payment row, provider has no matching record
+    'amount_mismatch',       -- provider amount != CRM payment amount
+    'duplicate_payment',     -- two payment rows for same provider_payment_id
+    'orphan_refund',         -- refund exists at provider, we haven't recorded it
+    'wrong_invoice_link',    -- payment linked to invoice we can't verify
+    'stale_open_invoice',    -- invoice open past due_date with no payment activity
+    'other'
+  )),
+
+  provider text,             -- 'stripe' | 'quickbooks' | 'paypal' | null
+  provider_ref text,         -- provider payment_id / invoice_id / event_id
+  crm_payment_id uuid REFERENCES payments(id) ON DELETE SET NULL,
+  crm_invoice_id uuid REFERENCES invoices(id) ON DELETE SET NULL,
+  amount_cents bigint,       -- expected or observed amount in the failure
+
+  note text NOT NULL,
+  detected_at timestamptz DEFAULT now(),
+
+  resolved_at timestamptz,
+  resolved_by uuid REFERENCES profiles(id),
+  resolution_note text,
+  resolution_action text     -- 'ignored' | 'reconciled' | 'refunded' | 'manual_entry' | 'other'
+);
+
+CREATE INDEX IF NOT EXISTS idx_recon_unresolved ON payment_reconciliation_exceptions(detected_at DESC) WHERE resolved_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_recon_type ON payment_reconciliation_exceptions(type, detected_at DESC);
+CREATE INDEX IF NOT EXISTS idx_recon_provider_ref ON payment_reconciliation_exceptions(provider, provider_ref);
+
+-- Track when each invoice was last poked by the reminder cron so we don't
+-- send the same reminder in two consecutive runs (belt+suspenders — audit
+-- log dedup also protects us).
+ALTER TABLE invoices
+  ADD COLUMN IF NOT EXISTS last_reminder_stage text,   -- 'sent' | 'pre_due_3' | 'due_today' | 'overdue_3' | 'overdue_7' | 'admin_escalation'
+  ADD COLUMN IF NOT EXISTS last_reminder_at timestamptz;
+
+-- Refunds carry a structured reason so we can slice the queue later. Notes
+-- stay free-form on payments.refund_reason (added in migration 105).
+-- We keep this as a soft constraint via API — no CHECK here so admin can add
+-- new reasons without a schema change if the seven below don't cover a case.
+
+-- RLS
+ALTER TABLE payment_reconciliation_exceptions ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "Service role only" ON payment_reconciliation_exceptions;
+CREATE POLICY "Service role only" ON payment_reconciliation_exceptions
+  FOR ALL TO service_role USING (true) WITH CHECK (true);

--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,14 @@
     {
       "path": "/api/cron/verification-reminders",
       "schedule": "0 * * * *"
+    },
+    {
+      "path": "/api/cron/reconciliation",
+      "schedule": "0 22 * * *"
+    },
+    {
+      "path": "/api/cron/reminders",
+      "schedule": "0 * * * *"
     }
   ]
 }


### PR DESCRIPTION
…g, reminders

Second phase of the financial rewire. Everything Phase 1 stubbed as "Ships in Phase 2" is now wired: admins can record refunds and chargebacks that flow through the ledger, Stripe dispute + refund + failure events auto-record, a daily reconciliation cron catches stale open invoices + missing webhook events + duplicate payments, invoice aging is visible at a glance, and hourly reminder emails go out on the T-3 / due / T+3 / T+7 / admin- escalation schedule. Vercel Cron drives both crons; nothing changes about Phase 1 tables or the existing checkout/webhook downstream handlers.

Migration 106 (additive, no existing tables touched):
- payment_reconciliation_exceptions — the queue. Fields: type (missing_ webhook | missing_provider | amount_mismatch | duplicate_payment | orphan_refund | wrong_invoice_link | stale_open_invoice | other), provider + provider_ref, crm_payment_id, crm_invoice_id, amount_cents, note, detected_at, resolved_at + resolved_by + resolution_action + resolution_note.
- invoices.last_reminder_stage + last_reminder_at — belt+suspenders on top of the audit-log dedup so we never double-send a stage.
- Service-role-only RLS on the exceptions table.

Refund + chargeback (src/lib/refundReasons.ts, /api/admin/financial/refunds, /admin/financial/refunds/page.tsx):
- Structured reason codes: customer_request, duplicate_payment, service_not_delivered, fraud, chargeback_response, admin_correction, other. Free-text notes attach.
- POST validates parent payment status is paid or partial_refund, amount fits, reason is one of the seven. Calls recordRefund() from paymentLedger which handles: negative-amount payment row, parent status flip (paid → partial_refund / refunded / chargeback), invoice recompute. Also writes an audit_logs row.
- UI: refund entry form (parent id, amount, reason, notes, provider refund id, chargeback checkbox), list view with parent payment linkage. Replaces the Phase-1 stub.

Stripe webhook coverage (src/lib/paymentIngest.ts):
- charge.refunded — iterates charge.refunds.data, calls recordRefund per refund with dedup by provider_payment_id.
- charge.dispute.created — flips parent to disputed + payment_status_history row. No negative amount yet (that fires on close-as-lost).
- charge.dispute.closed — if status=lost, recordRefund(isChargeback=true). If status=won/warning_closed, back to paid.
- payment_intent.payment_failed — upserts a payment row with status=failed
  + last_payment_error captured.

Reconciliation (src/lib/paymentReconciliation.ts + /api/cron/reconciliation
+ /admin/financial/reconciliation):
- Three sweeps:
  1. sweepStaleOpenInvoices: invoices past due_date get flipped to overdue. File exception if 7+ days past.
  2. sweepMissingProviderEvents: payments in last 30d with a non-manual provider and no linked event_id — probably a missed webhook.
  3. sweepDuplicatePayments: same (buyer_email, amount, order_id) tuple twice in 30 days.
- Dedup: won't file another exception with same (type, provider, provider_ref) if one is already unresolved.
- Cron endpoint accepts CRON_SECRET Bearer OR admin session — same URL serves the Vercel Cron and the UI "Run now" button.
- Admin UI: filter (open/resolved/all), per-row resolve buttons (reconciled / ignore) with optional resolution note, last-run summary card. Replaces the Phase-1 stub.

Invoice aging (/api/admin/financial/invoices + /admin/financial/invoices):
- Summary: total open A/R + four aging buckets (0-30 / 31-60 / 61-90 / 90+), anchored on due_date with sent_at fallback.
- Click a bucket to filter the detail table.
- Detail table: provider, buyer, total / paid / balance, status, due.
- Replaces the Phase-1 stub.

Reminders (src/lib/paymentReminders.ts + /api/cron/reminders):
- Six stages: sent, pre_due_3, due_today, overdue_3, overdue_7, admin_escalation.
- nextStageFor() computes the next stage per invoice given last_reminder_ stage + now vs due_date. Sequential — a fresh invoice caught at day+10 fires "sent" first, not "overdue_7".
- Renders one shared HTML template with the balance + due date table.
- admin_escalation goes to MARKETPLACE_ADMIN_NOTIFICATIONS_EMAIL (defaults to james@apexaivending.com); everything else goes to the buyer's email.
- Cron endpoint mirrors reconciliation's auth pattern.

Cron scheduling (vercel.json — additive):
- /api/cron/reconciliation — daily @ 22:00 UTC (5pm ET / 6pm ET during DST)
- /api/cron/reminders       — hourly on the top of the hour

New env var required in Vercel:
  CRON_SECRET=<any long random string> Vercel Cron sends "Authorization: Bearer $CRON_SECRET" per Vercel docs. Without it configured, cron requests are rejected as 403.

What Phase 2 does NOT touch (still Phase 3+):
- Commissions — Phase 4. Refunds recorded now already carry refund_of_payment_id so the Phase 4 reversal path can trace them.
- Attribution model — Phase 3.
- Rep-facing dashboards — Phase 5 (RLS + "My Performance" polish).
- QB payout batching — Phase 6.

Existing behavior preserved:
- Coffee / lead / machine / marketplace / agreement checkout flows, existing webhook downstream handlers, Resend receipt paths, and sales_commissions logic remain unchanged.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2