### PR TITLE
Fix: drop non-existent lead_id from purchase_agreements insert

### DIFF
--- a/src/app/api/sales/agreements/route.ts
+++ b/src/app/api/sales/agreements/route.ts
@@ -122,7 +122,9 @@ export async function POST(req: NextRequest) {
       ...basePayload,
       // Location contact (recipient of the agreement). Body values win over
       // lead prefill so the rep can override on the edit screen.
-      lead_id: leadRow?.id || null,
+      // Note: forward link to the lead lives on sales_leads.location_placement_agreement_id
+      // (stamped below) — purchase_agreements has no lead_id column, so we
+      // don't reference it here.
       location_business_name: body.location_business_name || leadRow?.business_name || "",
       location_contact_name: body.location_contact_name || leadRow?.contact_name || "",
       location_contact_email: body.location_contact_email || leadRow?.email || "",


### PR DESCRIPTION
Reverse link on sales_leads.location_placement_agreement_id (migration 114) is enough to trace the lead → agreement conversion. Removing the forward reference that Supabase's schema cache correctly rejected.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2