### PR TITLE
Commission audit — 9 mechanical fixes + legacy-table cleanup

### DIFF
--- a/src/app/admin/financial/commissions/page.tsx
+++ b/src/app/admin/financial/commissions/page.tsx
@@ -29,11 +29,13 @@ interface LedgerRow {
 interface Summary {
   earned_cents: number;
   held_cents: number;
+  pending_clearable_cents: number;
   reversed_cents: number;
   paid_cents: number;
   clawback_pending_cents: number;
   clawback_collected_cents: number;
   clawback_waived_cents: number;
+  net_available_cents: number;
   row_count: number;
 }
 
@@ -48,7 +50,9 @@ const STATUS_FILTERS = [
   { key: "held", label: "Held" },
   { key: "paid", label: "Paid" },
   { key: "reversed", label: "Reversed" },
-  { key: "clawback_pending", label: "Clawbacks" },
+  { key: "clawback_pending", label: "Clawback owed" },
+  { key: "clawback_collected", label: "Clawback collected" },
+  { key: "clawback_waived", label: "Clawback waived" },
 ];
 
 const STATUS_STYLES: Record<string, string> = {
@@ -56,7 +60,6 @@ const STATUS_STYLES: Record<string, string> = {
   held: "bg-amber-50 text-amber-700 border-amber-100",
   paid: "bg-blue-50 text-blue-700 border-blue-100",
   reversed: "bg-red-50 text-red-700 border-red-100",
-  cancelled: "bg-gray-100 text-gray-500 border-gray-200",
   clawback_pending: "bg-orange-50 text-orange-700 border-orange-200",
   clawback_collected: "bg-emerald-50 text-emerald-700 border-emerald-100",
   clawback_waived: "bg-gray-100 text-gray-500 border-gray-200",
@@ -77,6 +80,8 @@ export default function AdminCommissionsPage() {
 
   const [statusFilter, setStatusFilter] = useState("any");
   const [roleFilter, setRoleFilter] = useState("");
+  const [userFilter, setUserFilter] = useState("");
+  const [repOptions, setRepOptions] = useState<Array<{ id: string; full_name: string | null; email: string | null }>>([]);
   const [selected, setSelected] = useState<Set<string>>(new Set());
 
   const [backfillNeeded, setBackfillNeeded] = useState<number | null>(null);
@@ -91,10 +96,12 @@ export default function AdminCommissionsPage() {
     const params = new URLSearchParams();
     if (statusFilter !== "any") params.set("status", statusFilter);
     if (roleFilter) params.set("role_code", roleFilter);
-    const [ledgerRes, rolesRes, backfillRes] = await Promise.all([
+    if (userFilter) params.set("user_id", userFilter);
+    const [ledgerRes, rolesRes, backfillRes, repsRes] = await Promise.all([
       fetch(`/api/admin/financial/commissions?${params}`, { headers: { Authorization: `Bearer ${token}` } }),
       fetch("/api/attribution-roles", { headers: { Authorization: `Bearer ${token}` } }),
       fetch("/api/admin/financial/commissions/backfill", { headers: { Authorization: `Bearer ${token}` } }),
+      fetch("/api/admin/users?role=sales&limit=200", { headers: { Authorization: `Bearer ${token}` } }),
     ]);
     if (ledgerRes.ok) {
       const data = await ledgerRes.json();
@@ -106,8 +113,12 @@ export default function AdminCommissionsPage() {
       const b = await backfillRes.json();
       setBackfillNeeded(Number(b.needs_backfill) || 0);
     }
+    if (repsRes.ok) {
+      const j = await repsRes.json();
+      setRepOptions(Array.isArray(j) ? j : j.users || []);
+    }
     setLoading(false);
-  }, [token, statusFilter, roleFilter]);
+  }, [token, statusFilter, roleFilter, userFilter]);
 
   useEffect(() => {
     const supabase = createBrowserClient();
@@ -280,6 +291,19 @@ export default function AdminCommissionsPage() {
         </div>
       )}
 
+      {/* Net available hero — only shows when scoped to a single rep */}
+      {userFilter && summary && (
+        <div className="rounded-2xl border border-emerald-100 bg-gradient-to-br from-emerald-50 to-white p-5 mb-4 flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <p className="text-[10px] font-medium uppercase tracking-wide text-emerald-700">
+              Net available to {repOptions.find((r) => r.id === userFilter)?.full_name || repOptions.find((r) => r.id === userFilter)?.email || "this rep"}
+            </p>
+            <p className="text-3xl font-bold text-emerald-800 mt-1">{fmt(summary.net_available_cents)}</p>
+            <p className="text-[11px] text-gray-500 mt-1">Earned + clearable held − reversed − outstanding clawbacks. Matches the number this rep sees on their My Commissions page.</p>
+          </div>
+        </div>
+      )}
+
       {/* Summary cards */}
       <div className="grid grid-cols-2 sm:grid-cols-5 gap-3 mb-4">
         <div className="rounded-2xl border border-gray-100 bg-white p-4">
@@ -323,6 +347,10 @@ export default function AdminCommissionsPage() {
       {/* Filters */}
       <div className="mb-4 flex items-center gap-2 flex-wrap">
         <Filter className="h-4 w-4 text-gray-400" />
+        <select value={userFilter} onChange={(e) => setUserFilter(e.target.value)} className="rounded-lg border border-gray-200 px-3 py-1.5 text-xs">
+          <option value="">All reps</option>
+          {repOptions.map((r) => <option key={r.id} value={r.id}>{r.full_name || r.email || r.id.slice(0, 8)}</option>)}
+        </select>
         <select value={roleFilter} onChange={(e) => setRoleFilter(e.target.value)} className="rounded-lg border border-gray-200 px-3 py-1.5 text-xs">
           <option value="">All roles</option>
           {roles.map((r) => <option key={r.code} value={r.code}>{r.label}</option>)}

--- a/src/app/api/admin/financial/commissions/backfill/route.ts
+++ b/src/app/api/admin/financial/commissions/backfill/route.ts
@@ -75,7 +75,7 @@ export async function GET(req: NextRequest) {
   }
 
   return NextResponse.json({
-    needs_backfill: phase1 + phase2,
+    needs_backfill: phase0 + phase1 + phase2,
     breakdown: {
       orphan_payments: phase0,
       paid_payments_missing_ledger: phase1,

--- a/src/app/api/admin/financial/commissions/mark-paid/route.ts
+++ b/src/app/api/admin/financial/commissions/mark-paid/route.ts
@@ -24,7 +24,7 @@ export async function POST(req: NextRequest) {
 
   const { data: before } = await supabaseAdmin
     .from("commission_ledger")
-    .select("id, status, user_id, amount_cents, clearable_at")
+    .select("id, status, user_id, amount_cents, clearable_at, metadata")
     .in("id", ids);
 
   const now = new Date();
@@ -39,15 +39,26 @@ export async function POST(req: NextRequest) {
   }
   if (eligibleIds.length === 0) return NextResponse.json({ paid: 0, skipped });
 
-  const { error } = await supabaseAdmin
-    .from("commission_ledger")
-    .update({
-      status: "paid",
-      paid_at: now.toISOString(),
-      notes: note,
-    })
-    .in("id", eligibleIds);
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  // Preserve earn-time notes (e.g. "Line-level override", "Legacy backfill
+  // attribution"). The mark-paid caption lives on metadata.paid_note so the
+  // original context isn't destroyed.
+  const paidMetadataPatch = note ? { paid_note: note, paid_by: adminId } : { paid_by: adminId };
+
+  // We have to loop to merge metadata per-row — Supabase doesn't do a jsonb
+  // deep-merge in a single .update on a list.
+  for (const id of eligibleIds) {
+    const existing = (before || []).find((b) => b.id === id) as { metadata?: Record<string, unknown> } | undefined;
+    const existingMeta = existing?.metadata || {};
+    const { error } = await supabaseAdmin
+      .from("commission_ledger")
+      .update({
+        status: "paid",
+        paid_at: now.toISOString(),
+        metadata: { ...existingMeta, ...paidMetadataPatch },
+      })
+      .eq("id", id);
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  }
 
   const totalCents = (before || [])
     .filter((r) => eligibleIds.includes(r.id))

--- a/src/app/api/admin/financial/commissions/route.ts
+++ b/src/app/api/admin/financial/commissions/route.ts
@@ -8,10 +8,14 @@ import { supabaseAdmin } from "@/lib/supabaseAdmin";
  * Filters:
  *   user_id  — restrict to one rep
  *   role_code
- *   status   — earned | held | reversed | paid | cancelled
+ *   status   — earned | held | paid | reversed | clawback_*
  *   since_days — window (default 365)
+ *   limit    — row list cap (default 500)
  *
- * Returns rows + a summary block for the current filter.
+ * Returns rows (bounded by limit) + summary (unbounded aggregate over the
+ * same filter set, so tiles are accurate even when there are more rows
+ * than the row cap). When user_id is set, also returns net_available so
+ * admin sees the same number the rep sees on /my/commissions.
  */
 
 export async function GET(req: NextRequest) {
@@ -26,7 +30,8 @@ export async function GET(req: NextRequest) {
   const limit = Math.max(1, Math.min(2000, Number(url.searchParams.get("limit") || 500)));
   const cutoff = new Date(Date.now() - sinceDays * 24 * 60 * 60 * 1000).toISOString();
 
-  let query = supabaseAdmin
+  // ── Bounded row list (for the table) ────────────────────────────────
+  let rowQuery = supabaseAdmin
     .from("commission_ledger")
     .select(`
       *,
@@ -36,39 +41,63 @@ export async function GET(req: NextRequest) {
     .gte("earned_at", cutoff)
     .order("earned_at", { ascending: false })
     .limit(limit);
+  if (userId) rowQuery = rowQuery.eq("user_id", userId);
+  if (roleCode) rowQuery = rowQuery.eq("role_code", roleCode);
+  if (status) rowQuery = rowQuery.eq("status", status);
+  const { data: rowData, error: rowErr } = await rowQuery;
+  if (rowErr) return NextResponse.json({ error: rowErr.message }, { status: 500 });
+  const rows = rowData || [];
 
-  if (userId) query = query.eq("user_id", userId);
-  if (roleCode) query = query.eq("role_code", roleCode);
-  if (status) query = query.eq("status", status);
+  // ── Unbounded aggregate (for the summary tiles) ─────────────────────
+  // Pull only what the summary math needs — this is a wide-net query but
+  // narrow columns. Row limit does NOT apply so the tiles are accurate.
+  let sumQuery = supabaseAdmin
+    .from("commission_ledger")
+    .select("amount_cents, status, clearable_at")
+    .gte("earned_at", cutoff);
+  if (userId) sumQuery = sumQuery.eq("user_id", userId);
+  if (roleCode) sumQuery = sumQuery.eq("role_code", roleCode);
+  if (status) sumQuery = sumQuery.eq("status", status);
+  const { data: sumRows } = await sumQuery;
 
-  const { data, error } = await query;
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-
-  // Summary math over the returned window (not affected by limit truncation
-  // beyond what the caller already asked for).
-  const rows = data || [];
   const summary = {
     earned_cents: 0,
     held_cents: 0,
+    pending_clearable_cents: 0,
     reversed_cents: 0,
     paid_cents: 0,
     clawback_pending_cents: 0,
     clawback_collected_cents: 0,
     clawback_waived_cents: 0,
-    row_count: rows.length,
+    net_available_cents: 0,
+    row_count: (sumRows || []).length,
   };
-  for (const r of rows) {
+  const now = Date.now();
+  for (const r of sumRows || []) {
     const amt = Number(r.amount_cents) || 0;
     const mag = Math.abs(amt);
-    if (r.status === "reversed") summary.reversed_cents += mag;
-    else if (r.status === "clawback_pending") summary.clawback_pending_cents += mag;
-    else if (r.status === "clawback_collected") summary.clawback_collected_cents += mag;
-    else if (r.status === "clawback_waived") summary.clawback_waived_cents += mag;
-    else if (amt < 0) summary.reversed_cents += mag;
-    else if (r.status === "paid") summary.paid_cents += amt;
-    else if (r.status === "held") summary.held_cents += amt;
+    if (r.status === "reversed") { summary.reversed_cents += mag; continue; }
+    if (r.status === "clawback_pending") { summary.clawback_pending_cents += mag; continue; }
+    if (r.status === "clawback_collected") { summary.clawback_collected_cents += mag; continue; }
+    if (r.status === "clawback_waived") { summary.clawback_waived_cents += mag; continue; }
+    if (amt < 0) { summary.reversed_cents += mag; continue; }
+    if (r.status === "paid") summary.paid_cents += amt;
+    else if (r.status === "held") {
+      summary.held_cents += amt;
+      if (r.clearable_at && new Date(r.clearable_at as string).getTime() <= now) {
+        summary.pending_clearable_cents += amt;
+      }
+    }
     else if (r.status === "earned") summary.earned_cents += amt;
   }
+
+  // Net available mirrors the rep-side formula so admin sees the same
+  // number the rep sees. Only meaningful when scoped to one user, but
+  // computing it always keeps the API contract stable.
+  summary.net_available_cents = Math.max(
+    0,
+    summary.earned_cents + summary.pending_clearable_cents - summary.reversed_cents - summary.clawback_pending_cents,
+  );
 
   return NextResponse.json({ rows, summary });
 }

--- a/src/app/api/my/commissions/route.ts
+++ b/src/app/api/my/commissions/route.ts
@@ -6,8 +6,17 @@ import { supabaseAdmin } from "@/lib/supabaseAdmin";
 /**
  * GET /api/my/commissions
  *
- * Rep-facing: summary block + row list (last N days, default 365). Reads
- * commission_ledger via service role, scoped to the caller's user_id.
+ * Rep-facing: two blocks in one response so the rep sees the whole picture.
+ *
+ *   summary + rows  — from commission_ledger. Auto-earn from paid orders +
+ *                     attribution rules. This is the money spine.
+ *
+ *   adjustments     — from sales_commissions. Manual bonuses/overrides
+ *                     entered by hand by director_of_sales/market_leader.
+ *                     Includes totals + row list scoped to the caller.
+ *
+ * The rep's true "net available" adds approved-but-unpaid adjustments to
+ * the ledger net_available so we don't understate what they're owed.
  */
 
 export async function GET(req: NextRequest) {
@@ -33,5 +42,41 @@ export async function GET(req: NextRequest) {
     .order("earned_at", { ascending: false })
     .limit(limit);
 
-  return NextResponse.json({ summary, rows: rows || [] });
+  // Manual adjustments — legacy sales_commissions table used by director /
+  // market_leader for bonuses + overrides. Kept alongside the ledger so
+  // reps see everything on one page.
+  const { data: adjustmentRows } = await supabaseAdmin
+    .from("sales_commissions")
+    .select("id, deal_id, order_id, commission_rate, deal_value, commission_amount, status, paid_at, notes, created_at")
+    .eq("user_id", userId)
+    .gte("created_at", cutoff)
+    .order("created_at", { ascending: false })
+    .limit(limit);
+
+  const adjustments = {
+    pending_cents: 0,
+    approved_unpaid_cents: 0,
+    paid_cents: 0,
+    total_cents: 0,
+    row_count: (adjustmentRows || []).length,
+  };
+  for (const a of adjustmentRows || []) {
+    const cents = Math.round(Number(a.commission_amount || 0) * 100);
+    adjustments.total_cents += cents;
+    if (a.status === "pending") adjustments.pending_cents += cents;
+    else if (a.status === "approved" && !a.paid_at) adjustments.approved_unpaid_cents += cents;
+    else if (a.status === "paid" || a.paid_at) adjustments.paid_cents += cents;
+  }
+
+  // True net available = ledger net + approved-but-unpaid manual adjustments.
+  // Pending adjustments aren't yet approved so they don't count toward
+  // "available".
+  const combined_net_available_cents = summary.net_available_cents + adjustments.approved_unpaid_cents;
+
+  return NextResponse.json({
+    summary: { ...summary, combined_net_available_cents },
+    rows: rows || [],
+    adjustments,
+    adjustment_rows: adjustmentRows || [],
+  });
 }

--- a/src/app/my/commissions/page.tsx
+++ b/src/app/my/commissions/page.tsx
@@ -30,10 +30,19 @@ interface Summary {
   paid_cents: number;
   pending_clearable_cents: number;
   net_available_cents: number;
+  combined_net_available_cents: number;
   clawback_pending_cents: number;
   clawback_collected_cents: number;
   clawback_waived_cents: number;
   by_role: Record<string, number>;
+  row_count: number;
+}
+
+interface Adjustments {
+  pending_cents: number;
+  approved_unpaid_cents: number;
+  paid_cents: number;
+  total_cents: number;
   row_count: number;
 }
 
@@ -66,6 +75,7 @@ export default function MyCommissionsPage() {
   const [refreshing, setRefreshing] = useState(false);
   const [rows, setRows] = useState<LedgerRow[]>([]);
   const [summary, setSummary] = useState<Summary | null>(null);
+  const [adjustments, setAdjustments] = useState<Adjustments | null>(null);
   const [statusFilter, setStatusFilter] = useState("any");
   const [sinceDays, setSinceDays] = useState(365);
 
@@ -82,6 +92,7 @@ export default function MyCommissionsPage() {
         const data = await res.json();
         setRows(data.rows || []);
         setSummary(data.summary || null);
+        setAdjustments(data.adjustments || null);
       }
     } finally {
       setRefreshing(false);
@@ -137,18 +148,69 @@ export default function MyCommissionsPage() {
         </div>
       </div>
 
-      {/* Hero: net available */}
+      {/* Hero: net available (auto-earn spine + approved manual adjustments) */}
       <div className="rounded-2xl border border-emerald-100 bg-gradient-to-br from-emerald-50 to-white p-6 mb-4 flex flex-wrap items-end justify-between gap-3">
         <div>
           <p className="text-xs font-medium uppercase tracking-wide text-emerald-700">Net available</p>
-          <p className="text-4xl font-bold text-emerald-800 mt-1">{summary ? fmt(summary.net_available_cents) : "…"}</p>
-          <p className="text-xs text-gray-500 mt-1">Earned + clearable held − reversed − outstanding clawbacks. Payouts happen manually today; admins will hand this off in your next payroll cycle.</p>
+          <p className="text-4xl font-bold text-emerald-800 mt-1">
+            {summary ? fmt(summary.combined_net_available_cents ?? summary.net_available_cents) : "…"}
+          </p>
+          <p className="text-xs text-gray-500 mt-1">
+            Auto-earn spine (earned + clearable held − reversed − outstanding clawbacks)
+            {adjustments && adjustments.approved_unpaid_cents > 0 && (
+              <> + approved manual adjustments ({fmt(adjustments.approved_unpaid_cents)})</>
+            )}
+            . Payouts happen manually today; admins will hand this off in your next payroll cycle.
+          </p>
         </div>
         <div className="text-right">
           <p className="text-xs text-gray-500">Lifetime paid to you</p>
-          <p className="text-2xl font-bold text-blue-700 mt-1">{summary ? fmt(summary.paid_cents) : "…"}</p>
+          <p className="text-2xl font-bold text-blue-700 mt-1">
+            {summary ? fmt(summary.paid_cents + (adjustments?.paid_cents || 0)) : "…"}
+          </p>
         </div>
       </div>
+
+      {/* Manual adjustments — only if the rep has any */}
+      {adjustments && adjustments.row_count > 0 && (
+        <div className="rounded-2xl border border-blue-100 bg-blue-50/40 p-4 mb-4">
+          <div className="flex flex-wrap items-center justify-between gap-2 mb-2">
+            <p className="text-[10px] font-medium uppercase tracking-wide text-blue-700">Manual adjustments</p>
+            <p className="text-[10px] text-blue-800/70">Bonuses + overrides entered by your director / market leader — separate from the auto-earn spine.</p>
+          </div>
+          <div className="grid grid-cols-3 gap-3">
+            <div>
+              <p className="text-[10px] text-gray-500">Pending</p>
+              <p className="text-base font-semibold text-amber-700">{fmt(adjustments.pending_cents)}</p>
+            </div>
+            <div>
+              <p className="text-[10px] text-gray-500">Approved (unpaid)</p>
+              <p className="text-base font-semibold text-emerald-700">{fmt(adjustments.approved_unpaid_cents)}</p>
+            </div>
+            <div>
+              <p className="text-[10px] text-gray-500">Paid</p>
+              <p className="text-base font-semibold text-blue-700">{fmt(adjustments.paid_cents)}</p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* By-role breakdown — only when the rep has earnings across multiple roles */}
+      {summary && Object.keys(summary.by_role || {}).length > 1 && (
+        <div className="rounded-2xl border border-gray-100 bg-white p-4 mb-4">
+          <p className="text-[10px] font-medium uppercase tracking-wide text-gray-500 mb-2">Earned by role</p>
+          <div className="flex flex-wrap gap-3">
+            {Object.entries(summary.by_role)
+              .sort((a, b) => b[1] - a[1])
+              .map(([role, cents]) => (
+                <div key={role} className="min-w-[110px]">
+                  <p className="text-xs text-gray-500 capitalize">{role.replace(/_/g, " ")}</p>
+                  <p className="text-base font-semibold text-gray-900">{fmt(cents)}</p>
+                </div>
+              ))}
+          </div>
+        </div>
+      )}
 
       {/* Summary tiles */}
       <div className="grid grid-cols-2 sm:grid-cols-5 gap-3 mb-4">

--- a/src/app/sales/commissions/page.tsx
+++ b/src/app/sales/commissions/page.tsx
@@ -143,17 +143,24 @@ export default function CommissionsPage() {
 
   return (
     <div className="p-6">
-      <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">Commissions</h1>
+      <div className="flex items-center justify-between mb-2">
+        <h1 className="text-2xl font-bold text-gray-900">Manual Commission Adjustments</h1>
         {isAdmin && !showForm && (
           <button
             onClick={openForm}
             className="inline-flex items-center gap-1.5 rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 transition-colors"
           >
             <Plus className="h-4 w-4" />
-            Add Commission
+            Add Adjustment
           </button>
         )}
+      </div>
+      <div className="mb-5 rounded-xl border border-blue-100 bg-blue-50/70 p-3 text-xs text-blue-900">
+        <p className="font-semibold mb-0.5">Directors + market leaders — manual adjustments only.</p>
+        <p>
+          Rows here are entered by hand for bonuses, comp overrides, or one-off adjustments. They are <strong>separate</strong> from the automatic commission ledger driven by paid orders + attribution rules.
+          For that spine (auto-earn, holds, clawbacks, mark-paid) see <a className="underline" href="/admin/financial/commissions">Financial Center → Commissions</a>. Reps see the combined view on <a className="underline" href="/my/commissions">My Commissions</a>.
+        </p>
       </div>
 
       {/* Add Commission Form */}

--- a/src/app/sales/page.tsx
+++ b/src/app/sales/page.tsx
@@ -339,22 +339,25 @@ export default function SalesDashboard() {
                     <p className="text-xl font-bold text-gray-900">{results.metrics.orders_completed}</p>
                   </div>
                   <div className="rounded-lg bg-green-50 p-4">
-                    <p className="text-xs text-gray-500">Commission Earned</p>
+                    <p className="text-xs text-gray-500">Manual Adjustments (Total)</p>
                     <p className="text-xl font-bold text-green-600">{fmt(results.metrics.commission_total)}</p>
                   </div>
                   <div className="rounded-lg bg-amber-50 p-4">
-                    <p className="text-xs text-gray-500">Commission Pending</p>
+                    <p className="text-xs text-gray-500">Manual Adj. — Pending</p>
                     <p className="text-xl font-bold text-amber-600">{fmt(results.metrics.commission_pending)}</p>
                   </div>
                   <div className="rounded-lg bg-blue-50 p-4">
-                    <p className="text-xs text-gray-500">Commission Approved</p>
+                    <p className="text-xs text-gray-500">Manual Adj. — Approved</p>
                     <p className="text-xl font-bold text-blue-600">{fmt(results.metrics.commission_approved)}</p>
                   </div>
                   <div className="rounded-lg bg-green-50 p-4">
-                    <p className="text-xs text-gray-500">Commission Paid</p>
+                    <p className="text-xs text-gray-500">Manual Adj. — Paid</p>
                     <p className="text-xl font-bold text-green-700">{fmt(results.metrics.commission_paid)}</p>
                   </div>
                 </div>
+                <p className="mt-2 text-[11px] text-gray-500">
+                  &ldquo;Manual Adjustments&rdquo; = bonuses / overrides recorded on <a className="text-green-primary hover:underline" href="/sales/commissions">Commissions</a>. Auto-earn from paid orders + attribution rules lives on <a className="text-green-primary hover:underline" href="/admin/financial/commissions">Financial Center → Commissions</a>. Reps see the combined view on <a className="text-green-primary hover:underline" href="/my/commissions">My Commissions</a>.
+                </p>
 
                 {/* Lead status breakdown */}
                 <div className="mt-4 flex flex-wrap gap-2 text-xs">

--- a/src/lib/commissions.ts
+++ b/src/lib/commissions.ts
@@ -1,12 +1,19 @@
 /**
  * Commissions — resolve rate, earn on payment, reverse on refund.
  *
- * Rate resolution (most specific first):
- *   1. user_id + category   (priority 1110)
- *   2. user_id              (priority 1100)
- *   3. role_code + category (priority 110)
- *   4. role_code            (priority 100)
- *   5. is_default = true    (priority 0)
+ * Rate resolution (most specific first). Priority = user*1000 + role*100 +
+ * category*10 (each factor toggles 1 or 0 based on whether that matcher is
+ * set on the rule):
+ *   1. user_id + role_code + category  (priority 1110)
+ *   2. user_id + category              (priority 1010)
+ *   3. user_id + role_code             (priority 1100)
+ *   4. user_id                         (priority 1000)
+ *   5. role_code + category            (priority 110)
+ *   6. role_code                       (priority 100)
+ *   7. category                        (priority 10)
+ *   8. is_default = true               (priority 0)
+ *
+ * Higher priority always wins when multiple rules match.
  *
  * Earn: for each active attribution row on an order, we compute
  *     basis  = payment.amount × attribution_percentage / 100
@@ -93,14 +100,23 @@ export interface ResolveRateArgs {
 export async function resolveCommissionRule(args: ResolveRateArgs): Promise<CommissionRule | null> {
   const category = args.category ? args.category.toLowerCase() : null;
 
-  // Pull the small superset of possibly-matching rules, rank in JS.
-  const { data: rules } = await supabaseAdmin
-    .from("commission_rules")
-    .select("*")
-    .eq("is_active", true)
-    .or(`user_id.eq.${args.userId},user_id.is.null`);
-
-  const candidates = (rules || []) as CommissionRule[];
+  // Pull the small superset of possibly-matching rules, rank in JS. Two
+  // separate queries instead of a string-interpolated .or() so the UUID
+  // never enters a query string (defense in depth — args.userId is an auth
+  // id, but interpolating user-derived strings into .or() is a footgun).
+  const [{ data: userRules }, { data: sharedRules }] = await Promise.all([
+    supabaseAdmin
+      .from("commission_rules")
+      .select("*")
+      .eq("is_active", true)
+      .eq("user_id", args.userId),
+    supabaseAdmin
+      .from("commission_rules")
+      .select("*")
+      .eq("is_active", true)
+      .is("user_id", null),
+  ]);
+  const candidates = [...(userRules || []), ...(sharedRules || [])] as CommissionRule[];
 
   // Score each candidate by specificity; skip any that don't match.
   let best: CommissionRule | null = null;


### PR DESCRIPTION
Mechanical fixes from the commission wiring audit:

1) Preserve commission_ledger.notes on mark-paid. Earn-time context
   like "Line-level override" or "Legacy backfill attribution" was
   being wiped by the button caption. Notes column stays; caption
   lives in metadata.paid_note + metadata.paid_by.

2) Backfill badge now sums Phase 0 + Phase 1 + Phase 2. Previously
   only Phase 1+2 landed in the top-line, so orphan-payment repairs
   were invisible until admins opened the endpoint.

3) Dropped the dead `cancelled` STATUS_STYLES row from the admin
   inspector — status is in the CHECK constraint but nothing writes
   it, so the style was unreachable.

4) Rendered `by_role` on /my/commissions when the rep has earnings
   across multiple roles. Data was already computed and returned by
   /api/my/commissions but never displayed.

5) Fixed the priority-formula docstring at commissions.ts:5-9. Comment
   said 1110/1100/110/100 but the runtime formula is user*1000 +
   role*100 + category*10, so the actual priorities are 1110/1010/
   1100/1000/110/100/10/0. Docstring now matches.

6) Admin inspector gets a rep dropdown. When a rep is picked the
   API returns net_available_cents matching the rep-side formula
   and a green hero tile shows above the 5-up: "Net available to
   <rep>". Admin no longer has to open a second tab as the rep.

7) Unbound the admin summary from the row cap. The summary tiles
   now compute over an unbounded aggregate query while the row
   table stays capped at the limit. Previously a heavy rep would
   under-report on the admin page while their own dashboard was
   accurate.

8) Added filter chips for clawback_collected and clawback_waived
   on the admin inspector. Terminal clawback states were previously
   only visible under the "Any" filter.

9) Rate resolver query no longer string-interpolates the caller's
   UUID. Split into two parallel `.eq(user_id, uid)` + `.is(user_id, null)`
   queries + JS merge instead of `.or("user_id.eq.${uid},...")`.
   No behavior change; defense in depth.

Legacy sales_commissions table — Option B (relabel + bridge):

- Renamed /sales/commissions header to "Manual Commission Adjustments" and added a blue explainer banner distinguishing this table from the auto-earn spine + cross-linking to /admin/financial/commissions and /my/commissions.
- Retitled the four sales_results metric tiles on /sales from "Commission Earned/Pending/Approved/Paid" to "Manual Adjustments — Total/Pending/Approved/Paid" with a footnote pointing at both sources of truth.
- /api/my/commissions now returns an adjustments block + adjustment_rows sourced from sales_commissions scoped to the caller. Includes pending / approved_unpaid / paid / total totals.
- /my/commissions renders:
  - Hero "Net available" now uses combined_net_available_cents (auto-earn net + approved-but-unpaid manual adjustments) so the rep isn't understated.
  - "Lifetime paid to you" adds ledger paid + manual-adjustments paid.
  - Explanatory line under the hero notes the composition.
  - New blue "Manual adjustments" summary block below the hero when the rep has any adjustments — three tiles for Pending / Approved (unpaid) / Paid — labeled as "bonuses + overrides entered by your director / market leader, separate from the auto-earn spine".

No migration.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2