### PR TITLE
Locators can publish operator-rejected locations to the public market…

### DIFF
--- a/src/app/api/marketplace/submissions/[id]/publish/route.ts
+++ b/src/app/api/marketplace/submissions/[id]/publish/route.ts
@@ -1,0 +1,158 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getPlacementPartner, forbidden } from "@/lib/marketplaceAuth";
+import { sendLocationAgreementEmail } from "@/lib/locationAgreementEmail";
+
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "https://vendingconnector.com";
+const MIN_PRICE = 100;
+const MAX_PRICE = 10000;
+
+/**
+ * POST /api/marketplace/submissions/[id]/publish
+ *
+ * Publish a rejected placement submission to the public marketplace as a
+ * location listing. Salvages the PP's work when an operator declines a
+ * candidate location.
+ *
+ * GATES
+ *   - Caller must be a Placement Partner (getPlacementPartner).
+ *   - Caller must own the submission (partner_id === caller.id).
+ *   - Submission must have operator_status === 'rejected' — the whole point.
+ *   - Submission must not already have a public_listing_id (idempotent).
+ *
+ * PRIVACY (mirrors /api/sales/leads/[id]/publish)
+ *   - decision_maker_email/name are used ONLY to send the location-owner
+ *     verification email; they are NOT written to user_listings.contact_*.
+ *   - owner_name / owner_email ARE stored on the listing (verification link
+ *     uses them). Public GET on user_listings redacts them.
+ *   - Operator identity from the source contract is NEVER referenced —
+ *     nothing about the contract flows into the public listing. The listing
+ *     stands on its own.
+ *
+ * Body
+ *   description        — REQUIRED, min 40 chars
+ *   price              — REQUIRED, 100–10000
+ *   title              — optional, defaults to submission.business_name
+ *   entity_type, foot_traffic, square_footage, business_type — optional
+ */
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const user = await getPlacementPartner(req);
+  if (!user) return forbidden();
+  const { id } = await params;
+
+  const { data: submission } = await supabaseAdmin
+    .from("placement_submissions")
+    .select("id, partner_id, business_name, address, city, state, zip, industry, employees, decision_maker_name, decision_maker_email, operator_status, public_listing_id")
+    .eq("id", id)
+    .maybeSingle();
+  if (!submission) return NextResponse.json({ error: "Submission not found" }, { status: 404 });
+
+  if (submission.partner_id !== user.id) return forbidden();
+
+  if (submission.operator_status !== "rejected") {
+    return NextResponse.json(
+      { error: "Only submissions rejected by the operator can be published to the public marketplace." },
+      { status: 400 },
+    );
+  }
+
+  if (submission.public_listing_id) {
+    return NextResponse.json(
+      { error: "This submission is already listed publicly.", listing_id: submission.public_listing_id },
+      { status: 409 },
+    );
+  }
+
+  const body = await req.json().catch(() => ({}));
+  const description = typeof body.description === "string" ? body.description.trim() : "";
+  const priceRaw = Number(body.price);
+  const title = typeof body.title === "string" && body.title.trim()
+    ? body.title.trim()
+    : (submission.business_name || `Location in ${submission.state || "US"}`);
+
+  if (!description) return NextResponse.json({ error: "Description is required" }, { status: 400 });
+  if (description.length < 40) {
+    return NextResponse.json({ error: "Description must be at least 40 characters" }, { status: 400 });
+  }
+  if (!Number.isFinite(priceRaw) || priceRaw < MIN_PRICE || priceRaw > MAX_PRICE) {
+    return NextResponse.json(
+      { error: `Price must be between $${MIN_PRICE} and $${MAX_PRICE.toLocaleString()}` },
+      { status: 400 },
+    );
+  }
+  if (!submission.state) {
+    return NextResponse.json({ error: "Submission has no state on file; cannot publish." }, { status: 400 });
+  }
+  if (!submission.decision_maker_email || !submission.decision_maker_name) {
+    return NextResponse.json({
+      error: "Submission is missing the decision maker's name or email — those are required to send the owner verification link. Update the submission first.",
+    }, { status: 400 });
+  }
+
+  const { data: listing, error: listingErr } = await supabaseAdmin
+    .from("user_listings")
+    .insert({
+      seller_id: user.id,
+      source_submission_id: submission.id,
+      title,
+      description,
+      listing_type: "location",
+      price: priceRaw,
+      city: submission.city || null,
+      state: submission.state,
+      zip: submission.zip || null,
+      entity_type: body.entity_type || null,
+      foot_traffic: body.foot_traffic || null,
+      square_footage: body.square_footage || null,
+      business_type: body.business_type || submission.industry || null,
+      contact_name: null,
+      contact_phone: null,
+      contact_email: null,
+      owner_name: submission.decision_maker_name,
+      owner_email: submission.decision_maker_email.toLowerCase(),
+      status: "pending_verification",
+      is_public: false,
+    })
+    .select("*")
+    .single();
+  if (listingErr) return NextResponse.json({ error: listingErr.message }, { status: 500 });
+
+  try {
+    const { data: agreement } = await supabaseAdmin
+      .from("location_agreements")
+      .insert({
+        listing_id: listing.id,
+        business_name: title,
+        contact_name: submission.decision_maker_name,
+        email: submission.decision_maker_email.toLowerCase(),
+        address: [submission.city, submission.state, submission.zip].filter(Boolean).join(", ") || submission.address || null,
+      })
+      .select("token")
+      .single();
+
+    if (agreement) {
+      await sendLocationAgreementEmail({
+        to: submission.decision_maker_email.toLowerCase(),
+        recipientName: submission.decision_maker_name,
+        businessName: title,
+        agreementUrl: `${APP_URL}/location-agreement/${agreement.token}`,
+      });
+    }
+  } catch (emailErr) {
+    console.error("[submissions.publish] verification email failed:", emailErr);
+  }
+
+  await supabaseAdmin
+    .from("placement_submissions")
+    .update({ public_listing_id: listing.id })
+    .eq("id", submission.id);
+
+  await supabaseAdmin.from("placement_submission_activity").insert({
+    submission_id: submission.id,
+    actor_id: user.id,
+    activity_type: "published_to_marketplace",
+    description: `Published to public marketplace as ${title}`,
+  });
+
+  return NextResponse.json({ ok: true, listing_id: listing.id, status: listing.status });
+}

--- a/src/app/placement/submissions/[id]/page.tsx
+++ b/src/app/placement/submissions/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useCallback } from "react";
 import { useRouter, useParams } from "next/navigation";
 import Link from "next/link";
-import { Loader2, ArrowLeft, Upload, CheckCircle2, XCircle, Clock, AlertCircle, MapPin, User, Phone, Mail, Zap, Car, MessageSquare } from "lucide-react";
+import { Loader2, ArrowLeft, Upload, CheckCircle2, XCircle, Clock, AlertCircle, MapPin, User, Phone, Mail, Zap, Car, MessageSquare, Store, ExternalLink } from "lucide-react";
 import { createBrowserClient } from "@/lib/supabase";
 import RatingCard, { ExistingRating } from "@/app/components/RatingCard";
 
@@ -29,6 +29,8 @@ interface Submission {
   operator_status: string;
   operator_reviewed_at?: string | null;
   admin_review_note: string | null;
+  operator_review_note: string | null;
+  public_listing_id: string | null;
   created_at: string;
   placement_contracts: {
     title: string;
@@ -71,6 +73,15 @@ export default function SubmissionDetailPage() {
   const [rating, setRating] = useState<ExistingRating | null>(null);
   const [ratingSaving, setRatingSaving] = useState(false);
   const [ratingError, setRatingError] = useState<string | null>(null);
+
+  // Publish-to-marketplace panel (visible only when operator rejected)
+  const [publishOpen, setPublishOpen] = useState(false);
+  const [publishDescription, setPublishDescription] = useState("");
+  const [publishPrice, setPublishPrice] = useState<string>("");
+  const [publishTitle, setPublishTitle] = useState("");
+  const [publishSaving, setPublishSaving] = useState(false);
+  const [publishError, setPublishError] = useState<string | null>(null);
+  const [publishSuccess, setPublishSuccess] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     if (!token) return;
@@ -117,6 +128,40 @@ export default function SubmissionDetailPage() {
   }, [router, id]);
 
   useEffect(() => { load(); }, [load]);
+
+  async function publishToMarketplace() {
+    if (!submission) return;
+    setPublishError(null);
+    setPublishSuccess(null);
+    const price = Number(publishPrice);
+    if (!publishDescription.trim() || publishDescription.trim().length < 40) {
+      setPublishError("Description must be at least 40 characters.");
+      return;
+    }
+    if (!Number.isFinite(price) || price < 100 || price > 10000) {
+      setPublishError("Price must be between $100 and $10,000.");
+      return;
+    }
+    setPublishSaving(true);
+    const res = await fetch(`/api/marketplace/submissions/${id}/publish`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({
+        title: publishTitle.trim() || undefined,
+        description: publishDescription.trim(),
+        price,
+      }),
+    });
+    const body = await res.json().catch(() => ({}));
+    setPublishSaving(false);
+    if (!res.ok) {
+      setPublishError(body.error || "Failed to publish.");
+      return;
+    }
+    setPublishSuccess("Listed — verification email sent to the location owner.");
+    setPublishOpen(false);
+    await load();
+  }
 
   async function uploadPhoto(file: File) {
     setUploading(true);
@@ -177,6 +222,135 @@ export default function SubmissionDetailPage() {
             Rejected
           </p>
           <p className="text-sm text-red-800 whitespace-pre-wrap">{submission.admin_review_note}</p>
+        </div>
+      )}
+
+      {submission.operator_status === "rejected" && (
+        <div className="rounded-2xl border border-emerald-200 bg-gradient-to-br from-emerald-50 to-white p-5 mb-4">
+          {submission.public_listing_id ? (
+            <div className="flex items-start gap-3">
+              <div className="rounded-xl bg-emerald-100 p-2 shrink-0">
+                <Store className="h-5 w-5 text-emerald-700" />
+              </div>
+              <div className="flex-1">
+                <p className="text-sm font-semibold text-gray-900">
+                  Listed on the public marketplace
+                </p>
+                <p className="text-xs text-gray-600 mt-1">
+                  Operator declined this location, but it&apos;s now live for other buyers to discover.
+                  Waiting on the location owner to verify before it goes fully public.
+                </p>
+                <Link
+                  href={`/marketplace/${submission.public_listing_id}`}
+                  className="mt-2 inline-flex items-center gap-1.5 text-xs font-semibold text-emerald-700 hover:text-emerald-800"
+                >
+                  View listing <ExternalLink className="h-3 w-3" />
+                </Link>
+              </div>
+            </div>
+          ) : (
+            <div>
+              <div className="flex items-start gap-3">
+                <div className="rounded-xl bg-emerald-100 p-2 shrink-0">
+                  <Store className="h-5 w-5 text-emerald-700" />
+                </div>
+                <div className="flex-1">
+                  <p className="text-sm font-semibold text-gray-900">
+                    The operator declined — publish this location publicly
+                  </p>
+                  <p className="text-xs text-gray-600 mt-1">
+                    Don&apos;t let the work go to waste. List this location on the public marketplace
+                    so any buyer can pick it up. We&apos;ll send the decision maker a verification
+                    email; it goes fully public once they sign the acknowledgment.
+                  </p>
+                  {submission.operator_review_note && (
+                    <p className="text-xs text-gray-500 mt-2 italic">
+                      Operator note: {submission.operator_review_note}
+                    </p>
+                  )}
+                </div>
+              </div>
+              {!publishOpen ? (
+                <button
+                  onClick={() => {
+                    setPublishOpen(true);
+                    setPublishTitle(submission.business_name);
+                  }}
+                  className="mt-3 w-full inline-flex items-center justify-center gap-2 rounded-xl bg-emerald-600 hover:bg-emerald-700 px-4 py-2.5 text-sm font-semibold text-white cursor-pointer"
+                >
+                  Publish to Public Marketplace <Store className="h-4 w-4" />
+                </button>
+              ) : (
+                <div className="mt-4 space-y-3 border-t border-emerald-100 pt-4">
+                  <div>
+                    <label className="block text-xs font-medium text-gray-700 mb-1">
+                      Listing title
+                    </label>
+                    <input
+                      type="text"
+                      value={publishTitle}
+                      onChange={(e) => setPublishTitle(e.target.value)}
+                      placeholder={submission.business_name}
+                      className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs font-medium text-gray-700 mb-1">
+                      Description <span className="text-gray-400">(≥ 40 chars)</span>
+                    </label>
+                    <textarea
+                      value={publishDescription}
+                      onChange={(e) => setPublishDescription(e.target.value)}
+                      rows={4}
+                      placeholder="What makes this location a good vending placement? Foot traffic, industry, notable details…"
+                      className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs font-medium text-gray-700 mb-1">
+                      Asking price <span className="text-gray-400">($100 – $10,000)</span>
+                    </label>
+                    <input
+                      type="number"
+                      value={publishPrice}
+                      onChange={(e) => setPublishPrice(e.target.value)}
+                      min={100}
+                      max={10000}
+                      className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm"
+                    />
+                  </div>
+                  {publishError && (
+                    <div className="flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 p-2 text-xs text-red-700">
+                      <AlertCircle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+                      <span>{publishError}</span>
+                    </div>
+                  )}
+                  <div className="flex gap-2">
+                    <button
+                      onClick={publishToMarketplace}
+                      disabled={publishSaving}
+                      className="flex-1 inline-flex items-center justify-center gap-2 rounded-xl bg-emerald-600 hover:bg-emerald-700 px-4 py-2.5 text-sm font-semibold text-white cursor-pointer disabled:opacity-50"
+                    >
+                      {publishSaving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Store className="h-4 w-4" />}
+                      Publish Listing
+                    </button>
+                    <button
+                      onClick={() => { setPublishOpen(false); setPublishError(null); }}
+                      className="rounded-xl border border-gray-200 bg-white px-4 py-2.5 text-sm font-semibold text-gray-700 hover:bg-gray-50 cursor-pointer"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+          {publishSuccess && (
+            <div className="mt-3 flex items-start gap-2 rounded-lg border border-emerald-200 bg-white p-2 text-xs text-emerald-800">
+              <CheckCircle2 className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+              <span>{publishSuccess}</span>
+            </div>
+          )}
         </div>
       )}
 

--- a/supabase/migrations/116_submission_public_listing_links.sql
+++ b/supabase/migrations/116_submission_public_listing_links.sql
@@ -1,0 +1,27 @@
+-- Rejected placement submissions → public marketplace listings.
+--
+-- When an operator rejects a candidate location a PP submitted, the PP can
+-- salvage the work by publishing the location directly to the public
+-- marketplace as a user_listings row. We track both sides of the linkage so
+-- the submission surface can show "already published" without a duplicate,
+-- and admin can trace a listing back to the originating submission.
+--
+-- Reuses the location-owner verification flow the leads publish pipeline
+-- already set up: is_public stays false until the decision maker clicks the
+-- verification link.
+
+ALTER TABLE user_listings
+  ADD COLUMN IF NOT EXISTS source_submission_id uuid
+    REFERENCES placement_submissions(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_user_listings_source_submission
+  ON user_listings(source_submission_id)
+  WHERE source_submission_id IS NOT NULL;
+
+ALTER TABLE placement_submissions
+  ADD COLUMN IF NOT EXISTS public_listing_id uuid
+    REFERENCES user_listings(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_placement_submissions_public_listing
+  ON placement_submissions(public_listing_id)
+  WHERE public_listing_id IS NOT NULL;


### PR DESCRIPTION
…place

When an operator declines a candidate location a PP submitted, the PP's work goes to waste. Now they can salvage it by publishing the same location directly to /marketplace as a user_listings row so any buyer can pick it up.

* Migration 116 — user_listings.source_submission_id + reverse placement_submissions.public_listing_id, both nullable + indexed.

* POST /api/marketplace/submissions/[id]/publish — PP-only. Gates: caller owns the submission, operator_status === 'rejected', not already published. Inserts user_listings (is_public=false, status= pending_verification), fires the location-owner verification email to decision_maker_email, stamps the reverse link, records activity.

* Privacy mirrors the leads publish path: contact_* stays null so nothing private hits the wire; owner_name/owner_email are stored for the verification email and redacted by the public GET.

* Submission detail page — on operator-rejected rows, render either a "Publish to Public Marketplace" panel (title + description + price) or an "Already listed publicly" link with a jump to the marketplace listing.