### PR TITLE
Contracts — attach to an operator account (new + existing)

### DIFF
--- a/src/app/admin/marketplace/contracts/[id]/page.tsx
+++ b/src/app/admin/marketplace/contracts/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useCallback } from "react";
 import { useRouter, useParams } from "next/navigation";
 import Link from "next/link";
-import { Loader2, ArrowLeft, CheckCircle2, XCircle, Play, TrendingUp, Package, Clock, AlertCircle, ChevronRight } from "lucide-react";
+import { Loader2, ArrowLeft, CheckCircle2, XCircle, Play, TrendingUp, Package, Clock, AlertCircle, ChevronRight, Search, User as UserIcon, X, Link2 } from "lucide-react";
 import { createBrowserClient } from "@/lib/supabase";
 import { TIERS } from "@/lib/marketplacePricing";
 
@@ -24,7 +24,17 @@ interface Contract {
   status: string;
   notes: string | null;
   operator_business_name: string | null;
+  operator_profile_id: string | null;
   created_at: string;
+}
+
+interface OperatorHit {
+  id: string;
+  full_name: string | null;
+  email: string | null;
+  company_name: string | null;
+  city: string | null;
+  state: string | null;
 }
 
 interface Requirement {
@@ -103,6 +113,12 @@ export default function AdminContractDetailPage() {
   const [saving, setSaving] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+  // Operator attach picker
+  const [showAttach, setShowAttach] = useState(false);
+  const [opQuery, setOpQuery] = useState("");
+  const [opResults, setOpResults] = useState<OperatorHit[]>([]);
+  const [opSearching, setOpSearching] = useState(false);
+
   const load = useCallback(async () => {
     if (!token) return;
     setLoading(true);
@@ -122,6 +138,25 @@ export default function AdminContractDetailPage() {
   }, [router, id]);
 
   useEffect(() => { load(); }, [load]);
+
+  useEffect(() => {
+    if (!token || !showAttach) return;
+    const timer = setTimeout(async () => {
+      setOpSearching(true);
+      const res = await fetch(`/api/admin/marketplace/operators?q=${encodeURIComponent(opQuery)}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.ok) setOpResults(await res.json());
+      setOpSearching(false);
+    }, 200);
+    return () => clearTimeout(timer);
+  }, [opQuery, token, showAttach]);
+
+  async function attachOperator(operatorId: string | null) {
+    await contractAction("attach_operator", { operator_profile_id: operatorId });
+    setShowAttach(false);
+    setOpQuery("");
+  }
 
   async function contractAction(action: string, extra: Record<string, unknown> = {}) {
     setError(null);
@@ -178,8 +213,75 @@ export default function AdminContractDetailPage() {
               </span>
             </div>
             <h1 className="text-2xl font-bold text-gray-900">{contract.title}</h1>
-            {contract.operator_business_name && (
-              <p className="text-xs text-gray-500 mt-1">Operator: {contract.operator_business_name}</p>
+            <div className="mt-2 flex items-center gap-2 flex-wrap">
+              {contract.operator_profile_id ? (
+                <span className="inline-flex items-center gap-1.5 rounded-full bg-emerald-50 border border-emerald-200 px-2.5 py-0.5 text-xs">
+                  <UserIcon className="h-3 w-3 text-emerald-700" />
+                  <span className="text-emerald-900 font-medium">{contract.operator_business_name || "Operator attached"}</span>
+                  <button
+                    onClick={() => setShowAttach(true)}
+                    className="text-emerald-700 hover:text-emerald-900 ml-1 underline"
+                  >
+                    change
+                  </button>
+                  <button
+                    onClick={() => attachOperator(null)}
+                    disabled={saving === "attach_operator"}
+                    className="text-emerald-700 hover:text-red-700 ml-1"
+                    title="Detach"
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                </span>
+              ) : (
+                <button
+                  onClick={() => setShowAttach(true)}
+                  className="inline-flex items-center gap-1.5 rounded-full bg-amber-50 border border-amber-200 px-2.5 py-0.5 text-xs text-amber-900 hover:bg-amber-100 cursor-pointer"
+                >
+                  <Link2 className="h-3 w-3" /> No operator attached — click to attach
+                </button>
+              )}
+              {contract.operator_business_name && !contract.operator_profile_id && (
+                <span className="text-[10px] text-amber-700">(legacy free-text; not visible on operator side)</span>
+              )}
+            </div>
+
+            {showAttach && (
+              <div className="mt-3 rounded-xl border border-gray-200 bg-white p-3 max-w-md relative">
+                <div className="flex items-center justify-between mb-2">
+                  <p className="text-xs font-semibold text-gray-700">Attach to operator account</p>
+                  <button onClick={() => setShowAttach(false)} className="text-gray-400 hover:text-gray-600"><X className="h-3.5 w-3.5" /></button>
+                </div>
+                <div className="flex items-center gap-2 rounded-lg border border-gray-200 px-2 py-1.5 focus-within:border-green-primary">
+                  <Search className="h-3.5 w-3.5 text-gray-400" />
+                  <input
+                    type="text"
+                    value={opQuery}
+                    onChange={(e) => setOpQuery(e.target.value)}
+                    placeholder="Search operators by name, email, or company…"
+                    className="flex-1 text-xs outline-none"
+                    autoFocus
+                  />
+                  {opSearching && <Loader2 className="h-3 w-3 animate-spin text-gray-400" />}
+                </div>
+                <div className="mt-2 max-h-56 overflow-y-auto">
+                  {opResults.length === 0 ? (
+                    <p className="text-xs text-gray-500 px-2 py-1.5">No operators match.</p>
+                  ) : (
+                    opResults.map((op) => (
+                      <button
+                        key={op.id}
+                        onClick={() => attachOperator(op.id)}
+                        disabled={saving === "attach_operator"}
+                        className="w-full text-left px-2 py-1.5 hover:bg-gray-50 rounded-md text-xs border-b border-gray-50 last:border-b-0 disabled:opacity-50"
+                      >
+                        <p className="font-medium text-gray-900">{op.company_name || op.full_name}</p>
+                        <p className="text-gray-500">{op.email}{op.city ? ` · ${op.city}${op.state ? `, ${op.state}` : ""}` : ""}</p>
+                      </button>
+                    ))
+                  )}
+                </div>
+              </div>
             )}
           </div>
           <div className="flex flex-wrap gap-2">

--- a/src/app/admin/marketplace/contracts/new/page.tsx
+++ b/src/app/admin/marketplace/contracts/new/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { Loader2, ArrowLeft, Save, AlertCircle } from "lucide-react";
+import { Loader2, ArrowLeft, Save, AlertCircle, Search, X, User as UserIcon } from "lucide-react";
 import { createBrowserClient } from "@/lib/supabase";
 import { INDUSTRIES } from "@/app/placement/industries";
 import { US_STATES } from "@/lib/types";
@@ -25,6 +25,7 @@ export default function AdminNewContractPage() {
     locations_needed: 1,
     deadline_at: "",
     operator_business_name: "",
+    operator_profile_id: "" as string | "",
     power_required: true,
     parking_required: false,
     min_employees: "",
@@ -39,6 +40,14 @@ export default function AdminNewContractPage() {
     custom_pricing: false,
   });
 
+  // Operator picker
+  interface OperatorHit { id: string; full_name: string | null; email: string | null; company_name: string | null; city: string | null; state: string | null }
+  const [opQuery, setOpQuery] = useState("");
+  const [opResults, setOpResults] = useState<OperatorHit[]>([]);
+  const [opSearching, setOpSearching] = useState(false);
+  const [opSelected, setOpSelected] = useState<OperatorHit | null>(null);
+  const [opOpen, setOpOpen] = useState(false);
+
   useEffect(() => {
     const supabase = createBrowserClient();
     supabase.auth.getSession().then(({ data: { session } }) => {
@@ -46,6 +55,36 @@ export default function AdminNewContractPage() {
       setToken(session.access_token);
     });
   }, [router]);
+
+  // Debounced operator search
+  useEffect(() => {
+    if (!token || !opOpen) return;
+    const timer = setTimeout(async () => {
+      setOpSearching(true);
+      const res = await fetch(`/api/admin/marketplace/operators?q=${encodeURIComponent(opQuery)}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.ok) setOpResults(await res.json());
+      setOpSearching(false);
+    }, 200);
+    return () => clearTimeout(timer);
+  }, [opQuery, token, opOpen]);
+
+  function selectOperator(op: OperatorHit) {
+    setOpSelected(op);
+    setForm((f) => ({
+      ...f,
+      operator_profile_id: op.id,
+      operator_business_name: op.company_name || op.full_name || "",
+    }));
+    setOpOpen(false);
+    setOpQuery("");
+  }
+
+  function clearOperator() {
+    setOpSelected(null);
+    setForm((f) => ({ ...f, operator_profile_id: "", operator_business_name: "" }));
+  }
 
   function toggleIndustry(name: string) {
     setForm((f) => ({
@@ -75,6 +114,7 @@ export default function AdminNewContractPage() {
       locations_needed: Number(form.locations_needed) || 1,
       deadline_at: form.deadline_at || null,
       operator_business_name: form.operator_business_name.trim() || null,
+      operator_profile_id: form.operator_profile_id || null,
       power_required: form.power_required,
       parking_required: form.parking_required,
       min_employees: form.min_employees ? Number(form.min_employees) : null,
@@ -145,14 +185,75 @@ export default function AdminNewContractPage() {
               />
             </div>
             <div>
-              <label className={labelClass}>Operator (internal reference, not shown to partners)</label>
-              <input
-                type="text"
-                value={form.operator_business_name}
-                onChange={(e) => setForm((f) => ({ ...f, operator_business_name: e.target.value }))}
-                placeholder="Acme Vending LLC"
-                className={inputClass}
-              />
+              <label className={labelClass}>Attach to Operator Account</label>
+              <p className="text-[11px] text-gray-500 mb-2">The operator sees this contract on <code>/operator/contracts</code>, can review submitted locations, get billed for accepted ones, and receive notifications. Not shown to partners.</p>
+              {opSelected ? (
+                <div className="flex items-center justify-between gap-2 rounded-xl border border-emerald-200 bg-emerald-50 px-3 py-2">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <UserIcon className="h-4 w-4 text-emerald-700 shrink-0" />
+                    <div className="min-w-0">
+                      <p className="text-sm font-semibold text-emerald-900 truncate">{opSelected.company_name || opSelected.full_name}</p>
+                      <p className="text-xs text-emerald-700 truncate">{opSelected.email}{opSelected.city ? ` · ${opSelected.city}${opSelected.state ? `, ${opSelected.state}` : ""}` : ""}</p>
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={clearOperator}
+                    className="text-emerald-700 hover:text-emerald-900 shrink-0"
+                    title="Detach"
+                  >
+                    <X className="h-4 w-4" />
+                  </button>
+                </div>
+              ) : (
+                <div className="relative">
+                  <div className="flex items-center gap-2 rounded-xl border border-gray-200 px-3 py-2 focus-within:border-green-primary">
+                    <Search className="h-4 w-4 text-gray-400" />
+                    <input
+                      type="text"
+                      value={opQuery}
+                      onFocus={() => setOpOpen(true)}
+                      onChange={(e) => { setOpQuery(e.target.value); setOpOpen(true); }}
+                      placeholder="Search by name, email, or company…"
+                      className="flex-1 text-sm outline-none"
+                    />
+                    {opSearching && <Loader2 className="h-3.5 w-3.5 animate-spin text-gray-400" />}
+                  </div>
+                  {opOpen && (opResults.length > 0 || opQuery.length > 0) && (
+                    <div className="absolute top-full left-0 right-0 z-10 mt-1 rounded-xl border border-gray-200 bg-white shadow-lg max-h-64 overflow-y-auto">
+                      {opResults.length === 0 ? (
+                        <p className="px-3 py-2 text-xs text-gray-500">No operators match. Users must have <code>role=&apos;operator&apos;</code> to show here.</p>
+                      ) : (
+                        opResults.map((op) => (
+                          <button
+                            key={op.id}
+                            type="button"
+                            onClick={() => selectOperator(op)}
+                            className="w-full text-left px-3 py-2 text-xs hover:bg-gray-50 border-b border-gray-50 last:border-b-0"
+                          >
+                            <p className="font-medium text-gray-900">{op.company_name || op.full_name}</p>
+                            <p className="text-gray-500">{op.email}{op.city ? ` · ${op.city}${op.state ? `, ${op.state}` : ""}` : ""}</p>
+                          </button>
+                        ))
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
+              {/* Free-text fallback in case the operator has no profile yet — kept but de-emphasized */}
+              {!opSelected && (
+                <details className="mt-2">
+                  <summary className="text-[11px] text-gray-400 cursor-pointer">Operator has no account yet? Enter a business name manually</summary>
+                  <input
+                    type="text"
+                    value={form.operator_business_name}
+                    onChange={(e) => setForm((f) => ({ ...f, operator_business_name: e.target.value }))}
+                    placeholder="Acme Vending LLC"
+                    className={inputClass + " mt-1"}
+                  />
+                  <p className="text-[10px] text-amber-700 mt-1">Without an attached operator account, no one can see this contract on the operator side. Prefer attaching to a real account.</p>
+                </details>
+              )}
             </div>
           </div>
         </div>

--- a/src/app/api/admin/marketplace/contracts/[id]/route.ts
+++ b/src/app/api/admin/marketplace/contracts/[id]/route.ts
@@ -64,6 +64,25 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     updates.partner_payout = p.partner_payout;
     updates.platform_fee = p.platform_fee;
     activityDesc = `Tier set to ${tier} (PP $${p.partner_payout} / Op $${p.operator_price})`;
+  } else if (body.action === "attach_operator") {
+    const operatorId = typeof body.operator_profile_id === "string" ? body.operator_profile_id.trim() : "";
+    if (!operatorId) {
+      // Detach path — clear the link so the operator no longer sees it.
+      updates.operator_profile_id = null;
+      updates.operator_business_name = null;
+      activityDesc = "Operator detached from contract";
+    } else {
+      const { data: op } = await supabaseAdmin
+        .from("profiles")
+        .select("id, full_name, email, company_name, role")
+        .eq("id", operatorId)
+        .maybeSingle();
+      if (!op) return NextResponse.json({ error: "Operator profile not found" }, { status: 400 });
+      if (op.role !== "operator") return NextResponse.json({ error: "Selected profile is not an operator" }, { status: 400 });
+      updates.operator_profile_id = op.id;
+      updates.operator_business_name = op.company_name || op.full_name || op.email;
+      activityDesc = `Contract attached to operator ${op.company_name || op.full_name || op.email}`;
+    }
   } else if (body.action === "set_pricing") {
     // Admin-customizable pricing override — no tier tie-in.
     const parseCents = (v: unknown): number | null => {

--- a/src/app/api/admin/marketplace/operators/route.ts
+++ b/src/app/api/admin/marketplace/operators/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+
+/**
+ * GET /api/admin/marketplace/operators?q=<search>
+ *
+ * Admin-facing operator search. Used by the contract editor to attach a
+ * contract to an operator profile. Matches on business_name / full_name /
+ * email / company_name (case-insensitive).
+ */
+export async function GET(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const url = new URL(req.url);
+  const q = (url.searchParams.get("q") || "").trim();
+  const limit = Math.max(1, Math.min(50, Number(url.searchParams.get("limit") || 20)));
+
+  let query = supabaseAdmin
+    .from("profiles")
+    .select("id, full_name, email, company_name, city, state, role")
+    .eq("role", "operator")
+    .order("full_name", { ascending: true })
+    .limit(limit);
+
+  if (q) {
+    // Search across the four identity fields with an OR chain.
+    query = query.or(
+      `full_name.ilike.%${q}%,email.ilike.%${q}%,company_name.ilike.%${q}%`,
+    );
+  }
+
+  const { data, error } = await query;
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json(data || []);
+}


### PR DESCRIPTION
Root gap: admin-created contracts got operator_business_name as free text but never operator_profile_id, so the new /operator/contracts surface couldn't show them to the operator. getOperatorContractIds only matches on operator_profile_id or purchase_agreements.operator_email, which admin free-text contracts don't populate either.

Two ways to attach now:

1) On /admin/marketplace/contracts/new — the free-text Operator field
   is replaced with a searchable operator picker. Backed by new
   GET /api/admin/marketplace/operators?q=<query> which returns
   role='operator' profiles matched on full_name / email / company_name.
   Selecting an operator writes both operator_profile_id AND
   operator_business_name (auto from their company_name/full_name) so
   the operator's dashboard picks it up immediately. Kept the free-text
   fallback in a collapsed <details> for the edge case where the
   operator has no profile yet, with an amber warning that it won't
   surface to the operator side.

2) On /admin/marketplace/contracts/[id] — the operator line under the
   title is now interactive. When attached, shows a green pill with
   the operator name + change and X buttons. When empty, shows an amber
   "No operator attached — click to attach" button that opens the same
   searchable picker inline. Backed by new PATCH action='attach_operator'
   with body.operator_profile_id: id-to-attach or null-to-detach. The
   PATCH validates role='operator' server-side and stamps
   operator_business_name from the profile so the header display and
   partner-safe rollup queries stay consistent.

No migration.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2