### PR TITLE
Leads — send to placement agreement + publish publicly

### DIFF
--- a/src/app/api/sales/agreements/route.ts
+++ b/src/app/api/sales/agreements/route.ts
@@ -53,6 +53,49 @@ export async function POST(req: NextRequest) {
     ? "location_placement"
     : "machine_purchase";
 
+  // When from_lead_id is provided, pull the lead and derive default values
+  // for the location_* fields on a location_placement agreement. Rep can
+  // still override anything before signing.
+  interface LeadRow {
+    id: string;
+    business_name: string | null;
+    contact_name: string | null;
+    email: string | null;
+    phone: string | null;
+    address: string | null;
+    location_placement_agreement_id: string | null;
+  }
+  let leadRow: LeadRow | null = null;
+  if (typeof body.from_lead_id === "string" && body.from_lead_id) {
+    const { data } = await supabaseAdmin
+      .from("sales_leads")
+      .select("id, business_name, contact_name, email, phone, address, location_placement_agreement_id")
+      .eq("id", body.from_lead_id)
+      .maybeSingle();
+    leadRow = (data as unknown) as LeadRow | null;
+    if (!leadRow) return NextResponse.json({ error: "Lead not found" }, { status: 404 });
+    if (leadRow.location_placement_agreement_id) {
+      return NextResponse.json({
+        error: "This lead already has a placement agreement",
+        agreement_id: leadRow.location_placement_agreement_id,
+      }, { status: 409 });
+    }
+  }
+
+  // Best-effort city/state/zip parse off a single-line address.
+  function splitAddress(raw: string | null | undefined): { street: string; city: string; state: string; zip: string } {
+    if (!raw) return { street: "", city: "", state: "", zip: "" };
+    const s = raw.trim();
+    // Pattern: "..., City, ST 12345"
+    const m = s.match(/^(.*?),\s*([^,]+),\s*([A-Za-z]{2})\s+(\d{5}(?:-\d{4})?)\s*$/);
+    if (m) return { street: m[1].trim(), city: m[2].trim(), state: m[3].toUpperCase(), zip: m[4] };
+    // Pattern: "..., City, ST"
+    const m2 = s.match(/^(.*?),\s*([^,]+),\s*([A-Za-z]{2})\s*$/);
+    if (m2) return { street: m2[1].trim(), city: m2[2].trim(), state: m2[3].toUpperCase(), zip: "" };
+    return { street: s, city: "", state: "", zip: "" };
+  }
+  const leadAddress = splitAddress(leadRow?.address);
+
   const basePayload: Record<string, unknown> = {
     order_id: null,
     account_id: null,
@@ -77,16 +120,18 @@ export async function POST(req: NextRequest) {
   if (agreementType === "location_placement") {
     agreementPayload = {
       ...basePayload,
-      // Location contact (recipient of the agreement)
-      location_business_name: body.location_business_name || "",
-      location_contact_name: body.location_contact_name || "",
-      location_contact_email: body.location_contact_email || "",
-      location_contact_phone: body.location_contact_phone || "",
+      // Location contact (recipient of the agreement). Body values win over
+      // lead prefill so the rep can override on the edit screen.
+      lead_id: leadRow?.id || null,
+      location_business_name: body.location_business_name || leadRow?.business_name || "",
+      location_contact_name: body.location_contact_name || leadRow?.contact_name || "",
+      location_contact_email: body.location_contact_email || leadRow?.email || "",
+      location_contact_phone: body.location_contact_phone || leadRow?.phone || "",
       location_contact_title: body.location_contact_title || "",
-      location_address: body.location_address || "",
-      location_city: body.location_city || "",
-      location_state: body.location_state || "",
-      location_zip: body.location_zip || "",
+      location_address: body.location_address || leadAddress.street || "",
+      location_city: body.location_city || leadAddress.city || "",
+      location_state: body.location_state || leadAddress.state || "",
+      location_zip: body.location_zip || leadAddress.zip || "",
 
       // Placement terms
       placement_machine_count: body.placement_machine_count || 1,
@@ -164,8 +209,19 @@ export async function POST(req: NextRequest) {
     agreement_id: agreement.id,
     user_id: user.id,
     activity_type: "created",
-    description: "Standalone agreement created",
+    description: leadRow
+      ? `Location placement agreement drafted from lead ${leadRow.id.slice(0, 8)}`
+      : "Standalone agreement created",
   });
+
+  // Stamp reverse link on the lead so the leads page shows "already converted"
+  // and future clicks return the existing agreement instead of duplicating.
+  if (leadRow) {
+    await supabaseAdmin
+      .from("sales_leads")
+      .update({ location_placement_agreement_id: agreement.id })
+      .eq("id", leadRow.id);
+  }
 
   return NextResponse.json(agreement, { status: 201 });
 }

--- a/src/app/api/sales/leads/[id]/publish/route.ts
+++ b/src/app/api/sales/leads/[id]/publish/route.ts
@@ -1,0 +1,149 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser } from "@/lib/salesAuth";
+import { sendLocationAgreementEmail } from "@/lib/locationAgreementEmail";
+
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "https://vendingconnector.com";
+const MIN_PRICE = 100;
+const MAX_PRICE = 10000;
+
+/**
+ * POST /api/sales/leads/[id]/publish
+ *
+ * Publish a sales lead to the public marketplace as a location listing.
+ *
+ * PRIVACY MODEL:
+ *   - Lead's contact_name / email / phone are used ONLY to send the location
+ *     owner verification email — they do NOT get written to user_listings.
+ *     contact_* / owner_* columns on the listing stay null; only the
+ *     verification-token email link goes to the owner.
+ *   - The public GET on /api/user-listings already strips owner_email/name
+ *     for non-owner requests, so even if a rep accidentally set them the
+ *     public browse doesn't leak. We keep them null anyway for defense.
+ *
+ * Body:
+ *   description        — REQUIRED, marketing copy shown publicly
+ *   price              — REQUIRED, 100-10000
+ *   title              — optional, defaults to the lead's business name
+ *   city, state, zip   — optional, best-effort parsed from lead.address
+ *   entity_type, foot_traffic, square_footage, business_type — optional
+ */
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const user = await getSalesUser(req);
+  if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id } = await params;
+
+  const { data: lead } = await supabaseAdmin
+    .from("sales_leads")
+    .select("id, business_name, contact_name, email, phone, address, public_listing_id")
+    .eq("id", id)
+    .maybeSingle();
+  if (!lead) return NextResponse.json({ error: "Lead not found" }, { status: 404 });
+
+  // If a listing already exists for this lead, return it rather than
+  // duplicating. Front-end can decide whether to link to the existing one.
+  if (lead.public_listing_id) {
+    return NextResponse.json({
+      error: "This lead is already listed publicly",
+      listing_id: lead.public_listing_id,
+    }, { status: 409 });
+  }
+
+  const body = await req.json().catch(() => ({}));
+
+  const description = typeof body.description === "string" ? body.description.trim() : "";
+  const priceRaw = Number(body.price);
+  const title = typeof body.title === "string" && body.title.trim()
+    ? body.title.trim()
+    : (lead.business_name || `Location in ${body.state || "US"}`);
+  const state = typeof body.state === "string" ? body.state.trim() : "";
+  const city = typeof body.city === "string" ? body.city.trim() : "";
+  const zip = typeof body.zip === "string" ? body.zip.trim() : "";
+
+  if (!description) return NextResponse.json({ error: "Description is required" }, { status: 400 });
+  if (description.length < 40) return NextResponse.json({ error: "Description must be at least 40 characters" }, { status: 400 });
+  if (!Number.isFinite(priceRaw) || priceRaw < MIN_PRICE || priceRaw > MAX_PRICE) {
+    return NextResponse.json(
+      { error: `Price must be between $${MIN_PRICE} and $${MAX_PRICE.toLocaleString()}` },
+      { status: 400 },
+    );
+  }
+  if (!state) return NextResponse.json({ error: "State is required" }, { status: 400 });
+  if (!lead.email || !lead.contact_name) {
+    return NextResponse.json({
+      error: "Lead is missing contact name or email — those are required to send the owner verification link. Update the lead first.",
+    }, { status: 400 });
+  }
+
+  // Insert the listing. contact_* stays NULL by design so nothing private
+  // leaks to the public GET.
+  const { data: listing, error: listingErr } = await supabaseAdmin
+    .from("user_listings")
+    .insert({
+      seller_id: user.id,
+      source_lead_id: lead.id,
+      title,
+      description,
+      listing_type: "location",
+      price: priceRaw,
+      city: city || null,
+      state,
+      zip: zip || null,
+      entity_type: body.entity_type || null,
+      foot_traffic: body.foot_traffic || null,
+      square_footage: body.square_footage || null,
+      business_type: body.business_type || null,
+      // PRIVACY — never populate these from the lead. Public GET redacts
+      // them anyway; keeping them null means owner sale info never
+      // accidentally hits the wire.
+      contact_name: null,
+      contact_phone: null,
+      contact_email: null,
+      // Owner_name / owner_email ARE stored (verification uses them) but
+      // the public GET strips them the same way.
+      owner_name: lead.contact_name,
+      owner_email: lead.email.toLowerCase(),
+      status: "pending_verification",
+      is_public: false,
+    })
+    .select("*")
+    .single();
+  if (listingErr) return NextResponse.json({ error: listingErr.message }, { status: 500 });
+
+  // Send the owner verification email — private, goes only to the location
+  // owner. On verification, the listing flips to is_public=true.
+  try {
+    const { data: agreement } = await supabaseAdmin
+      .from("location_agreements")
+      .insert({
+        listing_id: listing.id,
+        business_name: title,
+        contact_name: lead.contact_name,
+        email: lead.email.toLowerCase(),
+        address: [city, state, zip].filter(Boolean).join(", ") || lead.address || null,
+      })
+      .select("token")
+      .single();
+
+    if (agreement) {
+      await sendLocationAgreementEmail({
+        to: lead.email.toLowerCase(),
+        recipientName: lead.contact_name,
+        businessName: title,
+        agreementUrl: `${APP_URL}/location-agreement/${agreement.token}`,
+      });
+    }
+  } catch (emailErr) {
+    console.error("[leads.publish] verification email failed:", emailErr);
+    // Non-fatal — listing exists but owner won't get the email. Admin can
+    // resend from the listings admin panel.
+  }
+
+  // Stamp reverse link on the lead so UI can show "already published".
+  await supabaseAdmin
+    .from("sales_leads")
+    .update({ public_listing_id: listing.id })
+    .eq("id", lead.id);
+
+  return NextResponse.json({ ok: true, listing_id: listing.id, status: listing.status });
+}

--- a/src/app/sales/leads/page.tsx
+++ b/src/app/sales/leads/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { createBrowserClient } from "@/lib/supabase";
-import { Plus, Loader2, Search, X, UserPlus, ArrowRight, Trash2, PhoneOff, Phone, Upload, FileSpreadsheet, AlertCircle, CheckCircle2, AlertTriangle, CheckSquare, Pencil, Building2, Mail, Send, Clock, ShieldCheck, Paperclip } from "lucide-react";
+import { Plus, Loader2, Search, X, UserPlus, ArrowRight, Trash2, PhoneOff, Phone, Upload, FileSpreadsheet, AlertCircle, CheckCircle2, AlertTriangle, CheckSquare, Pencil, Building2, Mail, Send, Clock, ShieldCheck, Paperclip, FileSignature, Globe } from "lucide-react";
 import { ENTITY_TYPES, IMMEDIATE_NEEDS, type SalesLead, type EntityType, type ImmediateNeed } from "@/lib/salesTypes";
 
 const LEAD_FIELDS: { key: LeadFieldKey; label: string; required?: boolean }[] = [
@@ -157,6 +157,24 @@ export default function LeadsPage() {
   const [convertError, setConvertError] = useState<string | null>(null);
   const [convertSaving, setConvertSaving] = useState(false);
   const [salesPipelines, setSalesPipelines] = useState<{ id: string; name: string }[]>([]);
+
+  // Lead → Placement Agreement + Publish state
+  const [placementCreating, setPlacementCreating] = useState<string | null>(null);
+  const [publishLead, setPublishLead] = useState<SalesLead | null>(null);
+  const [publishForm, setPublishForm] = useState({
+    title: "",
+    description: "",
+    price: "250",
+    city: "",
+    state: "",
+    zip: "",
+    entity_type: "",
+    foot_traffic: "",
+    square_footage: "",
+    business_type: "",
+  });
+  const [publishSaving, setPublishSaving] = useState(false);
+  const [publishError, setPublishError] = useState<string | null>(null);
 
   // CSV Import state
   const [showImport, setShowImport] = useState(false);
@@ -316,6 +334,98 @@ export default function LeadsPage() {
       alert(err.error || "Failed to remove duplicates");
     }
     setDeduping(false);
+  }
+
+  async function handleCreatePlacementAgreement(lead: SalesLead) {
+    if (lead.location_placement_agreement_id) {
+      router.push(`/sales/agreements/${lead.location_placement_agreement_id}`);
+      return;
+    }
+    setPlacementCreating(lead.id);
+    try {
+      const res = await fetch("/api/sales/agreements", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ agreement_type: "location_placement", from_lead_id: lead.id }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok && body.agreement_id) {
+        router.push(`/sales/agreements/${body.agreement_id}`);
+        return;
+      }
+      if (!res.ok) {
+        alert(body.error || "Failed to create agreement");
+        return;
+      }
+      router.push(`/sales/agreements/${body.id}`);
+    } catch (e) {
+      alert(e instanceof Error ? e.message : "Failed to create agreement");
+    } finally {
+      setPlacementCreating(null);
+    }
+  }
+
+  function openPublishModal(lead: SalesLead) {
+    setPublishLead(lead);
+    setPublishError(null);
+    // Best-effort parse of the lead's existing address for prefill.
+    const raw = lead.address || "";
+    const m = raw.match(/^(.*?),\s*([^,]+),\s*([A-Za-z]{2})\s+(\d{5}(?:-\d{4})?)\s*$/);
+    const m2 = raw.match(/^(.*?),\s*([^,]+),\s*([A-Za-z]{2})\s*$/);
+    let parsedCity = lead.city || "";
+    let parsedState = lead.state || "";
+    let parsedZip = "";
+    if (m) { parsedCity = parsedCity || m[2]; parsedState = parsedState || m[3].toUpperCase(); parsedZip = m[4]; }
+    else if (m2) { parsedCity = parsedCity || m2[2]; parsedState = parsedState || m2[3].toUpperCase(); }
+    setPublishForm({
+      title: lead.business_name || "",
+      description: "",
+      price: "250",
+      city: parsedCity,
+      state: parsedState,
+      zip: parsedZip,
+      entity_type: (lead.entity_type as string) || "",
+      foot_traffic: "",
+      square_footage: "",
+      business_type: "",
+    });
+  }
+
+  async function handlePublish() {
+    if (!publishLead) return;
+    setPublishSaving(true);
+    setPublishError(null);
+    try {
+      const res = await fetch(`/api/sales/leads/${publishLead.id}/publish`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+        body: JSON.stringify({
+          title: publishForm.title.trim() || undefined,
+          description: publishForm.description.trim(),
+          price: Number(publishForm.price),
+          city: publishForm.city.trim() || undefined,
+          state: publishForm.state.trim() || undefined,
+          zip: publishForm.zip.trim() || undefined,
+          entity_type: publishForm.entity_type || undefined,
+          foot_traffic: publishForm.foot_traffic || undefined,
+          square_footage: publishForm.square_footage || undefined,
+          business_type: publishForm.business_type || undefined,
+        }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setPublishError(body.error || "Failed to publish listing");
+        setPublishSaving(false);
+        return;
+      }
+      setPublishLead(null);
+      await fetchLeads();
+      alert("Listing created. A verification email was sent to the location owner — the listing goes live once they confirm.");
+    } catch (e) {
+      setPublishError(e instanceof Error ? e.message : "Failed to publish listing");
+    } finally {
+      setPublishSaving(false);
+    }
   }
 
   async function handleDelete(id: string) {
@@ -1369,6 +1479,22 @@ export default function LeadsPage() {
                         </button>
                       )}
                       <button
+                        onClick={() => handleCreatePlacementAgreement(lead)}
+                        disabled={placementCreating === lead.id}
+                        title={lead.location_placement_agreement_id ? "Open Placement Agreement" : "Send to Placement Agreement"}
+                        className={`rounded-lg p-1.5 cursor-pointer disabled:opacity-50 ${lead.location_placement_agreement_id ? "text-emerald-600 hover:bg-emerald-50" : "text-gray-400 hover:bg-purple-50 hover:text-purple-600"}`}
+                      >
+                        {placementCreating === lead.id ? <Loader2 className="h-4 w-4 animate-spin" /> : <FileSignature className="h-4 w-4" />}
+                      </button>
+                      <button
+                        onClick={() => openPublishModal(lead)}
+                        title={lead.public_listing_id ? "Already listed publicly" : "List Publicly"}
+                        disabled={!!lead.public_listing_id}
+                        className={`rounded-lg p-1.5 cursor-pointer disabled:opacity-50 ${lead.public_listing_id ? "text-emerald-600" : "text-gray-400 hover:bg-blue-50 hover:text-blue-600"}`}
+                      >
+                        <Globe className="h-4 w-4" />
+                      </button>
+                      <button
                         onClick={() => handleDelete(lead.id)}
                         title="Delete"
                         className="rounded-lg p-1.5 text-gray-400 hover:bg-red-50 hover:text-red-600 cursor-pointer"
@@ -1484,6 +1610,110 @@ export default function LeadsPage() {
               >
                 {convertSaving && <Loader2 className="h-4 w-4 animate-spin" />}
                 Convert
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Publish Lead to Public Marketplace Modal */}
+      {publishLead && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+          <div className="w-full max-w-lg rounded-2xl bg-white p-6 shadow-xl mx-4 max-h-[90vh] overflow-y-auto">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-lg font-bold text-gray-900 flex items-center gap-2">
+                <Globe className="h-5 w-5 text-blue-600" />
+                List Location Publicly
+              </h2>
+              <button onClick={() => setPublishLead(null)} className="rounded-lg p-1 text-gray-400 hover:text-gray-600 cursor-pointer">
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+
+            <div className="mb-4 rounded-lg border border-blue-100 bg-blue-50 p-3 text-xs text-blue-800">
+              <strong>Private info stays private.</strong> The location owner&apos;s name, phone, and email are NOT shown on the public listing. They only receive a verification email — the listing goes live once they confirm.
+            </div>
+
+            {publishError && (
+              <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{publishError}</div>
+            )}
+
+            <div className="space-y-3">
+              <div>
+                <label className="block text-xs font-medium text-gray-600 mb-1">Listing Title</label>
+                <input
+                  type="text"
+                  value={publishForm.title}
+                  onChange={(e) => setPublishForm((f) => ({ ...f, title: e.target.value }))}
+                  placeholder={publishLead.business_name || "Business name"}
+                  className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none"
+                />
+              </div>
+
+              <div>
+                <label className="block text-xs font-medium text-gray-600 mb-1">Description <span className="text-red-500">*</span> <span className="text-gray-400">(min 40 chars)</span></label>
+                <textarea
+                  value={publishForm.description}
+                  onChange={(e) => setPublishForm((f) => ({ ...f, description: e.target.value }))}
+                  rows={4}
+                  placeholder="Describe the location: type of business, foot traffic, employees, ideal machine placement, etc. This is what buyers see."
+                  className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none resize-none"
+                />
+                <p className="text-[10px] text-gray-400 mt-1">{publishForm.description.length}/40</p>
+              </div>
+
+              <div className="grid grid-cols-3 gap-2">
+                <div>
+                  <label className="block text-xs font-medium text-gray-600 mb-1">City</label>
+                  <input type="text" value={publishForm.city} onChange={(e) => setPublishForm((f) => ({ ...f, city: e.target.value }))} className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none" />
+                </div>
+                <div>
+                  <label className="block text-xs font-medium text-gray-600 mb-1">State <span className="text-red-500">*</span></label>
+                  <input type="text" value={publishForm.state} onChange={(e) => setPublishForm((f) => ({ ...f, state: e.target.value.toUpperCase().slice(0, 2) }))} maxLength={2} className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none font-mono uppercase" />
+                </div>
+                <div>
+                  <label className="block text-xs font-medium text-gray-600 mb-1">ZIP</label>
+                  <input type="text" value={publishForm.zip} onChange={(e) => setPublishForm((f) => ({ ...f, zip: e.target.value }))} className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none" />
+                </div>
+              </div>
+
+              <div className="grid grid-cols-2 gap-2">
+                <div>
+                  <label className="block text-xs font-medium text-gray-600 mb-1">Price ($) <span className="text-red-500">*</span></label>
+                  <input type="number" min={100} max={10000} step={25} value={publishForm.price} onChange={(e) => setPublishForm((f) => ({ ...f, price: e.target.value }))} className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none" />
+                </div>
+                <div>
+                  <label className="block text-xs font-medium text-gray-600 mb-1">Entity Type</label>
+                  <input type="text" value={publishForm.entity_type} onChange={(e) => setPublishForm((f) => ({ ...f, entity_type: e.target.value }))} placeholder="Office, gym, warehouse…" className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none" />
+                </div>
+              </div>
+
+              <div className="grid grid-cols-2 gap-2">
+                <div>
+                  <label className="block text-xs font-medium text-gray-600 mb-1">Foot Traffic</label>
+                  <input type="text" value={publishForm.foot_traffic} onChange={(e) => setPublishForm((f) => ({ ...f, foot_traffic: e.target.value }))} placeholder="e.g. 200/day" className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none" />
+                </div>
+                <div>
+                  <label className="block text-xs font-medium text-gray-600 mb-1">Square Footage</label>
+                  <input type="text" value={publishForm.square_footage} onChange={(e) => setPublishForm((f) => ({ ...f, square_footage: e.target.value }))} placeholder="e.g. 5000" className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none" />
+                </div>
+              </div>
+
+              <div>
+                <label className="block text-xs font-medium text-gray-600 mb-1">Business Type</label>
+                <input type="text" value={publishForm.business_type} onChange={(e) => setPublishForm((f) => ({ ...f, business_type: e.target.value }))} placeholder="e.g. Manufacturing, Healthcare, Retail" className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-500 focus:outline-none" />
+              </div>
+            </div>
+
+            <div className="flex gap-2 justify-end mt-5">
+              <button onClick={() => setPublishLead(null)} className="rounded-lg border border-gray-200 px-4 py-2 text-sm text-gray-600 hover:bg-gray-50 cursor-pointer">Cancel</button>
+              <button
+                onClick={handlePublish}
+                disabled={publishSaving || publishForm.description.trim().length < 40 || !publishForm.state.trim() || !publishForm.price}
+                className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-5 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 cursor-pointer"
+              >
+                {publishSaving && <Loader2 className="h-4 w-4 animate-spin" />}
+                Publish
               </button>
             </div>
           </div>

--- a/src/lib/salesTypes.ts
+++ b/src/lib/salesTypes.ts
@@ -48,6 +48,8 @@ export interface SalesLead {
   immediate_need?: ImmediateNeed | null;
   last_contacted_at?: string | null;
   next_followup_at?: string | null;
+  location_placement_agreement_id?: string | null;
+  public_listing_id?: string | null;
   created_at: string;
   updated_at?: string;
   // Joined

--- a/supabase/migrations/114_lead_conversion_links.sql
+++ b/supabase/migrations/114_lead_conversion_links.sql
@@ -1,0 +1,23 @@
+-- Lead → agreement + lead → public listing traceability.
+--
+-- When a sales rep converts a lead into a location placement agreement or
+-- publishes it to the public marketplace, we record the linkage so the
+-- lead row can show "already converted" state and prevent duplicates.
+
+ALTER TABLE user_listings
+  ADD COLUMN IF NOT EXISTS source_lead_id uuid REFERENCES sales_leads(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_user_listings_source_lead
+  ON user_listings(source_lead_id)
+  WHERE source_lead_id IS NOT NULL;
+
+ALTER TABLE sales_leads
+  ADD COLUMN IF NOT EXISTS location_placement_agreement_id uuid REFERENCES purchase_agreements(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS public_listing_id uuid REFERENCES user_listings(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_sales_leads_placement_agreement
+  ON sales_leads(location_placement_agreement_id)
+  WHERE location_placement_agreement_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_sales_leads_public_listing
+  ON sales_leads(public_listing_id)
+  WHERE public_listing_id IS NOT NULL;


### PR DESCRIPTION
Migration 114 adds:
- user_listings.source_lead_id  (traces public listings back to their lead)
- sales_leads.location_placement_agreement_id  (locks/routes the "→ Placement Agreement" button to the already-drafted one)
- sales_leads.public_listing_id  (marks a lead as already published, blocks duplicate publishes)

POST /api/sales/agreements accepts from_lead_id. When set, it pulls the lead, best-effort splits its single-line address into city/state/zip, and prefills every location_* field on the location_placement branch (rep can override anything before signing). Also stamps the reverse link on the lead and returns 409 with the existing agreement id if the lead was already converted.

New POST /api/sales/leads/[id]/publish creates a user_listings row for the location. Privacy-safe:
- contact_name / contact_phone / contact_email columns stay NULL (they wouldn't be shown to the public anyway — GET filter strips them — but we don't even store them, defense in depth)
- owner_name / owner_email come from the lead (used only to send the verification email to the actual location owner; public GET strips)
- description required (min 40 chars) per product ask
- price validated 100-10000 (matches user_listings CHECK constraint)
- Verification email fires — listing goes live once owner confirms (same flow as /listings/new, listing starts is_public=false, status='pending_verification')

Two new action-strip buttons on /sales/leads:
- FileSignature icon — creates/opens the placement agreement. Turns emerald when converted (opens existing agreement on click).
- Globe icon — opens the publish modal. Modal enforces required description with min-40 counter, price range, state; disables and turns emerald once the lead has been listed.

Publish modal explicitly tells the rep "private info stays private" so they know owner contact isn't leaking to the public browse.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2