### PR TITLE
Auto-mirror coffee orders into CRM sales_orders on payment

### DIFF
--- a/src/app/api/admin/coffee/mirror-backfill/route.ts
+++ b/src/app/api/admin/coffee/mirror-backfill/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAdminUserId } from "@/lib/adminAuth";
+import { mirrorPaidCoffeeOrdersBackfill } from "@/lib/coffeeCrmMirror";
+import { writeAuditLog } from "@/lib/paymentLedger";
+
+/**
+ * POST /api/admin/coffee/mirror-backfill
+ *
+ * Walks paid coffee_orders that don't have a linked sales_order_id and creates
+ * a matching sales_orders + order_items shell for each. Idempotent — running
+ * again is a no-op for already-mirrored orders.
+ *
+ * Body:
+ *   { limit?: number, since_days?: number }
+ * Defaults: limit=100, since_days=90.
+ */
+
+export async function POST(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const body = await req.json().catch(() => ({}));
+  const limit = Math.min(500, Math.max(1, Number(body.limit || 100)));
+  const sinceDays = Math.max(1, Math.min(3650, Number(body.since_days || 90)));
+
+  const summary = await mirrorPaidCoffeeOrdersBackfill({ limit, sinceDays });
+
+  await writeAuditLog({
+    actorId: adminId,
+    action: "coffee_crm_backfill_ran",
+    entityType: "system",
+    metadata: { limit, since_days: sinceDays, summary: summary as unknown as Record<string, unknown> },
+  });
+
+  return NextResponse.json(summary);
+}
+
+/** GET — same as POST but read-only friendly (returns a preview count). */
+export async function GET(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const { supabaseAdmin } = await import("@/lib/supabaseAdmin");
+  const { count } = await supabaseAdmin
+    .from("coffee_orders")
+    .select("*", { count: "exact", head: true })
+    .in("status", ["pending", "processing", "shipped", "delivered"])
+    .is("sales_order_id", null);
+  return NextResponse.json({ needs_backfill: count || 0 });
+}

--- a/src/lib/coffeeCrmMirror.ts
+++ b/src/lib/coffeeCrmMirror.ts
@@ -1,0 +1,253 @@
+/**
+ * Coffee → CRM order mirror.
+ *
+ * When a coffee_orders row gets paid (webhook fires handleCoffeeOrderCompleted),
+ * we synthesize a matching sales_orders row + order_items rows so the CRM
+ * order dashboard can surface it and the existing "Send Receipt" flow at
+ * /sales/orders/[id] works with zero extra plumbing.
+ *
+ * Idempotent by coffee_orders.sales_order_id — a re-fired webhook won't
+ * duplicate. Safe for backfill of historical paid coffee orders.
+ */
+
+import { supabaseAdmin } from "./supabaseAdmin";
+import { writeAuditLog } from "./paymentLedger";
+
+export interface MirrorResult {
+  status: "created" | "already_mirrored" | "skipped_not_paid" | "not_found";
+  coffeeOrderId: string;
+  salesOrderId?: string;
+  accountId?: string;
+  error?: string;
+}
+
+/**
+ * Find or create a sales_accounts row for a coffee-order buyer. Uses
+ * profile.email as the natural key. If nothing matches, creates a minimal
+ * account so the CRM link is preserved.
+ */
+async function ensureAccountForOperator(operatorId: string): Promise<string | null> {
+  const { data: profile } = await supabaseAdmin
+    .from("profiles")
+    .select("id, full_name, company_name, email, phone")
+    .eq("id", operatorId)
+    .maybeSingle();
+  if (!profile) return null;
+
+  // Try existing account by email
+  if (profile.email) {
+    const { data: existing } = await supabaseAdmin
+      .from("sales_accounts")
+      .select("id")
+      .eq("email", profile.email.toLowerCase())
+      .maybeSingle();
+    if (existing) return existing.id;
+  }
+
+  // Fall back to name match
+  const businessName = profile.company_name?.trim() || profile.full_name?.trim() || "Coffee Customer";
+  const { data: byName } = await supabaseAdmin
+    .from("sales_accounts")
+    .select("id")
+    .eq("business_name", businessName)
+    .maybeSingle();
+  if (byName) return byName.id;
+
+  // Create a new account. business_name is NOT NULL.
+  const { data: created, error } = await supabaseAdmin
+    .from("sales_accounts")
+    .insert({
+      business_name: businessName,
+      contact_name: profile.full_name || null,
+      email: profile.email?.toLowerCase() || null,
+      phone: profile.phone || null,
+    })
+    .select("id")
+    .single();
+  if (error || !created) return null;
+  return created.id;
+}
+
+export async function mirrorCoffeeOrderToCrm(coffeeOrderId: string): Promise<MirrorResult> {
+  const { data: coffeeOrder, error } = await supabaseAdmin
+    .from("coffee_orders")
+    .select("*, coffee_order_items(*)")
+    .eq("id", coffeeOrderId)
+    .maybeSingle();
+  if (error || !coffeeOrder) {
+    return { status: "not_found", coffeeOrderId, error: error?.message };
+  }
+
+  // Idempotency: already mirrored → done.
+  if (coffeeOrder.sales_order_id) {
+    return {
+      status: "already_mirrored",
+      coffeeOrderId,
+      salesOrderId: coffeeOrder.sales_order_id,
+    };
+  }
+
+  // Skip statuses that mean "not paid yet" — mirroring an unpaid order into
+  // CRM would create a fake paid record. handleCoffeeOrderCompleted only
+  // fires on paid, but backfill needs this guard.
+  const paidStatuses = new Set(["pending", "processing", "shipped", "delivered"]);
+  if (!paidStatuses.has(coffeeOrder.status)) {
+    return { status: "skipped_not_paid", coffeeOrderId };
+  }
+
+  const accountId = await ensureAccountForOperator(coffeeOrder.operator_id);
+
+  const { data: profile } = await supabaseAdmin
+    .from("profiles")
+    .select("full_name, email")
+    .eq("id", coffeeOrder.operator_id)
+    .maybeSingle();
+
+  const totalValue = Number(coffeeOrder.total || 0);
+  const now = new Date().toISOString();
+
+  const noteLines = [
+    `Auto-mirrored from coffee order ${coffeeOrder.order_number} on ${new Date().toISOString().slice(0, 10)}.`,
+  ];
+  if (coffeeOrder.notes?.trim()) noteLines.push(`Customer notes: ${coffeeOrder.notes.trim()}`);
+  const shippingLine = [
+    coffeeOrder.shipping_name,
+    coffeeOrder.shipping_address,
+    [coffeeOrder.shipping_city, coffeeOrder.shipping_state, coffeeOrder.shipping_zip].filter(Boolean).join(", "),
+  ].filter(Boolean).join(" · ");
+  if (shippingLine) noteLines.push(`Ship to: ${shippingLine}`);
+
+  // Create sales_orders row. Every status field is set to "already done" so
+  // it lands directly in a completed state — the receipt is the only next
+  // action available.
+  const { data: salesOrder, error: soErr } = await supabaseAdmin
+    .from("sales_orders")
+    .insert({
+      account_id: accountId,
+      created_by: coffeeOrder.operator_id,
+      assigned_rep_id: null,
+      total_value: totalValue,
+      status: "completed",
+      order_status: "paid",
+      order_type: "coffee",
+      document_type: "order",
+      payment_status: "paid",
+      invoice_status: "sent",
+      agreement_status: "not_required",
+      fulfillment_status: "in_progress",
+      receipt_status: "not_sent",
+      recipient_email: profile?.email || null,
+      notes: noteLines.join("\n"),
+      updated_at: now,
+    })
+    .select("id")
+    .single();
+  if (soErr || !salesOrder) {
+    return { status: "not_found", coffeeOrderId, error: soErr?.message || "sales_orders insert failed" };
+  }
+
+  // Mirror line items
+  const items = (coffeeOrder.coffee_order_items || []) as Array<{
+    product_name: string;
+    product_sku: string | null;
+    quantity: number;
+    unit_price: number;
+    line_total: number;
+  }>;
+  if (items.length > 0) {
+    const rows = items.map((i) => ({
+      order_id: salesOrder.id,
+      service_name: i.product_name,
+      item_type: "coffee",
+      description: i.product_sku || null,
+      quantity: Number(i.quantity),
+      unit_price: Number(i.unit_price),
+      total_price: Number(i.line_total),
+      price: Number(i.line_total),
+      status: "paid",
+    }));
+    // "price" is the old-column carryover (see migration 009). Newer rows
+    // use total_price; migration 082 kept "price" for compatibility. We fill
+    // both so old code paths continue to render.
+    await supabaseAdmin.from("order_items").insert(rows);
+  }
+
+  // Add a shipping line if the coffee estimate is non-zero
+  if (Number(coffeeOrder.shipping_estimate || 0) > 0) {
+    await supabaseAdmin.from("order_items").insert({
+      order_id: salesOrder.id,
+      service_name: "Shipping",
+      item_type: "shipping",
+      description: null,
+      quantity: 1,
+      unit_price: Number(coffeeOrder.shipping_estimate),
+      total_price: Number(coffeeOrder.shipping_estimate),
+      price: Number(coffeeOrder.shipping_estimate),
+      status: "paid",
+    });
+  }
+
+  // Link back so retries + future coffee-order edits don't re-mirror
+  await supabaseAdmin
+    .from("coffee_orders")
+    .update({ sales_order_id: salesOrder.id, updated_at: now })
+    .eq("id", coffeeOrderId);
+
+  // Audit
+  await writeAuditLog({
+    actorId: null,
+    action: "coffee_order_mirrored_to_crm",
+    entityType: "sales_order",
+    entityId: salesOrder.id,
+    metadata: {
+      coffee_order_id: coffeeOrderId,
+      coffee_order_number: coffeeOrder.order_number,
+      account_id: accountId,
+      total: totalValue,
+      item_count: items.length,
+    },
+  });
+
+  return {
+    status: "created",
+    coffeeOrderId,
+    salesOrderId: salesOrder.id,
+    accountId: accountId || undefined,
+  };
+}
+
+export async function mirrorPaidCoffeeOrdersBackfill(opts: { limit?: number; sinceDays?: number }): Promise<{
+  scanned: number;
+  created: number;
+  already: number;
+  skipped: number;
+  errors: string[];
+}> {
+  const summary = { scanned: 0, created: 0, already: 0, skipped: 0, errors: [] as string[] };
+  const limit = Math.min(500, Math.max(1, opts.limit ?? 100));
+  const cutoff = new Date(Date.now() - (opts.sinceDays ?? 90) * 24 * 60 * 60 * 1000).toISOString();
+
+  const { data } = await supabaseAdmin
+    .from("coffee_orders")
+    .select("id, status, sales_order_id")
+    .in("status", ["pending", "processing", "shipped", "delivered"])
+    .is("sales_order_id", null)
+    .gte("created_at", cutoff)
+    .order("created_at", { ascending: false })
+    .limit(limit);
+
+  for (const row of data || []) {
+    summary.scanned++;
+    try {
+      const result = await mirrorCoffeeOrderToCrm(row.id);
+      if (result.status === "created") summary.created++;
+      else if (result.status === "already_mirrored") summary.already++;
+      else summary.skipped++;
+      if (result.error) summary.errors.push(`${row.id.slice(0, 8)}: ${result.error}`);
+    } catch (e) {
+      summary.errors.push(`${row.id.slice(0, 8)}: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  return summary;
+}

--- a/src/lib/paymentHandlers.ts
+++ b/src/lib/paymentHandlers.ts
@@ -549,6 +549,20 @@ export async function handleCoffeeOrderCompleted(params: {
   } catch (e) {
     console.error("[payment-handler] Failed to send coffee order emails:", e);
   }
+
+  // Mirror into the CRM sales_orders spine so admins can view the coffee
+  // order alongside every other CRM order and use the existing "Send
+  // Receipt" flow at /sales/orders/[id]. Idempotent — a re-fired webhook
+  // won't duplicate the sales_orders row.
+  try {
+    const { mirrorCoffeeOrderToCrm } = await import("./coffeeCrmMirror");
+    const result = await mirrorCoffeeOrderToCrm(orderId);
+    if (result.status !== "created" && result.status !== "already_mirrored") {
+      console.warn("[payment-handler] Coffee → CRM mirror skipped:", result);
+    }
+  } catch (e) {
+    console.error("[payment-handler] Coffee → CRM mirror failed (non-fatal):", e);
+  }
 }
 
 // ─── Marketplace Purchase ───

--- a/supabase/migrations/107_coffee_orders_crm_mirror.sql
+++ b/supabase/migrations/107_coffee_orders_crm_mirror.sql
@@ -1,0 +1,9 @@
+-- Coffee orders auto-mirror to CRM sales_orders on payment. Adds a linkage
+-- column so we can skip re-mirroring on webhook retries and so the CRM page
+-- knows which coffee order it's rendering when we surface a "Source: Coffee"
+-- badge later.
+
+ALTER TABLE coffee_orders
+  ADD COLUMN IF NOT EXISTS sales_order_id uuid REFERENCES sales_orders(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_coffee_orders_sales_order_id ON coffee_orders(sales_order_id);


### PR DESCRIPTION
Side quest: coffee orders placed on /coffee never made it into the CRM's sales_orders table, so admins had no way to trigger the standard "Send Receipt" flow at /sales/orders/[id] for them. This wires the mirror.

Migration 107 — one additive column:
- coffee_orders.sales_order_id (uuid → sales_orders.id, nullable). Serves as both the reverse-lookup pointer and the idempotency key: mirror() no-ops if it's already set, so a re-fired webhook won't duplicate.

src/lib/coffeeCrmMirror.ts — the mirror:
- ensureAccountForOperator resolves a sales_accounts row for the coffee buyer: match on profile.email first, then business_name, then create a minimal one (business_name is NOT NULL, so we fall back through company_name → full_name → "Coffee Customer").
- mirrorCoffeeOrderToCrm(id):
  - Loads coffee_orders + coffee_order_items.
  - Idempotent: returns 'already_mirrored' if sales_order_id is set.
  - Guards against mirroring unpaid orders (status must be pending / processing / shipped / delivered — matches what handleCoffeeOrderCompleted sets).
  - Creates sales_orders row directly in completed / paid state so it lands on the CRM order list ready for receipt send: status='completed', order_status='paid', payment_status='paid', invoice_status='sent', receipt_status='not_sent' order_type='coffee', document_type='order' total_value = coffee.total, recipient_email = profile.email notes include coffee order number + shipping address.
  - Creates one order_items row per coffee_order_items row (service_name = product_name, item_type='coffee', description=SKU, quantity/unit_price/ total_price). Also fills the legacy 'price' column so older render code keeps working.
  - Adds a separate order_items row for shipping if shipping_estimate > 0.
  - Stamps coffee_orders.sales_order_id.
  - Writes an audit_logs row (action=coffee_order_mirrored_to_crm).
- mirrorPaidCoffeeOrdersBackfill({ limit, sinceDays }) — batches through historical paid orders that never got mirrored. Default 100 rows, 90-day cutoff.

paymentHandlers.ts — hook into handleCoffeeOrderCompleted:
- After the existing coffee email sends, imports mirrorCoffeeOrderToCrm and fires it. Non-fatal on error — a failed mirror just logs and lets the payment complete cleanly.

Backfill endpoint:
- POST /api/admin/coffee/mirror-backfill { limit?, since_days? } — admin triggers a batch run. Writes an audit log with the summary.
- GET returns a count of coffee_orders still needing backfill.

Existing behavior preserved:
- Coffee checkout flow, coffee dashboard, coffee_order_items, coffee email templates, Stripe/QB coffee webhook handling all untouched.
- Idempotent: safe to re-run backfill, safe against webhook retries.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2