### PR TITLE
Coffee checkout — mandatory billing + shipping address blocks

### DIFF
--- a/src/app/api/coffee/checkout/route.ts
+++ b/src/app/api/coffee/checkout/route.ts
@@ -4,6 +4,7 @@ import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { getCoffeeUser, forbiddenResponse } from "@/lib/coffeeAuth";
 import { isQuickBooks } from "@/lib/paymentProvider";
 import { createInvoice, sendInvoiceEmail, getInvoice } from "@/lib/quickbooks";
+import { sendCoffeeOrderNotification, sendCoffeeOrderConfirmation } from "@/lib/coffeeEmail";
 
 export async function POST(req: NextRequest) {
   try {
@@ -16,6 +17,35 @@ export async function POST(req: NextRequest) {
     }
 
     const body = await req.json();
+
+    // Business billing address AND shipping address are mandatory for every
+    // new order. Fail fast before touching the cart/QB so callers see a
+    // clear error and no ghost order/invoice gets created.
+    const trim = (v: unknown): string => (typeof v === "string" ? v.trim() : "");
+    const requiredFields: Array<[string, string]> = [
+      ["billing_business_name", "Billing business name is required"],
+      ["billing_contact_name", "Billing contact name is required"],
+      ["billing_email", "Billing email is required"],
+      ["billing_phone", "Billing phone is required"],
+      ["billing_address", "Billing street address is required"],
+      ["billing_city", "Billing city is required"],
+      ["billing_state", "Billing state is required"],
+      ["billing_zip", "Billing zip is required"],
+      ["shipping_business_name", "Shipping business name is required"],
+      ["shipping_name", "Shipping contact name is required"],
+      ["shipping_address", "Shipping street address is required"],
+      ["shipping_city", "Shipping city is required"],
+      ["shipping_state", "Shipping state is required"],
+      ["shipping_zip", "Shipping zip is required"],
+      ["shipping_phone", "Shipping phone is required"],
+    ];
+    for (const [field, message] of requiredFields) {
+      if (!trim(body[field])) return NextResponse.json({ error: message }, { status: 400 });
+    }
+    const billingEmail = trim(body.billing_email);
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(billingEmail)) {
+      return NextResponse.json({ error: "Billing email is not a valid address" }, { status: 400 });
+    }
 
     const { data: cartItems, error: cartError } = await supabaseAdmin
       .from("coffee_cart_items")
@@ -67,12 +97,23 @@ export async function POST(req: NextRequest) {
         operator_id: user.id,
         order_number: orderNumber,
         status: "awaiting_payment",
-        shipping_name: body.shipping_name ?? null,
-        shipping_address: body.shipping_address ?? null,
-        shipping_city: body.shipping_city ?? null,
-        shipping_state: body.shipping_state ?? null,
-        shipping_zip: body.shipping_zip ?? null,
-        shipping_phone: body.shipping_phone ?? null,
+        // Ship-to
+        shipping_business_name: trim(body.shipping_business_name),
+        shipping_name: trim(body.shipping_name),
+        shipping_address: trim(body.shipping_address),
+        shipping_city: trim(body.shipping_city),
+        shipping_state: trim(body.shipping_state),
+        shipping_zip: trim(body.shipping_zip),
+        shipping_phone: trim(body.shipping_phone),
+        // Bill-to
+        billing_business_name: trim(body.billing_business_name),
+        billing_contact_name: trim(body.billing_contact_name),
+        billing_email: trim(body.billing_email),
+        billing_phone: trim(body.billing_phone),
+        billing_address: trim(body.billing_address),
+        billing_city: trim(body.billing_city),
+        billing_state: trim(body.billing_state),
+        billing_zip: trim(body.billing_zip),
         subtotal,
         shipping_estimate: shippingTotal,
         total,
@@ -96,6 +137,43 @@ export async function POST(req: NextRequest) {
 
     if (itemsError) {
       return NextResponse.json({ error: itemsError.message }, { status: 500 });
+    }
+
+    // Fire "order placed" emails immediately at checkout submission so the
+    // buyer and fulfillment mailbox both see it right away — invoice link
+    // follows on the same page. handleCoffeeOrderCompleted fires a second
+    // confirmation once payment lands (via QB webhook).
+    try {
+      const emailParams = {
+        orderNumber,
+        operatorName: user.full_name || "Operator",
+        operatorEmail: user.email || "",
+        items: orderItems.map(({ shipping_cost: _, ...i }) => i),
+        subtotal,
+        shippingEstimate: shippingTotal,
+        total,
+        shippingBusinessName: trim(body.shipping_business_name),
+        shippingName: trim(body.shipping_name),
+        shippingAddress: trim(body.shipping_address),
+        shippingCity: trim(body.shipping_city),
+        shippingState: trim(body.shipping_state),
+        shippingZip: trim(body.shipping_zip),
+        shippingPhone: trim(body.shipping_phone),
+        billingBusinessName: trim(body.billing_business_name),
+        billingContactName: trim(body.billing_contact_name),
+        billingEmail: trim(body.billing_email),
+        billingPhone: trim(body.billing_phone),
+        billingAddress: trim(body.billing_address),
+        billingCity: trim(body.billing_city),
+        billingState: trim(body.billing_state),
+        billingZip: trim(body.billing_zip),
+      };
+      await Promise.all([
+        sendCoffeeOrderNotification(emailParams),
+        sendCoffeeOrderConfirmation(emailParams),
+      ]);
+    } catch {
+      // Email failures should not block the order
     }
 
     const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://vendingconnector.com";

--- a/src/app/api/coffee/orders/route.ts
+++ b/src/app/api/coffee/orders/route.ts
@@ -42,6 +42,34 @@ export async function POST(req: NextRequest) {
 
     const body = await req.json();
 
+    // Business billing address AND shipping address are mandatory for every
+    // new order.
+    const trim = (v: unknown): string => (typeof v === "string" ? v.trim() : "");
+    const requiredFields: Array<[string, string]> = [
+      ["billing_business_name", "Billing business name is required"],
+      ["billing_contact_name", "Billing contact name is required"],
+      ["billing_email", "Billing email is required"],
+      ["billing_phone", "Billing phone is required"],
+      ["billing_address", "Billing street address is required"],
+      ["billing_city", "Billing city is required"],
+      ["billing_state", "Billing state is required"],
+      ["billing_zip", "Billing zip is required"],
+      ["shipping_business_name", "Shipping business name is required"],
+      ["shipping_name", "Shipping contact name is required"],
+      ["shipping_address", "Shipping street address is required"],
+      ["shipping_city", "Shipping city is required"],
+      ["shipping_state", "Shipping state is required"],
+      ["shipping_zip", "Shipping zip is required"],
+      ["shipping_phone", "Shipping phone is required"],
+    ];
+    for (const [field, message] of requiredFields) {
+      if (!trim(body[field])) return NextResponse.json({ error: message }, { status: 400 });
+    }
+    const billingEmail = trim(body.billing_email);
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(billingEmail)) {
+      return NextResponse.json({ error: "Billing email is not a valid address" }, { status: 400 });
+    }
+
     const { data: cartItems, error: cartError } = await supabaseAdmin
       .from("coffee_cart_items")
       .select("*, coffee_products(id, name, sku, price, active, stock_status)")
@@ -89,12 +117,23 @@ export async function POST(req: NextRequest) {
       .insert({
         operator_id: user.id,
         order_number: orderNumber,
-        shipping_name: body.shipping_name ?? null,
-        shipping_address: body.shipping_address ?? null,
-        shipping_city: body.shipping_city ?? null,
-        shipping_state: body.shipping_state ?? null,
-        shipping_zip: body.shipping_zip ?? null,
-        shipping_phone: body.shipping_phone ?? null,
+        // Ship-to
+        shipping_business_name: trim(body.shipping_business_name),
+        shipping_name: trim(body.shipping_name),
+        shipping_address: trim(body.shipping_address),
+        shipping_city: trim(body.shipping_city),
+        shipping_state: trim(body.shipping_state),
+        shipping_zip: trim(body.shipping_zip),
+        shipping_phone: trim(body.shipping_phone),
+        // Bill-to
+        billing_business_name: trim(body.billing_business_name),
+        billing_contact_name: trim(body.billing_contact_name),
+        billing_email: trim(body.billing_email),
+        billing_phone: trim(body.billing_phone),
+        billing_address: trim(body.billing_address),
+        billing_city: trim(body.billing_city),
+        billing_state: trim(body.billing_state),
+        billing_zip: trim(body.billing_zip),
         subtotal,
         shipping_estimate: shippingEstimate,
         total,
@@ -133,11 +172,21 @@ export async function POST(req: NextRequest) {
       subtotal,
       shippingEstimate,
       total,
-      shippingName: body.shipping_name,
-      shippingAddress: body.shipping_address,
-      shippingCity: body.shipping_city,
-      shippingState: body.shipping_state,
-      shippingZip: body.shipping_zip,
+      shippingBusinessName: trim(body.shipping_business_name),
+      shippingName: trim(body.shipping_name),
+      shippingAddress: trim(body.shipping_address),
+      shippingCity: trim(body.shipping_city),
+      shippingState: trim(body.shipping_state),
+      shippingZip: trim(body.shipping_zip),
+      shippingPhone: trim(body.shipping_phone),
+      billingBusinessName: trim(body.billing_business_name),
+      billingContactName: trim(body.billing_contact_name),
+      billingEmail: trim(body.billing_email),
+      billingPhone: trim(body.billing_phone),
+      billingAddress: trim(body.billing_address),
+      billingCity: trim(body.billing_city),
+      billingState: trim(body.billing_state),
+      billingZip: trim(body.billing_zip),
     };
 
     try {

--- a/src/app/coffee/checkout/page.tsx
+++ b/src/app/coffee/checkout/page.tsx
@@ -44,14 +44,24 @@ function CheckoutContent() {
   const [error, setError] = useState("");
 
   const [form, setForm] = useState({
+    shipping_business_name: "",
     shipping_name: "",
     shipping_address: "",
     shipping_city: "",
     shipping_state: "",
     shipping_zip: "",
     shipping_phone: "",
+    billing_business_name: "",
+    billing_contact_name: "",
+    billing_email: "",
+    billing_phone: "",
+    billing_address: "",
+    billing_city: "",
+    billing_state: "",
+    billing_zip: "",
     notes: "",
   });
+  const [billingSameAsShipping, setBillingSameAsShipping] = useState(false);
 
   useEffect(() => {
     const supabase = createBrowserClient();
@@ -82,12 +92,21 @@ function CheckoutContent() {
           }
           setForm((prev) => ({
             ...prev,
+            shipping_business_name: data.company_name || "",
             shipping_name: data.full_name || "",
             shipping_address: data.address || "",
             shipping_city: data.city || "",
             shipping_state: data.state || "",
             shipping_zip: data.zip || "",
             shipping_phone: data.phone || "",
+            billing_business_name: data.company_name || "",
+            billing_contact_name: data.full_name || "",
+            billing_email: data.email || "",
+            billing_phone: data.phone || "",
+            billing_address: data.address || "",
+            billing_city: data.city || "",
+            billing_state: data.state || "",
+            billing_zip: data.zip || "",
           }));
         }
 
@@ -114,6 +133,29 @@ function CheckoutContent() {
     setForm((prev) => ({ ...prev, [field]: value }));
   }
 
+  // Effective billing values honor the "same as shipping" toggle.
+  const effectiveBilling = billingSameAsShipping
+    ? {
+        billing_business_name: form.shipping_business_name,
+        billing_contact_name: form.shipping_name,
+        billing_email: form.billing_email, // email doesn't have a shipping counterpart
+        billing_phone: form.shipping_phone,
+        billing_address: form.shipping_address,
+        billing_city: form.shipping_city,
+        billing_state: form.shipping_state,
+        billing_zip: form.shipping_zip,
+      }
+    : {
+        billing_business_name: form.billing_business_name,
+        billing_contact_name: form.billing_contact_name,
+        billing_email: form.billing_email,
+        billing_phone: form.billing_phone,
+        billing_address: form.billing_address,
+        billing_city: form.billing_city,
+        billing_state: form.billing_state,
+        billing_zip: form.billing_zip,
+      };
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (!token) return;
@@ -129,6 +171,7 @@ function CheckoutContent() {
         },
         body: JSON.stringify({
           ...form,
+          ...effectiveBilling,
           shipping_estimate: shipping,
         }),
       });
@@ -209,63 +252,81 @@ function CheckoutContent() {
             <h2 className="text-lg font-bold text-gray-900 mb-4">Shipping Information</h2>
             <div className="grid gap-4 sm:grid-cols-2">
               <div className="sm:col-span-2">
-                <label className="mb-1.5 block text-sm font-medium text-gray-700">Full Name</label>
-                <input
-                  type="text"
-                  required
-                  value={form.shipping_name}
-                  onChange={(e) => updateForm("shipping_name", e.target.value)}
-                  className={inputClass}
-                />
+                <label className="mb-1.5 block text-sm font-medium text-gray-700">Business Name <span className="text-red-500">*</span></label>
+                <input type="text" required value={form.shipping_business_name} onChange={(e) => updateForm("shipping_business_name", e.target.value)} className={inputClass} />
               </div>
               <div className="sm:col-span-2">
-                <label className="mb-1.5 block text-sm font-medium text-gray-700">Address</label>
-                <input
-                  type="text"
-                  required
-                  value={form.shipping_address}
-                  onChange={(e) => updateForm("shipping_address", e.target.value)}
-                  className={inputClass}
-                />
+                <label className="mb-1.5 block text-sm font-medium text-gray-700">Contact Name <span className="text-red-500">*</span></label>
+                <input type="text" required value={form.shipping_name} onChange={(e) => updateForm("shipping_name", e.target.value)} className={inputClass} />
+              </div>
+              <div className="sm:col-span-2">
+                <label className="mb-1.5 block text-sm font-medium text-gray-700">Street Address <span className="text-red-500">*</span></label>
+                <input type="text" required value={form.shipping_address} onChange={(e) => updateForm("shipping_address", e.target.value)} className={inputClass} />
               </div>
               <div>
-                <label className="mb-1.5 block text-sm font-medium text-gray-700">City</label>
-                <input
-                  type="text"
-                  required
-                  value={form.shipping_city}
-                  onChange={(e) => updateForm("shipping_city", e.target.value)}
-                  className={inputClass}
-                />
+                <label className="mb-1.5 block text-sm font-medium text-gray-700">City <span className="text-red-500">*</span></label>
+                <input type="text" required value={form.shipping_city} onChange={(e) => updateForm("shipping_city", e.target.value)} className={inputClass} />
               </div>
               <div>
-                <label className="mb-1.5 block text-sm font-medium text-gray-700">State</label>
-                <input
-                  type="text"
-                  required
-                  value={form.shipping_state}
-                  onChange={(e) => updateForm("shipping_state", e.target.value)}
-                  className={inputClass}
-                />
+                <label className="mb-1.5 block text-sm font-medium text-gray-700">State <span className="text-red-500">*</span></label>
+                <input type="text" required value={form.shipping_state} onChange={(e) => updateForm("shipping_state", e.target.value)} className={inputClass} />
               </div>
               <div>
-                <label className="mb-1.5 block text-sm font-medium text-gray-700">ZIP Code</label>
-                <input
-                  type="text"
-                  required
-                  value={form.shipping_zip}
-                  onChange={(e) => updateForm("shipping_zip", e.target.value)}
-                  className={inputClass}
-                />
+                <label className="mb-1.5 block text-sm font-medium text-gray-700">ZIP Code <span className="text-red-500">*</span></label>
+                <input type="text" required value={form.shipping_zip} onChange={(e) => updateForm("shipping_zip", e.target.value)} className={inputClass} />
               </div>
               <div>
-                <label className="mb-1.5 block text-sm font-medium text-gray-700">Phone</label>
+                <label className="mb-1.5 block text-sm font-medium text-gray-700">Phone <span className="text-red-500">*</span></label>
+                <input type="tel" required value={form.shipping_phone} onChange={(e) => updateForm("shipping_phone", e.target.value)} className={inputClass} />
+              </div>
+            </div>
+          </div>
+
+          <div className="rounded-2xl border border-gray-100 bg-white p-6 shadow-sm">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-lg font-bold text-gray-900">Billing Information</h2>
+              <label className="inline-flex items-center gap-2 text-sm text-gray-600 cursor-pointer">
                 <input
-                  type="tel"
-                  value={form.shipping_phone}
-                  onChange={(e) => updateForm("shipping_phone", e.target.value)}
-                  className={inputClass}
+                  type="checkbox"
+                  checked={billingSameAsShipping}
+                  onChange={(e) => setBillingSameAsShipping(e.target.checked)}
+                  className="rounded border-gray-300 text-green-600 focus:ring-green-500"
                 />
+                Same as shipping
+              </label>
+            </div>
+            <div className={`grid gap-4 sm:grid-cols-2 ${billingSameAsShipping ? "opacity-50 pointer-events-none" : ""}`}>
+              <div className="sm:col-span-2">
+                <label className="mb-1.5 block text-sm font-medium text-gray-700">Business / Legal Entity Name <span className="text-red-500">*</span></label>
+                <input type="text" required={!billingSameAsShipping} value={billingSameAsShipping ? form.shipping_business_name : form.billing_business_name} onChange={(e) => updateForm("billing_business_name", e.target.value)} className={inputClass} disabled={billingSameAsShipping} />
+              </div>
+              <div>
+                <label className="mb-1.5 block text-sm font-medium text-gray-700">Contact Name <span className="text-red-500">*</span></label>
+                <input type="text" required={!billingSameAsShipping} value={billingSameAsShipping ? form.shipping_name : form.billing_contact_name} onChange={(e) => updateForm("billing_contact_name", e.target.value)} className={inputClass} disabled={billingSameAsShipping} />
+              </div>
+              <div>
+                <label className="mb-1.5 block text-sm font-medium text-gray-700">Billing Email <span className="text-red-500">*</span></label>
+                <input type="email" required value={form.billing_email} onChange={(e) => updateForm("billing_email", e.target.value)} className={inputClass} />
+              </div>
+              <div>
+                <label className="mb-1.5 block text-sm font-medium text-gray-700">Billing Phone <span className="text-red-500">*</span></label>
+                <input type="tel" required={!billingSameAsShipping} value={billingSameAsShipping ? form.shipping_phone : form.billing_phone} onChange={(e) => updateForm("billing_phone", e.target.value)} className={inputClass} disabled={billingSameAsShipping} />
+              </div>
+              <div className="sm:col-span-2">
+                <label className="mb-1.5 block text-sm font-medium text-gray-700">Street Address <span className="text-red-500">*</span></label>
+                <input type="text" required={!billingSameAsShipping} value={billingSameAsShipping ? form.shipping_address : form.billing_address} onChange={(e) => updateForm("billing_address", e.target.value)} className={inputClass} disabled={billingSameAsShipping} />
+              </div>
+              <div>
+                <label className="mb-1.5 block text-sm font-medium text-gray-700">City <span className="text-red-500">*</span></label>
+                <input type="text" required={!billingSameAsShipping} value={billingSameAsShipping ? form.shipping_city : form.billing_city} onChange={(e) => updateForm("billing_city", e.target.value)} className={inputClass} disabled={billingSameAsShipping} />
+              </div>
+              <div>
+                <label className="mb-1.5 block text-sm font-medium text-gray-700">State <span className="text-red-500">*</span></label>
+                <input type="text" required={!billingSameAsShipping} value={billingSameAsShipping ? form.shipping_state : form.billing_state} onChange={(e) => updateForm("billing_state", e.target.value)} className={inputClass} disabled={billingSameAsShipping} />
+              </div>
+              <div>
+                <label className="mb-1.5 block text-sm font-medium text-gray-700">ZIP Code <span className="text-red-500">*</span></label>
+                <input type="text" required={!billingSameAsShipping} value={billingSameAsShipping ? form.shipping_zip : form.billing_zip} onChange={(e) => updateForm("billing_zip", e.target.value)} className={inputClass} disabled={billingSameAsShipping} />
               </div>
             </div>
           </div>

--- a/src/lib/coffeeEmail.ts
+++ b/src/lib/coffeeEmail.ts
@@ -30,18 +30,47 @@ interface OrderNotificationParams {
   subtotal: number;
   shippingEstimate: number;
   total: number;
+  // Ship-to
+  shippingBusinessName?: string | null;
   shippingName?: string | null;
   shippingAddress?: string | null;
   shippingCity?: string | null;
   shippingState?: string | null;
   shippingZip?: string | null;
+  shippingPhone?: string | null;
+  // Bill-to
+  billingBusinessName?: string | null;
+  billingContactName?: string | null;
+  billingEmail?: string | null;
+  billingPhone?: string | null;
+  billingAddress?: string | null;
+  billingCity?: string | null;
+  billingState?: string | null;
+  billingZip?: string | null;
+}
+
+function addressBlockHtml(label: string, business: string | null | undefined, contact: string | null | undefined, address: string | null | undefined, city: string | null | undefined, state: string | null | undefined, zip: string | null | undefined, phone: string | null | undefined, email: string | null | undefined): string {
+  const lines: string[] = [];
+  if (business) lines.push(`<strong>${business}</strong>`);
+  if (contact) lines.push(contact);
+  if (address) lines.push(address);
+  const cityState = [city, state].filter(Boolean).join(", ");
+  const cityZip = zip ? `${cityState} ${zip}` : cityState;
+  if (cityZip) lines.push(cityZip);
+  if (phone) lines.push(`Phone: ${phone}`);
+  if (email) lines.push(`Email: ${email}`);
+  if (lines.length === 0) return "";
+  return `
+    <div style="flex: 1; min-width: 220px; padding: 12px; background: #ffffff; border: 1px solid #e5e7eb; border-radius: 8px;">
+      <p style="margin: 0 0 6px; font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; color: #6b7280; font-weight: 600;">${label}</p>
+      <p style="margin: 0; font-size: 13px; color: #111827; line-height: 1.5;">${lines.join("<br/>")}</p>
+    </div>`;
 }
 
 export async function sendCoffeeOrderNotification(params: OrderNotificationParams) {
   const {
     orderNumber, operatorName, operatorEmail, items,
     subtotal, shippingEstimate, total,
-    shippingName, shippingAddress, shippingCity, shippingState, shippingZip,
   } = params;
 
   const itemRows = items
@@ -56,9 +85,31 @@ export async function sendCoffeeOrderNotification(params: OrderNotificationParam
     )
     .join("");
 
-  const shippingLine = [shippingName, shippingAddress, [shippingCity, shippingState].filter(Boolean).join(", "), shippingZip]
-    .filter(Boolean)
-    .join("<br/>");
+  const billingBlock = addressBlockHtml(
+    "Bill To",
+    params.billingBusinessName,
+    params.billingContactName,
+    params.billingAddress,
+    params.billingCity,
+    params.billingState,
+    params.billingZip,
+    params.billingPhone,
+    params.billingEmail,
+  );
+  const shippingBlock = addressBlockHtml(
+    "Ship To",
+    params.shippingBusinessName,
+    params.shippingName,
+    params.shippingAddress,
+    params.shippingCity,
+    params.shippingState,
+    params.shippingZip,
+    params.shippingPhone,
+    null,
+  );
+  const addressRow = (billingBlock || shippingBlock)
+    ? `<div style="display: flex; gap: 12px; flex-wrap: wrap; margin: 16px 0;">${billingBlock}${shippingBlock}</div>`
+    : "";
 
   const html = `
     <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 640px; margin: 0 auto; padding: 32px 24px;">
@@ -69,8 +120,8 @@ export async function sendCoffeeOrderNotification(params: OrderNotificationParam
 
       <div style="background: #f9fafb; border-radius: 12px; padding: 24px; margin-bottom: 24px;">
         <h2 style="margin: 0 0 16px; font-size: 18px; color: #111827;">Order ${orderNumber}</h2>
-        <p style="margin: 0 0 8px; font-size: 14px; color: #374151;"><strong>Operator:</strong> ${operatorName} (${operatorEmail})</p>
-        ${shippingLine ? `<p style="margin: 0 0 16px; font-size: 14px; color: #374151;"><strong>Ship To:</strong><br/>${shippingLine}</p>` : ""}
+        <p style="margin: 0 0 8px; font-size: 14px; color: #374151;"><strong>Placed by:</strong> ${operatorName} (${operatorEmail})</p>
+        ${addressRow}
 
         <table style="width: 100%; border-collapse: collapse; font-size: 13px; margin-top: 16px;">
           <thead>
@@ -130,6 +181,32 @@ export async function sendCoffeeOrderConfirmation(params: OrderNotificationParam
     )
     .join("");
 
+  const billingBlock = addressBlockHtml(
+    "Bill To",
+    params.billingBusinessName,
+    params.billingContactName,
+    params.billingAddress,
+    params.billingCity,
+    params.billingState,
+    params.billingZip,
+    params.billingPhone,
+    params.billingEmail,
+  );
+  const shippingBlock = addressBlockHtml(
+    "Ship To",
+    params.shippingBusinessName,
+    params.shippingName,
+    params.shippingAddress,
+    params.shippingCity,
+    params.shippingState,
+    params.shippingZip,
+    params.shippingPhone,
+    null,
+  );
+  const addressRow = (billingBlock || shippingBlock)
+    ? `<div style="display: flex; gap: 12px; flex-wrap: wrap; margin: 16px 0;">${billingBlock}${shippingBlock}</div>`
+    : "";
+
   const html = `
     <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 640px; margin: 0 auto; padding: 32px 24px;">
       <div style="text-align: center; margin-bottom: 32px;">
@@ -140,6 +217,7 @@ export async function sendCoffeeOrderConfirmation(params: OrderNotificationParam
       <div style="background: #f9fafb; border-radius: 12px; padding: 24px; margin-bottom: 24px;">
         <h2 style="margin: 0 0 16px; font-size: 18px; color: #111827;">Thank you for your order!</h2>
         <p style="margin: 0 0 16px; font-size: 14px; color: #374151;">Your order <strong>${orderNumber}</strong> has been received and is being processed.</p>
+        ${addressRow}
 
         <table style="width: 100%; border-collapse: collapse; font-size: 13px; margin-top: 16px;">
           <thead>

--- a/src/lib/paymentHandlers.ts
+++ b/src/lib/paymentHandlers.ts
@@ -535,11 +535,21 @@ export async function handleCoffeeOrderCompleted(params: {
       subtotal: Number(order.subtotal),
       shippingEstimate: Number(order.shipping_estimate),
       total: Number(order.total),
+      shippingBusinessName: order.shipping_business_name,
       shippingName: order.shipping_name,
       shippingAddress: order.shipping_address,
       shippingCity: order.shipping_city,
       shippingState: order.shipping_state,
       shippingZip: order.shipping_zip,
+      shippingPhone: order.shipping_phone,
+      billingBusinessName: order.billing_business_name,
+      billingContactName: order.billing_contact_name,
+      billingEmail: order.billing_email,
+      billingPhone: order.billing_phone,
+      billingAddress: order.billing_address,
+      billingCity: order.billing_city,
+      billingState: order.billing_state,
+      billingZip: order.billing_zip,
     };
 
     await Promise.all([

--- a/supabase/migrations/113_coffee_orders_billing.sql
+++ b/supabase/migrations/113_coffee_orders_billing.sql
@@ -1,0 +1,21 @@
+-- Coffee orders — collect billing information alongside shipping.
+--
+-- All billing_* columns are nullable at the DB level so existing rows don't
+-- break, but the API POST enforces them for every NEW order.
+
+ALTER TABLE coffee_orders
+  ADD COLUMN IF NOT EXISTS billing_business_name text,
+  ADD COLUMN IF NOT EXISTS billing_contact_name text,
+  ADD COLUMN IF NOT EXISTS billing_email text,
+  ADD COLUMN IF NOT EXISTS billing_phone text,
+  ADD COLUMN IF NOT EXISTS billing_address text,
+  ADD COLUMN IF NOT EXISTS billing_city text,
+  ADD COLUMN IF NOT EXISTS billing_state text,
+  ADD COLUMN IF NOT EXISTS billing_zip text,
+  ADD COLUMN IF NOT EXISTS shipping_business_name text;
+
+-- Business name is now mandatory on the ship-to side too.
+COMMENT ON COLUMN coffee_orders.shipping_business_name IS
+  'Ship-to business name. Required for every new order at the API layer.';
+COMMENT ON COLUMN coffee_orders.billing_business_name IS
+  'Bill-to business/legal entity name. Required for every new order at the API layer.';


### PR DESCRIPTION
Migration 113 adds billing_business_name, billing_contact_name, billing_email, billing_phone, billing_address, billing_city, billing_state, billing_zip and shipping_business_name to coffee_orders. All nullable at the DB level so existing rows don't break; enforced at the API layer for every new order.

Both /api/coffee/checkout and /api/coffee/orders now validate all 15 required fields (billing block + shipping block including business name on the ship-to side) before touching the cart or QB, and persist them to the order row.

Coffee checkout page adds:
- Business Name field to the Shipping Information section (required)
- New "Billing Information" section with full address block, contact name, business/legal entity name, billing email + phone
- "Same as shipping" checkbox that mirrors shipping into billing on submit and disables the billing inputs; email always remains independently editable (there's no shipping email)
- Prefills business name, address, phone, email from the operator's profile on load

Both order confirmation emails (fulfillment + operator) now render two side-by-side address cards (Bill To and Ship To) with business name, contact, full address, phone, and email. Confirmation goes to the operator via sendCoffeeOrderConfirmation; fulfillment notification goes to COFFEE_FULFILLMENT_EMAIL via sendCoffeeOrderNotification. Emails fire immediately at /api/coffee/checkout POST (order placement) AND again from handleCoffeeOrderCompleted (payment landed).


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2