### PR TITLE
PP flow fixes — identity leak, mark-paid, sequencing, prepaid

### DIFF
--- a/src/app/admin/marketplace/payouts/page.tsx
+++ b/src/app/admin/marketplace/payouts/page.tsx
@@ -54,6 +54,7 @@ const FILTERS = [
 
 const STATUS_COLORS: Record<string, string> = {
   queued: "bg-amber-50 text-amber-700",
+  awaiting_collection: "bg-orange-50 text-orange-700",
   sent_to_qb: "bg-blue-50 text-blue-700",
   paid: "bg-emerald-50 text-emerald-700",
   failed: "bg-red-50 text-red-700",
@@ -148,6 +149,23 @@ export default function AdminPayoutsPage() {
     const body = await res.json().catch(() => ({}));
     if (!res.ok) setError(body.error || "Failed to mark paid");
     else setMessage("Payout marked paid");
+    await load();
+    setSaving(null);
+  }
+
+  async function markInvoicePaid(id: string) {
+    const methodInput = prompt("Payment method used (ACH, Check, Zelle, Wire, etc.)?", "ACH");
+    if (methodInput === null) return;
+    const ref = prompt("Reference / confirmation # (optional)?", "");
+    setSaving(`mark-paid-${id}`);
+    const res = await fetch(`/api/admin/marketplace/operator-invoices/${id}/mark-paid`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ method: methodInput, reference: ref }),
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) setError(body.error || "Failed to mark paid");
+    else setMessage("Operator invoice marked paid — payout unlocked and queued to QB");
     await load();
     setSaving(null);
   }
@@ -371,16 +389,29 @@ export default function AdminPayoutsPage() {
                   <td className="px-4 py-3 text-xs text-gray-500 font-mono">{i.qb_invoice_id || "—"}</td>
                   <td className="px-4 py-3 text-xs text-gray-500">{new Date(i.triggered_at).toLocaleDateString()}</td>
                   <td className="px-4 py-3">
-                    {(i.status === "queued" || i.status === "failed") && (
-                      <button
-                        onClick={() => retry(i.id)}
-                        disabled={saving === `retry-${i.id}`}
-                        className="inline-flex items-center gap-1 rounded-lg border border-gray-200 hover:bg-gray-50 px-2 py-1 text-xs font-medium text-gray-700 cursor-pointer disabled:opacity-50"
-                      >
-                        {saving === `retry-${i.id}` ? <Loader2 className="h-3 w-3 animate-spin" /> : <RefreshCw className="h-3 w-3" />}
-                        Send
-                      </button>
-                    )}
+                    <div className="flex items-center gap-1 flex-wrap">
+                      {(i.status === "queued" || i.status === "failed") && (
+                        <button
+                          onClick={() => retry(i.id)}
+                          disabled={saving === `retry-${i.id}`}
+                          className="inline-flex items-center gap-1 rounded-lg border border-gray-200 hover:bg-gray-50 px-2 py-1 text-xs font-medium text-gray-700 cursor-pointer disabled:opacity-50"
+                        >
+                          {saving === `retry-${i.id}` ? <Loader2 className="h-3 w-3 animate-spin" /> : <RefreshCw className="h-3 w-3" />}
+                          Send
+                        </button>
+                      )}
+                      {i.status !== "paid" && i.status !== "cancelled" && (
+                        <button
+                          onClick={() => markInvoicePaid(i.id)}
+                          disabled={saving === `mark-paid-${i.id}`}
+                          className="inline-flex items-center gap-1 rounded-lg border border-emerald-200 bg-emerald-50 hover:bg-emerald-100 px-2 py-1 text-xs font-medium text-emerald-700 cursor-pointer disabled:opacity-50"
+                          title="Manually record operator payment — unlocks the paired PP payout"
+                        >
+                          {saving === `mark-paid-${i.id}` ? <Loader2 className="h-3 w-3 animate-spin" /> : <ClipboardCheck className="h-3 w-3" />}
+                          Mark paid
+                        </button>
+                      )}
+                    </div>
                   </td>
                 </tr>
               ))}

--- a/src/app/api/admin/marketplace/operator-invoices/[id]/mark-paid/route.ts
+++ b/src/app/api/admin/marketplace/operator-invoices/[id]/mark-paid/route.ts
@@ -1,0 +1,102 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+import { upsertPayment } from "@/lib/paymentLedger";
+
+/**
+ * Manually flip a marketplace_operator_invoices row to "paid" after admin
+ * confirms offline collection (check, ACH, etc.). Also writes a canonical
+ * `payments` row via upsertPayment so:
+ *
+ *   1. Financial Center + reconciliation see the collection
+ *   2. Payout sequencing is unlocked — the PP payout can now leave
+ *      `awaiting_collection` and push to QB
+ *   3. Commission auto-earn fires against the payment (if the source
+ *      contract is tied to a sales order)
+ */
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id } = await params;
+
+  const body = await req.json().catch(() => ({}));
+  const method = typeof body.method === "string" ? body.method.trim().slice(0, 40) : null;
+  const reference = typeof body.reference === "string" ? body.reference.trim().slice(0, 120) : null;
+
+  const { data: invoice } = await supabaseAdmin
+    .from("marketplace_operator_invoices")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+  if (!invoice) return NextResponse.json({ error: "Invoice not found" }, { status: 404 });
+  if (invoice.status === "paid") return NextResponse.json({ ok: true, already: true });
+
+  const nowIso = new Date().toISOString();
+
+  // Ledger write — provider='manual' so it flows through the same
+  // commissions + reconciliation pipeline as sales-side manual payments.
+  const amountCents = Math.max(0, Math.round(Number(invoice.amount) * 100));
+  try {
+    await upsertPayment({
+      provider: "manual",
+      providerPaymentId: `manual:marketplace_operator_invoice:${invoice.id}`,
+      buyerEmail: invoice.operator_email || null,
+      buyerProfileId: invoice.operator_profile_id || null,
+      amountCents,
+      method: method || "manual",
+      status: "paid",
+      paidAt: nowIso,
+      manualReference: reference,
+      metadata: {
+        source: "marketplace_operator_invoice",
+        marketplace_invoice_id: invoice.id,
+        submission_id: invoice.submission_id,
+        contract_id: invoice.contract_id,
+        qb_invoice_id: invoice.qb_invoice_id || null,
+      },
+      createdBy: adminId,
+    });
+  } catch (e) {
+    console.error("[op-invoice.mark-paid] ledger write failed:", e);
+    // Non-fatal — we still want the manual ack to succeed so admin doesn't
+    // get stuck on a payment they know landed. Reconciliation will surface
+    // the miss.
+  }
+
+  await supabaseAdmin
+    .from("marketplace_operator_invoices")
+    .update({
+      status: "paid",
+      paid_at: nowIso,
+      paid_method: method,
+      paid_reference: reference,
+      paid_by: adminId,
+      updated_at: nowIso,
+    })
+    .eq("id", id);
+
+  // Release the paired payout — if it was awaiting_collection, drop it back
+  // to queued so the QB Bill drain worker picks it up (or push it directly
+  // right here if you want zero-delay).
+  await supabaseAdmin
+    .from("marketplace_payouts")
+    .update({ status: "queued", updated_at: nowIso })
+    .eq("submission_id", invoice.submission_id)
+    .eq("status", "awaiting_collection");
+
+  // Trigger the payout QB Bill immediately. Fire-and-forget — errors get
+  // surfaced on /admin/marketplace/payouts.
+  try {
+    const { data: payout } = await supabaseAdmin
+      .from("marketplace_payouts")
+      .select("id, status")
+      .eq("submission_id", invoice.submission_id)
+      .maybeSingle();
+    if (payout && payout.status === "queued") {
+      const { pushPayoutToQb } = await import("@/lib/marketplaceQb");
+      pushPayoutToQb(payout.id).catch(() => undefined);
+    }
+  } catch { /* non-critical */ }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/operator/marketplace/submissions/[id]/decide/route.ts
+++ b/src/app/api/operator/marketplace/submissions/[id]/decide/route.ts
@@ -90,16 +90,22 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
       });
     }
 
-    // Queue payout + invoice, then best-effort push both to QuickBooks in the
-    // background. Any failures are surfaced on /admin/marketplace/payouts and
-    // can be retried there. Non-critical — decision is already recorded.
+    // Queue payout + invoice. Payout starts in 'awaiting_collection' unless
+    // the contract is billing_prepaid (VC already collected on the machine
+    // sale), in which case it goes straight to 'queued'. The operator
+    // invoice is skipped entirely for prepaid contracts.
+    //
+    // Only push what's actually ready to send:
+    //   - Non-prepaid: send the operator invoice to QB right away; payout
+    //     stays awaiting_collection until the operator pays.
+    //   - Prepaid: no invoice; push the payout to QB immediately.
     try {
       await queuePartnerPayoutForSubmission({ submissionId: id, triggeredBy: user.id });
       await queueOperatorInvoiceForSubmission({ submissionId: id, triggeredBy: user.id });
 
       const { data: newPayout } = await supabaseAdmin
         .from("marketplace_payouts")
-        .select("id")
+        .select("id, status")
         .eq("submission_id", id)
         .maybeSingle();
       const { data: newInvoice } = await supabaseAdmin
@@ -109,8 +115,10 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
         .maybeSingle();
 
       const { pushPayoutToQb, pushOperatorInvoiceToQb } = await import("@/lib/marketplaceQb");
-      if (newPayout) pushPayoutToQb(newPayout.id).catch(() => undefined);
       if (newInvoice) pushOperatorInvoiceToQb(newInvoice.id).catch(() => undefined);
+      if (newPayout && newPayout.status === "queued") {
+        pushPayoutToQb(newPayout.id).catch(() => undefined);
+      }
     } catch {
       // Non-critical — decision already recorded
     }

--- a/src/app/api/webhooks/quickbooks/route.ts
+++ b/src/app/api/webhooks/quickbooks/route.ts
@@ -371,7 +371,7 @@ async function handleQBPayment(paymentId: string, realmId: string) {
     // Check marketplace_operator_invoices (Phase 2.4 — placement fee billing)
     const { data: marketplaceOpInvoice } = await supabaseAdmin
       .from("marketplace_operator_invoices")
-      .select("id, status")
+      .select("id, status, submission_id")
       .eq("qb_invoice_id", invoiceId)
       .maybeSingle();
 
@@ -386,6 +386,27 @@ async function handleQBPayment(paymentId: string, realmId: string) {
             updated_at: new Date().toISOString(),
           })
           .eq("id", marketplaceOpInvoice.id);
+
+        // Release the paired PP payout — drop it from awaiting_collection to
+        // queued so the QB Bill drain picks it up. Then push immediately in
+        // the background so the partner sees their money moving quickly.
+        const nowIso = new Date().toISOString();
+        await supabaseAdmin
+          .from("marketplace_payouts")
+          .update({ status: "queued", updated_at: nowIso })
+          .eq("submission_id", marketplaceOpInvoice.submission_id)
+          .eq("status", "awaiting_collection");
+        try {
+          const { data: payout } = await supabaseAdmin
+            .from("marketplace_payouts")
+            .select("id, status")
+            .eq("submission_id", marketplaceOpInvoice.submission_id)
+            .maybeSingle();
+          if (payout && payout.status === "queued") {
+            const { pushPayoutToQb } = await import("@/lib/marketplaceQb");
+            pushPayoutToQb(payout.id).catch(() => undefined);
+          }
+        } catch { /* non-critical */ }
       }
       continue;
     }

--- a/src/lib/marketplaceHandoff.ts
+++ b/src/lib/marketplaceHandoff.ts
@@ -26,6 +26,8 @@ interface PurchaseAgreement {
   account_id: string | null;
   operator_id: string | null;
   created_by: string | null;
+  apex_placement_paid_at: string | null;
+  apex_placement_qb_invoice_id: string | null;
 }
 
 function parseCityState(address: string | null): { city: string | null; state: string | null } {
@@ -61,13 +63,24 @@ export async function createContractFromAgreement(agreementId: string): Promise<
   const locationsNeeded = Math.max(1, Number(ag.locations_purchased) || 1);
   const operatorProfileId = ag.operator_id || (await findOperatorProfileId(ag.operator_email));
 
+  // Identity-safe display: partner_visible_contracts exposes title + notes to
+  // every browsing PP. NEVER include operator name, email, phone, or the
+  // full delivery address — only city + state (market area). Full address is
+  // shared with the winning PP after the operator accepts their submission.
+  const marketLabel = city && state ? `${city}, ${state}` : (state || "Market TBD");
+  const machineLabel = ag.machine_model || "VendEra AI Machine";
+  // Prepaid flag: if the source agreement already collected the placement
+  // fee (apex_placement_paid_at is set), we skip the marketplace operator
+  // invoice on submission accept and drop the payout straight to queued.
+  const billingPrepaid = !!ag.apex_placement_paid_at;
+
   const insertRow = {
-    title: `${ag.operator_company_name || "Operator"} — ${locationsNeeded} location${locationsNeeded > 1 ? "s" : ""}`,
+    title: `Tier 1 — ${marketLabel} — ${locationsNeeded} location${locationsNeeded > 1 ? "s" : ""}`,
     tier: 1,
     operator_price: pricing.operator_price,
     partner_payout: pricing.partner_payout,
     platform_fee: pricing.platform_fee,
-    machine_type: ag.machine_model || "VendEra AI Machine",
+    machine_type: machineLabel,
     market_state: state,
     market_city: city,
     contract_type: locationsNeeded > 1 ? "multi" : "single",
@@ -77,8 +90,12 @@ export async function createContractFromAgreement(agreementId: string): Promise<
     source_agreement_id: ag.id,
     operator_profile_id: operatorProfileId,
     operator_business_name: ag.operator_company_name,
+    billing_prepaid: billingPrepaid,
     status: "open",
-    notes: `Auto-created from signed agreement. Delivery address: ${ag.operator_delivery_address || "—"}`,
+    // Generic notes — no operator name or street address. If the operator
+    // wants to add contract-specific direction, they can do it from the
+    // admin editor after auto-creation.
+    notes: `Auto-created from signed agreement. Location target: ${marketLabel}. Machine type: ${machineLabel}.${billingPrepaid ? " Placement fee prepaid on source agreement." : ""}`,
     created_by: ag.created_by,
   };
 
@@ -127,10 +144,16 @@ export async function queuePartnerPayoutForSubmission({ submissionId, triggeredB
 
   const { data: contract } = await supabaseAdmin
     .from("placement_contracts")
-    .select("partner_payout")
+    .select("partner_payout, billing_prepaid")
     .eq("id", sub.contract_id)
     .maybeSingle();
   if (!contract) return;
+
+  // Sequencing: normal flow holds the payout in 'awaiting_collection' until
+  // the operator invoice flips to paid. Prepaid contracts (fee already
+  // collected on the source machine sale) skip that gate — payout goes
+  // straight to 'queued' so the QB Bill drain picks it up.
+  const startingStatus = contract.billing_prepaid ? "queued" : "awaiting_collection";
 
   // Idempotent: unique on submission_id — swallow duplicate-key errors.
   try {
@@ -142,7 +165,7 @@ export async function queuePartnerPayoutForSubmission({ submissionId, triggeredB
         partner_id: sub.partner_id,
         company_id: sub.company_id,
         amount: contract.partner_payout,
-        status: "queued",
+        status: startingStatus,
         triggered_by: triggeredBy,
       });
   } catch {
@@ -160,10 +183,15 @@ export async function queueOperatorInvoiceForSubmission({ submissionId, triggere
 
   const { data: contract } = await supabaseAdmin
     .from("placement_contracts")
-    .select("operator_price, operator_profile_id, operator_business_name, source_agreement_id")
+    .select("operator_price, operator_profile_id, operator_business_name, source_agreement_id, billing_prepaid")
     .eq("id", sub.contract_id)
     .maybeSingle();
   if (!contract) return;
+
+  // Prepaid contracts skip the invoice entirely — placement fee was already
+  // collected on the source machine sale. The payout was queued directly by
+  // queuePartnerPayoutForSubmission (not held).
+  if (contract.billing_prepaid) return;
 
   let operatorEmail: string | null = null;
   if (contract.source_agreement_id) {

--- a/src/lib/marketplaceQb.ts
+++ b/src/lib/marketplaceQb.ts
@@ -163,6 +163,9 @@ export async function pushPayoutToQb(payoutId: string): Promise<QbPushResult> {
     .eq("id", payoutId)
     .maybeSingle();
   if (!payout) return { ok: false, error: "Payout not found" };
+  if (payout.status === "awaiting_collection") {
+    return { ok: false, error: "Payout is held until the operator invoice is paid" };
+  }
   if (payout.status !== "queued" && payout.status !== "failed") {
     return { ok: false, error: `Payout already ${payout.status}` };
   }

--- a/src/lib/operatorMarketplaceAuth.ts
+++ b/src/lib/operatorMarketplaceAuth.ts
@@ -10,12 +10,24 @@ export interface OperatorUser {
 }
 
 /**
- * Any signed-in profile can see marketplace submissions for contracts they
- * sourced (via a signed agreement). We match by contract.operator_profile_id
- * OR by the operator_email on the source purchase agreement — this way the
- * signing party sees their inbox even if their profile was created after the
- * agreement was drafted.
+ * Operators (and admins acting on their behalf) can see marketplace
+ * submissions for contracts they sourced. Match by
+ * contract.operator_profile_id OR by the operator_email on the source
+ * purchase agreement.
+ *
+ * Role gate: bare email matching is not enough — a locator or sales user
+ * whose email happens to collide with an operator_email must not read the
+ * submissions inbox. Only role in ('operator','admin','sales_manager',
+ * 'director_of_sales','market_leader') passes.
  */
+const OPERATOR_ROLES = new Set([
+  "operator",
+  "admin",
+  "sales_manager",
+  "director_of_sales",
+  "market_leader",
+]);
+
 export async function getOperatorUser(req: NextRequest): Promise<OperatorUser | null> {
   const userId = await getUserIdFromRequest(req);
   if (!userId) return null;
@@ -26,6 +38,7 @@ export async function getOperatorUser(req: NextRequest): Promise<OperatorUser | 
     .eq("id", userId)
     .maybeSingle();
   if (!profile) return null;
+  if (!OPERATOR_ROLES.has(profile.role)) return null;
   return {
     id: profile.id,
     email: profile.email,

--- a/supabase/migrations/111_marketplace_payout_sequencing.sql
+++ b/supabase/migrations/111_marketplace_payout_sequencing.sql
@@ -1,0 +1,41 @@
+-- Placement fee middleman sequencing.
+--
+-- Old behavior: on operator accept, we queued BOTH the operator invoice AND
+-- the PP payout and pushed both to QuickBooks immediately. That meant the
+-- QB Bill (VC → PP) was created before the QB Invoice (VC ← operator)
+-- had been paid — VC ate the float.
+--
+-- New behavior:
+--   1. Payout is created in status='awaiting_collection' (held).
+--   2. When the operator invoice flips to 'paid' (webhook or manual
+--      mark-paid), the paired payout drops to 'queued' and the QB Bill
+--      drain picks it up.
+--   3. If the contract is `billing_prepaid` (placement fee already
+--      collected as part of the machine sale), the operator invoice is
+--      SKIPPED entirely and the payout goes straight to 'queued'.
+
+-- ─── Expand payout status check ─────────────────────────────────────────
+ALTER TABLE marketplace_payouts
+  DROP CONSTRAINT IF EXISTS marketplace_payouts_status_check;
+
+ALTER TABLE marketplace_payouts
+  ADD CONSTRAINT marketplace_payouts_status_check
+  CHECK (status IN (
+    'awaiting_collection',
+    'queued',
+    'sent_to_qb',
+    'paid',
+    'failed',
+    'cancelled'
+  ));
+
+CREATE INDEX IF NOT EXISTS idx_marketplace_payouts_awaiting
+  ON marketplace_payouts(submission_id)
+  WHERE status = 'awaiting_collection';
+
+-- ─── Prepaid contracts ──────────────────────────────────────────────────
+ALTER TABLE placement_contracts
+  ADD COLUMN IF NOT EXISTS billing_prepaid boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN placement_contracts.billing_prepaid IS
+  'True when the placement fee was already collected as part of the source purchase agreement (or otherwise pre-paid). Suppresses the marketplace_operator_invoices creation on submission accept and drops the payout straight to queued instead of awaiting_collection.';


### PR DESCRIPTION
1. Identity leak on auto-created contracts (LIVE — was leaking) createContractFromAgreement no longer stamps operator company name into contract.title or the delivery address into contract.notes. partner_visible_contracts exposes both fields to every browsing PP. New title: "Tier N — City, ST — N locations". New notes: market + machine type only. Full delivery address is shared with the winning PP after the operator accepts their submission (via the private submission channel), never with the browsing pool.

   getOperatorUser now requires role in ('operator','admin', 'sales_manager','director_of_sales','market_leader'). Previously a locator or sales user whose email happened to collide with an operator_email on a purchase_agreements row could read that operator's submission inbox.

2. Operator invoice manual mark-paid New POST /api/admin/marketplace/operator-invoices/[id]/mark-paid mirrors the payout mark-paid endpoint. Writes a canonical payments row via upsertPayment(provider='manual') so it flows through Financial Center, reconciliation, and the commission auto-earn hook. Also unlocks the paired PP payout (see #3) and pushes the QB Bill in the background. New button on the operator invoices tab of /admin/marketplace/payouts.

3. Middleman payment sequencing (op pays VC → then VC pays PP) Migration 111 expands marketplace_payouts.status to include 'awaiting_collection'. New payouts land there instead of 'queued' so the QB Bill isn't created until the operator has actually paid. Two triggers release the hold: - QB webhook flips paired operator invoice to paid → payout drops to queued + QB Bill push kicks off - Manual mark-paid on the operator invoice does the same pushPayoutToQb refuses to send an awaiting_collection row as a defense-in-depth guard.

4. Prepaid contracts (placement fee already collected on machine sale) Migration 111 adds placement_contracts.billing_prepaid boolean. createContractFromAgreement now flips it true when the source purchase_agreements.apex_placement_paid_at is populated. queueOperatorInvoiceForSubmission short-circuits when prepaid — no operator invoice is created — and queuePartnerPayoutForSubmission drops the payout straight to 'queued' (skipping awaiting_collection) so the PP gets paid immediately.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2