### PR TITLE
Commission overrides + rep + PP visibility dashboards

### DIFF
--- a/src/app/api/placement/my/earnings/route.ts
+++ b/src/app/api/placement/my/earnings/route.ts
@@ -1,0 +1,88 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getPlacementPartner, forbidden } from "@/lib/marketplaceAuth";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+
+/**
+ * GET /api/placement/my/earnings
+ *
+ * PP-facing dashboard data. Aggregates over marketplace_payouts scoped to
+ * the authenticated partner, plus their submission activity (last N).
+ *
+ * Payout status meaning:
+ *   awaiting_collection — operator invoice not yet paid; you're queued but
+ *                          not billed to VC yet
+ *   queued              — operator paid; QB Bill about to be created
+ *   sent_to_qb          — QB Bill exists; you'll see it in QB / receive it
+ *   paid                — payment released to you
+ *   failed              — QB Bill creation errored; admin is looking at it
+ */
+
+export async function GET(req: NextRequest) {
+  const user = await getPlacementPartner(req);
+  if (!user) return forbidden();
+
+  const url = new URL(req.url);
+  const sinceDays = Math.max(1, Math.min(3650, Number(url.searchParams.get("since_days") || 365)));
+  const limit = Math.max(1, Math.min(500, Number(url.searchParams.get("limit") || 100)));
+  const cutoff = new Date(Date.now() - sinceDays * 24 * 60 * 60 * 1000).toISOString();
+
+  const { data: payouts } = await supabaseAdmin
+    .from("marketplace_payouts")
+    .select(`
+      id, submission_id, contract_id, amount, currency, status,
+      qb_bill_id, qb_error, triggered_at, sent_at, paid_at, paid_method, paid_reference,
+      contract:contract_id(title, tier, market_city, market_state),
+      submission:submission_id(business_name, city, state, admin_status, operator_status)
+    `)
+    .eq("partner_id", user.id)
+    .gte("triggered_at", cutoff)
+    .order("triggered_at", { ascending: false })
+    .limit(limit);
+
+  const payoutRows = payouts || [];
+
+  const summary = {
+    awaiting_collection_cents: 0,
+    queued_cents: 0,
+    sent_to_qb_cents: 0,
+    paid_cents: 0,
+    failed_cents: 0,
+    lifetime_paid_cents: 0,
+    row_count: payoutRows.length,
+  };
+  for (const p of payoutRows) {
+    const cents = Math.round(Number(p.amount || 0) * 100);
+    if (p.status === "awaiting_collection") summary.awaiting_collection_cents += cents;
+    else if (p.status === "queued") summary.queued_cents += cents;
+    else if (p.status === "sent_to_qb") summary.sent_to_qb_cents += cents;
+    else if (p.status === "paid") { summary.paid_cents += cents; summary.lifetime_paid_cents += cents; }
+    else if (p.status === "failed") summary.failed_cents += cents;
+  }
+
+  // Recent submission activity (approved-or-pending, includes operator decision)
+  const { data: submissions } = await supabaseAdmin
+    .from("placement_submissions")
+    .select(`
+      id, contract_id, business_name, city, state,
+      admin_status, operator_status, created_at,
+      contract:contract_id(title, tier)
+    `)
+    .eq("partner_id", user.id)
+    .gte("created_at", cutoff)
+    .order("created_at", { ascending: false })
+    .limit(50);
+
+  // Active contract count (accepted but not yet fulfilled from the PP's side)
+  const { count: activeAcceptances } = await supabaseAdmin
+    .from("placement_contract_acceptances")
+    .select("*", { count: "exact", head: true })
+    .eq("partner_id", user.id)
+    .is("released_at", null);
+
+  return NextResponse.json({
+    summary,
+    payouts: payoutRows,
+    submissions: submissions || [],
+    active_acceptances: activeAcceptances || 0,
+  });
+}

--- a/src/app/api/sales/orders/[id]/commission/route.ts
+++ b/src/app/api/sales/orders/[id]/commission/route.ts
@@ -1,0 +1,115 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+import { writeAuditLog } from "@/lib/paymentLedger";
+
+/**
+ * PATCH /api/sales/orders/[id]/commission
+ * Body: {
+ *   order_rate_pct?: number | null,    // 0-100, null clears
+ *   order_note?: string | null,
+ *   line_overrides?: Array<{ item_id: string, rate_pct: number | null, note?: string | null }>
+ * }
+ *
+ * Admin-only. Sets/clears commission rate overrides at both the order and
+ * per-line level. Existing commission_ledger rows are NOT recomputed —
+ * overrides only apply to earn events fired after this call. Use the
+ * commissions backfill endpoint if you need to re-run history.
+ */
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id } = await params;
+
+  const body = await req.json().catch(() => ({}));
+
+  const { data: before } = await supabaseAdmin
+    .from("sales_orders")
+    .select("id, commission_rate_bps_override, commission_override_note")
+    .eq("id", id)
+    .maybeSingle();
+  if (!before) return NextResponse.json({ error: "Order not found" }, { status: 404 });
+
+  const orderUpdates: Record<string, unknown> = {};
+  const nowIso = new Date().toISOString();
+
+  if ("order_rate_pct" in body) {
+    const val = body.order_rate_pct;
+    if (val === null || val === "") {
+      orderUpdates.commission_rate_bps_override = null;
+      orderUpdates.commission_override_note = null;
+      orderUpdates.commission_override_by = null;
+      orderUpdates.commission_override_at = null;
+    } else {
+      const pct = Number(val);
+      if (!Number.isFinite(pct) || pct < 0 || pct > 100) {
+        return NextResponse.json({ error: "order_rate_pct must be 0-100." }, { status: 400 });
+      }
+      orderUpdates.commission_rate_bps_override = Math.round(pct * 100);
+      orderUpdates.commission_override_note = body.order_note ? String(body.order_note) : null;
+      orderUpdates.commission_override_by = adminId;
+      orderUpdates.commission_override_at = nowIso;
+    }
+    orderUpdates.updated_at = nowIso;
+  }
+
+  if (Object.keys(orderUpdates).length > 0) {
+    const { error } = await supabaseAdmin
+      .from("sales_orders")
+      .update(orderUpdates)
+      .eq("id", id);
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  // Line-level overrides
+  const lineOverrides = Array.isArray(body.line_overrides) ? body.line_overrides : [];
+  const lineResults: Array<{ item_id: string; ok: boolean; error?: string }> = [];
+  for (const raw of lineOverrides) {
+    const itemId = typeof raw.item_id === "string" ? raw.item_id : null;
+    if (!itemId) { lineResults.push({ item_id: "?", ok: false, error: "missing item_id" }); continue; }
+
+    // Ensure the line belongs to this order (no cross-order override abuse).
+    const { data: item } = await supabaseAdmin
+      .from("order_items")
+      .select("id, order_id")
+      .eq("id", itemId)
+      .maybeSingle();
+    if (!item || item.order_id !== id) {
+      lineResults.push({ item_id: itemId, ok: false, error: "line not on this order" });
+      continue;
+    }
+
+    const val = raw.rate_pct;
+    const patch: Record<string, unknown> = { updated_at: nowIso };
+    if (val === null || val === "" || val === undefined) {
+      patch.commission_rate_bps_override = null;
+      patch.commission_override_note = null;
+    } else {
+      const pct = Number(val);
+      if (!Number.isFinite(pct) || pct < 0 || pct > 100) {
+        lineResults.push({ item_id: itemId, ok: false, error: "rate_pct must be 0-100" });
+        continue;
+      }
+      patch.commission_rate_bps_override = Math.round(pct * 100);
+      patch.commission_override_note = raw.note ? String(raw.note) : null;
+    }
+    const { error } = await supabaseAdmin
+      .from("order_items")
+      .update(patch)
+      .eq("id", itemId);
+    if (error) { lineResults.push({ item_id: itemId, ok: false, error: error.message }); continue; }
+    lineResults.push({ item_id: itemId, ok: true });
+  }
+
+  await writeAuditLog({
+    actorId: adminId,
+    action: "commission_override_updated",
+    entityType: "sales_order",
+    entityId: id,
+    before: before as unknown as Record<string, unknown>,
+    after: orderUpdates,
+    metadata: { line_results: lineResults },
+  });
+
+  return NextResponse.json({ ok: true, line_results: lineResults });
+}

--- a/src/app/my/commissions/page.tsx
+++ b/src/app/my/commissions/page.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Loader2, DollarSign, TrendingUp, Clock, AlertTriangle, CheckCircle2, Percent, ArrowLeft, RefreshCw } from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
+
+interface LedgerRow {
+  id: string;
+  order_id: string;
+  role_code: string;
+  attribution_percentage: number;
+  basis_cents: number;
+  rate_bps: number;
+  amount_cents: number;
+  hold_days: number;
+  status: string;
+  earned_at: string;
+  clearable_at: string | null;
+  paid_at: string | null;
+  reversal_reason: string | null;
+  order: { id: string; total_value: number | null; order_type: string | null; order_status: string; created_at: string } | null;
+}
+
+interface Summary {
+  earned_cents: number;
+  held_cents: number;
+  reversed_cents: number;
+  paid_cents: number;
+  pending_clearable_cents: number;
+  net_available_cents: number;
+  clawback_pending_cents: number;
+  clawback_collected_cents: number;
+  clawback_waived_cents: number;
+  by_role: Record<string, number>;
+  row_count: number;
+}
+
+const STATUS_STYLES: Record<string, string> = {
+  earned: "bg-emerald-50 text-emerald-700 border-emerald-100",
+  held: "bg-amber-50 text-amber-700 border-amber-100",
+  paid: "bg-blue-50 text-blue-700 border-blue-100",
+  reversed: "bg-red-50 text-red-700 border-red-100",
+  clawback_pending: "bg-orange-50 text-orange-700 border-orange-200",
+  clawback_collected: "bg-emerald-50 text-emerald-700 border-emerald-100",
+  clawback_waived: "bg-gray-100 text-gray-500 border-gray-200",
+};
+
+const FILTERS = [
+  { key: "any", label: "All" },
+  { key: "earned", label: "Earned (open)" },
+  { key: "held", label: "Held" },
+  { key: "paid", label: "Paid" },
+  { key: "clawback_pending", label: "Owed back" },
+];
+
+function fmt(cents: number): string {
+  return `$${(cents / 100).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+export default function MyCommissionsPage() {
+  const router = useRouter();
+  const [token, setToken] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [rows, setRows] = useState<LedgerRow[]>([]);
+  const [summary, setSummary] = useState<Summary | null>(null);
+  const [statusFilter, setStatusFilter] = useState("any");
+  const [sinceDays, setSinceDays] = useState(365);
+
+  const load = useCallback(async () => {
+    if (!token) return;
+    setRefreshing(true);
+    try {
+      const params = new URLSearchParams();
+      params.set("since_days", String(sinceDays));
+      const res = await fetch(`/api/my/commissions?${params}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setRows(data.rows || []);
+        setSummary(data.summary || null);
+      }
+    } finally {
+      setRefreshing(false);
+      setLoading(false);
+    }
+  }, [token, sinceDays]);
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!session?.access_token) { router.push("/login?redirect=/my/commissions"); return; }
+      setToken(session.access_token);
+    });
+  }, [router]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const filtered = statusFilter === "any" ? rows : rows.filter((r) => r.status === statusFilter);
+
+  return (
+    <div className="p-6 max-w-6xl mx-auto">
+      <Link href="/dashboard" className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-green-primary mb-4">
+        <ArrowLeft className="h-4 w-4" /> Dashboard
+      </Link>
+
+      <div className="mb-6 flex items-center justify-between flex-wrap gap-3">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
+            <Percent className="h-6 w-6 text-green-primary" /> My Commissions
+          </h1>
+          <p className="text-sm text-gray-500 mt-1">Everything you&apos;ve earned across attributed sales — earned, held, paid, and clawed back.</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <select
+            value={sinceDays}
+            onChange={(e) => setSinceDays(Number(e.target.value))}
+            className="rounded-lg border border-gray-200 px-3 py-1.5 text-xs"
+          >
+            <option value={30}>Last 30 days</option>
+            <option value={90}>Last 90 days</option>
+            <option value={180}>Last 6 months</option>
+            <option value={365}>Last year</option>
+            <option value={3650}>All time</option>
+          </select>
+          <button
+            onClick={load}
+            disabled={refreshing}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-gray-200 hover:bg-gray-50 px-3 py-1.5 text-xs font-medium text-gray-700 cursor-pointer disabled:opacity-50"
+          >
+            {refreshing ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      {/* Hero: net available */}
+      <div className="rounded-2xl border border-emerald-100 bg-gradient-to-br from-emerald-50 to-white p-6 mb-4 flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <p className="text-xs font-medium uppercase tracking-wide text-emerald-700">Net available</p>
+          <p className="text-4xl font-bold text-emerald-800 mt-1">{summary ? fmt(summary.net_available_cents) : "…"}</p>
+          <p className="text-xs text-gray-500 mt-1">Earned + clearable held − reversed − outstanding clawbacks. Payouts happen manually today; admins will hand this off in your next payroll cycle.</p>
+        </div>
+        <div className="text-right">
+          <p className="text-xs text-gray-500">Lifetime paid to you</p>
+          <p className="text-2xl font-bold text-blue-700 mt-1">{summary ? fmt(summary.paid_cents) : "…"}</p>
+        </div>
+      </div>
+
+      {/* Summary tiles */}
+      <div className="grid grid-cols-2 sm:grid-cols-5 gap-3 mb-4">
+        <Tile icon={<TrendingUp className="h-3.5 w-3.5 text-emerald-600" />} label="Earned (open)" value={summary ? fmt(summary.earned_cents) : "…"} tint="emerald" />
+        <Tile icon={<Clock className="h-3.5 w-3.5 text-amber-600" />} label="Held" value={summary ? fmt(summary.held_cents) : "…"} tint="amber" />
+        <Tile icon={<DollarSign className="h-3.5 w-3.5 text-blue-600" />} label="Paid" value={summary ? fmt(summary.paid_cents) : "…"} tint="blue" />
+        <Tile icon={<AlertTriangle className="h-3.5 w-3.5 text-red-600" />} label="Reversed" value={summary ? fmt(summary.reversed_cents) : "…"} tint="red" />
+        <Tile
+          icon={<AlertTriangle className="h-3.5 w-3.5 text-orange-600" />}
+          label="Owed back"
+          value={summary ? fmt(summary.clawback_pending_cents) : "…"}
+          tint={summary && summary.clawback_pending_cents > 0 ? "orange-strong" : "gray"}
+          note={summary && summary.clawback_pending_cents > 0 ? "Refunds on sales where commission was already paid" : undefined}
+        />
+      </div>
+
+      {/* Filters */}
+      <div className="mb-4 flex items-center gap-2 flex-wrap">
+        {FILTERS.map((f) => (
+          <button
+            key={f.key}
+            onClick={() => setStatusFilter(f.key)}
+            className={`rounded-lg px-3 py-1.5 text-xs font-medium cursor-pointer ${statusFilter === f.key ? "bg-green-100 text-green-700" : "bg-gray-100 text-gray-500 hover:bg-gray-200"}`}
+          >
+            {f.label}
+          </button>
+        ))}
+        {summary && (
+          <span className="ml-auto text-xs text-gray-400">{filtered.length} row{filtered.length === 1 ? "" : "s"}</span>
+        )}
+      </div>
+
+      {/* Rows */}
+      <div className="rounded-2xl border border-gray-100 bg-white p-5">
+        {loading ? (
+          <div className="flex justify-center py-8"><Loader2 className="h-5 w-5 animate-spin text-green-primary" /></div>
+        ) : filtered.length === 0 ? (
+          <div className="text-center py-10">
+            <CheckCircle2 className="h-8 w-8 mx-auto mb-2 text-gray-300" />
+            <p className="text-sm text-gray-500">No commission rows in this window.</p>
+            <p className="text-xs text-gray-400 mt-1">Commissions auto-earn when payments land on orders you&apos;re attributed to.</p>
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-xs text-gray-500 border-b border-gray-100">
+                  <th className="text-left py-2 px-2 font-medium">Order</th>
+                  <th className="text-left py-2 px-2 font-medium">Role</th>
+                  <th className="text-right py-2 px-2 font-medium">Basis / Rate</th>
+                  <th className="text-right py-2 px-2 font-medium">Amount</th>
+                  <th className="text-left py-2 px-2 font-medium">Status</th>
+                  <th className="text-left py-2 px-2 font-medium">Earned</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.map((r) => {
+                  const stStyle = STATUS_STYLES[r.status] || "bg-gray-100 text-gray-500 border-gray-200";
+                  return (
+                    <tr key={r.id} className="border-b border-gray-50 last:border-b-0">
+                      <td className="py-2 px-2 text-xs">
+                        <Link href={`/sales/orders/${r.order_id}`} className="font-mono text-green-primary hover:underline">
+                          {r.order_id.slice(0, 8)}
+                        </Link>
+                        {r.order?.order_type && <span className="ml-1 text-[10px] text-gray-400 uppercase">{r.order.order_type}</span>}
+                        {r.order?.total_value != null && (
+                          <p className="text-gray-400">Order total ${Number(r.order.total_value).toLocaleString(undefined, { minimumFractionDigits: 2 })}</p>
+                        )}
+                      </td>
+                      <td className="py-2 px-2 text-xs capitalize">
+                        {r.role_code.replace(/_/g, " ")}
+                        <p className="text-gray-400">{Number(r.attribution_percentage).toFixed(1)}% credit</p>
+                      </td>
+                      <td className="py-2 px-2 text-right text-xs">
+                        <p className="font-mono">{fmt(r.basis_cents)}</p>
+                        <p className="text-gray-400">× {(r.rate_bps / 100).toFixed(2)}%</p>
+                      </td>
+                      <td className={`py-2 px-2 text-right font-semibold ${r.amount_cents < 0 ? "text-red-700" : "text-emerald-700"}`}>
+                        {fmt(r.amount_cents)}
+                      </td>
+                      <td className="py-2 px-2">
+                        <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-medium ${stStyle}`}>
+                          {r.status === "clawback_pending" && <AlertTriangle className="h-2.5 w-2.5" />}
+                          {r.status.replace(/_/g, " ")}
+                        </span>
+                        {r.status === "held" && r.clearable_at && (
+                          <p className="text-[10px] text-gray-500 mt-0.5">Clears {new Date(r.clearable_at).toLocaleDateString()}</p>
+                        )}
+                        {r.reversal_reason && <p className="text-[10px] text-red-500 mt-0.5 italic">{r.reversal_reason}</p>}
+                      </td>
+                      <td className="py-2 px-2 text-xs text-gray-500">
+                        {new Date(r.earned_at).toLocaleDateString()}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Tile({ icon, label, value, tint, note }: { icon: React.ReactNode; label: string; value: string; tint: "emerald" | "amber" | "blue" | "red" | "orange-strong" | "gray"; note?: string }) {
+  const tints: Record<string, string> = {
+    emerald: "border-gray-100 bg-white text-emerald-700",
+    amber: "border-gray-100 bg-white text-amber-700",
+    blue: "border-gray-100 bg-white text-blue-700",
+    red: "border-gray-100 bg-white text-red-700",
+    "orange-strong": "border-orange-200 bg-orange-50 text-orange-800",
+    gray: "border-gray-100 bg-white text-gray-400",
+  };
+  return (
+    <div className={`rounded-2xl border p-4 ${tints[tint]}`}>
+      <p className="text-[10px] font-medium uppercase tracking-wide text-gray-500 flex items-center gap-1">{icon}{label}</p>
+      <p className="text-lg font-bold mt-1">{value}</p>
+      {note && <p className="text-[10px] text-gray-500 mt-0.5">{note}</p>}
+    </div>
+  );
+}

--- a/src/app/placement/earnings/page.tsx
+++ b/src/app/placement/earnings/page.tsx
@@ -1,0 +1,337 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Loader2, DollarSign, TrendingUp, Clock, AlertTriangle, CheckCircle2, ArrowLeft, RefreshCw, MapPin, HandCoins } from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
+
+interface Payout {
+  id: string;
+  submission_id: string;
+  contract_id: string;
+  amount: number;
+  currency: string;
+  status: string;
+  qb_bill_id: string | null;
+  qb_error: string | null;
+  triggered_at: string;
+  sent_at: string | null;
+  paid_at: string | null;
+  paid_method: string | null;
+  paid_reference: string | null;
+  contract: { title: string; tier: number; market_city: string | null; market_state: string | null } | null;
+  submission: { business_name: string; city: string | null; state: string | null; admin_status: string; operator_status: string } | null;
+}
+
+interface Submission {
+  id: string;
+  contract_id: string;
+  business_name: string;
+  city: string | null;
+  state: string | null;
+  admin_status: string;
+  operator_status: string;
+  created_at: string;
+  contract: { title: string; tier: number } | null;
+}
+
+interface Summary {
+  awaiting_collection_cents: number;
+  queued_cents: number;
+  sent_to_qb_cents: number;
+  paid_cents: number;
+  failed_cents: number;
+  lifetime_paid_cents: number;
+  row_count: number;
+}
+
+const STATUS_STYLES: Record<string, string> = {
+  awaiting_collection: "bg-orange-50 text-orange-700 border-orange-100",
+  queued: "bg-amber-50 text-amber-700 border-amber-100",
+  sent_to_qb: "bg-blue-50 text-blue-700 border-blue-100",
+  paid: "bg-emerald-50 text-emerald-700 border-emerald-100",
+  failed: "bg-red-50 text-red-700 border-red-100",
+  cancelled: "bg-gray-100 text-gray-500 border-gray-200",
+};
+
+const STATUS_LABEL: Record<string, string> = {
+  awaiting_collection: "Waiting on operator payment",
+  queued: "Ready to bill",
+  sent_to_qb: "Invoice created",
+  paid: "Paid",
+  failed: "Needs attention",
+  cancelled: "Cancelled",
+};
+
+function fmt(cents: number): string {
+  return `$${(cents / 100).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+export default function PlacementEarningsPage() {
+  const router = useRouter();
+  const [token, setToken] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [payouts, setPayouts] = useState<Payout[]>([]);
+  const [submissions, setSubmissions] = useState<Submission[]>([]);
+  const [summary, setSummary] = useState<Summary | null>(null);
+  const [activeAcceptances, setActiveAcceptances] = useState(0);
+  const [statusFilter, setStatusFilter] = useState<string>("any");
+  const [sinceDays, setSinceDays] = useState(365);
+
+  const load = useCallback(async () => {
+    if (!token) return;
+    setRefreshing(true);
+    try {
+      const params = new URLSearchParams();
+      params.set("since_days", String(sinceDays));
+      const res = await fetch(`/api/placement/my/earnings?${params}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setPayouts(data.payouts || []);
+        setSubmissions(data.submissions || []);
+        setSummary(data.summary || null);
+        setActiveAcceptances(Number(data.active_acceptances) || 0);
+      }
+    } finally {
+      setRefreshing(false);
+      setLoading(false);
+    }
+  }, [token, sinceDays]);
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!session?.access_token) { router.push("/login?redirect=/placement/earnings"); return; }
+      setToken(session.access_token);
+    });
+  }, [router]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const filtered = statusFilter === "any" ? payouts : payouts.filter((p) => p.status === statusFilter);
+  const pendingCents = summary
+    ? summary.awaiting_collection_cents + summary.queued_cents + summary.sent_to_qb_cents
+    : 0;
+
+  return (
+    <div className="p-6 max-w-6xl mx-auto">
+      <Link href="/placement" className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-green-primary mb-4">
+        <ArrowLeft className="h-4 w-4" /> Placement Dashboard
+      </Link>
+
+      <div className="mb-6 flex items-center justify-between flex-wrap gap-3">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
+            <HandCoins className="h-6 w-6 text-green-primary" /> My Earnings
+          </h1>
+          <p className="text-sm text-gray-500 mt-1">Every payout tied to your accepted submissions — pending, in-flight, and paid.</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <select
+            value={sinceDays}
+            onChange={(e) => setSinceDays(Number(e.target.value))}
+            className="rounded-lg border border-gray-200 px-3 py-1.5 text-xs"
+          >
+            <option value={30}>Last 30 days</option>
+            <option value={90}>Last 90 days</option>
+            <option value={180}>Last 6 months</option>
+            <option value={365}>Last year</option>
+            <option value={3650}>All time</option>
+          </select>
+          <button
+            onClick={load}
+            disabled={refreshing}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-gray-200 hover:bg-gray-50 px-3 py-1.5 text-xs font-medium text-gray-700 cursor-pointer disabled:opacity-50"
+          >
+            {refreshing ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      {/* Hero */}
+      <div className="rounded-2xl border border-emerald-100 bg-gradient-to-br from-emerald-50 to-white p-6 mb-4 flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <p className="text-xs font-medium uppercase tracking-wide text-emerald-700">Pending payment to you</p>
+          <p className="text-4xl font-bold text-emerald-800 mt-1">{summary ? fmt(pendingCents) : "…"}</p>
+          <p className="text-xs text-gray-500 mt-1">Total across awaiting-collection, queued, and sent-to-QB rows in this window. Awaiting-collection means the operator hasn&apos;t paid the invoice yet.</p>
+        </div>
+        <div className="text-right">
+          <p className="text-xs text-gray-500">Paid in window</p>
+          <p className="text-2xl font-bold text-blue-700 mt-1">{summary ? fmt(summary.paid_cents) : "…"}</p>
+        </div>
+      </div>
+
+      {/* Tiles */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
+        <Tile
+          icon={<Clock className="h-3.5 w-3.5 text-orange-600" />}
+          label="Awaiting operator"
+          value={summary ? fmt(summary.awaiting_collection_cents) : "…"}
+          tint={summary && summary.awaiting_collection_cents > 0 ? "orange" : "gray"}
+        />
+        <Tile
+          icon={<TrendingUp className="h-3.5 w-3.5 text-amber-600" />}
+          label="Queued to bill"
+          value={summary ? fmt(summary.queued_cents) : "…"}
+          tint="amber"
+        />
+        <Tile
+          icon={<DollarSign className="h-3.5 w-3.5 text-blue-600" />}
+          label="Invoice created"
+          value={summary ? fmt(summary.sent_to_qb_cents) : "…"}
+          tint="blue"
+        />
+        <Tile
+          icon={<AlertTriangle className="h-3.5 w-3.5 text-red-600" />}
+          label="Needs attention"
+          value={summary ? fmt(summary.failed_cents) : "…"}
+          tint={summary && summary.failed_cents > 0 ? "red" : "gray"}
+          note={summary && summary.failed_cents > 0 ? "Admin is looking at these" : undefined}
+        />
+      </div>
+
+      {/* Filters */}
+      <div className="mb-4 flex items-center gap-2 flex-wrap">
+        {[
+          { key: "any", label: "All payouts" },
+          { key: "awaiting_collection", label: "Awaiting operator" },
+          { key: "queued", label: "Queued" },
+          { key: "sent_to_qb", label: "Sent" },
+          { key: "paid", label: "Paid" },
+          { key: "failed", label: "Failed" },
+        ].map((f) => (
+          <button
+            key={f.key}
+            onClick={() => setStatusFilter(f.key)}
+            className={`rounded-lg px-3 py-1.5 text-xs font-medium cursor-pointer ${statusFilter === f.key ? "bg-green-100 text-green-700" : "bg-gray-100 text-gray-500 hover:bg-gray-200"}`}
+          >
+            {f.label}
+          </button>
+        ))}
+        <span className="ml-auto text-xs text-gray-400">{filtered.length} payout{filtered.length === 1 ? "" : "s"} · {activeAcceptances} active contract{activeAcceptances === 1 ? "" : "s"}</span>
+      </div>
+
+      {/* Payouts table */}
+      <div className="rounded-2xl border border-gray-100 bg-white p-5 mb-6 overflow-hidden">
+        {loading ? (
+          <div className="flex justify-center py-8"><Loader2 className="h-5 w-5 animate-spin text-green-primary" /></div>
+        ) : filtered.length === 0 ? (
+          <div className="text-center py-10">
+            <CheckCircle2 className="h-8 w-8 mx-auto mb-2 text-gray-300" />
+            <p className="text-sm text-gray-500">No payouts in this window.</p>
+            <p className="text-xs text-gray-400 mt-1">Payouts appear once an operator accepts one of your submissions.</p>
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-xs text-gray-500 border-b border-gray-100">
+                  <th className="text-left py-2 px-2 font-medium">Contract</th>
+                  <th className="text-left py-2 px-2 font-medium">Location</th>
+                  <th className="text-right py-2 px-2 font-medium">Amount</th>
+                  <th className="text-left py-2 px-2 font-medium">Status</th>
+                  <th className="text-left py-2 px-2 font-medium">Timeline</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.map((p) => {
+                  const stStyle = STATUS_STYLES[p.status] || "bg-gray-100 text-gray-500 border-gray-200";
+                  return (
+                    <tr key={p.id} className="border-b border-gray-50 last:border-b-0">
+                      <td className="py-2 px-2 text-xs">
+                        <p className="font-medium text-gray-900">{p.contract?.title || "—"}</p>
+                        <p className="text-gray-400">Tier {p.contract?.tier || "?"}</p>
+                      </td>
+                      <td className="py-2 px-2 text-xs">
+                        <p className="text-gray-900">{p.submission?.business_name || "—"}</p>
+                        <p className="text-gray-400 flex items-center gap-1">
+                          <MapPin className="h-3 w-3" />
+                          {[p.submission?.city, p.submission?.state].filter(Boolean).join(", ") || "—"}
+                        </p>
+                      </td>
+                      <td className="py-2 px-2 text-right font-semibold text-emerald-700">
+                        ${Number(p.amount).toLocaleString(undefined, { minimumFractionDigits: 2 })}
+                      </td>
+                      <td className="py-2 px-2">
+                        <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-medium ${stStyle}`}>
+                          {STATUS_LABEL[p.status] || p.status.replace(/_/g, " ")}
+                        </span>
+                        {p.qb_error && <p className="text-[10px] text-red-500 mt-0.5 italic max-w-xs truncate" title={p.qb_error}>{p.qb_error}</p>}
+                      </td>
+                      <td className="py-2 px-2 text-xs text-gray-500">
+                        <p>Triggered {new Date(p.triggered_at).toLocaleDateString()}</p>
+                        {p.sent_at && <p className="text-gray-400">Sent {new Date(p.sent_at).toLocaleDateString()}</p>}
+                        {p.paid_at && <p className="text-emerald-700 font-medium">Paid {new Date(p.paid_at).toLocaleDateString()}{p.paid_method ? ` · ${p.paid_method}` : ""}</p>}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {/* Recent submission activity */}
+      <div className="rounded-2xl border border-gray-100 bg-white p-5">
+        <h2 className="text-sm font-semibold text-gray-900 mb-3">Recent submissions</h2>
+        {submissions.length === 0 ? (
+          <p className="text-xs text-gray-500 text-center py-4">No submissions in this window.</p>
+        ) : (
+          <div className="space-y-1.5">
+            {submissions.slice(0, 20).map((s) => (
+              <div key={s.id} className="flex items-center justify-between border-b border-gray-50 last:border-b-0 py-1.5 text-xs">
+                <div className="flex-1 min-w-0">
+                  <p className="font-medium text-gray-900 truncate">{s.business_name}</p>
+                  <p className="text-gray-400">{[s.city, s.state].filter(Boolean).join(", ")} · {s.contract?.title || "—"}</p>
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                  <StatusBadge status={s.admin_status} label={`Admin: ${s.admin_status}`} />
+                  {s.admin_status === "approved" && <StatusBadge status={s.operator_status} label={`Op: ${s.operator_status}`} />}
+                  <span className="text-gray-400">{new Date(s.created_at).toLocaleDateString()}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StatusBadge({ status, label }: { status: string; label: string }) {
+  const styles: Record<string, string> = {
+    pending: "bg-amber-50 text-amber-700",
+    approved: "bg-emerald-50 text-emerald-700",
+    accepted: "bg-emerald-50 text-emerald-700",
+    rejected: "bg-red-50 text-red-700",
+    resubmit_requested: "bg-blue-50 text-blue-700",
+  };
+  return (
+    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium ${styles[status] || "bg-gray-100 text-gray-500"}`}>
+      {label}
+    </span>
+  );
+}
+
+function Tile({ icon, label, value, tint, note }: { icon: React.ReactNode; label: string; value: string; tint: "amber" | "blue" | "red" | "orange" | "gray"; note?: string }) {
+  const tints: Record<string, string> = {
+    amber: "border-gray-100 bg-white text-amber-700",
+    blue: "border-gray-100 bg-white text-blue-700",
+    red: "border-red-200 bg-red-50 text-red-800",
+    orange: "border-orange-200 bg-orange-50 text-orange-800",
+    gray: "border-gray-100 bg-white text-gray-400",
+  };
+  return (
+    <div className={`rounded-2xl border p-4 ${tints[tint]}`}>
+      <p className="text-[10px] font-medium uppercase tracking-wide text-gray-500 flex items-center gap-1">{icon}{label}</p>
+      <p className="text-lg font-bold mt-1">{value}</p>
+      {note && <p className="text-[10px] text-gray-500 mt-0.5">{note}</p>}
+    </div>
+  );
+}

--- a/src/app/placement/page.tsx
+++ b/src/app/placement/page.tsx
@@ -200,12 +200,26 @@ export default function PlacementDashboardPage() {
         </Link>
 
         <Link
-          href="/placement/payouts"
+          href="/placement/earnings"
           className="group rounded-2xl border border-gray-100 bg-white p-6 hover:border-green-200 hover:shadow-sm transition-all"
         >
           <div className="flex items-center justify-between mb-4">
             <div className="w-12 h-12 rounded-xl bg-emerald-50 flex items-center justify-center">
               <DollarSign className="h-6 w-6 text-emerald-600" />
+            </div>
+            <ArrowRight className="h-5 w-5 text-gray-300 group-hover:text-green-primary transition-colors" />
+          </div>
+          <h2 className="text-lg font-semibold text-gray-900 mb-1">My Earnings</h2>
+          <p className="text-sm text-gray-500">What you&apos;ve been paid, what&apos;s pending, and what&apos;s waiting on operator payment.</p>
+        </Link>
+
+        <Link
+          href="/placement/payouts"
+          className="group rounded-2xl border border-gray-100 bg-white p-6 hover:border-green-200 hover:shadow-sm transition-all"
+        >
+          <div className="flex items-center justify-between mb-4">
+            <div className="w-12 h-12 rounded-xl bg-gray-100 flex items-center justify-center">
+              <DollarSign className="h-6 w-6 text-gray-600" />
             </div>
             <ArrowRight className="h-5 w-5 text-gray-300 group-hover:text-green-primary transition-colors" />
           </div>

--- a/src/app/sales/orders/[id]/CommissionOverridePanel.tsx
+++ b/src/app/sales/orders/[id]/CommissionOverridePanel.tsx
@@ -1,0 +1,277 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Percent, Loader2, AlertTriangle, CheckCircle2, Lock } from "lucide-react";
+
+interface OrderRow {
+  id: string;
+  order_number: string | null;
+  total_value: number | null;
+  commission_rate_bps_override: number | null;
+  commission_override_note: string | null;
+  commission_override_by: string | null;
+  commission_override_at: string | null;
+}
+
+interface LineRow {
+  id: string;
+  description: string | null;
+  item_type: string | null;
+  quantity: number | null;
+  unit_price: number | null;
+  total_price: number | null;
+  commission_rate_bps_override: number | null;
+  commission_override_note: string | null;
+}
+
+interface Props {
+  orderId: string;
+  token: string;
+}
+
+function bpsToPct(bps: number | null | undefined): string {
+  if (bps == null) return "";
+  return (bps / 100).toFixed(2);
+}
+
+export default function CommissionOverridePanel({ orderId, token }: Props) {
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [order, setOrder] = useState<OrderRow | null>(null);
+  const [lines, setLines] = useState<LineRow[]>([]);
+  const [orderRatePct, setOrderRatePct] = useState("");
+  const [orderNote, setOrderNote] = useState("");
+  const [lineOverrides, setLineOverrides] = useState<Record<string, { pct: string; note: string }>>({});
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!token) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const [adminRes, orderRes] = await Promise.all([
+        fetch("/api/admin/check", { headers: { Authorization: `Bearer ${token}` } }).catch(() => null),
+        fetch(`/api/sales/orders/${orderId}`, { headers: { Authorization: `Bearer ${token}` } }),
+      ]);
+      if (adminRes && adminRes.ok) {
+        const admin = await adminRes.json();
+        setIsAdmin(!!admin.isAdmin);
+      }
+      if (orderRes.ok) {
+        const data = await orderRes.json();
+        const o = data.order || data;
+        setOrder(o);
+        setOrderRatePct(bpsToPct(o.commission_rate_bps_override));
+        setOrderNote(o.commission_override_note || "");
+        // API returns order_items nested on the order row from select("*, order_items(*)")
+        const items: LineRow[] = data.order_items || o.order_items || data.items || data.lines || [];
+        setLines(items);
+        const overrides: Record<string, { pct: string; note: string }> = {};
+        for (const li of items) {
+          overrides[li.id] = {
+            pct: bpsToPct(li.commission_rate_bps_override),
+            note: li.commission_override_note || "",
+          };
+        }
+        setLineOverrides(overrides);
+      }
+    } catch {
+      setError("Failed to load commission overrides");
+    } finally {
+      setLoading(false);
+    }
+  }, [orderId, token]);
+
+  useEffect(() => { load(); }, [load]);
+
+  async function save() {
+    setSaving(true);
+    setError(null);
+    setMessage(null);
+    try {
+      // Only send line overrides that changed.
+      const changed = lines
+        .map((l) => {
+          const state = lineOverrides[l.id] || { pct: "", note: "" };
+          const wasPct = bpsToPct(l.commission_rate_bps_override);
+          if (state.pct === wasPct && state.note === (l.commission_override_note || "")) return null;
+          return {
+            item_id: l.id,
+            rate_pct: state.pct === "" ? null : Number(state.pct),
+            note: state.note || null,
+          };
+        })
+        .filter(Boolean);
+
+      const res = await fetch(`/api/sales/orders/${orderId}/commission`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+        body: JSON.stringify({
+          order_rate_pct: orderRatePct === "" ? null : Number(orderRatePct),
+          order_note: orderNote || null,
+          line_overrides: changed,
+        }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(body.error || "Save failed");
+      } else {
+        setMessage("Commission overrides saved");
+        await load();
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (!isAdmin) {
+    // Non-admins see a read-only summary if any override is set.
+    if (!order?.commission_rate_bps_override && !lines.some((l) => l.commission_rate_bps_override != null)) {
+      return null;
+    }
+    return (
+      <div className="rounded-xl border border-gray-200 bg-white p-5">
+        <h3 className="text-sm font-semibold text-gray-900 flex items-center gap-2 mb-3">
+          <Percent className="h-4 w-4 text-green-primary" /> Commission Overrides
+          <span className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-500">
+            <Lock className="h-2.5 w-2.5" /> admin managed
+          </span>
+        </h3>
+        {order?.commission_rate_bps_override != null && (
+          <p className="text-xs text-gray-600">
+            Order-level: <span className="font-semibold text-emerald-700">{bpsToPct(order.commission_rate_bps_override)}%</span>
+            {order.commission_override_note && <span className="text-gray-400"> — {order.commission_override_note}</span>}
+          </p>
+        )}
+        {lines.some((l) => l.commission_rate_bps_override != null) && (
+          <ul className="mt-2 space-y-1">
+            {lines
+              .filter((l) => l.commission_rate_bps_override != null)
+              .map((l) => (
+                <li key={l.id} className="text-xs text-gray-600">
+                  {l.description || l.item_type || "Item"}:{" "}
+                  <span className="font-semibold text-emerald-700">{bpsToPct(l.commission_rate_bps_override)}%</span>
+                </li>
+              ))}
+          </ul>
+        )}
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="rounded-xl border border-gray-200 bg-white p-5">
+        <div className="flex justify-center py-4"><Loader2 className="h-5 w-5 animate-spin text-green-primary" /></div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-5">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-sm font-semibold text-gray-900 flex items-center gap-2">
+          <Percent className="h-4 w-4 text-green-primary" /> Commission Overrides
+          <span className="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2 py-0.5 text-[10px] font-medium text-blue-700">
+            <Lock className="h-2.5 w-2.5" /> admin only
+          </span>
+        </h3>
+      </div>
+      <p className="text-xs text-gray-500 mb-3">
+        Applies to future earn events on this order. Rate resolution: line override → order override → configured rule → default.
+      </p>
+
+      {message && (
+        <div className="mb-3 flex items-start gap-2 rounded-lg border border-emerald-200 bg-emerald-50 p-2 text-xs text-emerald-700">
+          <CheckCircle2 className="h-3.5 w-3.5 mt-0.5 shrink-0" /> {message}
+        </div>
+      )}
+      {error && (
+        <div className="mb-3 flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 p-2 text-xs text-red-700">
+          <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" /> {error}
+        </div>
+      )}
+
+      {/* Order-level */}
+      <div className="mb-4 rounded-lg border border-gray-100 bg-gray-50 p-3">
+        <p className="text-xs font-medium text-gray-700 mb-2">Whole-order override</p>
+        <div className="flex flex-wrap items-end gap-2">
+          <div>
+            <label className="block text-[11px] font-medium text-gray-500 mb-1">Rate %</label>
+            <input
+              type="number" step="0.01" min="0" max="100"
+              value={orderRatePct}
+              onChange={(e) => setOrderRatePct(e.target.value)}
+              placeholder="e.g. 7.5"
+              className="w-24 rounded-lg border border-gray-200 px-2 py-1.5 text-xs focus:border-green-primary focus:outline-none"
+            />
+          </div>
+          <div className="flex-1 min-w-[200px]">
+            <label className="block text-[11px] font-medium text-gray-500 mb-1">Note</label>
+            <input
+              type="text"
+              value={orderNote}
+              onChange={(e) => setOrderNote(e.target.value)}
+              placeholder="Reason for override"
+              className="w-full rounded-lg border border-gray-200 px-2 py-1.5 text-xs focus:border-green-primary focus:outline-none"
+            />
+          </div>
+        </div>
+        <p className="text-[10px] text-gray-500 mt-1">Leave blank to remove the order-level override.</p>
+      </div>
+
+      {/* Per-line */}
+      {lines.length > 0 && (
+        <div>
+          <p className="text-xs font-medium text-gray-700 mb-2">Per-line overrides</p>
+          <div className="space-y-2">
+            {lines.map((l) => (
+              <div key={l.id} className="rounded-lg border border-gray-100 p-2 flex flex-wrap items-end gap-2">
+                <div className="flex-1 min-w-[180px]">
+                  <p className="text-xs font-medium text-gray-800">{l.description || l.item_type || "Item"}</p>
+                  <p className="text-[10px] text-gray-500">
+                    {l.quantity ? `${l.quantity} × ` : ""}${Number(l.unit_price || 0).toLocaleString(undefined, { minimumFractionDigits: 2 })}
+                    {l.total_price != null && <> = <span className="font-semibold text-gray-700">${Number(l.total_price).toLocaleString(undefined, { minimumFractionDigits: 2 })}</span></>}
+                  </p>
+                </div>
+                <div>
+                  <label className="block text-[11px] font-medium text-gray-500 mb-1">Rate %</label>
+                  <input
+                    type="number" step="0.01" min="0" max="100"
+                    value={lineOverrides[l.id]?.pct ?? ""}
+                    onChange={(e) => setLineOverrides((s) => ({ ...s, [l.id]: { pct: e.target.value, note: s[l.id]?.note || "" } }))}
+                    className="w-20 rounded-lg border border-gray-200 px-2 py-1 text-xs"
+                  />
+                </div>
+                <div className="min-w-[140px] flex-1">
+                  <label className="block text-[11px] font-medium text-gray-500 mb-1">Note</label>
+                  <input
+                    type="text"
+                    value={lineOverrides[l.id]?.note ?? ""}
+                    onChange={(e) => setLineOverrides((s) => ({ ...s, [l.id]: { pct: s[l.id]?.pct || "", note: e.target.value } }))}
+                    className="w-full rounded-lg border border-gray-200 px-2 py-1 text-xs"
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="flex justify-end mt-3">
+        <button
+          onClick={save}
+          disabled={saving}
+          className="inline-flex items-center gap-1.5 rounded-lg bg-green-primary hover:bg-green-hover px-3 py-1.5 text-xs font-semibold text-white cursor-pointer disabled:opacity-50"
+        >
+          {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
+          Save overrides
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/sales/orders/[id]/page.tsx
+++ b/src/app/sales/orders/[id]/page.tsx
@@ -9,6 +9,7 @@ import {
   FileText, Clock, User, Building2, Trash2, ScrollText,
 } from "lucide-react";
 import AttributionPanel from "./AttributionPanel";
+import CommissionOverridePanel from "./CommissionOverridePanel";
 
 interface OrderItem {
   id: string;
@@ -567,6 +568,9 @@ export default function OrderDetailPage() {
 
           {/* Sales Attribution (Phase 3) */}
           {token && <AttributionPanel orderId={id} token={token} />}
+
+          {/* Commission override (Phase 4 — admin only, non-admins see read-only summary if set) */}
+          {token && <CommissionOverridePanel orderId={id} token={token} />}
 
           {/* Documents */}
           <div className="rounded-xl border border-gray-200 bg-white p-5">

--- a/src/lib/commissions.ts
+++ b/src/lib/commissions.ts
@@ -148,83 +148,194 @@ export interface EarnResult {
 
 /**
  * For each attribution row on the order, compute + write a ledger entry
- * against the given payment. Idempotent per (order_id, payment_id, user_id,
- * role_code) — a re-fire skips rows that already exist.
+ * against the given payment.
+ *
+ * Rate resolution (most-specific first):
+ *   1. order_items.commission_rate_bps_override  — per-line
+ *   2. sales_orders.commission_rate_bps_override — per-order
+ *   3. commission_rules chain (user+category > user > role+category > role)
+ *   4. commission_rules where is_default=true
+ *
+ * When ANY line on the order has a per-line override, we split the earn per
+ * line: `basis = payment × (line.total / order.total) × attribution %` and
+ * emit one ledger row per (attribution × line). Otherwise (or when the order
+ * has an order-level override or falls back to rule chain) we emit one row
+ * per attribution against the whole payment.
+ *
+ * Idempotency keys:
+ *   - Whole-order path: (order_id, payment_id, user_id, role_code)
+ *   - Per-line path:    (order_id, payment_id, user_id, role_code, order_item_id)
  */
 export async function earnCommissionsForPayment(args: EarnArgs): Promise<EarnResult> {
   if (!(args.paymentAmountCents > 0)) return { wrote: 0, skipped: 0, reason: "non_positive_amount", rows: [] };
 
-  // Load order for category context
+  // Load order for category + override context
   const { data: order } = await supabaseAdmin
     .from("sales_orders")
-    .select("id, order_type")
+    .select("id, order_type, commission_rate_bps_override, total_value")
     .eq("id", args.orderId)
     .maybeSingle();
   if (!order) return { wrote: 0, skipped: 0, reason: "order_not_found", rows: [] };
 
   const category = (order.order_type || null) as string | null;
+  const orderOverrideBps: number | null = typeof order.commission_rate_bps_override === "number"
+    ? order.commission_rate_bps_override
+    : null;
 
   const attributions = await getEffectiveAttribution(args.orderId);
   if (attributions.length === 0) return { wrote: 0, skipped: 0, reason: "no_attribution", rows: [] };
 
-  const { data: existing } = await supabaseAdmin
-    .from("commission_ledger")
-    .select("id, user_id, role_code")
-    .eq("order_id", args.orderId)
-    .eq("payment_id", args.paymentId);
-  const existingKey = new Set((existing || []).map((r) => `${r.user_id}|${r.role_code}`));
+  // Pull all lines. If any has a per-line override, we switch to line-split
+  // mode. We ALWAYS load them because we need line totals for per-line math.
+  const { data: items } = await supabaseAdmin
+    .from("order_items")
+    .select("id, total_price, commission_rate_bps_override")
+    .eq("order_id", args.orderId);
+  const lines = items || [];
+  const hasLineOverride = lines.some((l) => typeof l.commission_rate_bps_override === "number");
+  const linesTotal = lines.reduce((s, l) => s + Number(l.total_price || 0), 0);
+  const orderTotalDollars = Number(order.total_value || 0) || linesTotal;
 
   const wrote: CommissionLedgerRow[] = [];
   let skipped = 0;
 
-  for (const attr of attributions) {
-    const key = `${attr.user_id}|${attr.role_code}`;
-    if (existingKey.has(key)) { skipped++; continue; }
-
-    const rule = await resolveCommissionRule({
-      userId: attr.user_id,
-      roleCode: attr.role_code,
-      category,
-    });
-    if (!rule) { skipped++; continue; }
-
-    const basisCents = Math.round(args.paymentAmountCents * (Number(attr.percentage) / 100));
-    const amountCents = Math.round((basisCents * rule.rate_bps) / 10000);
-    if (amountCents === 0) { skipped++; continue; }
-
-    const holdMs = rule.hold_days * 24 * 60 * 60 * 1000;
-    const earnedAtIso = new Date().toISOString();
-    const clearableAtIso = new Date(Date.now() + holdMs).toISOString();
-    const status: CommissionStatus = rule.hold_days > 0 ? "held" : "earned";
-
-    // Implicit lead-owner rows have synthetic ids ("implicit-…"); persist
-    // attribution_id only for real rows.
-    const attributionRowId = attr.id.startsWith("implicit-") ? null : attr.id;
-
-    const { data: inserted, error } = await supabaseAdmin
+  if (hasLineOverride && linesTotal > 0) {
+    // Per-line path — emit (attribution × line) ledger rows.
+    const { data: existing } = await supabaseAdmin
       .from("commission_ledger")
-      .insert({
-        user_id: attr.user_id,
-        order_id: args.orderId,
-        attribution_id: attributionRowId,
-        role_code: attr.role_code,
-        payment_id: args.paymentId,
-        rule_id: rule.id,
-        attribution_percentage: attr.percentage,
-        basis_cents: basisCents,
-        rate_bps: rule.rate_bps,
-        amount_cents: amountCents,
-        hold_days: rule.hold_days,
-        status,
-        earned_at: earnedAtIso,
-        clearable_at: clearableAtIso,
-        notes: attr.is_legacy_backfill ? "Legacy backfill attribution" : null,
-        created_by: args.actorId || null,
-      })
-      .select("*")
-      .single();
-    if (error) throw error;
-    wrote.push(inserted as CommissionLedgerRow);
+      .select("id, user_id, role_code, order_item_id")
+      .eq("order_id", args.orderId)
+      .eq("payment_id", args.paymentId);
+    const existingKey = new Set(
+      (existing || []).map((r) => `${r.user_id}|${r.role_code}|${r.order_item_id || ""}`),
+    );
+
+    for (const attr of attributions) {
+      // Fall back to the rule chain if a specific line has no override.
+      const fallbackRule = await resolveCommissionRule({
+        userId: attr.user_id,
+        roleCode: attr.role_code,
+        category,
+      });
+
+      for (const line of lines) {
+        const linePriceDollars = Number(line.total_price || 0);
+        if (linePriceDollars <= 0) continue;
+
+        const key = `${attr.user_id}|${attr.role_code}|${line.id}`;
+        if (existingKey.has(key)) { skipped++; continue; }
+
+        // Line share of payment, then attribution share.
+        const lineShare = linePriceDollars / linesTotal;
+        const basisCents = Math.round(args.paymentAmountCents * lineShare * (Number(attr.percentage) / 100));
+
+        // Rate resolution: per-line override > order override > rule > skip
+        const rateBps =
+          typeof line.commission_rate_bps_override === "number"
+            ? line.commission_rate_bps_override
+            : (orderOverrideBps ?? fallbackRule?.rate_bps ?? null);
+        if (rateBps == null) { skipped++; continue; }
+
+        const holdDays = fallbackRule?.hold_days ?? 0;
+        const amountCents = Math.round((basisCents * rateBps) / 10000);
+        if (amountCents === 0) { skipped++; continue; }
+
+        const holdMs = holdDays * 24 * 60 * 60 * 1000;
+        const earnedAtIso = new Date().toISOString();
+        const clearableAtIso = new Date(Date.now() + holdMs).toISOString();
+        const status: CommissionStatus = holdDays > 0 ? "held" : "earned";
+        const attributionRowId = attr.id.startsWith("implicit-") ? null : attr.id;
+
+        const { data: inserted, error } = await supabaseAdmin
+          .from("commission_ledger")
+          .insert({
+            user_id: attr.user_id,
+            order_id: args.orderId,
+            order_item_id: line.id,
+            attribution_id: attributionRowId,
+            role_code: attr.role_code,
+            payment_id: args.paymentId,
+            rule_id: fallbackRule?.id || null,
+            attribution_percentage: attr.percentage,
+            basis_cents: basisCents,
+            rate_bps: rateBps,
+            amount_cents: amountCents,
+            hold_days: holdDays,
+            status,
+            earned_at: earnedAtIso,
+            clearable_at: clearableAtIso,
+            notes: typeof line.commission_rate_bps_override === "number"
+              ? "Line-level override"
+              : (orderOverrideBps != null ? "Order-level override" : (attr.is_legacy_backfill ? "Legacy backfill attribution" : null)),
+            created_by: args.actorId || null,
+          })
+          .select("*")
+          .single();
+        if (error) throw error;
+        wrote.push(inserted as CommissionLedgerRow);
+      }
+    }
+  } else {
+    // Whole-order path — one row per attribution.
+    const { data: existing } = await supabaseAdmin
+      .from("commission_ledger")
+      .select("id, user_id, role_code, order_item_id")
+      .eq("order_id", args.orderId)
+      .eq("payment_id", args.paymentId)
+      .is("order_item_id", null);
+    const existingKey = new Set((existing || []).map((r) => `${r.user_id}|${r.role_code}`));
+
+    for (const attr of attributions) {
+      const key = `${attr.user_id}|${attr.role_code}`;
+      if (existingKey.has(key)) { skipped++; continue; }
+
+      const rule = await resolveCommissionRule({
+        userId: attr.user_id,
+        roleCode: attr.role_code,
+        category,
+      });
+      // Order-level override wins over rule chain if set.
+      const rateBps = orderOverrideBps ?? rule?.rate_bps ?? null;
+      if (rateBps == null) { skipped++; continue; }
+
+      const holdDays = rule?.hold_days ?? 0;
+      const basisCents = Math.round(args.paymentAmountCents * (Number(attr.percentage) / 100));
+      const amountCents = Math.round((basisCents * rateBps) / 10000);
+      if (amountCents === 0) { skipped++; continue; }
+
+      const holdMs = holdDays * 24 * 60 * 60 * 1000;
+      const earnedAtIso = new Date().toISOString();
+      const clearableAtIso = new Date(Date.now() + holdMs).toISOString();
+      const status: CommissionStatus = holdDays > 0 ? "held" : "earned";
+      const attributionRowId = attr.id.startsWith("implicit-") ? null : attr.id;
+
+      const { data: inserted, error } = await supabaseAdmin
+        .from("commission_ledger")
+        .insert({
+          user_id: attr.user_id,
+          order_id: args.orderId,
+          attribution_id: attributionRowId,
+          role_code: attr.role_code,
+          payment_id: args.paymentId,
+          rule_id: rule?.id || null,
+          attribution_percentage: attr.percentage,
+          basis_cents: basisCents,
+          rate_bps: rateBps,
+          amount_cents: amountCents,
+          hold_days: holdDays,
+          status,
+          earned_at: earnedAtIso,
+          clearable_at: clearableAtIso,
+          notes: orderOverrideBps != null
+            ? "Order-level override"
+            : (attr.is_legacy_backfill ? "Legacy backfill attribution" : null),
+          created_by: args.actorId || null,
+        })
+        .select("*")
+        .single();
+      if (error) throw error;
+      wrote.push(inserted as CommissionLedgerRow);
+    }
   }
 
   if (wrote.length > 0) {
@@ -237,10 +348,13 @@ export async function earnCommissionsForPayment(args: EarnArgs): Promise<EarnRes
         payment_id: args.paymentId,
         payment_amount_cents: args.paymentAmountCents,
         rows: wrote.length,
+        line_split: hasLineOverride,
+        order_override_bps: orderOverrideBps,
       },
     });
   }
-
+  // Reference so lint doesn't flag orderTotalDollars if unused (kept for future audit)
+  void orderTotalDollars;
   return { wrote: wrote.length, skipped, rows: wrote };
 }
 

--- a/supabase/migrations/112_commission_overrides.sql
+++ b/supabase/migrations/112_commission_overrides.sql
@@ -1,0 +1,42 @@
+-- Per-order + per-line commission overrides.
+--
+-- Two new resolution tiers on top of the existing user/role/category rule
+-- chain:
+--   1. order_items.commission_rate_bps_override → line-level rate.
+--   2. sales_orders.commission_rate_bps_override → order-level rate.
+-- Line beats order; order beats rule chain; rule chain beats default.
+--
+-- commission_ledger gets an optional order_item_id so each line's earn is
+-- traceable independently. When no line override exists on any item, the
+-- earn function keeps the old whole-order behavior (one row per attribution)
+-- for smaller ledger size.
+
+-- ─── Order-level override ───────────────────────────────────────────────
+ALTER TABLE sales_orders
+  ADD COLUMN IF NOT EXISTS commission_rate_bps_override int
+    CHECK (commission_rate_bps_override IS NULL OR (commission_rate_bps_override >= 0 AND commission_rate_bps_override <= 10000)),
+  ADD COLUMN IF NOT EXISTS commission_override_note text,
+  ADD COLUMN IF NOT EXISTS commission_override_by uuid REFERENCES profiles(id),
+  ADD COLUMN IF NOT EXISTS commission_override_at timestamptz;
+
+CREATE INDEX IF NOT EXISTS idx_sales_orders_commission_override
+  ON sales_orders(commission_rate_bps_override)
+  WHERE commission_rate_bps_override IS NOT NULL;
+
+-- ─── Line-level override ────────────────────────────────────────────────
+ALTER TABLE order_items
+  ADD COLUMN IF NOT EXISTS commission_rate_bps_override int
+    CHECK (commission_rate_bps_override IS NULL OR (commission_rate_bps_override >= 0 AND commission_rate_bps_override <= 10000)),
+  ADD COLUMN IF NOT EXISTS commission_override_note text;
+
+CREATE INDEX IF NOT EXISTS idx_order_items_commission_override
+  ON order_items(order_id)
+  WHERE commission_rate_bps_override IS NOT NULL;
+
+-- ─── Commission ledger: track per-line origin ───────────────────────────
+ALTER TABLE commission_ledger
+  ADD COLUMN IF NOT EXISTS order_item_id uuid REFERENCES order_items(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_commission_ledger_order_item
+  ON commission_ledger(order_item_id)
+  WHERE order_item_id IS NOT NULL;


### PR DESCRIPTION
Migration 112 adds:
- sales_orders.commission_rate_bps_override + note/by/at
- order_items.commission_rate_bps_override + note
- commission_ledger.order_item_id Both override columns are CHECKed 0-10000 bps and clamp-safe.

earnCommissionsForPayment now resolves rates in this order:
  line override > order override > user+category rule > user rule >
  role+category rule > role rule > default rule
When ANY line has an override, earn switches to per-line mode: emits one ledger row per (attribution × line), with basis = payment × (line.total / order.total_of_lines) × attribution %. Otherwise it keeps the original whole-order behavior (one row per attribution) to keep the ledger small on the common case. Idempotency keys include order_item_id in per-line mode.

New admin API PATCH /api/sales/orders/[id]/commission accepts {order_rate_pct, order_note, line_overrides:[{item_id, rate_pct, note}]}. Overrides only affect future earn events — existing commission_ledger rows are untouched. Backfill endpoint is the recompute path.

CommissionOverridePanel on the order detail page: admin gets the editor block (whole-order rate + per-line rates + notes); non-admins see a read-only summary if any override is set.

New rep dashboard at /my/commissions: net-available hero tile, earned/held/paid/reversed/owed-back summary, filterable ledger table with per-row order link, clearable-date, and reversal reason.

New PP earnings dashboard at /placement/earnings backed by GET /api/placement/my/earnings: pending-to-you hero, awaiting-operator /queued/sent/failed tiles, per-payout status timeline showing when the QB Bill was created and paid, plus recent-submissions activity list. Card added to the /placement landing page above Payout Details.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2