### PR TITLE
Contracts open to all viewers + dual-role locator disposition

### DIFF
--- a/src/app/api/marketplace/contracts/[id]/route.ts
+++ b/src/app/api/marketplace/contracts/[id]/route.ts
@@ -1,14 +1,25 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
-import { getPlacementPartner, forbidden } from "@/lib/marketplaceAuth";
+import { getMarketplaceViewer } from "@/lib/marketplaceAuth";
 import { isPartnerEligibleForContract } from "@/lib/marketplaceEligibility";
 
+/**
+ * GET — contract detail. Open to any authed viewer (via getMarketplaceViewer)
+ * so operators/sales/requestors can preview a contract before adding locator
+ * capability to their account. Only the accept/submit/tier-propose routes
+ * require getPlacementPartner.
+ *
+ * Response includes `is_partner` so the client renders either the accept
+ * flow (for real PPs) or the "Add locator capability" CTA. When the caller
+ * has no placement_partners row, eligibility is synthesized as ineligible
+ * with a "become a locator" reason instead of hitting the eligibility helper
+ * (which assumes a partner row exists).
+ */
 export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const user = await getPlacementPartner(req);
-  if (!user) return forbidden();
+  const viewer = await getMarketplaceViewer(req);
+  if (!viewer) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   const { id } = await params;
 
-  // Anonymized view first
   const { data: contract, error } = await supabaseAdmin
     .from("partner_visible_contracts")
     .select("*")
@@ -16,13 +27,40 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
     .maybeSingle();
   if (error || !contract) return NextResponse.json({ error: "Contract not found" }, { status: 404 });
 
-  const [{ data: requirements }, { data: myAcceptance }, { data: myTierProposal }] = await Promise.all([
-    supabaseAdmin.from("placement_contract_requirements").select("*").eq("contract_id", id),
-    supabaseAdmin.from("placement_contract_acceptances").select("*").eq("contract_id", id).eq("partner_id", user.id).is("released_at", null).maybeSingle(),
-    supabaseAdmin.from("placement_contract_tier_proposals").select("*").eq("contract_id", id).eq("proposed_by", user.id).eq("status", "pending").maybeSingle(),
-  ]);
+  const requirementsPromise = supabaseAdmin
+    .from("placement_contract_requirements")
+    .select("*")
+    .eq("contract_id", id);
 
-  const eligibility = await isPartnerEligibleForContract(user.id, id);
+  const [{ data: requirements }, myAcceptance, myTierProposal, eligibility] = await Promise.all([
+    requirementsPromise,
+    viewer.is_partner
+      ? supabaseAdmin
+          .from("placement_contract_acceptances")
+          .select("*")
+          .eq("contract_id", id)
+          .eq("partner_id", viewer.id)
+          .is("released_at", null)
+          .maybeSingle()
+          .then((r) => r.data)
+      : Promise.resolve(null),
+    viewer.is_partner
+      ? supabaseAdmin
+          .from("placement_contract_tier_proposals")
+          .select("*")
+          .eq("contract_id", id)
+          .eq("proposed_by", viewer.id)
+          .eq("status", "pending")
+          .maybeSingle()
+          .then((r) => r.data)
+      : Promise.resolve(null),
+    viewer.is_partner
+      ? isPartnerEligibleForContract(viewer.id, id)
+      : Promise.resolve({
+          eligible: false,
+          reasons: ["Add locator capability to your account to accept contracts."],
+        }),
+  ]);
 
   return NextResponse.json({
     contract,
@@ -30,5 +68,8 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
     accepted: !!myAcceptance,
     my_pending_tier_proposal: myTierProposal,
     eligibility,
+    is_partner: viewer.is_partner,
+    partner_onboarding_complete: viewer.partner_onboarding_complete,
+    viewer_role: viewer.role,
   });
 }

--- a/src/app/api/marketplace/contracts/route.ts
+++ b/src/app/api/marketplace/contracts/route.ts
@@ -1,28 +1,39 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
-import { getPlacementPartner, forbidden } from "@/lib/marketplaceAuth";
+import { getMarketplaceViewer } from "@/lib/marketplaceAuth";
 import { contractHiddenFromPartnerTier, type Tier } from "@/lib/marketplaceScoring";
 
 /**
- * GET — return open + in_progress contracts visible to this partner.
- * Uses the partner_visible_contracts view so no operator identity is exposed.
- * Filters by territory (state / city) so partners only see contracts they can
- * actually accept. Attaches an `is_eligible` boolean per row.
+ * GET — return open + in_progress contracts.
+ *
+ * Any authed user can view (they hit the identity-scrubbed
+ * partner_visible_contracts view, so no operator identity leaks). The
+ * response wraps the row list with an `is_partner` flag so the client can
+ * render an "Add locator capability" CTA for non-locators instead of the
+ * accept flow.
+ *
+ * For real Placement Partners: filter by their territories, subtract
+ * already-accepted contracts, and apply tier-3 24h gold gate.
+ *
+ * For non-partners: no territory filter (they haven't set any yet); tier
+ * gate defaults to bronze so the browse view matches what a fresh PP would
+ * see, avoiding leaking newer tier-3 contracts before the 24h gold window.
  */
 export async function GET(req: NextRequest) {
-  const user = await getPlacementPartner(req);
-  if (!user) return forbidden();
+  const viewer = await getMarketplaceViewer(req);
+  if (!viewer) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  // Partner territories
-  const { data: territories } = await supabaseAdmin
-    .from("placement_territories")
-    .select("state, city")
-    .eq("owner_type", "partner")
-    .eq("owner_id", user.id);
+  // Partner territories (only meaningful when viewer.is_partner is true)
+  const { data: territories } = viewer.is_partner
+    ? await supabaseAdmin
+        .from("placement_territories")
+        .select("state, city")
+        .eq("owner_type", "partner")
+        .eq("owner_id", viewer.id)
+    : { data: [] as Array<{ state: string | null; city: string | null }> };
 
-  // "US" is a nationwide wildcard — partners with this territory see every
-  // contract regardless of market_state / market_city.
-  const hasNationwide = (territories || []).some(
+  // "US" is a nationwide wildcard. Non-partners are treated as nationwide.
+  const hasNationwide = !viewer.is_partner || (territories || []).some(
     (t) => (t.state || "").toUpperCase() === "US",
   );
   const states = hasNationwide
@@ -35,7 +46,6 @@ export async function GET(req: NextRequest) {
         ),
       );
 
-  // Pull open contracts through the anonymized view
   let query = supabaseAdmin.from("partner_visible_contracts").select("*").order("created_at", { ascending: false });
   if (!hasNationwide && states.length > 0) {
     query = query.in("market_state", states);
@@ -43,7 +53,6 @@ export async function GET(req: NextRequest) {
   const { data: rows, error } = await query;
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
-  // City filter (do in JS — the view is generic)
   const territoryCities = new Set(
     (territories || [])
       .filter((t) => t.city)
@@ -64,25 +73,36 @@ export async function GET(req: NextRequest) {
         return false;
       });
 
-  // Skip contracts the partner has already accepted (they appear under "My Contracts")
-  const { data: myAcceptances } = await supabaseAdmin
-    .from("placement_contract_acceptances")
-    .select("contract_id, released_at")
-    .eq("partner_id", user.id);
-  const acceptedIds = new Set(
-    (myAcceptances || []).filter((a) => !a.released_at).map((a) => a.contract_id),
-  );
+  // Partners hide contracts they've already accepted (those go under
+  // "My Contracts"). Non-partners see the full list.
+  let openToMe = filtered;
+  if (viewer.is_partner) {
+    const { data: myAcceptances } = await supabaseAdmin
+      .from("placement_contract_acceptances")
+      .select("contract_id, released_at")
+      .eq("partner_id", viewer.id);
+    const acceptedIds = new Set(
+      (myAcceptances || []).filter((a) => !a.released_at).map((a) => a.contract_id),
+    );
+    openToMe = filtered.filter((c) => !acceptedIds.has(c.id));
+  }
 
-  const openToMe = filtered.filter((c) => !acceptedIds.has(c.id));
-
-  // Phase 2.9 — Tier-3 contracts are gold-only for the first 24 hours.
-  const { data: partnerRow } = await supabaseAdmin
-    .from("placement_partners")
-    .select("partner_tier")
-    .eq("id", user.id)
-    .maybeSingle();
-  const partnerTier: Tier = (partnerRow?.partner_tier as Tier) || "bronze";
+  // Tier-3 24h gold gate — for partners, use their tier; for non-partners
+  // default to bronze so we don't leak newer tier-3 contracts.
+  const partnerTier: Tier = viewer.is_partner
+    ? await supabaseAdmin
+        .from("placement_partners")
+        .select("partner_tier")
+        .eq("id", viewer.id)
+        .maybeSingle()
+        .then((r) => (r.data?.partner_tier as Tier) || "bronze")
+    : "bronze";
   const gatedByTier = openToMe.filter((c) => !contractHiddenFromPartnerTier(c, partnerTier));
 
-  return NextResponse.json(gatedByTier);
+  return NextResponse.json({
+    contracts: gatedByTier,
+    is_partner: viewer.is_partner,
+    partner_onboarding_complete: viewer.partner_onboarding_complete,
+    viewer_role: viewer.role,
+  });
 }

--- a/src/app/api/marketplace/partners/route.ts
+++ b/src/app/api/marketplace/partners/route.ts
@@ -51,18 +51,17 @@ export async function POST(req: NextRequest) {
   const businessName = String(body.business_name || "").trim();
   const bio = String(body.bio || "").trim();
 
-  // Only upgrade the profile role if the caller has a "no role assigned yet"
-  // role. Admins, sales, and other CRM roles keep their existing role — they
-  // may be poking at the marketplace onboarding for testing purposes and
-  // should never lose access to their real tools. If they truly need to
-  // become a placement partner, admin can flip the role manually.
+  // Dual-role model: existence of the placement_partners row IS the "has
+  // locator capability" signal. We no longer overwrite the caller's primary
+  // profile.role — an operator remains an operator + gains PP capability.
+  // Only flip role to placement_partner if the account has no role yet at
+  // all (fresh signup that came in via the /placement flow directly).
   const { data: currentProfile } = await supabaseAdmin
     .from("profiles")
     .select("role")
     .eq("id", userId)
     .maybeSingle();
-  const upgradableRoles = ["requestor", "operator", "locator", "location_manager"];
-  if (!currentProfile?.role || upgradableRoles.includes(currentProfile.role)) {
+  if (!currentProfile?.role) {
     await supabaseAdmin
       .from("profiles")
       .update({ role: "placement_partner" })

--- a/src/app/api/marketplace/team/invite/[token]/route.ts
+++ b/src/app/api/marketplace/team/invite/[token]/route.ts
@@ -63,11 +63,11 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ tok
     );
   }
 
-  // Upgrade role — but preserve elevated CRM roles. An admin, sales manager,
-  // etc. accepting an invite still gets the team_members row (so they can
-  // work under the company) without losing their existing tools.
-  const upgradableRoles = ["requestor", "operator", "locator", "location_manager"];
-  if (!profile.role || upgradableRoles.includes(profile.role)) {
+  // Dual-role model: team membership + placement_partners row existence
+  // is enough to grant PP capability. We do NOT overwrite the caller's
+  // primary profile.role — operators, sales, admins keep their existing
+  // access. Only set role when the account has no role assigned yet.
+  if (!profile.role) {
     await supabaseAdmin.from("profiles").update({ role: "placement_partner" }).eq("id", userId);
   }
 

--- a/src/app/placement/contracts/[id]/page.tsx
+++ b/src/app/placement/contracts/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useCallback } from "react";
 import { useRouter, useParams } from "next/navigation";
 import Link from "next/link";
-import { Loader2, MapPin, Package, CheckCircle2, AlertCircle, ArrowRight, ArrowLeft } from "lucide-react";
+import { Loader2, Package, CheckCircle2, AlertCircle, ArrowRight, ArrowLeft, Sparkles } from "lucide-react";
 import { createBrowserClient } from "@/lib/supabase";
 
 interface Contract {
@@ -27,6 +27,9 @@ interface ContractDetail {
   requirements: Array<{ industry: string | null; min_employees: number | null; min_traffic_score: number | null; power_required: boolean; parking_required: boolean }>;
   accepted: boolean;
   eligibility: { eligible: boolean; reasons: string[] };
+  is_partner: boolean;
+  viewer_role: string | null;
+  partner_onboarding_complete?: boolean;
 }
 
 export default function ContractDetailPage() {
@@ -78,7 +81,8 @@ export default function ContractDetailPage() {
     return <div className="flex justify-center py-20"><Loader2 className="h-6 w-6 animate-spin text-green-primary" /></div>;
   }
 
-  const { contract, requirements, accepted, eligibility } = data;
+  const { contract, requirements, accepted, eligibility, is_partner, viewer_role, partner_onboarding_complete } = data;
+  const roleLabel = viewer_role ? viewer_role.replace(/_/g, " ") : "account";
 
   return (
     <div className="mx-auto max-w-3xl px-4 py-8 sm:px-6">
@@ -145,44 +149,84 @@ export default function ContractDetailPage() {
         </div>
       )}
 
-      {!eligibility.eligible && (
-        <div className="mb-4 rounded-xl border border-amber-200 bg-amber-50 p-4">
-          <p className="text-sm font-semibold text-amber-900 mb-2 flex items-center gap-2">
-            <AlertCircle className="h-4 w-4" /> Not currently eligible
-          </p>
-          <ul className="text-xs text-amber-800 space-y-1 list-disc list-inside">
-            {eligibility.reasons.map((r, i) => <li key={i}>{r}</li>)}
-          </ul>
-        </div>
-      )}
-
-      {accepted ? (
-        <div className="space-y-3">
-          <div className="rounded-2xl border border-emerald-200 bg-emerald-50 p-5 flex items-start gap-3">
-            <CheckCircle2 className="h-6 w-6 text-emerald-600 shrink-0 mt-0.5" />
+      {!is_partner ? (
+        <div className="rounded-2xl border border-emerald-200 bg-gradient-to-br from-emerald-50 to-white p-6">
+          <div className="flex items-start gap-3 mb-4">
+            <div className="rounded-xl bg-emerald-100 p-2 shrink-0">
+              <Sparkles className="h-5 w-5 text-emerald-700" />
+            </div>
             <div className="flex-1">
-              <p className="font-semibold text-emerald-900">You&apos;re working on this contract</p>
-              <p className="text-xs text-emerald-700 mt-0.5">Submit as many candidate locations as you can — every accepted location pays out ${Number(contract.partner_payout).toLocaleString()}. This contract stays open to other Placement Providers until every slot is filled.</p>
+              <p className="text-base font-semibold text-gray-900">Add locator capability to accept</p>
+              <p className="text-sm text-gray-600 mt-1">
+                You&apos;re browsing as {roleLabel}. Locators sell placements against contracts like this one
+                and earn ${Number(contract.partner_payout).toLocaleString()} per accepted location. Adding this
+                capability keeps your current {roleLabel} account intact — it just unlocks the sell side.
+              </p>
+              <ul className="text-xs text-gray-600 mt-3 space-y-1 list-disc list-inside">
+                <li>Set your territories + industries</li>
+                <li>Upload W-9 + government ID</li>
+                <li>Add payout details</li>
+                <li>Sign the Placement Provider Agreement</li>
+              </ul>
             </div>
           </div>
           <Link
-            href={`/placement/submissions/new?contract=${contract.id}`}
-            className="w-full inline-flex items-center justify-center gap-2 rounded-xl bg-green-primary hover:bg-green-hover px-6 py-3 text-sm font-semibold text-white cursor-pointer"
+            href="/placement/onboarding?add=1"
+            className="w-full inline-flex items-center justify-center gap-2 rounded-xl bg-emerald-600 hover:bg-emerald-700 px-6 py-3 text-sm font-semibold text-white cursor-pointer"
           >
-            <Package className="h-4 w-4" /> Submit a Location
+            Add Locator Capability <ArrowRight className="h-4 w-4" />
           </Link>
         </div>
       ) : (
-        <div className="space-y-3">
-          <button
-            onClick={acceptContract}
-            disabled={!eligibility.eligible || saving === "accept"}
-            className="w-full inline-flex items-center justify-center gap-2 rounded-xl bg-green-primary hover:bg-green-hover px-6 py-3 text-sm font-semibold text-white cursor-pointer disabled:opacity-50"
-          >
-            {saving === "accept" ? <Loader2 className="h-4 w-4 animate-spin" /> : <CheckCircle2 className="h-4 w-4" />}
-            Accept Contract at Tier {contract.tier} (${Number(contract.partner_payout).toLocaleString()}/location)
-          </button>
-        </div>
+        <>
+          {!eligibility.eligible && (
+            <div className="mb-4 rounded-xl border border-amber-200 bg-amber-50 p-4">
+              <p className="text-sm font-semibold text-amber-900 mb-2 flex items-center gap-2">
+                <AlertCircle className="h-4 w-4" /> Not currently eligible
+              </p>
+              <ul className="text-xs text-amber-800 space-y-1 list-disc list-inside">
+                {eligibility.reasons.map((r, i) => <li key={i}>{r}</li>)}
+              </ul>
+              {partner_onboarding_complete === false && (
+                <Link
+                  href="/placement/onboarding?add=1"
+                  className="mt-3 inline-flex items-center gap-1.5 rounded-lg bg-amber-600 hover:bg-amber-700 px-3 py-1.5 text-xs font-semibold text-white"
+                >
+                  Finish Locator Onboarding <ArrowRight className="h-3 w-3" />
+                </Link>
+              )}
+            </div>
+          )}
+
+          {accepted ? (
+            <div className="space-y-3">
+              <div className="rounded-2xl border border-emerald-200 bg-emerald-50 p-5 flex items-start gap-3">
+                <CheckCircle2 className="h-6 w-6 text-emerald-600 shrink-0 mt-0.5" />
+                <div className="flex-1">
+                  <p className="font-semibold text-emerald-900">You&apos;re working on this contract</p>
+                  <p className="text-xs text-emerald-700 mt-0.5">Submit as many candidate locations as you can — every accepted location pays out ${Number(contract.partner_payout).toLocaleString()}. This contract stays open to other Placement Providers until every slot is filled.</p>
+                </div>
+              </div>
+              <Link
+                href={`/placement/submissions/new?contract=${contract.id}`}
+                className="w-full inline-flex items-center justify-center gap-2 rounded-xl bg-green-primary hover:bg-green-hover px-6 py-3 text-sm font-semibold text-white cursor-pointer"
+              >
+                <Package className="h-4 w-4" /> Submit a Location
+              </Link>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              <button
+                onClick={acceptContract}
+                disabled={!eligibility.eligible || saving === "accept"}
+                className="w-full inline-flex items-center justify-center gap-2 rounded-xl bg-green-primary hover:bg-green-hover px-6 py-3 text-sm font-semibold text-white cursor-pointer disabled:opacity-50"
+              >
+                {saving === "accept" ? <Loader2 className="h-4 w-4 animate-spin" /> : <CheckCircle2 className="h-4 w-4" />}
+                Accept Contract at Tier {contract.tier} (${Number(contract.partner_payout).toLocaleString()}/location)
+              </button>
+            </div>
+          )}
+        </>
       )}
 
     </div>

--- a/src/app/placement/contracts/page.tsx
+++ b/src/app/placement/contracts/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { Loader2, MapPin, Package, Clock, ArrowRight, Filter } from "lucide-react";
+import { Loader2, MapPin, Package, Clock, ArrowRight, Filter, Sparkles } from "lucide-react";
 import { createBrowserClient } from "@/lib/supabase";
 
 interface Contract {
@@ -37,6 +37,8 @@ export default function PartnerContractsPage() {
   const [contracts, setContracts] = useState<Contract[]>([]);
   const [myContracts, setMyContracts] = useState<MyContract[]>([]);
   const [filter, setFilter] = useState<"all" | "tier1" | "tier2" | "tier3">("all");
+  const [isPartner, setIsPartner] = useState(true);
+  const [viewerRole, setViewerRole] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     if (!token) return;
@@ -45,8 +47,17 @@ export default function PartnerContractsPage() {
       fetch("/api/marketplace/contracts", { headers: { Authorization: `Bearer ${token}` } }),
       fetch("/api/marketplace/my-contracts", { headers: { Authorization: `Bearer ${token}` } }),
     ]);
-    if (availRes.ok) setContracts(await availRes.json());
+    if (availRes.ok) {
+      const body = await availRes.json();
+      setContracts(Array.isArray(body) ? body : body.contracts || []);
+      if (!Array.isArray(body)) {
+        setIsPartner(body.is_partner !== false);
+        setViewerRole(body.viewer_role || null);
+      }
+    }
+    // /my-contracts returns 403 for non-partners — treat that as "empty"
     if (mineRes.ok) setMyContracts(await mineRes.json());
+    else setMyContracts([]);
     setLoading(false);
   }, [token]);
 
@@ -73,6 +84,31 @@ export default function PartnerContractsPage() {
         <p className="text-sm text-gray-500 mt-1">Browse open contracts or track the ones you&apos;re working on.</p>
       </div>
 
+      {!isPartner && !loading && (
+        <div className="mb-4 rounded-2xl border border-emerald-200 bg-gradient-to-br from-emerald-50 to-white p-5">
+          <div className="flex items-start gap-3">
+            <div className="rounded-xl bg-emerald-100 p-2 shrink-0">
+              <Sparkles className="h-5 w-5 text-emerald-700" />
+            </div>
+            <div className="flex-1">
+              <p className="text-sm font-semibold text-gray-900">
+                Browsing as {viewerRole ? viewerRole.replace(/_/g, " ") : "guest"} — you can view all contracts.
+              </p>
+              <p className="text-xs text-gray-600 mt-1">
+                Add locator capability to your existing account so you can sell against these contracts too.
+                You&apos;ll keep your current {viewerRole ? viewerRole.replace(/_/g, " ") : "account"} access.
+              </p>
+              <Link
+                href="/placement/onboarding?add=1"
+                className="mt-3 inline-flex items-center gap-1.5 rounded-xl bg-emerald-600 hover:bg-emerald-700 px-4 py-2 text-xs font-semibold text-white cursor-pointer"
+              >
+                Add Locator Capability <ArrowRight className="h-3.5 w-3.5" />
+              </Link>
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Tabs */}
       <div className="mb-4 flex items-center gap-1 border-b border-gray-100">
         <button
@@ -81,12 +117,14 @@ export default function PartnerContractsPage() {
         >
           Available ({contracts.length})
         </button>
-        <button
-          onClick={() => setTab("mine")}
-          className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px cursor-pointer ${tab === "mine" ? "border-green-primary text-green-primary" : "border-transparent text-gray-500 hover:text-gray-700"}`}
-        >
-          My Active Contracts ({myContracts.length})
-        </button>
+        {isPartner && (
+          <button
+            onClick={() => setTab("mine")}
+            className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px cursor-pointer ${tab === "mine" ? "border-green-primary text-green-primary" : "border-transparent text-gray-500 hover:text-gray-700"}`}
+          >
+            My Active Contracts ({myContracts.length})
+          </button>
+        )}
       </div>
 
       {tab === "available" && (

--- a/src/app/placement/onboarding/page.tsx
+++ b/src/app/placement/onboarding/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import {
   Loader2, CheckCircle2, ArrowRight, ArrowLeft, Building2, MapPin, Briefcase,
-  FileText, User, AlertCircle, Upload,
+  FileText, User, AlertCircle, Upload, Sparkles,
 } from "lucide-react";
 import { createBrowserClient } from "@/lib/supabase";
 import { INDUSTRIES } from "../industries";
@@ -66,6 +66,10 @@ export default function MarketplaceOnboardingPage() {
   const [ppaAcknowledge, setPpaAcknowledge] = useState(false);
   const [ppaConsentEsign, setPpaConsentEsign] = useState(false);
 
+  // Dual-role banner — surfaced when the caller already has a non-PP primary
+  // role so they see "you'll keep your <role> access" before starting.
+  const [existingRole, setExistingRole] = useState<string | null>(null);
+
   // Load existing state
   const load = useCallback(async () => {
     setLoading(true);
@@ -83,6 +87,9 @@ export default function MarketplaceOnboardingPage() {
         return;
       }
       const data = await res.json();
+      if (data.profile?.role) {
+        setExistingRole(data.profile.role);
+      }
       if (data.partner) {
         setPartnerType(data.partner.partner_type === "company_owner" ? "company_owner" : "individual");
         setBusinessName(data.partner.business_name || "");
@@ -392,6 +399,25 @@ export default function MarketplaceOnboardingPage() {
           Set up your profile so we can match you with contracts in your territory.
         </p>
       </div>
+
+      {existingRole && existingRole !== "placement_partner" && (
+        <div className="mb-6 rounded-2xl border border-emerald-200 bg-gradient-to-br from-emerald-50 to-white p-4">
+          <div className="flex items-start gap-3">
+            <div className="rounded-xl bg-emerald-100 p-2 shrink-0">
+              <Sparkles className="h-4 w-4 text-emerald-700" />
+            </div>
+            <div className="flex-1">
+              <p className="text-sm font-semibold text-gray-900">
+                Adding locator capability to your {existingRole.replace(/_/g, " ")} account
+              </p>
+              <p className="text-xs text-gray-600 mt-0.5">
+                Your existing {existingRole.replace(/_/g, " ")} access stays exactly as it is. Completing
+                this onboarding just unlocks the ability to sell against placement contracts.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Step indicator */}
       <div className="mb-6 flex items-center gap-2">

--- a/src/lib/marketplaceAuth.ts
+++ b/src/lib/marketplaceAuth.ts
@@ -17,9 +17,16 @@ export interface PlacementPartnerUser {
 }
 
 /**
- * Validate the request is a Placement Partner (or team member).
- * Returns null if unauthorized. Fully self-contained — does not depend on
- * getSalesUser or any admin-side check.
+ * Validate the request can act as a Placement Partner. As of the dual-role
+ * work, a placement_partners row is the source of truth for "has locator
+ * capability" — operators, sales, requestors etc. can hold that row alongside
+ * their primary profile role without losing access to their real tools.
+ *
+ * Accepts:
+ *  - profile.role === 'placement_partner' — legacy PPs (may or may not have
+ *    a placement_partners row yet if they're mid-onboarding)
+ *  - profile.role === 'admin' — Vending Connector admin (QA / support flows)
+ *  - anyone with an active placement_partners row — dual-role users
  */
 export async function getPlacementPartner(req: NextRequest): Promise<PlacementPartnerUser | null> {
   const userId = await getUserIdFromRequest(req);
@@ -31,15 +38,6 @@ export async function getPlacementPartner(req: NextRequest): Promise<PlacementPa
     .eq("id", userId)
     .single();
   if (!profile) return null;
-
-  // Accept:
-  //  - placement_partner: normal PPs going through their own dashboard
-  //  - admin: so a Vending Connector admin can walk through the wizard
-  //    (for QA / debugging / supporting a partner over the phone) without
-  //    the "don't clobber elevated roles" guard in POST /partners blocking
-  //    them out of Step 2 onwards.
-  const allowed = profile.role === "placement_partner" || profile.role === "admin";
-  if (!allowed) return null;
 
   const { data: partner } = await supabaseAdmin
     .from("placement_partners")
@@ -53,6 +51,11 @@ export async function getPlacementPartner(req: NextRequest): Promise<PlacementPa
     .eq("profile_id", userId)
     .eq("active", true);
 
+  const hasPartnerRow = !!partner && partner.active !== false;
+  const hasTeamMembership = (memberships || []).length > 0;
+  const roleAllowed = profile.role === "placement_partner" || profile.role === "admin";
+  if (!hasPartnerRow && !hasTeamMembership && !roleAllowed) return null;
+
   return {
     id: userId,
     email: profile.email,
@@ -63,6 +66,53 @@ export async function getPlacementPartner(req: NextRequest): Promise<PlacementPa
     partner_type: partner?.partner_type || "individual",
     business_name: partner?.business_name || null,
     companies: (memberships || []).map((m) => ({ company_id: m.company_id, role: m.role as CompanyRole })),
+  };
+}
+
+export interface MarketplaceViewer {
+  id: string;
+  email: string;
+  full_name: string;
+  role: string | null;
+  is_partner: boolean;              // true if they have an active placement_partners row
+  partner_active: boolean;          // partner row exists and .active !== false
+  partner_onboarding_complete: boolean;
+}
+
+/**
+ * Lightweight viewer for the marketplace browse surfaces. Any authed user can
+ * be a viewer — an operator/sales/requestor who wants to browse open contracts
+ * before deciding to add locator capability, an existing PP, or an admin.
+ *
+ * Use this on GET /api/marketplace/contracts + detail. Mutations
+ * (accept, submit, tier-propose) must keep using getPlacementPartner.
+ */
+export async function getMarketplaceViewer(req: NextRequest): Promise<MarketplaceViewer | null> {
+  const userId = await getUserIdFromRequest(req);
+  if (!userId) return null;
+
+  const { data: profile } = await supabaseAdmin
+    .from("profiles")
+    .select("id, full_name, email, role")
+    .eq("id", userId)
+    .maybeSingle();
+  if (!profile) return null;
+
+  const { data: partner } = await supabaseAdmin
+    .from("placement_partners")
+    .select("active, onboarding_complete")
+    .eq("id", userId)
+    .maybeSingle();
+
+  const partner_active = !!partner && partner.active !== false;
+  return {
+    id: userId,
+    email: profile.email,
+    full_name: profile.full_name,
+    role: profile.role,
+    is_partner: partner_active,
+    partner_active,
+    partner_onboarding_complete: partner?.onboarding_complete === true,
   };
 }
 


### PR DESCRIPTION
Previously /placement/contracts was gated on profile.role === placement_partner, so an operator or requestor who wanted to browse open contracts couldn't. And if they tried to onboard as a Placement Provider, the POST /partners route silently overwrote their profile role, losing their operator/requestor access.

Change:

* getMarketplaceViewer — new lightweight helper for GET routes; any authed user can browse. is_partner flag surfaced in the response payload so the client renders the right CTA.

* /api/marketplace/contracts + [id] — swap to viewer. Non-partners still see identity-scrubbed rows via partner_visible_contracts. Non-partners get treated as bronze/nationwide so we don't leak tier-3 gold-window contracts.

* Contract detail — when viewer isn't a PP, hide Accept and render an "Add locator capability to your account" panel linking to onboarding. When they are a PP but not fully eligible, surface a "Finish Locator Onboarding" shortcut.

* Contracts index — non-partner banner up top; hide the "My Active Contracts" tab since it's empty for them.

* getPlacementPartner — widened to accept ANY authed user with an active placement_partners row OR active team membership. The row is now the source of truth for "has locator capability"; primary profile.role stays as-is (operator/requestor/etc).

* Stop role clobber — /api/marketplace/partners + /marketplace/team/invite no longer overwrite an existing profile.role. Only assign placement_partner when the account has no role at all.

* Onboarding banner — when the caller has an existing non-PP role, surface "Adding locator capability to your {role} account — your existing access stays exactly as it is."

No migration needed — placement_partners row existence is the disposition signal, and the row + team-member tables already exist. proxy.ts isolation block only fires on JWT metadata role === placement_partner, so dual-role operators (role stays 'operator') are never routed into the PP-only sandbox.