### PR TITLE
PPA — standalone sign page + admin send-agreement email

### DIFF
--- a/src/app/admin/marketplace/partners/[id]/page.tsx
+++ b/src/app/admin/marketplace/partners/[id]/page.tsx
@@ -5,7 +5,7 @@ import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import {
   Loader2, ArrowLeft, CheckCircle2, XCircle, Building2, Mail, Phone,
-  MapPin, Briefcase, FileText, Shield, Ban, Activity, User,
+  MapPin, Briefcase, FileText, Shield, Ban, Activity, User, Send,
 } from "lucide-react";
 import { createBrowserClient } from "@/lib/supabase";
 
@@ -82,6 +82,20 @@ export default function AdminPartnerDetailPage() {
       const err = await res.json().catch(() => ({}));
       alert(err.error || "Action failed");
     }
+    await load();
+    setSaving(null);
+  }
+
+  async function sendAgreement() {
+    if (!confirm("Email this Placement Provider a request to sign the current Placement Provider Agreement?")) return;
+    setSaving("send_agreement");
+    const res = await fetch(`/api/admin/marketplace/partners/${id}/send-agreement`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) alert(body.error || "Send failed");
+    else alert("Agreement request sent — the partner will receive an email with a signing link.");
     await load();
     setSaving(null);
   }
@@ -305,6 +319,23 @@ export default function AdminPartnerDetailPage() {
                 disabled={saving === "verify_bank"}
                 onClick={() => doAction("verify_bank")}
               />
+            </div>
+
+            {/* Send Placement Provider Agreement — for existing PPs who signed
+                up before the workflow existed, or when a new version is
+                published and they need to re-sign. */}
+            <div className="mt-4 pt-4 border-t border-gray-100">
+              <p className="text-xs text-gray-500 mb-2">
+                Email this partner a request to review and sign the current Placement Provider Agreement.
+              </p>
+              <button
+                onClick={sendAgreement}
+                disabled={saving === "send_agreement"}
+                className="inline-flex items-center gap-1.5 rounded-lg bg-blue-600 hover:bg-blue-700 px-3 py-1.5 text-xs font-semibold text-white cursor-pointer disabled:opacity-50"
+              >
+                {saving === "send_agreement" ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Send className="h-3.5 w-3.5" />}
+                Send Agreement Request
+              </button>
             </div>
           </div>
 

--- a/src/app/api/admin/marketplace/partners/[id]/send-agreement/route.ts
+++ b/src/app/api/admin/marketplace/partners/[id]/send-agreement/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Resend } from "resend";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+import { getOrStartAgreement } from "@/lib/placementAgreements";
+
+/**
+ * POST /api/admin/marketplace/partners/[id]/send-agreement
+ *
+ * Emails the placement partner a link to the Placement Provider Agreement
+ * sign page and lazily creates the user_agreements row against the active
+ * template so their status is trackable in the admin queue.
+ *
+ * Idempotent — repeated calls just re-send the email.
+ */
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id: partnerId } = await params;
+
+  // Confirm the target is a placement partner and grab their email.
+  const { data: profile } = await supabaseAdmin
+    .from("profiles")
+    .select("id, full_name, email, role")
+    .eq("id", partnerId)
+    .maybeSingle();
+  if (!profile) return NextResponse.json({ error: "Partner not found" }, { status: 404 });
+  if (profile.role !== "placement_partner" && profile.role !== "admin") {
+    return NextResponse.json({ error: "Target user is not a placement partner" }, { status: 400 });
+  }
+  if (!profile.email) return NextResponse.json({ error: "Partner has no email on file" }, { status: 400 });
+
+  // Lazily create the user_agreements row (so status becomes visible in the
+  // admin queue even before the PP hits the sign page).
+  const start = await getOrStartAgreement(partnerId, "placement_provider");
+  if (!start) return NextResponse.json({ error: "No active PPA template" }, { status: 500 });
+
+  // Fire the email.
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || "https://vendingconnector.com";
+  const signUrl = `${appUrl}/placement/agreement`;
+  const from = process.env.FROM_EMAIL || "receipts@bytebitevending.com";
+
+  try {
+    const resend = new Resend(process.env.RESEND_API_KEY);
+    await resend.emails.send({
+      from,
+      to: profile.email,
+      subject: "Action required: sign your Placement Provider Agreement",
+      html: `
+        <div style="max-width:560px;margin:0 auto;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:24px">
+          <h1 style="color:#16a34a;font-size:22px;margin:0 0 12px">Vending Connector</h1>
+          <p style="font-size:14px;color:#374151;line-height:1.6">Hi ${escapeHtml(profile.full_name || "there")},</p>
+          <p style="font-size:14px;color:#374151;line-height:1.6">
+            To keep your Placement Provider account active, please review and sign the current
+            <strong>Placement Provider Agreement</strong>.
+          </p>
+          <p style="font-size:14px;color:#374151;line-height:1.6">
+            Once you sign, Vending Connector will countersign and email you a fully executed copy.
+          </p>
+          <p style="margin:24px 0">
+            <a href="${signUrl}" style="display:inline-block;background:#16a34a;color:#fff;padding:12px 20px;border-radius:8px;text-decoration:none;font-weight:600;font-size:14px">Review &amp; sign the agreement →</a>
+          </p>
+          <p style="font-size:12px;color:#6b7280;line-height:1.6">
+            If the button doesn&apos;t work, paste this link into your browser:<br/>
+            <span style="font-family:monospace">${signUrl}</span>
+          </p>
+          <p style="font-size:12px;color:#6b7280;margin-top:20px">
+            Questions? Reply to this email.
+          </p>
+        </div>
+      `,
+    });
+  } catch (e) {
+    return NextResponse.json({ error: e instanceof Error ? e.message : "Email failed" }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true, agreement_id: start.agreement.id, status: start.agreement.status });
+}
+
+function escapeHtml(s: string): string {
+  return String(s).replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c] as string));
+}

--- a/src/app/placement/agreement/page.tsx
+++ b/src/app/placement/agreement/page.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Loader2, FileSignature, ArrowLeft, CheckCircle2, AlertCircle, Clock, XCircle } from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
+
+interface Template {
+  id: string;
+  version: number;
+  title: string;
+  effective_date: string;
+  content_html: string;
+}
+
+interface Agreement {
+  id: string;
+  status: string;
+  provider_signed_at: string | null;
+  provider_typed_name: string | null;
+  countersigned_at: string | null;
+  countersigner_name_snapshot: string | null;
+  decline_reason: string | null;
+  correction_request_reason: string | null;
+  agreement_version: number;
+}
+
+const STATUS_STYLES: Record<string, string> = {
+  not_started: "bg-gray-100 text-gray-700 border-gray-200",
+  provider_signed_pending_company_countersign: "bg-amber-50 text-amber-700 border-amber-200",
+  correction_requested: "bg-orange-50 text-orange-700 border-orange-200",
+  declined: "bg-red-50 text-red-700 border-red-200",
+  fully_executed: "bg-emerald-50 text-emerald-700 border-emerald-200",
+  legacy_approved: "bg-emerald-50 text-emerald-700 border-emerald-200",
+};
+
+const STATUS_LABEL: Record<string, string> = {
+  not_started: "Not started",
+  provider_signed_pending_company_countersign: "Awaiting Vending Connector countersignature",
+  correction_requested: "Correction requested — please re-sign",
+  declined: "Declined by Vending Connector",
+  fully_executed: "Fully executed",
+  legacy_approved: "Legacy approved by admin",
+};
+
+export default function PlacementAgreementPage() {
+  const router = useRouter();
+  const [token, setToken] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [template, setTemplate] = useState<Template | null>(null);
+  const [agreement, setAgreement] = useState<Agreement | null>(null);
+  const [typedName, setTypedName] = useState("");
+  const [acknowledge, setAcknowledge] = useState(false);
+  const [consentEsign, setConsentEsign] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!token) return;
+    setLoading(true);
+    const res = await fetch("/api/placement/agreement", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setTemplate(data.template);
+      setAgreement(data.agreement);
+      if (data.agreement?.provider_typed_name) setTypedName(data.agreement.provider_typed_name);
+    } else {
+      const body = await res.json().catch(() => ({}));
+      setError(body.error || "Failed to load agreement");
+    }
+    setLoading(false);
+  }, [token]);
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!session?.access_token) { router.push("/login?redirect=/placement/agreement"); return; }
+      setToken(session.access_token);
+    });
+  }, [router]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const canSign =
+    !!agreement &&
+    (agreement.status === "not_started" || agreement.status === "draft" || agreement.status === "correction_requested");
+  const alreadyExecuted = !!agreement && (agreement.status === "fully_executed" || agreement.status === "legacy_approved");
+  const pendingCountersign = agreement?.status === "provider_signed_pending_company_countersign";
+
+  async function submit() {
+    if (!token) return;
+    if (!typedName.trim()) { setError("Type your legal name"); return; }
+    if (!acknowledge) { setError("Please acknowledge you have reviewed the agreement"); return; }
+    if (!consentEsign) { setError("Please consent to electronic signature"); return; }
+
+    setSaving(true);
+    setError(null);
+    setSuccess(null);
+    const res = await fetch("/api/placement/agreement/sign", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ typed_name: typedName.trim(), consent_esign: consentEsign }),
+    });
+    setSaving(false);
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      setError(body.error || "Failed to submit signature");
+      return;
+    }
+    setSuccess("Signature submitted — Vending Connector will countersign shortly.");
+    await load();
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-8">
+      <Link href="/placement" className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-green-primary mb-4">
+        <ArrowLeft className="h-4 w-4" /> Placement Dashboard
+      </Link>
+
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
+          <FileSignature className="h-6 w-6 text-green-primary" /> Placement Provider Agreement
+        </h1>
+        <p className="text-sm text-gray-500 mt-1">Review, sign, and view the status of your Vending Connector Placement Provider Agreement.</p>
+      </div>
+
+      {loading ? (
+        <div className="flex justify-center py-12"><Loader2 className="h-6 w-6 animate-spin text-green-primary" /></div>
+      ) : !template || !agreement ? (
+        <div className="rounded-2xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+          Failed to load the agreement. Contact support.
+        </div>
+      ) : (
+        <>
+          {/* Status pill */}
+          <div className={`mb-4 rounded-2xl border p-4 flex items-start gap-3 ${STATUS_STYLES[agreement.status] || STATUS_STYLES.not_started}`}>
+            {agreement.status === "fully_executed" || agreement.status === "legacy_approved" ? (
+              <CheckCircle2 className="h-5 w-5 mt-0.5 shrink-0" />
+            ) : agreement.status === "declined" ? (
+              <XCircle className="h-5 w-5 mt-0.5 shrink-0" />
+            ) : (
+              <Clock className="h-5 w-5 mt-0.5 shrink-0" />
+            )}
+            <div>
+              <p className="text-sm font-semibold">{STATUS_LABEL[agreement.status] || agreement.status}</p>
+              {agreement.provider_signed_at && (
+                <p className="text-xs mt-0.5">Signed by you on {new Date(agreement.provider_signed_at).toLocaleString()}{agreement.provider_typed_name ? ` as ${agreement.provider_typed_name}` : ""}.</p>
+              )}
+              {agreement.countersigned_at && (
+                <p className="text-xs mt-0.5">Countersigned by Vending Connector on {new Date(agreement.countersigned_at).toLocaleString()}{agreement.countersigner_name_snapshot ? ` — ${agreement.countersigner_name_snapshot}` : ""}.</p>
+              )}
+              {agreement.decline_reason && <p className="text-xs mt-0.5 italic">Reason: {agreement.decline_reason}</p>}
+              {agreement.correction_request_reason && <p className="text-xs mt-0.5 italic">Correction: {agreement.correction_request_reason}</p>}
+            </div>
+          </div>
+
+          {success && (
+            <div className="mb-4 flex items-start gap-2 rounded-xl border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-700">
+              <CheckCircle2 className="h-4 w-4 mt-0.5" /><span>{success}</span>
+            </div>
+          )}
+          {error && (
+            <div className="mb-4 flex items-start gap-2 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+              <AlertCircle className="h-4 w-4 mt-0.5" /><span>{error}</span>
+            </div>
+          )}
+
+          {/* Agreement body */}
+          <div className="rounded-2xl border border-gray-100 bg-white p-6 mb-4">
+            <div className="text-xs text-gray-500 mb-3">
+              <strong className="text-gray-700">{template.title}</strong> · v{template.version} · effective {template.effective_date}
+            </div>
+            <div
+              className="max-h-96 overflow-y-auto rounded-xl border border-gray-100 bg-gray-50 p-4 text-sm text-gray-800 leading-relaxed prose prose-sm max-w-none"
+              dangerouslySetInnerHTML={{ __html: template.content_html }}
+            />
+          </div>
+
+          {/* Sign form */}
+          {canSign ? (
+            <div className="rounded-2xl border border-gray-100 bg-white p-6">
+              <h2 className="text-sm font-semibold text-gray-900 mb-3">Sign Agreement</h2>
+              <div className="space-y-2 mb-4">
+                <label className="flex items-start gap-2 text-sm text-gray-700 cursor-pointer">
+                  <input type="checkbox" checked={acknowledge} onChange={(e) => setAcknowledge(e.target.checked)} className="mt-0.5 rounded border-gray-300 text-green-primary" />
+                  <span>I have reviewed and agree to the Placement Provider Agreement.</span>
+                </label>
+                <label className="flex items-start gap-2 text-sm text-gray-700 cursor-pointer">
+                  <input type="checkbox" checked={consentEsign} onChange={(e) => setConsentEsign(e.target.checked)} className="mt-0.5 rounded border-gray-300 text-green-primary" />
+                  <span>I consent to conduct this transaction electronically. My typed name below is my electronic signature.</span>
+                </label>
+              </div>
+              <div className="mb-4">
+                <label className="block text-xs font-medium text-gray-600 mb-1">Type your full legal name <span className="text-red-500">*</span></label>
+                <input
+                  type="text"
+                  value={typedName}
+                  onChange={(e) => setTypedName(e.target.value)}
+                  className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:border-green-primary focus:outline-none"
+                  placeholder="Your legal name"
+                />
+              </div>
+              <button
+                onClick={submit}
+                disabled={saving || !acknowledge || !consentEsign || !typedName.trim()}
+                className="inline-flex items-center gap-2 rounded-xl bg-green-primary hover:bg-green-hover px-5 py-2.5 text-sm font-semibold text-white cursor-pointer disabled:opacity-50"
+              >
+                {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <FileSignature className="h-4 w-4" />}
+                Sign Agreement
+              </button>
+            </div>
+          ) : pendingCountersign ? (
+            <div className="rounded-2xl border border-gray-100 bg-white p-6 text-sm text-gray-500">
+              You&apos;ve signed the agreement. Vending Connector will countersign shortly — you&apos;ll receive a copy of the fully executed document by email.
+            </div>
+          ) : alreadyExecuted ? (
+            <div className="rounded-2xl border border-gray-100 bg-white p-6 text-sm text-gray-500">
+              Your agreement is fully executed. A copy was emailed to you at signing.
+            </div>
+          ) : null}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/placement/page.tsx
+++ b/src/app/placement/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { Loader2, ArrowRight, CheckCircle2, Clock, Building2, Briefcase, Package, Users, Star, Bell, DollarSign } from "lucide-react";
+import { Loader2, ArrowRight, CheckCircle2, Clock, Building2, Briefcase, Package, Users, Star, Bell, DollarSign, FileSignature } from "lucide-react";
 import { createBrowserClient } from "@/lib/supabase";
 
 interface Partner {
@@ -89,6 +89,7 @@ export default function PlacementDashboardPage() {
       { label: "Platform Agreement Countersigned", done: !!partner.agreement_signed_at },
       { label: "Bank / Payout Info", done: !!partner.bank_verified_at },
     ];
+    const needsAgreement = !partner.agreement_signed_at;
     return (
       <div className="mx-auto max-w-2xl px-4 py-8 sm:px-6">
         <h1 className="text-2xl font-bold text-gray-900 mb-1">Welcome{partner.business_name ? `, ${partner.business_name}` : ""}</h1>
@@ -112,6 +113,28 @@ export default function PlacementDashboardPage() {
             Typical turnaround is 1 business day. We&apos;ll email you the moment you&apos;re approved.
           </p>
         </div>
+
+        {needsAgreement && (
+          <div className="mt-4 rounded-2xl border border-amber-200 bg-amber-50 p-5">
+            <div className="flex items-start gap-3">
+              <div className="w-10 h-10 rounded-lg bg-amber-100 flex items-center justify-center shrink-0">
+                <FileSignature className="h-5 w-5 text-amber-700" />
+              </div>
+              <div className="flex-1">
+                <p className="text-sm font-semibold text-amber-900 mb-1">Sign your Placement Provider Agreement</p>
+                <p className="text-xs text-amber-800 mb-3">
+                  Vending Connector needs your signed Placement Provider Agreement on file before you can accept contracts.
+                </p>
+                <Link
+                  href="/placement/agreement"
+                  className="inline-flex items-center gap-1.5 rounded-lg bg-amber-600 hover:bg-amber-700 px-4 py-2 text-xs font-semibold text-white cursor-pointer"
+                >
+                  Review &amp; sign <ArrowRight className="h-3.5 w-3.5" />
+                </Link>
+              </div>
+            </div>
+          </div>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
Existing Placement Providers who signed up before the onboarding Step 6 was added now have two ways to complete the agreement:

1. Standalone page /placement/agreement they can visit anytime. Shows current status pill (not_started / provider_signed_pending / correction_requested / fully_executed / legacy_approved / declined), agreement body, sign form when applicable, or a "you're done" state. Reuses the same GET /api/placement/agreement + POST .../sign so audit + IP + UA capture stay consistent with onboarding.

2. Admin panel button on /admin/marketplace/partners/[id] that emails the partner a link to /placement/agreement. Lazily creates the user_agreements row against the active template so the partner shows up in the admin countersign queue immediately (still in not_started state until they sign).

Also added a linked amber "Sign your Placement Provider Agreement" banner on the /placement verification screen for onboarded partners who still need to sign — one click to /placement/agreement.

Backfill note: partners with agreement_signed_at set from the pre- workflow admin toggle are still accepted by the guard via the legacy_approved status branch; this new flow lets an admin ask them for a real signature at any time without breaking their current access.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2