### PR TITLE
Financial spine — Phase 3: multi-user attribution + lock + admin config

### DIFF
--- a/src/app/admin/financial/attributions/page.tsx
+++ b/src/app/admin/financial/attributions/page.tsx
@@ -1,18 +1,191 @@
-import { Clock } from "lucide-react";
+"use client";
 
-export default function AttributionsStub() {
+import { useEffect, useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Loader2, Users, ArrowLeft, Lock, Filter, Play } from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
+
+interface AttributionRow {
+  id: string;
+  order_id: string;
+  user_id: string;
+  role_code: string;
+  percentage: number;
+  locked_at: string | null;
+  locked_by_event: string | null;
+  is_legacy_backfill: boolean;
+  created_at: string;
+  order: { id: string; total_value: number; order_status: string; payment_status: string; created_at: string; assigned_rep_id: string | null } | null;
+  user: { full_name: string; email: string } | null;
+}
+
+interface RoleOption {
+  code: string;
+  label: string;
+}
+
+const LOCKED_FILTERS = [
+  { key: "any", label: "Any lock state" },
+  { key: "true", label: "Locked" },
+  { key: "false", label: "Unlocked" },
+];
+
+export default function AdminAttributionsPage() {
+  const router = useRouter();
+  const [token, setToken] = useState("");
+  const [rows, setRows] = useState<AttributionRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [roles, setRoles] = useState<RoleOption[]>([]);
+  const [roleFilter, setRoleFilter] = useState("");
+  const [lockedFilter, setLockedFilter] = useState("any");
+  const [running, setRunning] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!token) return;
+    setLoading(true);
+    const params = new URLSearchParams();
+    if (roleFilter) params.set("role_code", roleFilter);
+    if (lockedFilter !== "any") params.set("locked", lockedFilter);
+    const [rowsRes, rolesRes] = await Promise.all([
+      fetch(`/api/admin/financial/attributions?${params}`, { headers: { Authorization: `Bearer ${token}` } }),
+      fetch("/api/attribution-roles", { headers: { Authorization: `Bearer ${token}` } }),
+    ]);
+    if (rowsRes.ok) setRows(await rowsRes.json());
+    if (rolesRes.ok) setRoles(await rolesRes.json());
+    setLoading(false);
+  }, [token, roleFilter, lockedFilter]);
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!session?.access_token) { router.push("/login?redirect=/admin/financial/attributions"); return; }
+      setToken(session.access_token);
+    });
+  }, [router]);
+
+  useEffect(() => { load(); }, [load]);
+
+  async function runBackfill() {
+    if (!confirm("Seed implicit 100% Lead Owner rows for every legacy order without attribution? Idempotent — safe to re-run.")) return;
+    setRunning(true);
+    setError(null);
+    setMessage(null);
+    const res = await fetch("/api/admin/financial/attributions/backfill", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ limit: 1000, since_days: 3650 }),
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) setError(body.error || "Backfill failed");
+    else setMessage(`Backfill complete — seeded ${body.seeded}, skipped ${body.skipped_existing + body.skipped_no_rep}.`);
+    await load();
+    setRunning(false);
+  }
+
   return (
     <div className="p-6">
-      <h1 className="text-2xl font-bold text-gray-900 mb-2">Attributions</h1>
-      <p className="text-sm text-gray-500 mb-6">
-        Multi-credit sales attribution (Lead Owner / Closer / Referrer / Assist / Manager Override).
-      </p>
-      <div className="rounded-2xl border border-amber-200 bg-amber-50 p-6 flex items-center gap-3">
-        <Clock className="h-6 w-6 text-amber-600" />
+      <Link href="/admin/financial" className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-green-primary mb-4">
+        <ArrowLeft className="h-4 w-4" /> Financial Center
+      </Link>
+
+      <div className="flex items-center justify-between mb-4 flex-wrap gap-3">
         <div>
-          <p className="text-sm font-medium text-amber-900">Ships in Phase 3</p>
-          <p className="text-xs text-amber-700">Attribution model + configurable roles + lock at order creation + audited admin overrides.</p>
+          <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
+            <Users className="h-6 w-6 text-green-primary" /> Attribution Inspector
+          </h1>
+          <p className="text-sm text-gray-500 mt-1">
+            Every credited user across every order. Filter by role or lock state. Individual splits are edited on the order page.
+          </p>
         </div>
+        <button
+          onClick={runBackfill}
+          disabled={running}
+          className="inline-flex items-center gap-1.5 rounded-xl border border-gray-200 hover:bg-gray-50 px-4 py-2.5 text-sm font-semibold text-gray-700 cursor-pointer disabled:opacity-50"
+        >
+          {running ? <Loader2 className="h-4 w-4 animate-spin" /> : <Play className="h-4 w-4" />}
+          Backfill legacy orders
+        </button>
+      </div>
+
+      {message && <div className="mb-4 rounded-xl border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-700">{message}</div>}
+      {error && <div className="mb-4 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700">{error}</div>}
+
+      <div className="mb-4 flex items-center gap-2 flex-wrap">
+        <Filter className="h-4 w-4 text-gray-400" />
+        <select value={roleFilter} onChange={(e) => setRoleFilter(e.target.value)} className="rounded-lg border border-gray-200 px-3 py-1.5 text-xs">
+          <option value="">All roles</option>
+          {roles.map((r) => <option key={r.code} value={r.code}>{r.label}</option>)}
+        </select>
+        {LOCKED_FILTERS.map((f) => (
+          <button
+            key={f.key}
+            onClick={() => setLockedFilter(f.key)}
+            className={`rounded-lg px-3 py-1.5 text-xs font-medium cursor-pointer ${lockedFilter === f.key ? "bg-green-100 text-green-700" : "bg-gray-100 text-gray-500 hover:bg-gray-200"}`}
+          >
+            {f.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="rounded-2xl border border-gray-100 bg-white p-5 overflow-hidden">
+        {loading ? (
+          <div className="flex justify-center py-8"><Loader2 className="h-5 w-5 animate-spin text-green-primary" /></div>
+        ) : rows.length === 0 ? (
+          <p className="text-sm text-gray-500 text-center py-8">No attribution rows match the current filters.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-xs text-gray-500 border-b border-gray-100">
+                  <th className="text-left py-2 px-2 font-medium">User</th>
+                  <th className="text-left py-2 px-2 font-medium">Role</th>
+                  <th className="text-right py-2 px-2 font-medium">%</th>
+                  <th className="text-left py-2 px-2 font-medium">Order</th>
+                  <th className="text-right py-2 px-2 font-medium">Order $</th>
+                  <th className="text-left py-2 px-2 font-medium">Status</th>
+                  <th className="text-left py-2 px-2 font-medium">Set</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((r) => (
+                  <tr key={r.id} className="border-b border-gray-50 last:border-b-0">
+                    <td className="py-2 px-2 text-xs">
+                      <p className="font-medium text-gray-900">{r.user?.full_name || r.user?.email || r.user_id.slice(0, 8)}</p>
+                      <p className="text-gray-400">{r.user?.email}</p>
+                    </td>
+                    <td className="py-2 px-2 text-xs capitalize">{r.role_code.replace(/_/g, " ")}</td>
+                    <td className="py-2 px-2 text-right font-semibold text-emerald-700">{Number(r.percentage).toFixed(1)}%</td>
+                    <td className="py-2 px-2 text-xs">
+                      <Link href={`/sales/orders/${r.order_id}`} className="font-mono text-green-primary hover:underline">
+                        {r.order_id.slice(0, 8)}
+                      </Link>
+                    </td>
+                    <td className="py-2 px-2 text-right text-xs">
+                      ${(Number(r.order?.total_value || 0)).toLocaleString(undefined, { minimumFractionDigits: 2 })}
+                    </td>
+                    <td className="py-2 px-2">
+                      {r.locked_at ? (
+                        <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700">
+                          <Lock className="h-3 w-3" />
+                          {r.locked_by_event?.replace(/_/g, " ") || "locked"}
+                        </span>
+                      ) : (
+                        <span className="text-xs text-gray-400">unlocked</span>
+                      )}
+                    </td>
+                    <td className="py-2 px-2 text-xs text-gray-500">
+                      {new Date(r.created_at).toLocaleDateString()}
+                      {r.is_legacy_backfill && <span className="ml-1 text-[10px] text-amber-600">(legacy)</span>}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/app/admin/financial/settings/page.tsx
+++ b/src/app/admin/financial/settings/page.tsx
@@ -1,18 +1,224 @@
-import { Clock } from "lucide-react";
+"use client";
 
-export default function SettingsStub() {
+import { useEffect, useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Loader2, ArrowLeftRight, ArrowLeft, Plus, Trash2, AlertCircle, CheckCircle2, Lock } from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
+
+interface Role {
+  id: string;
+  code: string;
+  label: string;
+  description: string | null;
+  sort_order: number;
+  is_active: boolean;
+  is_system: boolean;
+  created_at: string;
+}
+
+export default function FinancialSettingsPage() {
+  const router = useRouter();
+  const [token, setToken] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [roles, setRoles] = useState<Role[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [saving, setSaving] = useState<string | null>(null);
+  const [showNew, setShowNew] = useState(false);
+  const [newRole, setNewRole] = useState({ code: "", label: "", description: "", sort_order: 100 });
+
+  const load = useCallback(async () => {
+    if (!token) return;
+    setLoading(true);
+    const res = await fetch("/api/admin/financial/attribution-roles", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.ok) setRoles(await res.json());
+    setLoading(false);
+  }, [token]);
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!session?.access_token) { router.push("/login?redirect=/admin/financial/settings"); return; }
+      setToken(session.access_token);
+    });
+  }, [router]);
+
+  useEffect(() => { load(); }, [load]);
+
+  async function create() {
+    setError(null);
+    setMessage(null);
+    setSaving("new");
+    const res = await fetch("/api/admin/financial/attribution-roles", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify(newRole),
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) setError(body.error || "Create failed");
+    else {
+      setMessage(`Created role "${body.label}"`);
+      setNewRole({ code: "", label: "", description: "", sort_order: 100 });
+      setShowNew(false);
+      await load();
+    }
+    setSaving(null);
+  }
+
+  async function toggle(role: Role) {
+    setSaving(role.id);
+    setError(null);
+    const res = await fetch(`/api/admin/financial/attribution-roles/${role.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ is_active: !role.is_active }),
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) setError(body.error || "Update failed");
+    else await load();
+    setSaving(null);
+  }
+
+  async function remove(role: Role) {
+    if (!confirm(`Deactivate role "${role.label}"?`)) return;
+    setSaving(role.id);
+    const res = await fetch(`/api/admin/financial/attribution-roles/${role.id}`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) setError(body.error || "Delete failed");
+    else await load();
+    setSaving(null);
+  }
+
+  const inputClass = "w-full rounded-xl border border-gray-200 px-3 py-2 text-sm focus:border-green-primary focus:outline-none";
+  const labelClass = "block text-xs font-medium text-gray-600 mb-1";
+
   return (
     <div className="p-6">
-      <h1 className="text-2xl font-bold text-gray-900 mb-2">Financial Settings</h1>
-      <p className="text-sm text-gray-500 mb-6">
-        Company-wide commission defaults, category rates, reminder cadence, reconciliation window.
-      </p>
-      <div className="rounded-2xl border border-amber-200 bg-amber-50 p-6 flex items-center gap-3">
-        <Clock className="h-6 w-6 text-amber-600" />
-        <div>
-          <p className="text-sm font-medium text-amber-900">Ships in Phase 4</p>
-          <p className="text-xs text-amber-700">Default commission %, category rates, priority order, hold periods, reminder schedule.</p>
+      <Link href="/admin/financial" className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-green-primary mb-4">
+        <ArrowLeft className="h-4 w-4" /> Financial Center
+      </Link>
+
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
+          <ArrowLeftRight className="h-6 w-6 text-green-primary" /> Financial Settings
+        </h1>
+        <p className="text-sm text-gray-500 mt-1">Attribution roles today. Commission rules, categories, and reminder schedule ship in Phase 4.</p>
+      </div>
+
+      <div className="rounded-2xl border border-gray-100 bg-white p-5 mb-4">
+        <div className="flex items-center justify-between mb-3">
+          <div>
+            <h2 className="text-sm font-semibold text-gray-900">Attribution Roles</h2>
+            <p className="text-xs text-gray-500 mt-0.5">Configurable roles for sales credit. System roles can be renamed but not deactivated.</p>
+          </div>
+          <button
+            onClick={() => setShowNew((s) => !s)}
+            className="inline-flex items-center gap-1.5 rounded-lg bg-green-primary hover:bg-green-hover px-3 py-1.5 text-xs font-semibold text-white cursor-pointer"
+          >
+            <Plus className="h-3.5 w-3.5" /> New role
+          </button>
         </div>
+
+        {message && (
+          <div className="mb-3 flex items-start gap-2 rounded-xl border border-emerald-200 bg-emerald-50 p-2.5 text-xs text-emerald-700">
+            <CheckCircle2 className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+            <span>{message}</span>
+          </div>
+        )}
+        {error && (
+          <div className="mb-3 flex items-start gap-2 rounded-xl border border-red-200 bg-red-50 p-2.5 text-xs text-red-700">
+            <AlertCircle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+            <span>{error}</span>
+          </div>
+        )}
+
+        {showNew && (
+          <div className="mb-3 rounded-xl border border-gray-200 bg-gray-50 p-4 space-y-2">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div>
+                <label className={labelClass}>Label *</label>
+                <input type="text" value={newRole.label} onChange={(e) => setNewRole((r) => ({ ...r, label: e.target.value }))} className={inputClass} placeholder="Solution Engineer" />
+              </div>
+              <div>
+                <label className={labelClass}>Code (machine key) *</label>
+                <input type="text" value={newRole.code} onChange={(e) => setNewRole((r) => ({ ...r, code: e.target.value }))} className={inputClass + " font-mono"} placeholder="solution_engineer" />
+              </div>
+            </div>
+            <div>
+              <label className={labelClass}>Description</label>
+              <input type="text" value={newRole.description} onChange={(e) => setNewRole((r) => ({ ...r, description: e.target.value }))} className={inputClass} />
+            </div>
+            <div className="flex justify-end gap-2 pt-1">
+              <button onClick={() => setShowNew(false)} className="rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 cursor-pointer">
+                Cancel
+              </button>
+              <button
+                onClick={create}
+                disabled={saving === "new" || !newRole.label.trim() || !newRole.code.trim()}
+                className="inline-flex items-center gap-1.5 rounded-lg bg-green-primary hover:bg-green-hover px-4 py-1.5 text-xs font-semibold text-white cursor-pointer disabled:opacity-50"
+              >
+                {saving === "new" ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
+                Create role
+              </button>
+            </div>
+          </div>
+        )}
+
+        {loading ? (
+          <div className="flex justify-center py-8"><Loader2 className="h-5 w-5 animate-spin text-green-primary" /></div>
+        ) : roles.length === 0 ? (
+          <p className="text-sm text-gray-500 text-center py-6">No roles yet.</p>
+        ) : (
+          <ul className="divide-y divide-gray-100">
+            {roles.map((role) => (
+              <li key={role.id} className="flex items-center justify-between gap-3 py-2.5">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <p className={`text-sm font-medium ${role.is_active ? "text-gray-900" : "text-gray-400 line-through"}`}>{role.label}</p>
+                    <span className="text-xs font-mono text-gray-400">{role.code}</span>
+                    {role.is_system && (
+                      <span className="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2 py-0.5 text-[10px] font-medium text-blue-700">
+                        <Lock className="h-2.5 w-2.5" /> system
+                      </span>
+                    )}
+                  </div>
+                  {role.description && <p className="text-xs text-gray-500 mt-0.5">{role.description}</p>}
+                </div>
+                <div className="flex items-center gap-2">
+                  {!role.is_system && (
+                    <button
+                      onClick={() => toggle(role)}
+                      disabled={saving === role.id}
+                      className="rounded-lg border border-gray-200 hover:bg-gray-50 px-3 py-1 text-xs font-medium text-gray-700 cursor-pointer disabled:opacity-50"
+                    >
+                      {role.is_active ? "Deactivate" : "Activate"}
+                    </button>
+                  )}
+                  {!role.is_system && role.is_active && (
+                    <button
+                      onClick={() => remove(role)}
+                      disabled={saving === role.id}
+                      className="rounded-lg p-1.5 text-gray-400 hover:bg-red-50 hover:text-red-600 cursor-pointer disabled:opacity-50"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div className="rounded-2xl border border-amber-200 bg-amber-50 p-5">
+        <p className="text-sm font-semibold text-amber-900">Ships in Phase 4</p>
+        <p className="text-xs text-amber-700 mt-1">Commission rules (default %, per-user overrides, category rates, hold periods), reminder cadence, and reconciliation window will all live here.</p>
       </div>
     </div>
   );

--- a/src/app/api/admin/financial/attribution-roles/[id]/route.ts
+++ b/src/app/api/admin/financial/attribution-roles/[id]/route.ts
@@ -1,0 +1,84 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+import { writeAuditLog } from "@/lib/paymentLedger";
+
+/**
+ * PATCH — rename, reorder, or activate/deactivate a role.
+ *   System roles (is_system=true) can't be deactivated — they're referenced
+ *   by legacy backfills. Renaming the label is fine either way.
+ * DELETE — soft delete (sets is_active=false). System roles reject.
+ */
+
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id } = await params;
+
+  const { data: before } = await supabaseAdmin
+    .from("attribution_roles")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+  if (!before) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const body = await req.json().catch(() => ({}));
+  const updates: Record<string, unknown> = { updated_at: new Date().toISOString() };
+  if (typeof body.label === "string" && body.label.trim()) updates.label = body.label.trim();
+  if (typeof body.description === "string") updates.description = body.description.trim() || null;
+  if (Number.isFinite(Number(body.sort_order))) updates.sort_order = Math.max(0, Math.min(9999, Number(body.sort_order)));
+  if (typeof body.is_active === "boolean") {
+    if (!body.is_active && before.is_system) {
+      return NextResponse.json({ error: "System roles cannot be deactivated" }, { status: 400 });
+    }
+    updates.is_active = body.is_active;
+  }
+
+  const { data: after, error } = await supabaseAdmin
+    .from("attribution_roles")
+    .update(updates)
+    .eq("id", id)
+    .select("*")
+    .single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  await writeAuditLog({
+    actorId: adminId,
+    action: "attribution_role_updated",
+    entityType: "attribution_role",
+    entityId: id,
+    before,
+    after,
+  });
+
+  return NextResponse.json(after);
+}
+
+export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id } = await params;
+
+  const { data: before } = await supabaseAdmin
+    .from("attribution_roles")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+  if (!before) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  if (before.is_system) return NextResponse.json({ error: "System roles cannot be deleted. Deactivate a custom role instead." }, { status: 400 });
+
+  await supabaseAdmin
+    .from("attribution_roles")
+    .update({ is_active: false, updated_at: new Date().toISOString() })
+    .eq("id", id);
+
+  await writeAuditLog({
+    actorId: adminId,
+    action: "attribution_role_deactivated",
+    entityType: "attribution_role",
+    entityId: id,
+    before,
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/admin/financial/attribution-roles/route.ts
+++ b/src/app/api/admin/financial/attribution-roles/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+import { writeAuditLog } from "@/lib/paymentLedger";
+
+/**
+ * GET — list all roles (active + inactive) for admin.
+ *   Rep-facing dropdowns hit the RLS-scoped view directly which only returns
+ *   active rows; this endpoint returns everything for the settings page.
+ * POST — create a new role.
+ */
+
+export async function GET(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const { data, error } = await supabaseAdmin
+    .from("attribution_roles")
+    .select("*")
+    .order("sort_order", { ascending: true });
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json(data || []);
+}
+
+export async function POST(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const body = await req.json().catch(() => ({}));
+  const code = String(body.code || "").trim().toLowerCase().replace(/[^a-z0-9_]/g, "_");
+  const label = String(body.label || "").trim();
+  const description = String(body.description || "").trim();
+  const sortOrder = Number.isFinite(Number(body.sort_order)) ? Math.max(0, Math.min(9999, Number(body.sort_order))) : 100;
+
+  if (!code) return NextResponse.json({ error: "code is required" }, { status: 400 });
+  if (!label) return NextResponse.json({ error: "label is required" }, { status: 400 });
+
+  const { data, error } = await supabaseAdmin
+    .from("attribution_roles")
+    .insert({
+      code,
+      label,
+      description: description || null,
+      sort_order: sortOrder,
+      is_active: true,
+      is_system: false,
+    })
+    .select("*")
+    .single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  await writeAuditLog({
+    actorId: adminId,
+    action: "attribution_role_created",
+    entityType: "attribution_role",
+    entityId: data.id,
+    after: data,
+  });
+
+  return NextResponse.json(data);
+}

--- a/src/app/api/admin/financial/attributions/backfill/route.ts
+++ b/src/app/api/admin/financial/attributions/backfill/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAdminUserId } from "@/lib/adminAuth";
+import { backfillAttributions } from "@/lib/salesAttribution";
+import { writeAuditLog } from "@/lib/paymentLedger";
+
+/**
+ * POST /api/admin/financial/attributions/backfill
+ *
+ * Seeds existing sales_orders rows with implicit 100% Lead Owner attribution
+ * from assigned_rep_id / created_by. Marked is_legacy_backfill=true so future
+ * admin views can distinguish "we backfilled" from "someone set this".
+ * Idempotent — orders that already have any attribution row are skipped.
+ *
+ * Body: { limit?: 500, since_days?: 3650 }
+ */
+
+export async function POST(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const body = await req.json().catch(() => ({}));
+  const limit = Math.min(1000, Math.max(1, Number(body.limit || 500)));
+  const sinceDays = Math.max(1, Math.min(3650, Number(body.since_days || 3650)));
+
+  const summary = await backfillAttributions({ limit, sinceDays });
+
+  await writeAuditLog({
+    actorId: adminId,
+    action: "attribution_backfill_ran",
+    entityType: "system",
+    metadata: { limit, since_days: sinceDays, summary: summary as unknown as Record<string, unknown> },
+  });
+
+  return NextResponse.json(summary);
+}

--- a/src/app/api/admin/financial/attributions/route.ts
+++ b/src/app/api/admin/financial/attributions/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+
+/**
+ * Admin attribution inspector — list every attribution row grouped by order,
+ * optionally filtered by user, locked status, or date range.
+ */
+
+export async function GET(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const { searchParams } = new URL(req.url);
+  const userId = searchParams.get("user_id");
+  const roleCode = searchParams.get("role_code");
+  const locked = searchParams.get("locked"); // 'true' | 'false' | null
+  const limit = Math.min(500, Math.max(1, Number(searchParams.get("limit") || 200)));
+
+  let query = supabaseAdmin
+    .from("sales_attributions")
+    .select("*, order:order_id(id, total_value, order_status, payment_status, created_at, assigned_rep_id), user:user_id(full_name, email)")
+    .order("created_at", { ascending: false })
+    .limit(limit);
+  if (userId) query = query.eq("user_id", userId);
+  if (roleCode) query = query.eq("role_code", roleCode);
+  if (locked === "true") query = query.not("locked_at", "is", null);
+  else if (locked === "false") query = query.is("locked_at", null);
+
+  const { data, error } = await query;
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json(data || []);
+}

--- a/src/app/api/attribution-roles/route.ts
+++ b/src/app/api/attribution-roles/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getUserIdFromRequest } from "@/lib/apiAuth";
+
+/**
+ * GET — active attribution roles. Any authenticated user can read; used to
+ * populate the roles dropdown in the order attribution panel and elsewhere.
+ * Admin CRUD lives at /api/admin/financial/attribution-roles.
+ */
+export async function GET(req: NextRequest) {
+  const userId = await getUserIdFromRequest(req);
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { data, error } = await supabaseAdmin
+    .from("attribution_roles")
+    .select("code, label, description, sort_order")
+    .eq("is_active", true)
+    .order("sort_order", { ascending: true });
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json(data || []);
+}

--- a/src/app/api/sales/agreements/[id]/send/route.ts
+++ b/src/app/api/sales/agreements/[id]/send/route.ts
@@ -273,6 +273,17 @@ export async function POST(
     })
     .eq("id", id);
 
+  // Phase 3 — lock attribution on the linked order (if any). Agreements
+  // are the tightest lock event because the customer is about to sign.
+  if (agreement.order_id) {
+    try {
+      const { lockAttribution } = await import("@/lib/salesAttribution");
+      await lockAttribution(agreement.order_id, "agreement_sent", user.id);
+    } catch (e) {
+      console.error("[agreements/send] attribution lock failed (non-fatal):", e);
+    }
+  }
+
   // Log activity
   const audience = sendToOperator ? "operator" : isLocationPlacement ? "location" : "operator";
   await supabaseAdmin.from("agreement_activity_log").insert({

--- a/src/app/api/sales/orders/[id]/attributions/route.ts
+++ b/src/app/api/sales/orders/[id]/attributions/route.ts
@@ -1,0 +1,123 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser, isElevatedRole } from "@/lib/salesAuth";
+import { getEffectiveAttribution, setAttributions, isOrderLocked, type AttributionInput } from "@/lib/salesAttribution";
+
+/**
+ * GET /api/sales/orders/[id]/attributions
+ *   Returns the current attribution rows + a `locked` flag + the current
+ *   user's permission to edit.
+ *
+ * PUT — replace the full attribution set for this order.
+ *   Body: { rows: [{ user_id, role_code, percentage, notes? }], change_reason? }
+ *   Rules:
+ *     - Non-elevated reps can only edit if unlocked AND they're either the
+ *       assigned_rep_id / created_by of the order (Lead Owner rights).
+ *       They CANNOT assign themselves credit on another rep's order.
+ *     - Admins can always edit — reason required if locked.
+ */
+
+interface OrderMeta {
+  assigned_rep_id: string | null;
+  created_by: string | null;
+}
+
+async function loadOrderMeta(id: string): Promise<OrderMeta | null> {
+  const { data } = await supabaseAdmin
+    .from("sales_orders")
+    .select("assigned_rep_id, created_by")
+    .eq("id", id)
+    .maybeSingle();
+  return data as OrderMeta | null;
+}
+
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const user = await getSalesUser(req);
+  if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id } = await params;
+
+  const meta = await loadOrderMeta(id);
+  if (!meta) return NextResponse.json({ error: "Order not found" }, { status: 404 });
+
+  const rows = await getEffectiveAttribution(id);
+  const locked = await isOrderLocked(id);
+
+  const isAdmin = isElevatedRole(user.role);
+  const isLeadOwner = meta.assigned_rep_id === user.id || meta.created_by === user.id;
+  const canEdit = isAdmin || (!locked && isLeadOwner);
+
+  // Non-admin non-lead-owner reps see only their own row (privacy on
+  // percentages that belong to other users). Lead Owner + admin see all.
+  const visibleRows = isAdmin || isLeadOwner ? rows : rows.filter((r) => r.user_id === user.id);
+
+  // Fetch display names for the visible rows
+  const userIds = Array.from(new Set(visibleRows.map((r) => r.user_id)));
+  const { data: profiles } = userIds.length > 0
+    ? await supabaseAdmin.from("profiles").select("id, full_name, email").in("id", userIds)
+    : { data: [] };
+  const nameMap = new Map((profiles || []).map((p) => [p.id, { name: p.full_name, email: p.email }]));
+
+  return NextResponse.json({
+    rows: visibleRows.map((r) => ({
+      ...r,
+      user_name: nameMap.get(r.user_id)?.name || null,
+      user_email: nameMap.get(r.user_id)?.email || null,
+    })),
+    locked,
+    can_edit: canEdit,
+    is_admin_editor: isAdmin,
+    total_percentage: visibleRows.reduce((sum, r) => sum + Number(r.percentage || 0), 0),
+  });
+}
+
+export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const user = await getSalesUser(req);
+  if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id } = await params;
+
+  const meta = await loadOrderMeta(id);
+  if (!meta) return NextResponse.json({ error: "Order not found" }, { status: 404 });
+
+  const isAdmin = isElevatedRole(user.role);
+  const isLeadOwner = meta.assigned_rep_id === user.id || meta.created_by === user.id;
+  const locked = await isOrderLocked(id);
+
+  if (!isAdmin) {
+    if (locked) return NextResponse.json({ error: "Attribution is locked. Contact an admin to change it." }, { status: 403 });
+    if (!isLeadOwner) return NextResponse.json({ error: "Only the Lead Owner or an admin can set attribution for this order." }, { status: 403 });
+  }
+
+  const body = await req.json().catch(() => ({}));
+  const rawRows = Array.isArray(body.rows) ? body.rows : [];
+  const rows: AttributionInput[] = rawRows
+    .filter((r: unknown): r is Record<string, unknown> => !!r && typeof r === "object")
+    .map((r: Record<string, unknown>) => ({
+      user_id: String(r.user_id || ""),
+      role_code: String(r.role_code || ""),
+      percentage: Number(r.percentage || 0),
+      notes: typeof r.notes === "string" ? r.notes : null,
+    }));
+
+  // Lead Owner sanity: non-admin reps cannot remove themselves entirely.
+  // They can share credit but must retain at least 1%.
+  if (!isAdmin) {
+    const selfShare = rows.find((r) => r.user_id === user.id);
+    if (!selfShare || Number(selfShare.percentage) <= 0) {
+      return NextResponse.json({ error: "As Lead Owner you must retain at least 1% credit. Ask an admin to reassign fully." }, { status: 400 });
+    }
+  }
+
+  try {
+    const written = await setAttributions({
+      orderId: id,
+      rows,
+      actorId: user.id,
+      authorizedAsAdmin: isAdmin,
+      changeReason: typeof body.change_reason === "string" ? body.change_reason : null,
+    });
+    return NextResponse.json({ ok: true, rows: written });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Failed to save";
+    return NextResponse.json({ error: msg }, { status: 400 });
+  }
+}

--- a/src/app/api/sales/orders/[id]/send/route.ts
+++ b/src/app/api/sales/orders/[id]/send/route.ts
@@ -224,6 +224,15 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
       activity_type: isQuote ? "quote_sent" : "order_sent",
       description: `${isQuote ? "Quote" : "Order"} emailed to ${recipientEmail}` + (ccEmails.length > 0 ? ` (CC: ${ccEmails.join(", ")})` : ""),
     });
+
+    // Phase 3 — lock sales attribution once the quote/order goes out.
+    // Seeds an implicit 100% Lead Owner row if nothing was set explicitly.
+    try {
+      const { lockAttribution } = await import("@/lib/salesAttribution");
+      await lockAttribution(orderId, isQuote ? "quote_sent" : "order_sent", user.id);
+    } catch (e) {
+      console.error("[orders/send] attribution lock failed (non-fatal):", e);
+    }
   }
 
   return NextResponse.json({

--- a/src/app/sales/orders/[id]/AttributionPanel.tsx
+++ b/src/app/sales/orders/[id]/AttributionPanel.tsx
@@ -1,0 +1,256 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { Loader2, Users, Lock, Plus, Trash2, AlertCircle, CheckCircle2, PenSquare } from "lucide-react";
+
+interface AttributionRow {
+  id: string;
+  user_id: string;
+  role_code: string;
+  percentage: number;
+  notes: string | null;
+  locked_at: string | null;
+  locked_by_event: string | null;
+  is_legacy_backfill: boolean;
+  user_name?: string | null;
+  user_email?: string | null;
+}
+
+interface AttributionData {
+  rows: AttributionRow[];
+  locked: boolean;
+  can_edit: boolean;
+  is_admin_editor: boolean;
+  total_percentage: number;
+}
+
+interface Role {
+  code: string;
+  label: string;
+  description?: string | null;
+  is_active: boolean;
+}
+
+interface RepOption {
+  id: string;
+  full_name: string;
+  email: string;
+}
+
+interface DraftRow {
+  user_id: string;
+  role_code: string;
+  percentage: number;
+  notes: string;
+}
+
+interface Props {
+  orderId: string;
+  token: string;
+}
+
+export default function AttributionPanel({ orderId, token }: Props) {
+  const [loading, setLoading] = useState(true);
+  const [data, setData] = useState<AttributionData | null>(null);
+  const [roles, setRoles] = useState<Role[]>([]);
+  const [reps, setReps] = useState<RepOption[]>([]);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState<DraftRow[]>([]);
+  const [changeReason, setChangeReason] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    const [attribRes, rolesRes, repsRes] = await Promise.all([
+      fetch(`/api/sales/orders/${orderId}/attributions`, { headers: { Authorization: `Bearer ${token}` } }),
+      fetch("/api/attribution-roles", { headers: { Authorization: `Bearer ${token}` } }).catch(() => null),
+      fetch("/api/sales/users", { headers: { Authorization: `Bearer ${token}` } }),
+    ]);
+    if (attribRes.ok) setData(await attribRes.json());
+    if (rolesRes && rolesRes.ok) setRoles(await rolesRes.json());
+    if (repsRes.ok) setReps(await repsRes.json());
+    setLoading(false);
+  }, [orderId, token]);
+
+  useEffect(() => { load(); }, [load]);
+
+  function startEditing() {
+    if (!data) return;
+    setDraft(data.rows.map((r) => ({
+      user_id: r.user_id,
+      role_code: r.role_code,
+      percentage: Number(r.percentage),
+      notes: r.notes || "",
+    })));
+    setChangeReason("");
+    setError(null);
+    setEditing(true);
+  }
+
+  function addRow() {
+    setDraft((d) => [...d, { user_id: reps[0]?.id || "", role_code: roles[0]?.code || "lead_owner", percentage: 0, notes: "" }]);
+  }
+  function removeRow(idx: number) {
+    setDraft((d) => d.filter((_, i) => i !== idx));
+  }
+  function updateRow(idx: number, patch: Partial<DraftRow>) {
+    setDraft((d) => d.map((r, i) => (i === idx ? { ...r, ...patch } : r)));
+  }
+
+  const draftTotal = draft.reduce((sum, r) => sum + Number(r.percentage || 0), 0);
+  const withinTolerance = Math.abs(draftTotal - 100) < 0.001;
+
+  async function save() {
+    if (!withinTolerance) { setError(`Percentages must sum to 100 (currently ${draftTotal.toFixed(2)})`); return; }
+    if (data?.locked && data?.is_admin_editor && !changeReason.trim()) {
+      setError("Change reason required to modify locked attribution.");
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    const res = await fetch(`/api/sales/orders/${orderId}/attributions`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ rows: draft, change_reason: changeReason || null }),
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) setError(body.error || "Failed to save");
+    else {
+      setEditing(false);
+      await load();
+    }
+    setSaving(false);
+  }
+
+  if (loading) {
+    return (
+      <div className="rounded-2xl border border-gray-100 bg-white p-5">
+        <div className="flex items-center gap-2 text-sm text-gray-500"><Loader2 className="h-4 w-4 animate-spin" /> Loading attribution…</div>
+      </div>
+    );
+  }
+  if (!data) return null;
+
+  return (
+    <div className="rounded-2xl border border-gray-100 bg-white p-5">
+      <div className="flex items-center justify-between mb-3 flex-wrap gap-2">
+        <div className="flex items-center gap-2">
+          <Users className="h-4 w-4 text-gray-400" />
+          <h3 className="text-sm font-semibold text-gray-900">Sales Attribution</h3>
+          {data.locked && (
+            <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700">
+              <Lock className="h-3 w-3" /> Locked
+            </span>
+          )}
+        </div>
+        {!editing && data.can_edit && (
+          <button
+            onClick={startEditing}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-gray-200 hover:bg-gray-50 px-3 py-1.5 text-xs font-medium text-gray-700 cursor-pointer"
+          >
+            <PenSquare className="h-3.5 w-3.5" /> Edit
+          </button>
+        )}
+      </div>
+
+      {error && (
+        <div className="mb-3 flex items-start gap-2 rounded-xl border border-red-200 bg-red-50 p-2.5 text-xs text-red-700">
+          <AlertCircle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {!editing ? (
+        <div className="space-y-2">
+          {data.rows.length === 0 ? (
+            <p className="text-xs text-gray-500">No credited users. The system-assigned rep receives implicit 100% Lead Owner credit until set explicitly.</p>
+          ) : (
+            data.rows.map((r) => (
+              <div key={r.id} className="flex items-center justify-between gap-3 rounded-lg border border-gray-100 p-2.5 text-sm">
+                <div className="flex-1 min-w-0">
+                  <p className="font-medium text-gray-900 truncate">{r.user_name || r.user_email || r.user_id.slice(0, 8)}</p>
+                  <p className="text-xs text-gray-500 capitalize">{r.role_code.replace(/_/g, " ")}{r.is_legacy_backfill && " · legacy backfill"}</p>
+                </div>
+                <div className="text-right">
+                  <p className="text-base font-bold text-emerald-700">{Number(r.percentage).toFixed(1)}%</p>
+                </div>
+              </div>
+            ))
+          )}
+          <div className="flex items-center justify-between pt-1 text-xs text-gray-500 border-t border-gray-100">
+            <span>Total</span>
+            <span className={data.total_percentage === 100 ? "font-semibold text-emerald-700" : "font-semibold text-amber-700"}>
+              {data.total_percentage.toFixed(1)}%
+            </span>
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {draft.map((r, i) => (
+            <div key={i} className="grid grid-cols-1 sm:grid-cols-[1fr_140px_100px_40px] gap-2 items-center rounded-lg border border-gray-100 p-2">
+              <select value={r.user_id} onChange={(e) => updateRow(i, { user_id: e.target.value })} className="rounded-lg border border-gray-200 px-2 py-1.5 text-xs">
+                {reps.map((rep) => <option key={rep.id} value={rep.id}>{rep.full_name || rep.email}</option>)}
+              </select>
+              <select value={r.role_code} onChange={(e) => updateRow(i, { role_code: e.target.value })} className="rounded-lg border border-gray-200 px-2 py-1.5 text-xs">
+                {roles.filter((role) => role.is_active).map((role) => <option key={role.code} value={role.code}>{role.label}</option>)}
+              </select>
+              <input
+                type="number"
+                min="0"
+                max="100"
+                step="0.1"
+                value={r.percentage}
+                onChange={(e) => updateRow(i, { percentage: Number(e.target.value) || 0 })}
+                className="rounded-lg border border-gray-200 px-2 py-1.5 text-xs text-right"
+              />
+              <button onClick={() => removeRow(i)} className="rounded-lg p-1.5 text-gray-400 hover:bg-red-50 hover:text-red-600 cursor-pointer">
+                <Trash2 className="h-4 w-4" />
+              </button>
+            </div>
+          ))}
+          <button
+            onClick={addRow}
+            className="w-full rounded-lg border border-dashed border-gray-300 py-2 text-xs text-gray-500 hover:bg-gray-50 cursor-pointer inline-flex items-center justify-center gap-1"
+          >
+            <Plus className="h-3.5 w-3.5" /> Add credit
+          </button>
+
+          <div className="flex items-center justify-between text-xs pt-2 border-t border-gray-100">
+            <span className="text-gray-500">Total</span>
+            <span className={withinTolerance ? "font-semibold text-emerald-700" : "font-semibold text-red-600"}>
+              {draftTotal.toFixed(1)}% {withinTolerance ? <CheckCircle2 className="inline h-3 w-3" /> : "(must be 100%)"}
+            </span>
+          </div>
+
+          {data.locked && data.is_admin_editor && (
+            <div>
+              <label className="block text-xs font-medium text-gray-600 mb-1">Change reason (required for locked orders)</label>
+              <textarea
+                value={changeReason}
+                onChange={(e) => setChangeReason(e.target.value)}
+                rows={2}
+                placeholder="Why is this attribution being adjusted after lock?"
+                className="w-full rounded-xl border border-gray-200 px-3 py-2 text-sm focus:border-green-primary focus:outline-none resize-none"
+              />
+            </div>
+          )}
+
+          <div className="flex justify-end gap-2 pt-2">
+            <button onClick={() => setEditing(false)} className="rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 cursor-pointer">
+              Cancel
+            </button>
+            <button
+              onClick={save}
+              disabled={saving || !withinTolerance}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-green-primary hover:bg-green-hover px-4 py-1.5 text-xs font-semibold text-white cursor-pointer disabled:opacity-50"
+            >
+              {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
+              Save Attribution
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/sales/orders/[id]/page.tsx
+++ b/src/app/sales/orders/[id]/page.tsx
@@ -8,6 +8,7 @@ import {
   Package, MapPin, Coffee, Monitor, Wrench, DollarSign,
   FileText, Clock, User, Building2, Trash2, ScrollText,
 } from "lucide-react";
+import AttributionPanel from "./AttributionPanel";
 
 interface OrderItem {
   id: string;
@@ -563,6 +564,9 @@ export default function OrderDetailPage() {
               </div>
             )}
           </div>
+
+          {/* Sales Attribution (Phase 3) */}
+          {token && <AttributionPanel orderId={id} token={token} />}
 
           {/* Documents */}
           <div className="rounded-xl border border-gray-200 bg-white p-5">

--- a/src/lib/salesAttribution.ts
+++ b/src/lib/salesAttribution.ts
@@ -1,0 +1,313 @@
+/**
+ * Sales attribution — multi-user credit per order.
+ *
+ * Rules:
+ *   - Sum of percentages per order must equal 100 (when any row exists).
+ *   - Once ANY row on an order is locked, the whole order is considered
+ *     locked. Reps cannot edit; admins can override with a written reason.
+ *   - Lead Owner default: if no rows exist, an implicit 100% goes to the
+ *     order's assigned_rep_id / created_by (whichever is set first).
+ *
+ * All writes go through this module so audit + validation stay consistent.
+ */
+
+import { supabaseAdmin } from "./supabaseAdmin";
+import { writeAuditLog } from "./paymentLedger";
+
+export type LockEvent = "quote_sent" | "agreement_sent" | "order_sent" | "manual_admin_lock";
+
+export interface AttributionRow {
+  id: string;
+  order_id: string;
+  user_id: string;
+  role_code: string;
+  percentage: number;
+  notes: string | null;
+  locked_at: string | null;
+  locked_by_event: LockEvent | null;
+  is_legacy_backfill: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AttributionInput {
+  user_id: string;
+  role_code: string;
+  percentage: number;
+  notes?: string | null;
+}
+
+const SUM_EPSILON = 0.001;
+
+/** Sum-to-100 check with tolerance for floating point. */
+function assertSum100(rows: AttributionInput[]): void {
+  const total = rows.reduce((sum, r) => sum + Number(r.percentage || 0), 0);
+  if (Math.abs(total - 100) > SUM_EPSILON) {
+    throw new Error(`Attribution percentages must sum to exactly 100 (got ${total.toFixed(3)}).`);
+  }
+}
+
+/** Basic validation — same user can't appear twice with same role, etc. */
+function validateRows(rows: AttributionInput[]): void {
+  if (rows.length === 0) return; // empty means "clear and fall back to implicit lead owner"
+  if (rows.length > 25) throw new Error("Too many attribution rows (max 25).");
+  const seen = new Set<string>();
+  for (const r of rows) {
+    if (!r.user_id) throw new Error("Every attribution row needs a user_id.");
+    if (!r.role_code) throw new Error("Every attribution row needs a role_code.");
+    const p = Number(r.percentage);
+    if (!Number.isFinite(p) || p < 0 || p > 100) throw new Error(`Percentage must be 0-100 (got ${r.percentage}).`);
+    const key = `${r.user_id}|${r.role_code}`;
+    if (seen.has(key)) throw new Error(`Duplicate row: user ${r.user_id.slice(0, 8)} with role ${r.role_code}.`);
+    seen.add(key);
+  }
+  assertSum100(rows);
+}
+
+/**
+ * Load all attribution rows for an order.
+ */
+export async function getAttributions(orderId: string): Promise<AttributionRow[]> {
+  const { data } = await supabaseAdmin
+    .from("sales_attributions")
+    .select("*")
+    .eq("order_id", orderId)
+    .order("percentage", { ascending: false });
+  return (data || []) as AttributionRow[];
+}
+
+/**
+ * Is any row on this order locked? A locked order can only be modified by an
+ * admin override.
+ */
+export async function isOrderLocked(orderId: string): Promise<boolean> {
+  const { count } = await supabaseAdmin
+    .from("sales_attributions")
+    .select("*", { count: "exact", head: true })
+    .eq("order_id", orderId)
+    .not("locked_at", "is", null);
+  return (count || 0) > 0;
+}
+
+/**
+ * Get the "effective" attribution for an order — either the persisted rows
+ * or the implicit 100% Lead Owner fallback derived from
+ * sales_orders.assigned_rep_id (or created_by).
+ */
+export async function getEffectiveAttribution(orderId: string): Promise<AttributionRow[]> {
+  const persisted = await getAttributions(orderId);
+  if (persisted.length > 0) return persisted;
+
+  const { data: order } = await supabaseAdmin
+    .from("sales_orders")
+    .select("assigned_rep_id, created_by, created_at")
+    .eq("id", orderId)
+    .maybeSingle();
+  if (!order) return [];
+  const userId = order.assigned_rep_id || order.created_by;
+  if (!userId) return [];
+
+  return [{
+    id: `implicit-${orderId}`,
+    order_id: orderId,
+    user_id: userId,
+    role_code: "lead_owner",
+    percentage: 100,
+    notes: "Implicit default — no explicit attribution set.",
+    locked_at: null,
+    locked_by_event: null,
+    is_legacy_backfill: false,
+    created_at: order.created_at || new Date().toISOString(),
+    updated_at: order.created_at || new Date().toISOString(),
+  }];
+}
+
+/**
+ * Replace attribution rows for an order. Atomic-ish: DELETE existing rows for
+ * this order + INSERT new rows in a single logical unit. Failures leave the
+ * DB in a valid state (either all old rows or all new rows), but Supabase
+ * doesn't expose true multi-statement transactions from the JS client —
+ * callers should NOT retry on partial failure without checking state.
+ *
+ * If the order is locked, `authorized_as_admin` must be true and a
+ * `change_reason` must be provided. Both get written to audit_logs.
+ */
+export interface SetAttributionsArgs {
+  orderId: string;
+  rows: AttributionInput[];
+  actorId: string;
+  authorizedAsAdmin: boolean;
+  changeReason?: string | null;
+}
+
+export async function setAttributions(args: SetAttributionsArgs): Promise<AttributionRow[]> {
+  validateRows(args.rows);
+
+  const locked = await isOrderLocked(args.orderId);
+  if (locked && !args.authorizedAsAdmin) {
+    throw new Error("Attribution is locked. Only an admin can change it.");
+  }
+  if (locked && (!args.changeReason || !args.changeReason.trim())) {
+    throw new Error("A change reason is required to modify locked attribution.");
+  }
+
+  // Capture the before-state for the audit trail
+  const before = await getAttributions(args.orderId);
+
+  // Wipe existing rows for this order
+  await supabaseAdmin
+    .from("sales_attributions")
+    .delete()
+    .eq("order_id", args.orderId);
+
+  if (args.rows.length === 0) {
+    // Cleared — implicit lead owner fallback re-engages.
+    await writeAuditLog({
+      actorId: args.actorId,
+      action: locked ? "attribution_cleared_admin_override" : "attribution_cleared",
+      entityType: "sales_order",
+      entityId: args.orderId,
+      reason: args.changeReason || null,
+      before: { rows: before },
+      after: { rows: [] },
+    });
+    return [];
+  }
+
+  const inserted: AttributionRow[] = [];
+  for (const r of args.rows) {
+    const { data, error } = await supabaseAdmin
+      .from("sales_attributions")
+      .insert({
+        order_id: args.orderId,
+        user_id: r.user_id,
+        role_code: r.role_code,
+        percentage: r.percentage,
+        notes: r.notes || null,
+        created_by: args.actorId,
+      })
+      .select("*")
+      .single();
+    if (error) throw error;
+    inserted.push(data as AttributionRow);
+  }
+
+  await writeAuditLog({
+    actorId: args.actorId,
+    action: locked ? "attribution_admin_override" : (before.length > 0 ? "attribution_updated" : "attribution_set"),
+    entityType: "sales_order",
+    entityId: args.orderId,
+    reason: args.changeReason || null,
+    before: { rows: before },
+    after: { rows: inserted },
+  });
+
+  return inserted;
+}
+
+/**
+ * Lock every attribution row on an order — called from send routes when a
+ * quote/agreement/order goes out. If no rows exist yet, seeds an implicit
+ * 100% Lead Owner row before locking.
+ */
+export async function lockAttribution(orderId: string, event: LockEvent, actorId: string | null): Promise<void> {
+  const existing = await getAttributions(orderId);
+  if (existing.length === 0) {
+    // Seed the implicit default before locking so the row is real
+    const { data: order } = await supabaseAdmin
+      .from("sales_orders")
+      .select("assigned_rep_id, created_by")
+      .eq("id", orderId)
+      .maybeSingle();
+    const userId = order?.assigned_rep_id || order?.created_by;
+    if (!userId) {
+      // Can't seed without a rep — silently skip; will retry on next send.
+      return;
+    }
+    await supabaseAdmin
+      .from("sales_attributions")
+      .insert({
+        order_id: orderId,
+        user_id: userId,
+        role_code: "lead_owner",
+        percentage: 100,
+        notes: `Auto-locked on ${event}`,
+        locked_at: new Date().toISOString(),
+        locked_by_event: event,
+        created_by: actorId,
+        is_legacy_backfill: false,
+      });
+  } else if (existing.some((r) => !r.locked_at)) {
+    // Lock in place — no data changes, just stamp the lock fields.
+    await supabaseAdmin
+      .from("sales_attributions")
+      .update({
+        locked_at: new Date().toISOString(),
+        locked_by_event: event,
+      })
+      .eq("order_id", orderId)
+      .is("locked_at", null);
+  }
+
+  await writeAuditLog({
+    actorId,
+    action: "attribution_locked",
+    entityType: "sales_order",
+    entityId: orderId,
+    metadata: { event },
+  });
+}
+
+/**
+ * Backfill: for every sales_orders row that has no attribution rows yet,
+ * seed a 100% Lead Owner row from assigned_rep_id / created_by. Marked as
+ * legacy so future admin views can distinguish "we filled this in" from
+ * "someone set this deliberately".
+ */
+export async function backfillAttributions(opts: { limit?: number; sinceDays?: number }): Promise<{
+  scanned: number;
+  seeded: number;
+  skipped_no_rep: number;
+  skipped_existing: number;
+  errors: string[];
+}> {
+  const summary = { scanned: 0, seeded: 0, skipped_no_rep: 0, skipped_existing: 0, errors: [] as string[] };
+  const limit = Math.min(1000, Math.max(1, opts.limit ?? 500));
+  const cutoff = new Date(Date.now() - (opts.sinceDays ?? 3650) * 24 * 60 * 60 * 1000).toISOString();
+
+  const { data: orders } = await supabaseAdmin
+    .from("sales_orders")
+    .select("id, assigned_rep_id, created_by")
+    .gte("created_at", cutoff)
+    .order("created_at", { ascending: false })
+    .limit(limit);
+
+  for (const o of orders || []) {
+    summary.scanned++;
+
+    const { count } = await supabaseAdmin
+      .from("sales_attributions")
+      .select("*", { count: "exact", head: true })
+      .eq("order_id", o.id);
+    if ((count || 0) > 0) { summary.skipped_existing++; continue; }
+
+    const userId = o.assigned_rep_id || o.created_by;
+    if (!userId) { summary.skipped_no_rep++; continue; }
+
+    try {
+      await supabaseAdmin.from("sales_attributions").insert({
+        order_id: o.id,
+        user_id: userId,
+        role_code: "lead_owner",
+        percentage: 100,
+        notes: "Legacy backfill — implicit 100% to assigned_rep_id.",
+        is_legacy_backfill: true,
+      });
+      summary.seeded++;
+    } catch (e) {
+      summary.errors.push(`${o.id.slice(0, 8)}: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  return summary;
+}

--- a/supabase/migrations/108_sales_attributions.sql
+++ b/supabase/migrations/108_sales_attributions.sql
@@ -1,0 +1,94 @@
+-- Phase 3 — Sales attribution model.
+--
+-- Every order can carry one-to-many credited users, each with a role code
+-- and a percentage. The sum of percentages on an unreleased order must equal
+-- 100 (enforced at the API layer — sum-as-you-build via trigger would need
+-- deferrable constraints and blocks partial edits).
+--
+-- Once a "lock event" fires (quote_sent | agreement_sent | order_sent),
+-- attribution locks:
+--   - Sales reps can no longer edit
+--   - Admins can override with a documented reason (audit_logs row)
+--
+-- Roles are configurable — five defaults ship, admin can add/rename/soft-
+-- delete via /admin/financial/settings.
+
+-- ─── Attribution roles (configurable) ────────────────────────────────────
+CREATE TABLE IF NOT EXISTS attribution_roles (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  code text NOT NULL UNIQUE,        -- machine-readable identifier
+  label text NOT NULL,              -- human-facing label
+  description text,
+  sort_order int NOT NULL DEFAULT 100,
+  is_active boolean NOT NULL DEFAULT true,
+  is_system boolean NOT NULL DEFAULT false,   -- system roles can't be deleted
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_attribution_roles_active ON attribution_roles(is_active, sort_order);
+
+-- Seed the five defaults
+INSERT INTO attribution_roles (code, label, description, sort_order, is_system)
+VALUES
+  ('lead_owner', 'Lead Owner', 'The rep who created or properly claimed the lead. Default 100% attribution.', 10, true),
+  ('closer', 'Closer', 'The rep who owned the deal at close.', 20, true),
+  ('referrer', 'Referrer', 'Person or partner who referred the lead.', 30, true),
+  ('assist', 'Support / Assist', 'Anyone who materially helped close the deal without owning it.', 40, true),
+  ('manager_override', 'Manager Override', 'Manager or director credit on team plays.', 50, true)
+ON CONFLICT (code) DO NOTHING;
+
+-- ─── Sales attributions ─────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS sales_attributions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  order_id uuid NOT NULL REFERENCES sales_orders(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES profiles(id) ON DELETE RESTRICT,
+  role_code text NOT NULL REFERENCES attribution_roles(code) ON DELETE RESTRICT,
+  percentage numeric(6,3) NOT NULL CHECK (percentage >= 0 AND percentage <= 100),
+  notes text,
+
+  -- Lock state (set on quote_sent / agreement_sent / order_sent)
+  locked_at timestamptz,
+  locked_by_event text CHECK (locked_by_event IS NULL OR locked_by_event IN (
+    'quote_sent', 'agreement_sent', 'order_sent', 'manual_admin_lock'
+  )),
+
+  is_legacy_backfill boolean NOT NULL DEFAULT false,
+
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now(),
+  created_by uuid REFERENCES profiles(id),
+
+  UNIQUE (order_id, user_id, role_code)   -- one credit per (order, user, role)
+);
+
+CREATE INDEX IF NOT EXISTS idx_attributions_order ON sales_attributions(order_id);
+CREATE INDEX IF NOT EXISTS idx_attributions_user ON sales_attributions(user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_attributions_role ON sales_attributions(role_code);
+CREATE INDEX IF NOT EXISTS idx_attributions_locked ON sales_attributions(order_id) WHERE locked_at IS NOT NULL;
+
+-- ─── RLS ─────────────────────────────────────────────────────────────────
+ALTER TABLE attribution_roles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE sales_attributions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Service role only" ON attribution_roles;
+CREATE POLICY "Service role only" ON attribution_roles
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- Every authenticated user can read the role list (populates dropdowns).
+DROP POLICY IF EXISTS "Read roles" ON attribution_roles;
+CREATE POLICY "Read roles" ON attribution_roles
+  FOR SELECT TO authenticated
+  USING (is_active = true);
+
+DROP POLICY IF EXISTS "Service role only" ON sales_attributions;
+CREATE POLICY "Service role only" ON sales_attributions
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- Reps can SELECT rows where they're credited (used by "My Performance"
+-- pages in Phase 5). Admin-facing "all orders" views hit through the API
+-- layer with service role.
+DROP POLICY IF EXISTS "Rep reads own attributions" ON sales_attributions;
+CREATE POLICY "Rep reads own attributions" ON sales_attributions
+  FOR SELECT TO authenticated
+  USING (user_id = auth.uid());


### PR DESCRIPTION
Ships the sales-credit backbone. Every order can now carry N credited users with roles + percentages, locks automatically when a quote/agreement/order is sent, admins can override with a documented reason, and every attribution change writes to audit_logs. Backfill seeds legacy orders with implicit 100% Lead Owner credit.

Migration 108 (additive):
- attribution_roles: configurable role list. Seeds 5 defaults marked is_system=true: lead_owner, closer, referrer, assist, manager_override. System roles can be renamed but not deactivated (referenced by legacy backfills).
- sales_attributions: order_id + user_id + role_code + percentage + locked_at + locked_by_event (quote_sent | agreement_sent | order_sent | manual_admin_lock) + is_legacy_backfill. UNIQUE on (order, user, role) so the same user can't stack the same role twice.
- RLS: service_role owns writes; authenticated reads roles (populates dropdowns); reps SELECT their own attribution rows (used by Phase 5 rep dashboards).

src/lib/salesAttribution.ts:
- validateRows: sum-to-100 with 0.001 epsilon, max 25 rows, no duplicate (user, role) pairs.
- getAttributions / isOrderLocked / getEffectiveAttribution — read helpers. Effective = persisted rows OR implicit 100% fallback to assigned_rep_id / created_by.
- setAttributions: DELETE-then-INSERT replace semantics. Rejects if order is locked and caller isn't admin, requires change_reason if admin overrides a locked order. Writes audit_logs with before/after JSONB.
- lockAttribution: called from send routes. Seeds implicit Lead Owner if no rows exist, then stamps locked_at + locked_by_event on every unlocked row.
- backfillAttributions: idempotent seed of 100% Lead Owner rows on legacy sales_orders using assigned_rep_id → created_by fallback. Marks is_legacy_backfill=true so admin views can distinguish.

APIs:
- GET /api/attribution-roles — active roles list. Authenticated (RLS- scoped view). Populates the panel dropdown.
- GET /api/sales/orders/[id]/attributions — rep-scoped. Non-admin non- Lead-Owner reps only see their own row. Also returns { locked, can_edit, is_admin_editor, total_percentage }.
- PUT /api/sales/orders/[id]/attributions — validation-heavy:
  - Non-admin can't edit locked orders.
  - Non-admin can only edit if they're the Lead Owner (assigned_rep_id / created_by).
  - Non-admin Lead Owner must retain ≥1% for themselves.
- GET /api/admin/financial/attributions — admin inspector. Filters: role_code, locked=true/false, user_id.
- POST /api/admin/financial/attributions/backfill — one-shot seed for legacy orders. Writes an audit_logs row.
- GET/POST /api/admin/financial/attribution-roles + PATCH/DELETE /[id] — admin CRUD. System roles reject deactivation/delete; custom roles soft-delete (is_active=false).

Order attribution panel (/sales/orders/[id]/AttributionPanel.tsx):
- Renders on every order detail page above Documents.
- Read view: per-row user + role + %, total, lock badge if locked.
- Edit view: add/remove rows, per-row user picker + role dropdown + percentage; live sum tracker turns red if != 100.
- If admin AND order locked → requires change reason textarea before save.
- Non-editing reps see only rows they're on unless they're admin or Lead Owner.

Admin pages:
- /admin/financial/attributions replaces the Phase-1 stub — attribution inspector table with role + locked + user filters + one-click backfill button.
- /admin/financial/settings replaces the Phase-1 stub — attribution roles editor: create new custom role, rename, deactivate/reactivate, delete (soft). System roles show a "system" lock badge and refuse deletion.

Lock hooks (existing send routes — additive):
- POST /api/sales/orders/[id]/send: after successful send, calls lockAttribution(orderId, isQuote ? 'quote_sent' : 'order_sent'). Seeds implicit Lead Owner if nothing was set. Non-fatal.
- POST /api/sales/agreements/[id]/send: locks the linked order's attribution via 'agreement_sent' if agreement.order_id is set.

Existing behavior preserved:
- Zero changes to sales_orders schema, order_items, existing send flows' return values, sales_commissions table, RLS on other tables, or webhook handlers.
- lockAttribution is wrapped in try/catch — a failure there won't fail a send.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2