### PR TITLE
Phase 4 — commission rules + ledger + auto-earn + auto-reverse

### DIFF
--- a/src/app/admin/financial/commissions/page.tsx
+++ b/src/app/admin/financial/commissions/page.tsx
@@ -1,18 +1,346 @@
-import { Clock } from "lucide-react";
+"use client";
 
-export default function CommissionsStub() {
+import { useEffect, useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Loader2, Percent, ArrowLeft, Filter, Play, DollarSign, CheckSquare, Square, AlertCircle, CheckCircle2, Database } from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
+
+interface LedgerRow {
+  id: string;
+  user_id: string;
+  order_id: string;
+  role_code: string;
+  attribution_percentage: number;
+  basis_cents: number;
+  rate_bps: number;
+  amount_cents: number;
+  hold_days: number;
+  status: string;
+  earned_at: string;
+  clearable_at: string | null;
+  paid_at: string | null;
+  reversed_of_id: string | null;
+  reversal_reason: string | null;
+  user: { id: string; full_name: string | null; email: string | null } | null;
+  order: { id: string; total_value: number; order_type: string | null; order_status: string; created_at: string } | null;
+}
+
+interface Summary {
+  earned_cents: number;
+  held_cents: number;
+  reversed_cents: number;
+  paid_cents: number;
+  row_count: number;
+}
+
+interface RoleOption {
+  code: string;
+  label: string;
+}
+
+const STATUS_FILTERS = [
+  { key: "any", label: "Any status" },
+  { key: "earned", label: "Earned" },
+  { key: "held", label: "Held" },
+  { key: "paid", label: "Paid" },
+  { key: "reversed", label: "Reversed" },
+];
+
+const STATUS_STYLES: Record<string, string> = {
+  earned: "bg-emerald-50 text-emerald-700 border-emerald-100",
+  held: "bg-amber-50 text-amber-700 border-amber-100",
+  paid: "bg-blue-50 text-blue-700 border-blue-100",
+  reversed: "bg-red-50 text-red-700 border-red-100",
+  cancelled: "bg-gray-100 text-gray-500 border-gray-200",
+};
+
+function fmt(cents: number): string {
+  const dollars = cents / 100;
+  return `$${dollars.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+export default function AdminCommissionsPage() {
+  const router = useRouter();
+  const [token, setToken] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [rows, setRows] = useState<LedgerRow[]>([]);
+  const [summary, setSummary] = useState<Summary | null>(null);
+  const [roles, setRoles] = useState<RoleOption[]>([]);
+
+  const [statusFilter, setStatusFilter] = useState("any");
+  const [roleFilter, setRoleFilter] = useState("");
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  const [backfillNeeded, setBackfillNeeded] = useState<number | null>(null);
+  const [running, setRunning] = useState(false);
+  const [marking, setMarking] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!token) return;
+    setLoading(true);
+    const params = new URLSearchParams();
+    if (statusFilter !== "any") params.set("status", statusFilter);
+    if (roleFilter) params.set("role_code", roleFilter);
+    const [ledgerRes, rolesRes, backfillRes] = await Promise.all([
+      fetch(`/api/admin/financial/commissions?${params}`, { headers: { Authorization: `Bearer ${token}` } }),
+      fetch("/api/attribution-roles", { headers: { Authorization: `Bearer ${token}` } }),
+      fetch("/api/admin/financial/commissions/backfill", { headers: { Authorization: `Bearer ${token}` } }),
+    ]);
+    if (ledgerRes.ok) {
+      const data = await ledgerRes.json();
+      setRows(data.rows || []);
+      setSummary(data.summary || null);
+    }
+    if (rolesRes.ok) setRoles(await rolesRes.json());
+    if (backfillRes.ok) {
+      const b = await backfillRes.json();
+      setBackfillNeeded(Number(b.needs_backfill) || 0);
+    }
+    setLoading(false);
+  }, [token, statusFilter, roleFilter]);
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!session?.access_token) { router.push("/login?redirect=/admin/financial/commissions"); return; }
+      setToken(session.access_token);
+    });
+  }, [router]);
+
+  useEffect(() => { load(); }, [load]);
+
+  async function runBackfill() {
+    if (!confirm("Compute commission ledger rows for paid payments that don't have any yet? Idempotent — safe to re-run.")) return;
+    setRunning(true);
+    setError(null); setMessage(null);
+    const res = await fetch("/api/admin/financial/commissions/backfill", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ limit: 1000, since_days: 365 }),
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) setError(body.error || "Backfill failed");
+    else setMessage(`Backfill complete — scanned ${body.scanned}, earned rows on ${body.earned} payments.`);
+    await load();
+    setRunning(false);
+  }
+
+  function toggleSelected(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  }
+
+  function toggleAllVisible() {
+    const eligible = rows
+      .filter((r) => r.status === "earned" || (r.status === "held" && r.clearable_at && new Date(r.clearable_at).getTime() <= Date.now()))
+      .map((r) => r.id);
+    if (eligible.every((id) => selected.has(id)) && eligible.length > 0) {
+      setSelected(new Set());
+    } else {
+      setSelected(new Set(eligible));
+    }
+  }
+
+  async function markPaid() {
+    if (selected.size === 0) return;
+    if (!confirm(`Mark ${selected.size} commission row${selected.size === 1 ? "" : "s"} as paid? This does not send money — Phase 6 will hand off to QB.`)) return;
+    setMarking(true);
+    setError(null); setMessage(null);
+    const res = await fetch("/api/admin/financial/commissions/mark-paid", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ ids: Array.from(selected), note: "Manual mark-paid from admin inspector" }),
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) setError(body.error || "Mark-paid failed");
+    else setMessage(`Marked ${body.paid} rows as paid (${fmt(body.total_cents)}).`);
+    setSelected(new Set());
+    await load();
+    setMarking(false);
+  }
+
+  const eligibleCount = rows.filter((r) =>
+    r.status === "earned" || (r.status === "held" && r.clearable_at && new Date(r.clearable_at).getTime() <= Date.now())
+  ).length;
+
   return (
     <div className="p-6">
-      <h1 className="text-2xl font-bold text-gray-900 mb-2">Commissions</h1>
-      <p className="text-sm text-gray-500 mb-6">
-        Company-wide commission ledger, category rates, per-user rate overrides, payout batches.
-      </p>
-      <div className="rounded-2xl border border-amber-200 bg-amber-50 p-6 flex items-center gap-3">
-        <Clock className="h-6 w-6 text-amber-600" />
+      <Link href="/admin/financial" className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-green-primary mb-4">
+        <ArrowLeft className="h-4 w-4" /> Financial Center
+      </Link>
+
+      <div className="flex items-center justify-between mb-4 flex-wrap gap-3">
         <div>
-          <p className="text-sm font-medium text-amber-900">Ships in Phase 4</p>
-          <p className="text-xs text-amber-700">Rules editor, ledger view, auto-earn on collection, hold periods, snapshot-at-earn.</p>
+          <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
+            <Percent className="h-6 w-6 text-green-primary" /> Commission Ledger
+          </h1>
+          <p className="text-sm text-gray-500 mt-1">Auto-earn fires on paid payments using active attribution + rate rules. Refunds and chargebacks write pro-rata reversals.</p>
         </div>
+        <div className="flex items-center gap-2">
+          <Link href="/admin/financial/settings" className="rounded-xl border border-gray-200 hover:bg-gray-50 px-3 py-2 text-xs font-semibold text-gray-700">
+            Rules & holds
+          </Link>
+          <button
+            onClick={runBackfill}
+            disabled={running}
+            className="inline-flex items-center gap-1.5 rounded-xl border border-gray-200 hover:bg-gray-50 px-4 py-2 text-xs font-semibold text-gray-700 cursor-pointer disabled:opacity-50"
+          >
+            {running ? <Loader2 className="h-4 w-4 animate-spin" /> : <Play className="h-4 w-4" />}
+            Backfill
+            {backfillNeeded !== null && backfillNeeded > 0 && <span className="ml-1 rounded-full bg-amber-100 px-1.5 text-[10px] text-amber-700">{backfillNeeded}</span>}
+          </button>
+        </div>
+      </div>
+
+      {message && (
+        <div className="mb-4 flex items-start gap-2 rounded-xl border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-700">
+          <CheckCircle2 className="h-4 w-4 mt-0.5 shrink-0" />
+          <span>{message}</span>
+        </div>
+      )}
+      {error && (
+        <div className="mb-4 flex items-start gap-2 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {/* Summary cards */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
+        <div className="rounded-2xl border border-gray-100 bg-white p-4">
+          <p className="text-[10px] font-medium uppercase tracking-wide text-gray-500">Earned (open)</p>
+          <p className="text-lg font-bold text-emerald-700 mt-1">{summary ? fmt(summary.earned_cents) : "…"}</p>
+        </div>
+        <div className="rounded-2xl border border-gray-100 bg-white p-4">
+          <p className="text-[10px] font-medium uppercase tracking-wide text-gray-500">Held</p>
+          <p className="text-lg font-bold text-amber-700 mt-1">{summary ? fmt(summary.held_cents) : "…"}</p>
+        </div>
+        <div className="rounded-2xl border border-gray-100 bg-white p-4">
+          <p className="text-[10px] font-medium uppercase tracking-wide text-gray-500">Paid</p>
+          <p className="text-lg font-bold text-blue-700 mt-1">{summary ? fmt(summary.paid_cents) : "…"}</p>
+        </div>
+        <div className="rounded-2xl border border-gray-100 bg-white p-4">
+          <p className="text-[10px] font-medium uppercase tracking-wide text-gray-500">Reversed</p>
+          <p className="text-lg font-bold text-red-700 mt-1">{summary ? fmt(summary.reversed_cents) : "…"}</p>
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div className="mb-4 flex items-center gap-2 flex-wrap">
+        <Filter className="h-4 w-4 text-gray-400" />
+        <select value={roleFilter} onChange={(e) => setRoleFilter(e.target.value)} className="rounded-lg border border-gray-200 px-3 py-1.5 text-xs">
+          <option value="">All roles</option>
+          {roles.map((r) => <option key={r.code} value={r.code}>{r.label}</option>)}
+        </select>
+        {STATUS_FILTERS.map((f) => (
+          <button
+            key={f.key}
+            onClick={() => setStatusFilter(f.key)}
+            className={`rounded-lg px-3 py-1.5 text-xs font-medium cursor-pointer ${statusFilter === f.key ? "bg-green-100 text-green-700" : "bg-gray-100 text-gray-500 hover:bg-gray-200"}`}
+          >
+            {f.label}
+          </button>
+        ))}
+        {selected.size > 0 && (
+          <button
+            onClick={markPaid}
+            disabled={marking}
+            className="ml-auto inline-flex items-center gap-1.5 rounded-lg bg-green-primary hover:bg-green-hover px-3 py-1.5 text-xs font-semibold text-white cursor-pointer disabled:opacity-50"
+          >
+            {marking ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <DollarSign className="h-3.5 w-3.5" />}
+            Mark {selected.size} paid
+          </button>
+        )}
+      </div>
+
+      <div className="rounded-2xl border border-gray-100 bg-white p-5 overflow-hidden">
+        {loading ? (
+          <div className="flex justify-center py-8"><Loader2 className="h-5 w-5 animate-spin text-green-primary" /></div>
+        ) : rows.length === 0 ? (
+          <div className="text-center py-12 text-sm text-gray-500">
+            <Database className="h-8 w-8 mx-auto mb-2 text-gray-300" />
+            <p>No commission rows match the current filters.</p>
+            {backfillNeeded !== null && backfillNeeded > 0 && (
+              <p className="text-xs text-gray-400 mt-1">{backfillNeeded} paid payment{backfillNeeded === 1 ? "" : "s"} could be backfilled.</p>
+            )}
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-xs text-gray-500 border-b border-gray-100">
+                  <th className="text-left py-2 px-2 font-medium w-8">
+                    <button onClick={toggleAllVisible} className="cursor-pointer text-gray-400 hover:text-gray-700" title="Select eligible">
+                      {eligibleCount > 0 && rows.filter((r) => selected.has(r.id)).length >= eligibleCount ? <CheckSquare className="h-4 w-4" /> : <Square className="h-4 w-4" />}
+                    </button>
+                  </th>
+                  <th className="text-left py-2 px-2 font-medium">User</th>
+                  <th className="text-left py-2 px-2 font-medium">Role</th>
+                  <th className="text-right py-2 px-2 font-medium">Rate</th>
+                  <th className="text-right py-2 px-2 font-medium">Amount</th>
+                  <th className="text-left py-2 px-2 font-medium">Order</th>
+                  <th className="text-left py-2 px-2 font-medium">Status</th>
+                  <th className="text-left py-2 px-2 font-medium">Earned</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((r) => {
+                  const eligible = r.status === "earned" || (r.status === "held" && r.clearable_at && new Date(r.clearable_at).getTime() <= Date.now());
+                  const stStyle = STATUS_STYLES[r.status] || "bg-gray-100 text-gray-500 border-gray-200";
+                  return (
+                    <tr key={r.id} className={`border-b border-gray-50 last:border-b-0 ${selected.has(r.id) ? "bg-green-50/40" : ""}`}>
+                      <td className="py-2 px-2">
+                        {eligible ? (
+                          <button onClick={() => toggleSelected(r.id)} className="cursor-pointer text-gray-400 hover:text-gray-700">
+                            {selected.has(r.id) ? <CheckSquare className="h-4 w-4" /> : <Square className="h-4 w-4" />}
+                          </button>
+                        ) : (
+                          <Square className="h-4 w-4 text-gray-200" />
+                        )}
+                      </td>
+                      <td className="py-2 px-2 text-xs">
+                        <p className="font-medium text-gray-900">{r.user?.full_name || r.user?.email || r.user_id.slice(0, 8)}</p>
+                        <p className="text-gray-400">{r.user?.email}</p>
+                      </td>
+                      <td className="py-2 px-2 text-xs capitalize">{r.role_code.replace(/_/g, " ")}</td>
+                      <td className="py-2 px-2 text-right text-xs">
+                        <span className="font-mono">{(r.rate_bps / 100).toFixed(2)}%</span>
+                        <span className="text-gray-400 block">× {Number(r.attribution_percentage).toFixed(1)}% attr</span>
+                      </td>
+                      <td className={`py-2 px-2 text-right font-semibold ${r.amount_cents < 0 ? "text-red-700" : "text-emerald-700"}`}>
+                        {fmt(r.amount_cents)}
+                      </td>
+                      <td className="py-2 px-2 text-xs">
+                        <Link href={`/sales/orders/${r.order_id}`} className="font-mono text-green-primary hover:underline">
+                          {r.order_id.slice(0, 8)}
+                        </Link>
+                        {r.order?.order_type && <span className="ml-1 text-[10px] text-gray-400 uppercase">{r.order.order_type}</span>}
+                      </td>
+                      <td className="py-2 px-2">
+                        <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-medium ${stStyle}`}>
+                          {r.status}
+                          {r.status === "held" && r.clearable_at && (
+                            <span className="ml-1 text-gray-500">→ {new Date(r.clearable_at).toLocaleDateString()}</span>
+                          )}
+                        </span>
+                        {r.reversal_reason && <p className="text-[10px] text-red-500 mt-0.5 italic">{r.reversal_reason}</p>}
+                      </td>
+                      <td className="py-2 px-2 text-xs text-gray-500">
+                        {new Date(r.earned_at).toLocaleDateString()}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/app/admin/financial/settings/page.tsx
+++ b/src/app/admin/financial/settings/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { Loader2, ArrowLeftRight, ArrowLeft, Plus, Trash2, AlertCircle, CheckCircle2, Lock } from "lucide-react";
+import { Loader2, ArrowLeftRight, ArrowLeft, Plus, Trash2, AlertCircle, CheckCircle2, Lock, Percent, Clock, User as UserIcon, Tag } from "lucide-react";
 import { createBrowserClient } from "@/lib/supabase";
 
 interface Role {
@@ -17,24 +17,54 @@ interface Role {
   created_at: string;
 }
 
+interface CommissionRule {
+  id: string;
+  user_id: string | null;
+  role_code: string | null;
+  category: string | null;
+  rate_bps: number;
+  hold_days: number;
+  priority: number;
+  is_default: boolean;
+  is_active: boolean;
+  notes: string | null;
+  user?: { id: string; full_name: string | null; email: string | null } | null;
+}
+
 export default function FinancialSettingsPage() {
   const router = useRouter();
   const [token, setToken] = useState("");
   const [loading, setLoading] = useState(true);
   const [roles, setRoles] = useState<Role[]>([]);
+  const [rules, setRules] = useState<CommissionRule[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
   const [saving, setSaving] = useState<string | null>(null);
-  const [showNew, setShowNew] = useState(false);
+
+  // Role UI
+  const [showNewRole, setShowNewRole] = useState(false);
   const [newRole, setNewRole] = useState({ code: "", label: "", description: "", sort_order: 100 });
+
+  // Rule UI
+  const [showNewRule, setShowNewRule] = useState(false);
+  const [newRule, setNewRule] = useState({
+    role_code: "",
+    user_id: "",
+    category: "",
+    rate_pct: "",
+    hold_days: "0",
+    notes: "",
+  });
 
   const load = useCallback(async () => {
     if (!token) return;
     setLoading(true);
-    const res = await fetch("/api/admin/financial/attribution-roles", {
-      headers: { Authorization: `Bearer ${token}` },
-    });
-    if (res.ok) setRoles(await res.json());
+    const [rolesRes, rulesRes] = await Promise.all([
+      fetch("/api/admin/financial/attribution-roles", { headers: { Authorization: `Bearer ${token}` } }),
+      fetch("/api/admin/financial/commission-rules", { headers: { Authorization: `Bearer ${token}` } }),
+    ]);
+    if (rolesRes.ok) setRoles(await rolesRes.json());
+    if (rulesRes.ok) setRules(await rulesRes.json());
     setLoading(false);
   }, [token]);
 
@@ -48,10 +78,8 @@ export default function FinancialSettingsPage() {
 
   useEffect(() => { load(); }, [load]);
 
-  async function create() {
-    setError(null);
-    setMessage(null);
-    setSaving("new");
+  async function createRole() {
+    setError(null); setMessage(null); setSaving("new-role");
     const res = await fetch("/api/admin/financial/attribution-roles", {
       method: "POST",
       headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
@@ -62,15 +90,14 @@ export default function FinancialSettingsPage() {
     else {
       setMessage(`Created role "${body.label}"`);
       setNewRole({ code: "", label: "", description: "", sort_order: 100 });
-      setShowNew(false);
+      setShowNewRole(false);
       await load();
     }
     setSaving(null);
   }
 
-  async function toggle(role: Role) {
-    setSaving(role.id);
-    setError(null);
+  async function toggleRole(role: Role) {
+    setSaving(role.id); setError(null);
     const res = await fetch(`/api/admin/financial/attribution-roles/${role.id}`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
@@ -82,7 +109,7 @@ export default function FinancialSettingsPage() {
     setSaving(null);
   }
 
-  async function remove(role: Role) {
+  async function removeRole(role: Role) {
     if (!confirm(`Deactivate role "${role.label}"?`)) return;
     setSaving(role.id);
     const res = await fetch(`/api/admin/financial/attribution-roles/${role.id}`, {
@@ -95,8 +122,83 @@ export default function FinancialSettingsPage() {
     setSaving(null);
   }
 
+  async function createRule() {
+    setError(null); setMessage(null); setSaving("new-rule");
+    const ratePct = Number(newRule.rate_pct);
+    if (!Number.isFinite(ratePct) || ratePct < 0 || ratePct > 100) {
+      setError("Rate must be a number between 0 and 100");
+      setSaving(null);
+      return;
+    }
+    const payload: Record<string, unknown> = {
+      role_code: newRule.role_code || null,
+      user_id: newRule.user_id.trim() || null,
+      category: newRule.category.trim() || null,
+      rate_bps: Math.round(ratePct * 100),
+      hold_days: Number(newRule.hold_days) || 0,
+      notes: newRule.notes.trim() || null,
+    };
+    if (!payload.role_code && !payload.user_id && !payload.category) {
+      setError("Choose at least one of role / user / category. Use the default rule for the blanket rate.");
+      setSaving(null);
+      return;
+    }
+    const res = await fetch("/api/admin/financial/commission-rules", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify(payload),
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) setError(body.error || "Create failed");
+    else {
+      setMessage(`Created rule at ${ratePct}% (hold ${newRule.hold_days}d)`);
+      setNewRule({ role_code: "", user_id: "", category: "", rate_pct: "", hold_days: "0", notes: "" });
+      setShowNewRule(false);
+      await load();
+    }
+    setSaving(null);
+  }
+
+  async function updateRule(rule: CommissionRule, patch: Partial<CommissionRule>) {
+    setSaving(rule.id); setError(null);
+    const res = await fetch(`/api/admin/financial/commission-rules/${rule.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify(patch),
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) setError(body.error || "Update failed");
+    else await load();
+    setSaving(null);
+  }
+
+  async function deleteRule(rule: CommissionRule) {
+    if (rule.is_default) return;
+    if (!confirm("Delete this rule? Existing ledger entries stay intact.")) return;
+    setSaving(rule.id);
+    const res = await fetch(`/api/admin/financial/commission-rules/${rule.id}`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) setError(body.error || "Delete failed");
+    else await load();
+    setSaving(null);
+  }
+
   const inputClass = "w-full rounded-xl border border-gray-200 px-3 py-2 text-sm focus:border-green-primary focus:outline-none";
   const labelClass = "block text-xs font-medium text-gray-600 mb-1";
+
+  const defaultRule = rules.find((r) => r.is_default);
+  const customRules = rules.filter((r) => !r.is_default);
+
+  function ruleTargetLabel(rule: CommissionRule): string {
+    const parts: string[] = [];
+    if (rule.user_id) parts.push(`User: ${rule.user?.full_name || rule.user?.email || rule.user_id.slice(0, 8)}`);
+    if (rule.role_code) parts.push(`Role: ${roles.find((r) => r.code === rule.role_code)?.label || rule.role_code}`);
+    if (rule.category) parts.push(`Category: ${rule.category}`);
+    return parts.length ? parts.join(" · ") : "All commissions (default)";
+  }
 
   return (
     <div className="p-6">
@@ -108,37 +210,184 @@ export default function FinancialSettingsPage() {
         <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
           <ArrowLeftRight className="h-6 w-6 text-green-primary" /> Financial Settings
         </h1>
-        <p className="text-sm text-gray-500 mt-1">Attribution roles today. Commission rules, categories, and reminder schedule ship in Phase 4.</p>
+        <p className="text-sm text-gray-500 mt-1">Attribution roles + commission rules. Auto-earn fires on paid payments; auto-reverse fires on refunds and chargebacks.</p>
       </div>
 
+      {message && (
+        <div className="mb-4 flex items-start gap-2 rounded-xl border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-700">
+          <CheckCircle2 className="h-4 w-4 mt-0.5 shrink-0" />
+          <span>{message}</span>
+        </div>
+      )}
+      {error && (
+        <div className="mb-4 flex items-start gap-2 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {/* Commission rules */}
       <div className="rounded-2xl border border-gray-100 bg-white p-5 mb-4">
         <div className="flex items-center justify-between mb-3">
           <div>
-            <h2 className="text-sm font-semibold text-gray-900">Attribution Roles</h2>
+            <h2 className="text-sm font-semibold text-gray-900 flex items-center gap-1.5"><Percent className="h-4 w-4 text-green-primary" /> Commission Rules</h2>
+            <p className="text-xs text-gray-500 mt-0.5">Priority: user + category → user → role + category → role → default.</p>
+          </div>
+          <button
+            onClick={() => setShowNewRule((s) => !s)}
+            className="inline-flex items-center gap-1.5 rounded-lg bg-green-primary hover:bg-green-hover px-3 py-1.5 text-xs font-semibold text-white cursor-pointer"
+          >
+            <Plus className="h-3.5 w-3.5" /> New rule
+          </button>
+        </div>
+
+        {showNewRule && (
+          <div className="mb-3 rounded-xl border border-gray-200 bg-gray-50 p-4 space-y-3">
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+              <div>
+                <label className={labelClass}>Role (optional)</label>
+                <select value={newRule.role_code} onChange={(e) => setNewRule((r) => ({ ...r, role_code: e.target.value }))} className={inputClass}>
+                  <option value="">— any role —</option>
+                  {roles.filter((r) => r.is_active).map((r) => <option key={r.code} value={r.code}>{r.label}</option>)}
+                </select>
+              </div>
+              <div>
+                <label className={labelClass}>User ID (optional)</label>
+                <input type="text" value={newRule.user_id} onChange={(e) => setNewRule((r) => ({ ...r, user_id: e.target.value }))} className={inputClass + " font-mono"} placeholder="uuid — leave blank for all users" />
+              </div>
+              <div>
+                <label className={labelClass}>Category (optional)</label>
+                <input type="text" value={newRule.category} onChange={(e) => setNewRule((r) => ({ ...r, category: e.target.value }))} className={inputClass} placeholder="coffee, machine, service, …" />
+              </div>
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+              <div>
+                <label className={labelClass}>Rate (%)</label>
+                <input type="number" step="0.01" min="0" max="100" value={newRule.rate_pct} onChange={(e) => setNewRule((r) => ({ ...r, rate_pct: e.target.value }))} className={inputClass} placeholder="5.0" />
+              </div>
+              <div>
+                <label className={labelClass}>Hold (days)</label>
+                <input type="number" min="0" max="365" value={newRule.hold_days} onChange={(e) => setNewRule((r) => ({ ...r, hold_days: e.target.value }))} className={inputClass} />
+              </div>
+              <div>
+                <label className={labelClass}>Notes</label>
+                <input type="text" value={newRule.notes} onChange={(e) => setNewRule((r) => ({ ...r, notes: e.target.value }))} className={inputClass} placeholder="Why this override exists" />
+              </div>
+            </div>
+            <div className="flex justify-end gap-2">
+              <button onClick={() => setShowNewRule(false)} className="rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 cursor-pointer">Cancel</button>
+              <button
+                onClick={createRule}
+                disabled={saving === "new-rule" || !newRule.rate_pct}
+                className="inline-flex items-center gap-1.5 rounded-lg bg-green-primary hover:bg-green-hover px-4 py-1.5 text-xs font-semibold text-white cursor-pointer disabled:opacity-50"
+              >
+                {saving === "new-rule" ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
+                Create rule
+              </button>
+            </div>
+          </div>
+        )}
+
+        {loading ? (
+          <div className="flex justify-center py-8"><Loader2 className="h-5 w-5 animate-spin text-green-primary" /></div>
+        ) : (
+          <div className="space-y-2">
+            {defaultRule && (
+              <div className="rounded-xl border border-emerald-100 bg-emerald-50/50 p-3 flex items-center gap-3">
+                <div className="flex-1">
+                  <p className="text-sm font-semibold text-gray-900 flex items-center gap-2">
+                    Default rate
+                    <span className="inline-flex items-center gap-1 rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-medium text-emerald-700">
+                      <Lock className="h-2.5 w-2.5" /> system
+                    </span>
+                  </p>
+                  <p className="text-xs text-gray-500 mt-0.5">Applies when no more-specific rule matches.</p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <label className="text-xs text-gray-500">Rate %</label>
+                  <input
+                    type="number" step="0.01" min="0" max="100"
+                    defaultValue={(defaultRule.rate_bps / 100).toFixed(2)}
+                    onBlur={(e) => {
+                      const pct = Number(e.target.value);
+                      if (Number.isFinite(pct) && pct >= 0 && pct <= 100 && Math.round(pct * 100) !== defaultRule.rate_bps) {
+                        updateRule(defaultRule, { rate_bps: Math.round(pct * 100) });
+                      }
+                    }}
+                    className="w-24 rounded-lg border border-gray-200 px-2 py-1 text-xs"
+                  />
+                  <label className="text-xs text-gray-500 ml-2">Hold</label>
+                  <input
+                    type="number" min="0" max="365"
+                    defaultValue={defaultRule.hold_days}
+                    onBlur={(e) => {
+                      const d = Number(e.target.value);
+                      if (Number.isFinite(d) && d >= 0 && d <= 365 && d !== defaultRule.hold_days) {
+                        updateRule(defaultRule, { hold_days: d });
+                      }
+                    }}
+                    className="w-20 rounded-lg border border-gray-200 px-2 py-1 text-xs"
+                  />
+                  <span className="text-xs text-gray-400">d</span>
+                </div>
+              </div>
+            )}
+            {customRules.length === 0 ? (
+              <p className="text-sm text-gray-500 text-center py-4">No overrides yet. Add one to give a role, user, or category a different rate.</p>
+            ) : (
+              customRules.map((rule) => (
+                <div key={rule.id} className="rounded-xl border border-gray-100 bg-white p-3 flex items-center gap-3">
+                  <div className="flex-1 min-w-0">
+                    <p className={`text-sm font-medium ${rule.is_active ? "text-gray-900" : "text-gray-400 line-through"}`}>
+                      {ruleTargetLabel(rule)}
+                    </p>
+                    <div className="flex items-center gap-3 text-xs text-gray-500 mt-0.5">
+                      <span className="inline-flex items-center gap-0.5"><Percent className="h-3 w-3" />{(rule.rate_bps / 100).toFixed(2)}%</span>
+                      <span className="inline-flex items-center gap-0.5"><Clock className="h-3 w-3" />{rule.hold_days}d hold</span>
+                      <span className="text-gray-400">priority {rule.priority}</span>
+                      {rule.notes && <span className="italic truncate">{rule.notes}</span>}
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={() => updateRule(rule, { is_active: !rule.is_active })}
+                      disabled={saving === rule.id}
+                      className="rounded-lg border border-gray-200 hover:bg-gray-50 px-3 py-1 text-xs font-medium text-gray-700 cursor-pointer disabled:opacity-50"
+                    >
+                      {rule.is_active ? "Deactivate" : "Activate"}
+                    </button>
+                    <button
+                      onClick={() => deleteRule(rule)}
+                      disabled={saving === rule.id}
+                      className="rounded-lg p-1.5 text-gray-400 hover:bg-red-50 hover:text-red-600 cursor-pointer disabled:opacity-50"
+                      title="Delete rule"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Attribution roles */}
+      <div className="rounded-2xl border border-gray-100 bg-white p-5 mb-4">
+        <div className="flex items-center justify-between mb-3">
+          <div>
+            <h2 className="text-sm font-semibold text-gray-900 flex items-center gap-1.5"><UserIcon className="h-4 w-4 text-green-primary" /> Attribution Roles</h2>
             <p className="text-xs text-gray-500 mt-0.5">Configurable roles for sales credit. System roles can be renamed but not deactivated.</p>
           </div>
           <button
-            onClick={() => setShowNew((s) => !s)}
+            onClick={() => setShowNewRole((s) => !s)}
             className="inline-flex items-center gap-1.5 rounded-lg bg-green-primary hover:bg-green-hover px-3 py-1.5 text-xs font-semibold text-white cursor-pointer"
           >
             <Plus className="h-3.5 w-3.5" /> New role
           </button>
         </div>
 
-        {message && (
-          <div className="mb-3 flex items-start gap-2 rounded-xl border border-emerald-200 bg-emerald-50 p-2.5 text-xs text-emerald-700">
-            <CheckCircle2 className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-            <span>{message}</span>
-          </div>
-        )}
-        {error && (
-          <div className="mb-3 flex items-start gap-2 rounded-xl border border-red-200 bg-red-50 p-2.5 text-xs text-red-700">
-            <AlertCircle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-            <span>{error}</span>
-          </div>
-        )}
-
-        {showNew && (
+        {showNewRole && (
           <div className="mb-3 rounded-xl border border-gray-200 bg-gray-50 p-4 space-y-2">
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
               <div>
@@ -155,15 +404,13 @@ export default function FinancialSettingsPage() {
               <input type="text" value={newRole.description} onChange={(e) => setNewRole((r) => ({ ...r, description: e.target.value }))} className={inputClass} />
             </div>
             <div className="flex justify-end gap-2 pt-1">
-              <button onClick={() => setShowNew(false)} className="rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 cursor-pointer">
-                Cancel
-              </button>
+              <button onClick={() => setShowNewRole(false)} className="rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 cursor-pointer">Cancel</button>
               <button
-                onClick={create}
-                disabled={saving === "new" || !newRole.label.trim() || !newRole.code.trim()}
+                onClick={createRole}
+                disabled={saving === "new-role" || !newRole.label.trim() || !newRole.code.trim()}
                 className="inline-flex items-center gap-1.5 rounded-lg bg-green-primary hover:bg-green-hover px-4 py-1.5 text-xs font-semibold text-white cursor-pointer disabled:opacity-50"
               >
-                {saving === "new" ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
+                {saving === "new-role" ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
                 Create role
               </button>
             </div>
@@ -171,7 +418,7 @@ export default function FinancialSettingsPage() {
         )}
 
         {loading ? (
-          <div className="flex justify-center py-8"><Loader2 className="h-5 w-5 animate-spin text-green-primary" /></div>
+          <div className="flex justify-center py-6"><Loader2 className="h-5 w-5 animate-spin text-green-primary" /></div>
         ) : roles.length === 0 ? (
           <p className="text-sm text-gray-500 text-center py-6">No roles yet.</p>
         ) : (
@@ -193,7 +440,7 @@ export default function FinancialSettingsPage() {
                 <div className="flex items-center gap-2">
                   {!role.is_system && (
                     <button
-                      onClick={() => toggle(role)}
+                      onClick={() => toggleRole(role)}
                       disabled={saving === role.id}
                       className="rounded-lg border border-gray-200 hover:bg-gray-50 px-3 py-1 text-xs font-medium text-gray-700 cursor-pointer disabled:opacity-50"
                     >
@@ -202,7 +449,7 @@ export default function FinancialSettingsPage() {
                   )}
                   {!role.is_system && role.is_active && (
                     <button
-                      onClick={() => remove(role)}
+                      onClick={() => removeRole(role)}
                       disabled={saving === role.id}
                       className="rounded-lg p-1.5 text-gray-400 hover:bg-red-50 hover:text-red-600 cursor-pointer disabled:opacity-50"
                     >
@@ -217,8 +464,12 @@ export default function FinancialSettingsPage() {
       </div>
 
       <div className="rounded-2xl border border-amber-200 bg-amber-50 p-5">
-        <p className="text-sm font-semibold text-amber-900">Ships in Phase 4</p>
-        <p className="text-xs text-amber-700 mt-1">Commission rules (default %, per-user overrides, category rates, hold periods), reminder cadence, and reconciliation window will all live here.</p>
+        <p className="text-sm font-semibold text-amber-900">Ships in Phase 5+</p>
+        <p className="text-xs text-amber-700 mt-1">Reconciliation window controls and reminder cadence editors land next. Categories inherit from <code>sales_orders.order_type</code> today.</p>
+      </div>
+
+      <div className="mt-3 flex items-center gap-1.5 text-xs text-gray-500">
+        <Tag className="h-3 w-3" /> Inspector: <Link href="/admin/financial/commissions" className="text-green-primary hover:underline">Commission Ledger</Link>
       </div>
     </div>
   );

--- a/src/app/api/admin/financial/commission-rules/[id]/route.ts
+++ b/src/app/api/admin/financial/commission-rules/[id]/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAdminUserId } from "@/lib/adminAuth";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { writeAuditLog } from "@/lib/paymentLedger";
+
+/**
+ * PATCH — update rate_bps, hold_days, is_active, notes. Matchers are
+ *   immutable — replacing them requires deleting + recreating so the audit
+ *   log stays clean.
+ * DELETE — hard delete for non-default rules only. Default rule can only be
+ *   toggled active/inactive via PATCH.
+ */
+
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id } = await params;
+
+  const { data: before } = await supabaseAdmin
+    .from("commission_rules")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+  if (!before) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const body = await req.json().catch(() => ({}));
+  const updates: Record<string, unknown> = { updated_at: new Date().toISOString() };
+
+  if (body.rate_bps !== undefined) {
+    const n = Number(body.rate_bps);
+    if (!Number.isFinite(n) || n < 0 || n > 10000) {
+      return NextResponse.json({ error: "rate_bps must be 0-10000." }, { status: 400 });
+    }
+    updates.rate_bps = n;
+  }
+  if (body.hold_days !== undefined) {
+    const n = Number(body.hold_days);
+    if (!Number.isFinite(n) || n < 0 || n > 365) {
+      return NextResponse.json({ error: "hold_days must be 0-365." }, { status: 400 });
+    }
+    updates.hold_days = n;
+  }
+  if (typeof body.is_active === "boolean") updates.is_active = body.is_active;
+  if (body.notes !== undefined) updates.notes = body.notes ? String(body.notes) : null;
+
+  const { data: after, error } = await supabaseAdmin
+    .from("commission_rules")
+    .update(updates)
+    .eq("id", id)
+    .select("*")
+    .single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 400 });
+
+  await writeAuditLog({
+    actorId: adminId,
+    action: "commission_rule_updated",
+    entityType: "commission_rule",
+    entityId: id,
+    before,
+    after,
+  });
+
+  return NextResponse.json(after);
+}
+
+export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id } = await params;
+
+  const { data: before } = await supabaseAdmin
+    .from("commission_rules")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+  if (!before) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  if (before.is_default) {
+    return NextResponse.json({ error: "Cannot delete the default rule — deactivate or edit instead." }, { status: 400 });
+  }
+
+  await supabaseAdmin.from("commission_rules").delete().eq("id", id);
+
+  await writeAuditLog({
+    actorId: adminId,
+    action: "commission_rule_deleted",
+    entityType: "commission_rule",
+    entityId: id,
+    before,
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/admin/financial/commission-rules/route.ts
+++ b/src/app/api/admin/financial/commission-rules/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAdminUserId } from "@/lib/adminAuth";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { writeAuditLog } from "@/lib/paymentLedger";
+
+/**
+ * GET  /api/admin/financial/commission-rules — list all (active + archived)
+ * POST /api/admin/financial/commission-rules — create a new rule
+ */
+
+function computePriority(userId: string | null, roleCode: string | null, category: string | null): number {
+  return (userId ? 1000 : 0) + (roleCode ? 100 : 0) + (category ? 10 : 0);
+}
+
+export async function GET(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const { data, error } = await supabaseAdmin
+    .from("commission_rules")
+    .select("*, user:user_id(id, full_name, email)")
+    .order("priority", { ascending: false })
+    .order("created_at", { ascending: false });
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json(data || []);
+}
+
+export async function POST(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const body = await req.json().catch(() => ({}));
+  const user_id = body.user_id ? String(body.user_id) : null;
+  const role_code = body.role_code ? String(body.role_code) : null;
+  const category = body.category ? String(body.category).toLowerCase().trim() : null;
+  const rate_bps = Number(body.rate_bps);
+  const hold_days = Number(body.hold_days ?? 0);
+  const notes = body.notes ? String(body.notes) : null;
+  const is_default = !!body.is_default;
+
+  if (!Number.isFinite(rate_bps) || rate_bps < 0 || rate_bps > 10000) {
+    return NextResponse.json({ error: "rate_bps must be 0-10000." }, { status: 400 });
+  }
+  if (!Number.isFinite(hold_days) || hold_days < 0 || hold_days > 365) {
+    return NextResponse.json({ error: "hold_days must be 0-365." }, { status: 400 });
+  }
+  if (is_default && (user_id || role_code || category)) {
+    return NextResponse.json({ error: "Default rule cannot target a user/role/category." }, { status: 400 });
+  }
+  if (!is_default && !user_id && !role_code && !category) {
+    return NextResponse.json({ error: "Non-default rule must specify at least one of user, role, category." }, { status: 400 });
+  }
+
+  const priority = computePriority(user_id, role_code, category);
+
+  const { data, error } = await supabaseAdmin
+    .from("commission_rules")
+    .insert({
+      user_id,
+      role_code,
+      category,
+      rate_bps,
+      hold_days,
+      priority,
+      is_default,
+      is_active: true,
+      notes,
+      created_by: adminId,
+    })
+    .select("*")
+    .single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 400 });
+
+  await writeAuditLog({
+    actorId: adminId,
+    action: "commission_rule_created",
+    entityType: "commission_rule",
+    entityId: data.id,
+    after: data as unknown as Record<string, unknown>,
+  });
+
+  return NextResponse.json(data);
+}

--- a/src/app/api/admin/financial/commissions/backfill/route.ts
+++ b/src/app/api/admin/financial/commissions/backfill/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAdminUserId } from "@/lib/adminAuth";
+import { backfillCommissions } from "@/lib/commissions";
+import { writeAuditLog } from "@/lib/paymentLedger";
+
+/**
+ * POST /api/admin/financial/commissions/backfill
+ * Body: { limit?: 500, since_days?: 365 }
+ *
+ * Walks paid payments in the window that lack commission_ledger entries and
+ * produces earn rows using current rules + current attribution. Safe to
+ * re-run — earn is idempotent per (order, payment, user, role).
+ *
+ * GET returns the count of paid payments that don't have any commission rows
+ * yet, so the UI can show "N needing backfill" before running.
+ */
+
+export async function GET(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const url = new URL(req.url);
+  const sinceDays = Math.max(1, Math.min(3650, Number(url.searchParams.get("since_days") || 365)));
+  const cutoff = new Date(Date.now() - sinceDays * 24 * 60 * 60 * 1000).toISOString();
+
+  const { supabaseAdmin } = await import("@/lib/supabaseAdmin");
+  const { data: paidWithOrders } = await supabaseAdmin
+    .from("payments")
+    .select("id, order_id")
+    .eq("status", "paid")
+    .not("order_id", "is", null)
+    .gte("paid_at", cutoff)
+    .limit(5000);
+
+  if (!paidWithOrders || paidWithOrders.length === 0) {
+    return NextResponse.json({ needs_backfill: 0 });
+  }
+
+  const paymentIds = paidWithOrders.map((p) => p.id);
+  const { data: existing } = await supabaseAdmin
+    .from("commission_ledger")
+    .select("payment_id")
+    .in("payment_id", paymentIds);
+  const covered = new Set((existing || []).map((r) => r.payment_id));
+  const needsBackfill = paidWithOrders.filter((p) => !covered.has(p.id)).length;
+
+  return NextResponse.json({ needs_backfill: needsBackfill });
+}
+
+export async function POST(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const body = await req.json().catch(() => ({}));
+  const limit = Math.max(1, Math.min(2000, Number(body.limit || 500)));
+  const sinceDays = Math.max(1, Math.min(3650, Number(body.since_days || 365)));
+
+  const summary = await backfillCommissions({ limit, sinceDays, actorId: adminId });
+
+  await writeAuditLog({
+    actorId: adminId,
+    action: "commissions_backfill_ran",
+    entityType: "system",
+    metadata: { limit, since_days: sinceDays, summary: summary as unknown as Record<string, unknown> },
+  });
+
+  return NextResponse.json(summary);
+}

--- a/src/app/api/admin/financial/commissions/mark-paid/route.ts
+++ b/src/app/api/admin/financial/commissions/mark-paid/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAdminUserId } from "@/lib/adminAuth";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { writeAuditLog } from "@/lib/paymentLedger";
+
+/**
+ * POST /api/admin/financial/commissions/mark-paid
+ * Body: { ids: string[], note?: string }
+ *
+ * Flips the given commission_ledger rows from 'earned' (or clearable 'held')
+ * to 'paid' and stamps paid_at. This is the human-in-the-loop endpoint that
+ * Phase 6 will replace with QB batch payouts.
+ */
+
+export async function POST(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const body = await req.json().catch(() => ({}));
+  const ids: string[] = Array.isArray(body.ids) ? body.ids.filter((v: unknown) => typeof v === "string") : [];
+  const note = body.note ? String(body.note) : null;
+  if (ids.length === 0) return NextResponse.json({ error: "No commission ids provided." }, { status: 400 });
+  if (ids.length > 500) return NextResponse.json({ error: "Too many ids (max 500 per call)." }, { status: 400 });
+
+  const { data: before } = await supabaseAdmin
+    .from("commission_ledger")
+    .select("id, status, user_id, amount_cents, clearable_at")
+    .in("id", ids);
+
+  const now = new Date();
+  const eligibleIds: string[] = [];
+  let skipped = 0;
+  for (const r of before || []) {
+    if (r.status === "earned" || (r.status === "held" && r.clearable_at && new Date(r.clearable_at).getTime() <= now.getTime())) {
+      eligibleIds.push(r.id);
+    } else {
+      skipped++;
+    }
+  }
+  if (eligibleIds.length === 0) return NextResponse.json({ paid: 0, skipped });
+
+  const { error } = await supabaseAdmin
+    .from("commission_ledger")
+    .update({
+      status: "paid",
+      paid_at: now.toISOString(),
+      notes: note,
+    })
+    .in("id", eligibleIds);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  const totalCents = (before || [])
+    .filter((r) => eligibleIds.includes(r.id))
+    .reduce((s, r) => s + Number(r.amount_cents || 0), 0);
+
+  await writeAuditLog({
+    actorId: adminId,
+    action: "commissions_marked_paid",
+    entityType: "commission_ledger",
+    reason: note,
+    metadata: { ids: eligibleIds, total_cents: totalCents },
+  });
+
+  return NextResponse.json({ paid: eligibleIds.length, skipped, total_cents: totalCents });
+}

--- a/src/app/api/admin/financial/commissions/route.ts
+++ b/src/app/api/admin/financial/commissions/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAdminUserId } from "@/lib/adminAuth";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+
+/**
+ * GET /api/admin/financial/commissions
+ *
+ * Filters:
+ *   user_id  — restrict to one rep
+ *   role_code
+ *   status   — earned | held | reversed | paid | cancelled
+ *   since_days — window (default 365)
+ *
+ * Returns rows + a summary block for the current filter.
+ */
+
+export async function GET(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const url = new URL(req.url);
+  const userId = url.searchParams.get("user_id");
+  const roleCode = url.searchParams.get("role_code");
+  const status = url.searchParams.get("status");
+  const sinceDays = Math.max(1, Math.min(3650, Number(url.searchParams.get("since_days") || 365)));
+  const limit = Math.max(1, Math.min(2000, Number(url.searchParams.get("limit") || 500)));
+  const cutoff = new Date(Date.now() - sinceDays * 24 * 60 * 60 * 1000).toISOString();
+
+  let query = supabaseAdmin
+    .from("commission_ledger")
+    .select(`
+      *,
+      user:user_id(id, full_name, email),
+      order:order_id(id, total_value, order_type, order_status, created_at)
+    `)
+    .gte("earned_at", cutoff)
+    .order("earned_at", { ascending: false })
+    .limit(limit);
+
+  if (userId) query = query.eq("user_id", userId);
+  if (roleCode) query = query.eq("role_code", roleCode);
+  if (status) query = query.eq("status", status);
+
+  const { data, error } = await query;
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  // Summary math over the returned window (not affected by limit truncation
+  // beyond what the caller already asked for).
+  const rows = data || [];
+  const summary = {
+    earned_cents: 0,
+    held_cents: 0,
+    reversed_cents: 0,
+    paid_cents: 0,
+    row_count: rows.length,
+  };
+  for (const r of rows) {
+    const amt = Number(r.amount_cents) || 0;
+    if (r.status === "reversed" || amt < 0) summary.reversed_cents += Math.abs(amt);
+    else if (r.status === "paid") summary.paid_cents += amt;
+    else if (r.status === "held") summary.held_cents += amt;
+    else if (r.status === "earned") summary.earned_cents += amt;
+  }
+
+  return NextResponse.json({ rows, summary });
+}

--- a/src/app/api/my/commissions/route.ts
+++ b/src/app/api/my/commissions/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getUserIdFromRequest } from "@/lib/apiAuth";
+import { summarizeCommissionsForUser } from "@/lib/commissions";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+
+/**
+ * GET /api/my/commissions
+ *
+ * Rep-facing: summary block + row list (last N days, default 365). Reads
+ * commission_ledger via service role, scoped to the caller's user_id.
+ */
+
+export async function GET(req: NextRequest) {
+  const userId = await getUserIdFromRequest(req);
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const url = new URL(req.url);
+  const sinceDays = Math.max(1, Math.min(3650, Number(url.searchParams.get("since_days") || 365)));
+  const limit = Math.max(1, Math.min(500, Number(url.searchParams.get("limit") || 200)));
+  const cutoff = new Date(Date.now() - sinceDays * 24 * 60 * 60 * 1000).toISOString();
+
+  const summary = await summarizeCommissionsForUser(userId, sinceDays);
+
+  const { data: rows } = await supabaseAdmin
+    .from("commission_ledger")
+    .select(`
+      id, order_id, role_code, attribution_percentage, basis_cents, rate_bps, amount_cents,
+      hold_days, status, earned_at, clearable_at, paid_at, reversed_of_id, reversal_reason,
+      order:order_id(id, total_value, order_type, order_status, created_at)
+    `)
+    .eq("user_id", userId)
+    .gte("earned_at", cutoff)
+    .order("earned_at", { ascending: false })
+    .limit(limit);
+
+  return NextResponse.json({ summary, rows: rows || [] });
+}

--- a/src/lib/commissions.ts
+++ b/src/lib/commissions.ts
@@ -1,0 +1,480 @@
+/**
+ * Commissions — resolve rate, earn on payment, reverse on refund.
+ *
+ * Rate resolution (most specific first):
+ *   1. user_id + category   (priority 1110)
+ *   2. user_id              (priority 1100)
+ *   3. role_code + category (priority 110)
+ *   4. role_code            (priority 100)
+ *   5. is_default = true    (priority 0)
+ *
+ * Earn: for each active attribution row on an order, we compute
+ *     basis  = payment.amount × attribution_percentage / 100
+ *     amount = basis × rate_bps / 10000
+ * and write a `commission_ledger` row per (user, order, payment, role).
+ *
+ * Reverse: when a payment is refunded or charged back, we walk the ledger
+ * rows for that payment and write matching negative-amount rows referencing
+ * `reversed_of_id`. The refund amount is applied pro-rata across rows if the
+ * refund is partial.
+ *
+ * All writes are idempotent per (order_id, payment_id, user_id, role_code)
+ * for earns, and per (reversed_of_id, refund payment_id) for reversals.
+ */
+
+import { supabaseAdmin } from "./supabaseAdmin";
+import { writeAuditLog } from "./paymentLedger";
+import { getEffectiveAttribution } from "./salesAttribution";
+
+export type CommissionStatus = "pending" | "held" | "earned" | "reversed" | "paid" | "cancelled";
+
+export interface CommissionRule {
+  id: string;
+  user_id: string | null;
+  role_code: string | null;
+  category: string | null;
+  rate_bps: number;
+  hold_days: number;
+  priority: number;
+  is_default: boolean;
+  is_active: boolean;
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CommissionLedgerRow {
+  id: string;
+  user_id: string;
+  order_id: string;
+  attribution_id: string | null;
+  role_code: string;
+  payment_id: string | null;
+  rule_id: string | null;
+  attribution_percentage: number;
+  basis_cents: number;
+  rate_bps: number;
+  amount_cents: number;
+  hold_days: number;
+  status: CommissionStatus;
+  earned_at: string;
+  clearable_at: string | null;
+  paid_at: string | null;
+  reversed_of_id: string | null;
+  reversal_reason: string | null;
+  notes: string | null;
+  metadata: Record<string, unknown> | null;
+  created_at: string;
+}
+
+// ─── Rate resolver ──────────────────────────────────────────────────────
+
+export interface ResolveRateArgs {
+  userId: string;
+  roleCode: string;
+  category?: string | null;
+}
+
+/**
+ * Find the most-specific active rule for (user, role, category). Falls back
+ * to the seeded default rule (rate 500 bps = 5%, no hold) if nothing matches.
+ * Returns null only if the default rule is missing entirely (should never
+ * happen once migration 109 has run).
+ */
+export async function resolveCommissionRule(args: ResolveRateArgs): Promise<CommissionRule | null> {
+  const category = args.category ? args.category.toLowerCase() : null;
+
+  // Pull the small superset of possibly-matching rules, rank in JS.
+  const { data: rules } = await supabaseAdmin
+    .from("commission_rules")
+    .select("*")
+    .eq("is_active", true)
+    .or(`user_id.eq.${args.userId},user_id.is.null`);
+
+  const candidates = (rules || []) as CommissionRule[];
+
+  // Score each candidate by specificity; skip any that don't match.
+  let best: CommissionRule | null = null;
+  let bestPriority = -1;
+  for (const r of candidates) {
+    if (r.user_id && r.user_id !== args.userId) continue;
+    if (r.role_code && r.role_code !== args.roleCode) continue;
+    if (r.category && r.category.toLowerCase() !== category) continue;
+    // priority already computed on write, but recompute to be safe if the
+    // trigger/db value was stale.
+    const p =
+      (r.user_id ? 1000 : 0) +
+      (r.role_code ? 100 : 0) +
+      (r.category ? 10 : 0);
+    if (p > bestPriority) {
+      bestPriority = p;
+      best = r;
+    }
+  }
+  if (best) return best;
+
+  const { data: fallback } = await supabaseAdmin
+    .from("commission_rules")
+    .select("*")
+    .eq("is_default", true)
+    .maybeSingle();
+  return (fallback as CommissionRule) || null;
+}
+
+// ─── Earn ───────────────────────────────────────────────────────────────
+
+export interface EarnArgs {
+  orderId: string;
+  paymentId: string;
+  paymentAmountCents: number;    // positive
+  actorId?: string | null;       // system when auto-earned via webhook
+}
+
+export interface EarnResult {
+  wrote: number;
+  skipped: number;
+  reason?: string;
+  rows: CommissionLedgerRow[];
+}
+
+/**
+ * For each attribution row on the order, compute + write a ledger entry
+ * against the given payment. Idempotent per (order_id, payment_id, user_id,
+ * role_code) — a re-fire skips rows that already exist.
+ */
+export async function earnCommissionsForPayment(args: EarnArgs): Promise<EarnResult> {
+  if (!(args.paymentAmountCents > 0)) return { wrote: 0, skipped: 0, reason: "non_positive_amount", rows: [] };
+
+  // Load order for category context
+  const { data: order } = await supabaseAdmin
+    .from("sales_orders")
+    .select("id, order_type")
+    .eq("id", args.orderId)
+    .maybeSingle();
+  if (!order) return { wrote: 0, skipped: 0, reason: "order_not_found", rows: [] };
+
+  const category = (order.order_type || null) as string | null;
+
+  const attributions = await getEffectiveAttribution(args.orderId);
+  if (attributions.length === 0) return { wrote: 0, skipped: 0, reason: "no_attribution", rows: [] };
+
+  const { data: existing } = await supabaseAdmin
+    .from("commission_ledger")
+    .select("id, user_id, role_code")
+    .eq("order_id", args.orderId)
+    .eq("payment_id", args.paymentId);
+  const existingKey = new Set((existing || []).map((r) => `${r.user_id}|${r.role_code}`));
+
+  const wrote: CommissionLedgerRow[] = [];
+  let skipped = 0;
+
+  for (const attr of attributions) {
+    const key = `${attr.user_id}|${attr.role_code}`;
+    if (existingKey.has(key)) { skipped++; continue; }
+
+    const rule = await resolveCommissionRule({
+      userId: attr.user_id,
+      roleCode: attr.role_code,
+      category,
+    });
+    if (!rule) { skipped++; continue; }
+
+    const basisCents = Math.round(args.paymentAmountCents * (Number(attr.percentage) / 100));
+    const amountCents = Math.round((basisCents * rule.rate_bps) / 10000);
+    if (amountCents === 0) { skipped++; continue; }
+
+    const holdMs = rule.hold_days * 24 * 60 * 60 * 1000;
+    const earnedAtIso = new Date().toISOString();
+    const clearableAtIso = new Date(Date.now() + holdMs).toISOString();
+    const status: CommissionStatus = rule.hold_days > 0 ? "held" : "earned";
+
+    // Implicit lead-owner rows have synthetic ids ("implicit-…"); persist
+    // attribution_id only for real rows.
+    const attributionRowId = attr.id.startsWith("implicit-") ? null : attr.id;
+
+    const { data: inserted, error } = await supabaseAdmin
+      .from("commission_ledger")
+      .insert({
+        user_id: attr.user_id,
+        order_id: args.orderId,
+        attribution_id: attributionRowId,
+        role_code: attr.role_code,
+        payment_id: args.paymentId,
+        rule_id: rule.id,
+        attribution_percentage: attr.percentage,
+        basis_cents: basisCents,
+        rate_bps: rule.rate_bps,
+        amount_cents: amountCents,
+        hold_days: rule.hold_days,
+        status,
+        earned_at: earnedAtIso,
+        clearable_at: clearableAtIso,
+        notes: attr.is_legacy_backfill ? "Legacy backfill attribution" : null,
+        created_by: args.actorId || null,
+      })
+      .select("*")
+      .single();
+    if (error) throw error;
+    wrote.push(inserted as CommissionLedgerRow);
+  }
+
+  if (wrote.length > 0) {
+    await writeAuditLog({
+      actorId: args.actorId || null,
+      action: "commissions_earned",
+      entityType: "sales_order",
+      entityId: args.orderId,
+      metadata: {
+        payment_id: args.paymentId,
+        payment_amount_cents: args.paymentAmountCents,
+        rows: wrote.length,
+      },
+    });
+  }
+
+  return { wrote: wrote.length, skipped, rows: wrote };
+}
+
+// ─── Reverse ────────────────────────────────────────────────────────────
+
+export interface ReverseArgs {
+  parentPaymentId: string;          // the ORIGINAL payment; NOT the refund row
+  refundPaymentId: string;          // the negative-amount refund row
+  refundAmountCents: number;        // positive input (magnitude of refund)
+  reason?: string | null;
+  isChargeback?: boolean;
+  actorId?: string | null;
+}
+
+export interface ReverseResult {
+  wrote: number;
+  skipped: number;
+  reason?: string;
+  rows: CommissionLedgerRow[];
+}
+
+/**
+ * Walk earn rows tied to the parent payment and write pro-rata reversals.
+ * Idempotent per (reversed_of_id, refund payment_id) — a re-fire will find
+ * the reversal row already exists and skip.
+ */
+export async function reverseCommissionsForRefund(args: ReverseArgs): Promise<ReverseResult> {
+  if (!(args.refundAmountCents > 0)) return { wrote: 0, skipped: 0, reason: "non_positive_amount", rows: [] };
+
+  // Find original payment amount so we can compute the refund ratio.
+  const { data: parent } = await supabaseAdmin
+    .from("payments")
+    .select("id, amount_cents")
+    .eq("id", args.parentPaymentId)
+    .maybeSingle();
+  if (!parent) return { wrote: 0, skipped: 0, reason: "parent_not_found", rows: [] };
+  const parentMagnitude = Math.abs(Number(parent.amount_cents || 0));
+  if (parentMagnitude === 0) return { wrote: 0, skipped: 0, reason: "zero_parent", rows: [] };
+
+  const refundRatio = Math.min(1, args.refundAmountCents / parentMagnitude);
+
+  const { data: earns } = await supabaseAdmin
+    .from("commission_ledger")
+    .select("*")
+    .eq("payment_id", args.parentPaymentId)
+    .gt("amount_cents", 0)
+    .in("status", ["held", "earned", "paid"]);
+
+  const earnRows = (earns || []) as CommissionLedgerRow[];
+  if (earnRows.length === 0) return { wrote: 0, skipped: 0, reason: "no_earn_rows", rows: [] };
+
+  // Existing reversals for this refund
+  const { data: existingReversals } = await supabaseAdmin
+    .from("commission_ledger")
+    .select("id, reversed_of_id")
+    .eq("payment_id", args.refundPaymentId)
+    .lt("amount_cents", 0);
+  const alreadyReversed = new Set((existingReversals || []).map((r) => r.reversed_of_id).filter(Boolean));
+
+  const wrote: CommissionLedgerRow[] = [];
+  let skipped = 0;
+
+  for (const earn of earnRows) {
+    if (alreadyReversed.has(earn.id)) { skipped++; continue; }
+
+    const reverseAmount = -Math.round(Number(earn.amount_cents) * refundRatio);
+    const reverseBasis = -Math.round(Number(earn.basis_cents) * refundRatio);
+    if (reverseAmount === 0) { skipped++; continue; }
+
+    const { data: inserted, error } = await supabaseAdmin
+      .from("commission_ledger")
+      .insert({
+        user_id: earn.user_id,
+        order_id: earn.order_id,
+        attribution_id: earn.attribution_id,
+        role_code: earn.role_code,
+        payment_id: args.refundPaymentId,
+        rule_id: earn.rule_id,
+        attribution_percentage: earn.attribution_percentage,
+        basis_cents: reverseBasis,
+        rate_bps: earn.rate_bps,
+        amount_cents: reverseAmount,
+        hold_days: 0,
+        status: "reversed",
+        earned_at: new Date().toISOString(),
+        clearable_at: new Date().toISOString(),
+        reversed_of_id: earn.id,
+        reversal_reason: args.reason || (args.isChargeback ? "chargeback" : "refund"),
+        notes: args.isChargeback ? "Auto-reversal (chargeback)" : "Auto-reversal (refund)",
+        created_by: args.actorId || null,
+      })
+      .select("*")
+      .single();
+    if (error) throw error;
+    wrote.push(inserted as CommissionLedgerRow);
+
+    // If the reversal is at least as large as the original earn, flip the
+    // original to 'reversed' status so summary math doesn't double-count.
+    if (Math.abs(reverseAmount) >= Number(earn.amount_cents)) {
+      await supabaseAdmin
+        .from("commission_ledger")
+        .update({ status: "reversed" })
+        .eq("id", earn.id);
+    }
+  }
+
+  if (wrote.length > 0) {
+    await writeAuditLog({
+      actorId: args.actorId || null,
+      action: args.isChargeback ? "commissions_reversed_chargeback" : "commissions_reversed_refund",
+      entityType: "payment",
+      entityId: args.refundPaymentId,
+      reason: args.reason || null,
+      metadata: {
+        parent_payment_id: args.parentPaymentId,
+        refund_amount_cents: args.refundAmountCents,
+        rows: wrote.length,
+      },
+    });
+  }
+
+  return { wrote: wrote.length, skipped, rows: wrote };
+}
+
+// ─── Backfill ───────────────────────────────────────────────────────────
+
+export interface BackfillArgs {
+  limit?: number;
+  sinceDays?: number;
+  actorId?: string | null;
+}
+
+export interface BackfillSummary {
+  scanned: number;
+  earned: number;
+  skipped_existing: number;
+  skipped_no_payment: number;
+  skipped_other: number;
+  errors: string[];
+}
+
+/**
+ * Walk paid payments in the window whose linked orders lack commission ledger
+ * rows, and run earn logic. Reversal backfill is intentionally NOT here —
+ * refund/chargeback events since Phase 2 have already run through the ledger,
+ * so any earn we produce now for an already-refunded payment is what we want
+ * (attribution existed at time of refund only implicitly).
+ */
+export async function backfillCommissions(args: BackfillArgs): Promise<BackfillSummary> {
+  const summary: BackfillSummary = {
+    scanned: 0,
+    earned: 0,
+    skipped_existing: 0,
+    skipped_no_payment: 0,
+    skipped_other: 0,
+    errors: [],
+  };
+  const limit = Math.min(2000, Math.max(1, args.limit ?? 500));
+  const cutoff = new Date(Date.now() - (args.sinceDays ?? 365) * 24 * 60 * 60 * 1000).toISOString();
+
+  const { data: payments } = await supabaseAdmin
+    .from("payments")
+    .select("id, order_id, amount_cents, status, paid_at, created_at")
+    .eq("status", "paid")
+    .not("order_id", "is", null)
+    .gte("paid_at", cutoff)
+    .order("paid_at", { ascending: false })
+    .limit(limit);
+
+  for (const p of payments || []) {
+    summary.scanned++;
+    if (!p.order_id) { summary.skipped_no_payment++; continue; }
+    if (!(Number(p.amount_cents) > 0)) { summary.skipped_other++; continue; }
+
+    try {
+      const result = await earnCommissionsForPayment({
+        orderId: p.order_id,
+        paymentId: p.id,
+        paymentAmountCents: Number(p.amount_cents),
+        actorId: args.actorId || null,
+      });
+      if (result.wrote > 0) summary.earned++;
+      else summary.skipped_existing++;
+    } catch (e) {
+      summary.errors.push(`${p.id.slice(0, 8)}: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  return summary;
+}
+
+// ─── Summary helpers ────────────────────────────────────────────────────
+
+export interface CommissionSummary {
+  earned_cents: number;
+  held_cents: number;
+  reversed_cents: number;
+  paid_cents: number;
+  pending_clearable_cents: number;
+  net_available_cents: number;
+  by_role: Record<string, number>;
+  row_count: number;
+}
+
+export async function summarizeCommissionsForUser(userId: string, sinceDays = 365): Promise<CommissionSummary> {
+  const cutoff = new Date(Date.now() - sinceDays * 24 * 60 * 60 * 1000).toISOString();
+  const { data: rows } = await supabaseAdmin
+    .from("commission_ledger")
+    .select("amount_cents, status, role_code, clearable_at")
+    .eq("user_id", userId)
+    .gte("earned_at", cutoff);
+
+  const summary: CommissionSummary = {
+    earned_cents: 0,
+    held_cents: 0,
+    reversed_cents: 0,
+    paid_cents: 0,
+    pending_clearable_cents: 0,
+    net_available_cents: 0,
+    by_role: {},
+    row_count: (rows || []).length,
+  };
+  const now = Date.now();
+
+  for (const r of rows || []) {
+    const amt = Number(r.amount_cents) || 0;
+    if (r.status === "reversed" || amt < 0) {
+      summary.reversed_cents += Math.abs(amt);
+      continue;
+    }
+    summary.by_role[r.role_code] = (summary.by_role[r.role_code] || 0) + amt;
+    if (r.status === "paid") summary.paid_cents += amt;
+    else if (r.status === "held") {
+      summary.held_cents += amt;
+      if (r.clearable_at && new Date(r.clearable_at).getTime() <= now) {
+        summary.pending_clearable_cents += amt;
+      }
+    } else if (r.status === "earned") {
+      summary.earned_cents += amt;
+    }
+  }
+
+  summary.net_available_cents = summary.earned_cents + summary.pending_clearable_cents - summary.reversed_cents;
+  if (summary.net_available_cents < 0) summary.net_available_cents = 0;
+  return summary;
+}

--- a/src/lib/paymentLedger.ts
+++ b/src/lib/paymentLedger.ts
@@ -286,6 +286,11 @@ export async function upsertPayment(args: UpsertPaymentArgs): Promise<PaymentRow
       if (existing.invoice_id) {
         await recomputeInvoiceTotals(existing.invoice_id);
       }
+
+      // Newly-paid transition — fire commission earn hook.
+      if (args.status === "paid" && existing.status !== "paid") {
+        await maybeEarnCommissionsForPayment(existing.id, args.orderId ?? null, existing.invoice_id, args.amountCents, args.createdBy || null);
+      }
     }
     return { ...existing, status: args.status };
   }
@@ -334,7 +339,56 @@ export async function upsertPayment(args: UpsertPaymentArgs): Promise<PaymentRow
     await recomputeInvoiceTotals(args.invoiceId);
   }
 
+  if (args.status === "paid") {
+    await maybeEarnCommissionsForPayment(
+      inserted.id,
+      args.orderId ?? null,
+      args.invoiceId ?? null,
+      args.amountCents,
+      args.createdBy || null,
+    );
+  }
+
   return inserted as PaymentRow;
+}
+
+/**
+ * Bridge to the commissions module — kept out of the hot path via dynamic
+ * import so a commissions failure never fails the payment write. Resolves the
+ * effective order_id (using invoice.order_id if the payment row didn't carry
+ * one) and then walks the attribution rows.
+ */
+async function maybeEarnCommissionsForPayment(
+  paymentId: string,
+  paymentOrderId: string | null,
+  invoiceId: string | null,
+  amountCents: number,
+  actorId: string | null,
+): Promise<void> {
+  if (!(amountCents > 0)) return;
+  try {
+    let orderId = paymentOrderId;
+    if (!orderId && invoiceId) {
+      const { data: inv } = await supabaseAdmin
+        .from("invoices")
+        .select("order_id")
+        .eq("id", invoiceId)
+        .maybeSingle();
+      orderId = inv?.order_id || null;
+    }
+    if (!orderId) return;
+
+    const { earnCommissionsForPayment } = await import("./commissions");
+    await earnCommissionsForPayment({
+      orderId,
+      paymentId,
+      paymentAmountCents: amountCents,
+      actorId,
+    });
+  } catch (e) {
+    // Never fail the payment write on a commissions hiccup.
+    console.error("[commissions] earn hook failed:", e);
+  }
 }
 
 /**
@@ -460,6 +514,21 @@ export async function recordRefund(args: RecordRefundArgs): Promise<PaymentRow |
   });
 
   if (parent.invoice_id) await recomputeInvoiceTotals(parent.invoice_id);
+
+  // Commission auto-reverse — pro-rata against original earn rows.
+  try {
+    const { reverseCommissionsForRefund } = await import("./commissions");
+    await reverseCommissionsForRefund({
+      parentPaymentId: parent.id,
+      refundPaymentId: (refund as PaymentRow).id,
+      refundAmountCents: Math.abs(args.amountCents),
+      reason: args.reason || null,
+      isChargeback: !!args.isChargeback,
+      actorId: args.createdBy || null,
+    });
+  } catch (e) {
+    console.error("[commissions] reverse hook failed:", e);
+  }
 
   return refund as PaymentRow;
 }

--- a/supabase/migrations/109_commissions.sql
+++ b/supabase/migrations/109_commissions.sql
@@ -1,0 +1,147 @@
+-- Phase 4 — Commissions.
+--
+-- Commission rules resolve a rate for (user, role, category, order_amount).
+-- Resolution priority (highest wins):
+--   1. per-user + per-category override
+--   2. per-user override
+--   3. per-role + per-category rate
+--   4. per-role rate
+--   5. default (system) rate
+--
+-- Commission ledger records every earn / reverse / hold / clear event.
+-- Reversals are negative-amount rows that reference the original earn via
+-- reversed_of_id. Refund and chargeback events auto-write reversals.
+--
+-- Amounts are basis points (bps) for rates and cents for money to avoid
+-- float drift.
+
+-- ─── Commission rules ────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS commission_rules (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- Matcher (nullable = "any")
+  user_id uuid REFERENCES profiles(id) ON DELETE CASCADE,
+  role_code text REFERENCES attribution_roles(code) ON DELETE CASCADE,
+  category text,                        -- lowercased order/product category, or NULL
+
+  -- Rate + hold
+  rate_bps int NOT NULL CHECK (rate_bps >= 0 AND rate_bps <= 10000),
+  hold_days int NOT NULL DEFAULT 0 CHECK (hold_days >= 0 AND hold_days <= 365),
+
+  -- Priority: higher wins. Derived from specificity so we don't need
+  -- app-level tie-breaking when two rules have equal specificity.
+  --   +1000 if user_id set
+  --   + 100 if role_code set
+  --   +  10 if category set
+  priority int NOT NULL DEFAULT 0,
+
+  is_default boolean NOT NULL DEFAULT false,   -- the singleton fallback rate
+  is_active boolean NOT NULL DEFAULT true,
+  notes text,
+
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now(),
+  created_by uuid REFERENCES profiles(id),
+
+  -- Prevent duplicate specifiers. NULL == NULL under UNIQUE in Postgres, so
+  -- we coerce via unique index on COALESCE.
+  UNIQUE NULLS NOT DISTINCT (user_id, role_code, category)
+);
+
+CREATE INDEX IF NOT EXISTS idx_commission_rules_user ON commission_rules(user_id) WHERE user_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_commission_rules_role ON commission_rules(role_code) WHERE role_code IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_commission_rules_active ON commission_rules(is_active, priority DESC);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_commission_rules_singleton_default
+  ON commission_rules((true))
+  WHERE is_default = true;
+
+-- Seed the default rule (5% flat, no hold) if not present.
+INSERT INTO commission_rules (rate_bps, hold_days, is_default, priority, notes)
+SELECT 500, 0, true, 0, 'System default commission rate. Edit or override per role/user/category.'
+WHERE NOT EXISTS (SELECT 1 FROM commission_rules WHERE is_default = true);
+
+-- ─── Commission ledger ───────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS commission_ledger (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  user_id uuid NOT NULL REFERENCES profiles(id) ON DELETE RESTRICT,
+  order_id uuid NOT NULL REFERENCES sales_orders(id) ON DELETE CASCADE,
+  attribution_id uuid REFERENCES sales_attributions(id) ON DELETE SET NULL,
+  role_code text NOT NULL REFERENCES attribution_roles(code) ON DELETE RESTRICT,
+
+  payment_id uuid REFERENCES payments(id) ON DELETE SET NULL,
+  rule_id uuid REFERENCES commission_rules(id) ON DELETE SET NULL,
+
+  -- Money math
+  attribution_percentage numeric(6,3) NOT NULL,   -- copy of the attribution % at earn time
+  basis_cents bigint NOT NULL,                    -- payment amount × attribution % (signed)
+  rate_bps int NOT NULL,                          -- rate at time of earn
+  amount_cents bigint NOT NULL,                   -- commission amount, signed (negative = reversal)
+
+  hold_days int NOT NULL DEFAULT 0,
+  status text NOT NULL DEFAULT 'earned'
+    CHECK (status IN ('pending','held','earned','reversed','paid','cancelled')),
+
+  earned_at timestamptz NOT NULL DEFAULT now(),
+  clearable_at timestamptz,          -- earned_at + hold_days; when hold_days=0 == earned_at
+  paid_at timestamptz,
+
+  reversed_of_id uuid REFERENCES commission_ledger(id) ON DELETE SET NULL,
+  reversal_reason text,
+
+  notes text,
+  metadata jsonb,
+
+  created_at timestamptz DEFAULT now(),
+  created_by uuid REFERENCES profiles(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_commission_ledger_user ON commission_ledger(user_id, earned_at DESC);
+CREATE INDEX IF NOT EXISTS idx_commission_ledger_order ON commission_ledger(order_id);
+CREATE INDEX IF NOT EXISTS idx_commission_ledger_payment ON commission_ledger(payment_id);
+CREATE INDEX IF NOT EXISTS idx_commission_ledger_status ON commission_ledger(status);
+CREATE INDEX IF NOT EXISTS idx_commission_ledger_reversal ON commission_ledger(reversed_of_id) WHERE reversed_of_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_commission_ledger_clearable ON commission_ledger(status, clearable_at)
+  WHERE status IN ('held','earned');
+
+-- ─── RLS ─────────────────────────────────────────────────────────────────
+ALTER TABLE commission_rules ENABLE ROW LEVEL SECURITY;
+ALTER TABLE commission_ledger ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Service role only" ON commission_rules;
+CREATE POLICY "Service role only" ON commission_rules
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- Reps can read the active rules that apply to them or their role — populates
+-- "My Commissions" explainer copy.
+DROP POLICY IF EXISTS "Read applicable rules" ON commission_rules;
+CREATE POLICY "Read applicable rules" ON commission_rules
+  FOR SELECT TO authenticated
+  USING (
+    is_active = true
+    AND (user_id IS NULL OR user_id = auth.uid())
+  );
+
+DROP POLICY IF EXISTS "Service role only" ON commission_ledger;
+CREATE POLICY "Service role only" ON commission_ledger
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- Reps read their own ledger — the whole point of the rep-facing "My
+-- Commissions" page.
+DROP POLICY IF EXISTS "Rep reads own commissions" ON commission_ledger;
+CREATE POLICY "Rep reads own commissions" ON commission_ledger
+  FOR SELECT TO authenticated
+  USING (user_id = auth.uid());
+
+-- ─── Updated_at trigger ─────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION touch_commission_rules_updated_at() RETURNS trigger AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_commission_rules_updated_at ON commission_rules;
+CREATE TRIGGER trg_commission_rules_updated_at
+  BEFORE UPDATE ON commission_rules
+  FOR EACH ROW EXECUTE FUNCTION touch_commission_rules_updated_at();


### PR DESCRIPTION
Migration 109 adds commission_rules and commission_ledger.

Rules resolve by specificity: user+category > user > role+category > role >
default. Seeded default = 5%, no hold. RLS scopes ledger reads to the row's user_id so reps can only see their own credits.

Auto-earn fires from paymentLedger.upsertPayment on any paid transition: for each attribution row on the linked order it computes basis = payment × attribution % and amount = basis × rate_bps / 10000, then writes a commission_ledger row. Idempotent per (order, payment, user, role).

Auto-reverse fires from recordRefund: walks earn rows for the parent payment and writes pro-rata negative-amount reversal rows tied via reversed_of_id. Full reversal flips the original row to 'reversed' so summary math doesn't double-count.

Admin surfaces:
- /api/admin/financial/commission-rules (GET/POST + [id] PATCH/DELETE)
- /api/admin/financial/commissions (GET with filters + summary)
- /api/admin/financial/commissions/backfill (GET count, POST run)
- /api/admin/financial/commissions/mark-paid (batch mark paid)
- /admin/financial/settings extended with a rules editor
- /admin/financial/commissions replaces the Phase 4 stub with a real inspector: summary tiles, filters, bulk mark-paid, backfill button

Rep surface:
- /api/my/commissions returns summary + rows scoped to the caller

Never fails the payment write on a commissions hiccup — earn/reverse hooks are wrapped in try/catch that logs and moves on.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2