### PR TITLE
Coffee Supply Agreement — real virtual sign flow + admin CC on orders

### DIFF
--- a/src/app/admin/coffee/agreements/page.tsx
+++ b/src/app/admin/coffee/agreements/page.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Loader2, FileSignature, ArrowLeft, Filter, CheckCircle2, AlertCircle, XCircle, Undo2, Coffee } from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
+
+interface CoffeeMetadata {
+  customer_name?: string;
+  customer_address?: string;
+  num_machines?: number;
+  authorized_representative_name?: string;
+  authorized_representative_title?: string;
+}
+
+interface AgreementRow {
+  id: string;
+  user_id: string;
+  status: string;
+  agreement_version: number;
+  provider_signed_at: string | null;
+  provider_typed_name: string | null;
+  provider_email_snapshot: string | null;
+  countersigned_at: string | null;
+  countersigner_name_snapshot: string | null;
+  decline_reason: string | null;
+  correction_request_reason: string | null;
+  admin_override_reason: string | null;
+  metadata: CoffeeMetadata | null;
+  created_at: string;
+  user: { id: string; full_name: string | null; email: string | null } | null;
+  template: { id: string; version: number; title: string; effective_date: string } | null;
+}
+
+const FILTERS = [
+  { key: "provider_signed_pending_company_countersign", label: "Pending countersign" },
+  { key: "fully_executed", label: "Fully executed" },
+  { key: "correction_requested", label: "Correction requested" },
+  { key: "declined", label: "Declined" },
+  { key: "legacy_approved", label: "Legacy (unsigned)" },
+  { key: "any", label: "All" },
+];
+
+const STATUS_STYLES: Record<string, string> = {
+  provider_signed_pending_company_countersign: "bg-amber-50 text-amber-700 border-amber-100",
+  fully_executed: "bg-emerald-50 text-emerald-700 border-emerald-100",
+  correction_requested: "bg-orange-50 text-orange-700 border-orange-100",
+  declined: "bg-red-50 text-red-700 border-red-100",
+  legacy_approved: "bg-blue-50 text-blue-700 border-blue-100",
+  not_started: "bg-gray-100 text-gray-500 border-gray-200",
+};
+
+export default function AdminCoffeeAgreementsPage() {
+  const router = useRouter();
+  const [token, setToken] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [rows, setRows] = useState<AgreementRow[]>([]);
+  const [statusFilter, setStatusFilter] = useState("provider_signed_pending_company_countersign");
+  const [saving, setSaving] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!token) return;
+    setLoading(true);
+    const params = new URLSearchParams({ type: "coffee_supply" });
+    if (statusFilter !== "any") params.set("status", statusFilter);
+    const res = await fetch(`/api/admin/marketplace/agreements?${params}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.ok) setRows(await res.json());
+    setLoading(false);
+  }, [token, statusFilter]);
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!session?.access_token) { router.push("/login?redirect=/admin/coffee/agreements"); return; }
+      setToken(session.access_token);
+    });
+  }, [router]);
+
+  useEffect(() => { load(); }, [load]);
+
+  async function countersign(row: AgreementRow) {
+    if (!confirm(`Countersign the Coffee Supply Agreement for ${row.metadata?.customer_name || row.user?.email}?`)) return;
+    setSaving(`countersign-${row.id}`);
+    setError(null); setMessage(null);
+    const res = await fetch(`/api/admin/marketplace/agreements/${row.id}/countersign`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) setError(body.error || "Countersign failed");
+    else setMessage("Agreement fully executed. Operator notified.");
+    await load();
+    setSaving(null);
+  }
+
+  async function declineOrCorrect(row: AgreementRow, action: "decline" | "request_correction") {
+    const label = action === "decline" ? "decline" : "request correction";
+    const reason = prompt(`Reason to ${label}?`, "");
+    if (!reason) return;
+    setSaving(`${action}-${row.id}`);
+    setError(null); setMessage(null);
+    const res = await fetch(`/api/admin/marketplace/agreements/${row.id}/decline`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ action, reason }),
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) setError(body.error || `Failed to ${label}`);
+    else setMessage(action === "decline" ? "Agreement declined" : "Correction requested");
+    await load();
+    setSaving(null);
+  }
+
+  return (
+    <div className="p-6 max-w-6xl mx-auto">
+      <Link href="/admin" className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-green-primary mb-4">
+        <ArrowLeft className="h-4 w-4" /> Admin
+      </Link>
+
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
+          <Coffee className="h-6 w-6 text-emerald-600" /> Coffee Supply Agreements
+        </h1>
+        <p className="text-sm text-gray-500 mt-1">
+          Countersign Equipment Loan &amp; Beverage Supply Agreements signed by operators.
+          Executed copies land in the private user-agreements bucket and are emailed to the operator.
+        </p>
+      </div>
+
+      {message && <div className="mb-4 flex items-start gap-2 rounded-xl border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-700"><CheckCircle2 className="h-4 w-4 mt-0.5" />{message}</div>}
+      {error && <div className="mb-4 flex items-start gap-2 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700"><AlertCircle className="h-4 w-4 mt-0.5" />{error}</div>}
+
+      <div className="mb-4 flex items-center gap-2 flex-wrap">
+        <Filter className="h-4 w-4 text-gray-400" />
+        {FILTERS.map((f) => (
+          <button
+            key={f.key}
+            onClick={() => setStatusFilter(f.key)}
+            className={`rounded-lg px-3 py-1.5 text-xs font-medium cursor-pointer ${statusFilter === f.key ? "bg-emerald-100 text-emerald-700" : "bg-gray-100 text-gray-500 hover:bg-gray-200"}`}
+          >
+            {f.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="rounded-2xl border border-gray-100 bg-white p-5">
+        {loading ? (
+          <div className="flex justify-center py-8"><Loader2 className="h-5 w-5 animate-spin text-emerald-600" /></div>
+        ) : rows.length === 0 ? (
+          <p className="text-sm text-gray-500 text-center py-8">No agreements match the current filter.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-xs text-gray-500 border-b border-gray-100">
+                  <th className="text-left py-2 px-2 font-medium">Customer</th>
+                  <th className="text-left py-2 px-2 font-medium">Machines</th>
+                  <th className="text-left py-2 px-2 font-medium">Status</th>
+                  <th className="text-left py-2 px-2 font-medium">Signed</th>
+                  <th className="text-left py-2 px-2 font-medium">Countersigned</th>
+                  <th className="text-right py-2 px-2 font-medium">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((r) => {
+                  const stStyle = STATUS_STYLES[r.status] || "bg-gray-100 text-gray-500 border-gray-200";
+                  const meta = r.metadata || {};
+                  return (
+                    <tr key={r.id} className="border-b border-gray-50 last:border-b-0 align-top">
+                      <td className="py-2 px-2 text-xs">
+                        <p className="font-medium text-gray-900">{meta.customer_name || r.user?.full_name || r.user?.email || r.user_id.slice(0, 8)}</p>
+                        {meta.customer_address && <p className="text-gray-400">{meta.customer_address}</p>}
+                        {meta.authorized_representative_name && (
+                          <p className="text-gray-400 mt-0.5">
+                            Rep: {meta.authorized_representative_name}{meta.authorized_representative_title ? `, ${meta.authorized_representative_title}` : ""}
+                          </p>
+                        )}
+                        <p className="text-gray-400 mt-0.5">{r.user?.email}</p>
+                      </td>
+                      <td className="py-2 px-2 text-xs">{meta.num_machines ?? "—"}</td>
+                      <td className="py-2 px-2">
+                        <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-medium ${stStyle}`}>
+                          {r.status.replace(/_/g, " ")}
+                        </span>
+                        {r.decline_reason && <p className="text-[10px] text-red-500 mt-0.5 italic">{r.decline_reason}</p>}
+                        {r.correction_request_reason && <p className="text-[10px] text-orange-600 mt-0.5 italic">{r.correction_request_reason}</p>}
+                      </td>
+                      <td className="py-2 px-2 text-xs text-gray-500">
+                        {r.provider_signed_at ? (
+                          <>
+                            <p>{new Date(r.provider_signed_at).toLocaleDateString()}</p>
+                            {r.provider_typed_name && <p className="text-gray-400">{r.provider_typed_name}</p>}
+                          </>
+                        ) : "—"}
+                      </td>
+                      <td className="py-2 px-2 text-xs text-gray-500">
+                        {r.countersigned_at ? (
+                          <>
+                            <p>{new Date(r.countersigned_at).toLocaleDateString()}</p>
+                            {r.countersigner_name_snapshot && <p className="text-gray-400">{r.countersigner_name_snapshot}</p>}
+                          </>
+                        ) : "—"}
+                      </td>
+                      <td className="py-2 px-2 text-right whitespace-nowrap">
+                        {r.status === "provider_signed_pending_company_countersign" && (
+                          <div className="inline-flex gap-1">
+                            <button
+                              onClick={() => countersign(r)}
+                              disabled={saving === `countersign-${r.id}`}
+                              className="inline-flex items-center gap-1 rounded-md bg-emerald-600 hover:bg-emerald-700 px-2 py-0.5 text-[11px] font-semibold text-white cursor-pointer disabled:opacity-50"
+                            >
+                              {saving === `countersign-${r.id}` ? <Loader2 className="h-3 w-3 animate-spin" /> : <FileSignature className="h-3 w-3" />} Countersign
+                            </button>
+                            <button
+                              onClick={() => declineOrCorrect(r, "request_correction")}
+                              disabled={saving === `request_correction-${r.id}`}
+                              className="inline-flex items-center gap-1 rounded-md border border-orange-200 hover:bg-orange-50 px-2 py-0.5 text-[11px] font-medium text-orange-700 cursor-pointer disabled:opacity-50"
+                            >
+                              <Undo2 className="h-3 w-3" /> Correct
+                            </button>
+                            <button
+                              onClick={() => declineOrCorrect(r, "decline")}
+                              disabled={saving === `decline-${r.id}`}
+                              className="inline-flex items-center gap-1 rounded-md border border-red-200 hover:bg-red-50 px-2 py-0.5 text-[11px] font-medium text-red-700 cursor-pointer disabled:opacity-50"
+                            >
+                              <XCircle className="h-3 w-3" /> Decline
+                            </button>
+                          </div>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/admin/marketplace/agreements/[id]/countersign/route.ts
+++ b/src/app/api/admin/marketplace/agreements/[id]/countersign/route.ts
@@ -32,15 +32,17 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
       adminEmailSnapshot: admin.email || "",
     });
 
-    // Render + persist the executed document.
-    const template = await getActiveTemplate("placement_provider");
+    // Render + persist the executed document. Uses the agreement's own type
+    // (placement_provider, coffee_supply, …) so the countersign flow works
+    // for every template kind.
+    const template = await getActiveTemplate(updated.agreement_type);
     if (template) {
       const html = renderExecutedHtml({ template, agreement: updated });
       await persistExecutedDocument(updated, html);
 
       // Email the provider a copy.
       try {
-        const providerAgreement = await getUserAgreement(updated.user_id, "placement_provider");
+        const providerAgreement = await getUserAgreement(updated.user_id, updated.agreement_type);
         const recipient = providerAgreement?.provider_email_snapshot;
         if (recipient) {
           const resend = new Resend(process.env.RESEND_API_KEY);
@@ -48,12 +50,12 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
           await resend.emails.send({
             from,
             to: recipient,
-            subject: `Placement Provider Agreement — fully executed`,
-            html: `<p>Your Placement Provider Agreement has been fully executed by Vending Connector. A copy is attached below.</p>${html}`,
+            subject: `${template.title} — fully executed`,
+            html: `<p>Your ${template.title} has been fully executed by Vending Connector. A copy is attached below.</p>${html}`,
           });
         }
       } catch (e) {
-        console.error("[ppa.countersign] provider email failed:", e);
+        console.error("[agreement.countersign] provider email failed:", e);
       }
     }
 

--- a/src/app/api/coffee/agreement/route.ts
+++ b/src/app/api/coffee/agreement/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getUserIdFromRequest } from "@/lib/apiAuth";
+import { getActiveTemplate, getOrStartAgreement } from "@/lib/placementAgreements";
+
+/**
+ * GET /api/coffee/agreement
+ *
+ * Returns the currently-active coffee supply agreement template + the
+ * calling operator's user_agreements row (creating a not_started row on
+ * first hit). Also returns lightweight profile fields (business name,
+ * shipping address) so the sign page can prefill the customer-name /
+ * address blocks from the coffee application data the operator already
+ * gave us.
+ */
+export async function GET(req: NextRequest) {
+  const userId = await getUserIdFromRequest(req);
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const template = await getActiveTemplate("coffee_supply");
+  if (!template) {
+    return NextResponse.json(
+      { error: "No active Equipment Loan & Beverage Supply Agreement template" },
+      { status: 500 },
+    );
+  }
+
+  const start = await getOrStartAgreement(userId, "coffee_supply");
+  if (!start) {
+    return NextResponse.json({ error: "Could not initialize agreement" }, { status: 500 });
+  }
+
+  // Prefill hints — read from the most recent coffee_applications row
+  // (that's where the business name + shipping address were captured) and
+  // fall back to the profile.
+  const { data: profile } = await supabaseAdmin
+    .from("profiles")
+    .select("id, full_name, email")
+    .eq("id", userId)
+    .maybeSingle();
+
+  const { data: application } = await supabaseAdmin
+    .from("coffee_applications")
+    .select("business_name, contact_name, shipping_address, shipping_city, shipping_state, shipping_zip")
+    .eq("operator_id", userId)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  return NextResponse.json({
+    template: start.template,
+    agreement: start.agreement,
+    prefill: {
+      full_name: profile?.full_name || "",
+      email: profile?.email || "",
+      business_name: application?.business_name || "",
+      contact_name: application?.contact_name || profile?.full_name || "",
+      customer_address: [
+        application?.shipping_address,
+        application?.shipping_city,
+        application?.shipping_state,
+        application?.shipping_zip,
+      ].filter(Boolean).join(", "),
+    },
+  });
+}

--- a/src/app/api/coffee/agreement/sign/route.ts
+++ b/src/app/api/coffee/agreement/sign/route.ts
@@ -1,0 +1,134 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Resend } from "resend";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getUserIdFromRequest } from "@/lib/apiAuth";
+import { signAsProvider, getOrStartAgreement } from "@/lib/placementAgreements";
+
+/**
+ * POST /api/coffee/agreement/sign
+ *
+ * Body: {
+ *   typed_name,                       // required — legal name
+ *   consent_esign,                    // required true
+ *   customer_name,                    // legal name / business
+ *   customer_address,                 // full address
+ *   num_machines,                     // integer >= 1
+ *   authorized_representative_name,   // signer's printed name
+ *   authorized_representative_title,  // signer's title
+ *   ack_exclusive_supply,             // required true
+ *   ack_minimum_purchase,             // required true
+ *   ack_installation_maintenance      // required true
+ * }
+ *
+ * Coffee-specific fields land on user_agreements.metadata so we can render
+ * them into the executed HTML doc at countersign time and audit exactly
+ * what the customer agreed to.
+ */
+export async function POST(req: NextRequest) {
+  const userId = await getUserIdFromRequest(req);
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { data: profile } = await supabaseAdmin
+    .from("profiles")
+    .select("id, full_name, email")
+    .eq("id", userId)
+    .maybeSingle();
+  if (!profile) return NextResponse.json({ error: "Profile not found" }, { status: 404 });
+
+  const body = await req.json().catch(() => ({}));
+
+  const typedName = String(body.typed_name || "").trim();
+  const consentEsign = !!body.consent_esign;
+  const customerName = String(body.customer_name || "").trim();
+  const customerAddress = String(body.customer_address || "").trim();
+  const numMachinesRaw = Number(body.num_machines);
+  const authRepName = String(body.authorized_representative_name || "").trim();
+  const authRepTitle = String(body.authorized_representative_title || "").trim();
+  const ackSupply = !!body.ack_exclusive_supply;
+  const ackMin = !!body.ack_minimum_purchase;
+  const ackInstall = !!body.ack_installation_maintenance;
+
+  if (!typedName) return NextResponse.json({ error: "Typed legal name is required" }, { status: 400 });
+  if (!consentEsign) return NextResponse.json({ error: "You must consent to conduct business electronically" }, { status: 400 });
+  if (!customerName) return NextResponse.json({ error: "Customer name is required" }, { status: 400 });
+  if (!customerAddress) return NextResponse.json({ error: "Customer address is required" }, { status: 400 });
+  if (!Number.isFinite(numMachinesRaw) || numMachinesRaw < 1) {
+    return NextResponse.json({ error: "Number of machines must be at least 1" }, { status: 400 });
+  }
+  if (!authRepName) return NextResponse.json({ error: "Authorized representative name is required" }, { status: 400 });
+  if (!authRepTitle) return NextResponse.json({ error: "Authorized representative title is required" }, { status: 400 });
+  if (!ackSupply || !ackMin || !ackInstall) {
+    return NextResponse.json({ error: "You must acknowledge all three requirements" }, { status: 400 });
+  }
+
+  const start = await getOrStartAgreement(userId, "coffee_supply");
+  if (!start) {
+    return NextResponse.json({ error: "No active coffee supply agreement template" }, { status: 500 });
+  }
+
+  const ip = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || null;
+  const ua = req.headers.get("user-agent") || null;
+
+  const numMachines = Math.floor(numMachinesRaw);
+  const coffeeMetadata = {
+    customer_name: customerName,
+    customer_address: customerAddress,
+    num_machines: numMachines,
+    authorized_representative_name: authRepName,
+    authorized_representative_title: authRepTitle,
+    ack_exclusive_supply: true,
+    ack_minimum_purchase: true,
+    ack_installation_maintenance: true,
+  };
+
+  // Merge coffee-specific data onto metadata BEFORE flipping the signature
+  // status. Sign-as-provider then locks the row into pending-countersign.
+  await supabaseAdmin
+    .from("user_agreements")
+    .update({ metadata: coffeeMetadata })
+    .eq("id", start.agreement.id);
+
+  try {
+    const updated = await signAsProvider({
+      agreementId: start.agreement.id,
+      actingUserId: userId,
+      typedName,
+      consentEsign,
+      emailSnapshot: profile.email,
+      ipAddress: ip,
+      userAgent: ua,
+    });
+
+    // Notify admin so they know to countersign.
+    try {
+      const resend = new Resend(process.env.RESEND_API_KEY);
+      const adminInbox = process.env.COFFEE_ADMIN_EMAIL || "james@apexaivending.com";
+      const from = process.env.FROM_EMAIL || "receipts@bytebitevending.com";
+      await resend.emails.send({
+        from,
+        to: adminInbox,
+        subject: `Coffee Supply Agreement signed by ${customerName} — countersign needed`,
+        html: `
+          <p>${escapeHtml(profile.full_name || profile.email)} signed the Equipment Loan &amp; Beverage Supply Agreement.</p>
+          <p><strong>Customer:</strong> ${escapeHtml(customerName)}</p>
+          <p><strong>Address:</strong> ${escapeHtml(customerAddress)}</p>
+          <p><strong>Number of machines:</strong> ${numMachines}</p>
+          <p><strong>Authorized rep:</strong> ${escapeHtml(authRepName)} (${escapeHtml(authRepTitle)})</p>
+          <p><strong>Signed at:</strong> ${escapeHtml(updated.provider_signed_at || "")}</p>
+          <p><strong>Typed name:</strong> ${escapeHtml(typedName)}</p>
+          <p><a href="${process.env.NEXT_PUBLIC_APP_URL || "https://vendingconnector.com"}/admin/coffee/agreements">Open the coffee agreements queue →</a></p>
+        `,
+      });
+    } catch (e) {
+      console.error("[coffee.agreement.sign] admin notification failed:", e);
+    }
+
+    return NextResponse.json({ ok: true, agreement: updated });
+  } catch (e) {
+    return NextResponse.json({ error: e instanceof Error ? e.message : "Sign failed" }, { status: 400 });
+  }
+}
+
+function escapeHtml(s: string): string {
+  return String(s).replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c] as string));
+}

--- a/src/app/api/coffee/checkout/route.ts
+++ b/src/app/api/coffee/checkout/route.ts
@@ -5,6 +5,7 @@ import { getCoffeeUser, forbiddenResponse } from "@/lib/coffeeAuth";
 import { isQuickBooks } from "@/lib/paymentProvider";
 import { createInvoice, sendInvoiceEmail, getInvoice } from "@/lib/quickbooks";
 import { sendCoffeeOrderNotification, sendCoffeeOrderConfirmation } from "@/lib/coffeeEmail";
+import { requireExecutedCoffeeSupplyAgreement } from "@/lib/placementAgreements";
 
 export async function POST(req: NextRequest) {
   try {
@@ -14,6 +15,17 @@ export async function POST(req: NextRequest) {
     }
     if (!user.coffee_access_enabled) {
       return forbiddenResponse();
+    }
+
+    // Real Equipment Loan & Beverage Supply Agreement gate — must be fully
+    // executed (or grandfathered legacy_approved) before any order can be
+    // placed. Returns a clear "sign here" message when it isn't.
+    const agreementBlock = await requireExecutedCoffeeSupplyAgreement(user.id);
+    if (agreementBlock) {
+      return NextResponse.json(
+        { error: agreementBlock, sign_url: "/coffee/agreement" },
+        { status: 403 },
+      );
     }
 
     const body = await req.json();

--- a/src/app/coffee/agreement/page.tsx
+++ b/src/app/coffee/agreement/page.tsx
@@ -1,0 +1,329 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { Loader2, ArrowLeft, CheckCircle2, AlertCircle, Coffee, ShieldCheck } from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
+
+interface Template {
+  id: string;
+  version: number;
+  title: string;
+  effective_date: string;
+  content_html: string;
+}
+
+interface Agreement {
+  id: string;
+  status: string;
+  provider_signed_at: string | null;
+  provider_typed_name: string | null;
+  countersigned_at: string | null;
+  countersigner_name_snapshot: string | null;
+  metadata: Record<string, unknown> | null;
+}
+
+interface Prefill {
+  full_name: string;
+  email: string;
+  business_name: string;
+  contact_name: string;
+  customer_address: string;
+}
+
+export default function CoffeeAgreementPage() {
+  const router = useRouter();
+  const [token, setToken] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [template, setTemplate] = useState<Template | null>(null);
+  const [agreement, setAgreement] = useState<Agreement | null>(null);
+
+  // Form
+  const [customerName, setCustomerName] = useState("");
+  const [customerAddress, setCustomerAddress] = useState("");
+  const [numMachines, setNumMachines] = useState<string>("1");
+  const [authRepName, setAuthRepName] = useState("");
+  const [authRepTitle, setAuthRepTitle] = useState("");
+  const [ackSupply, setAckSupply] = useState(false);
+  const [ackMin, setAckMin] = useState(false);
+  const [ackInstall, setAckInstall] = useState(false);
+  const [typedName, setTypedName] = useState("");
+  const [consent, setConsent] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const supabase = createBrowserClient();
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session?.access_token) { router.push("/login?redirect=/coffee/agreement"); return; }
+      setToken(session.access_token);
+      const res = await fetch("/api/coffee/agreement", {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      });
+      if (!res.ok) {
+        setError((await res.json().catch(() => ({}))).error || "Failed to load agreement");
+        return;
+      }
+      const data = await res.json();
+      setTemplate(data.template);
+      setAgreement(data.agreement);
+      const prefill: Prefill = data.prefill || {};
+      const meta = (data.agreement?.metadata || {}) as Record<string, unknown>;
+      setCustomerName(String(meta.customer_name || prefill.business_name || ""));
+      setCustomerAddress(String(meta.customer_address || prefill.customer_address || ""));
+      setNumMachines(String(meta.num_machines || 1));
+      setAuthRepName(String(meta.authorized_representative_name || prefill.contact_name || prefill.full_name || ""));
+      setAuthRepTitle(String(meta.authorized_representative_title || ""));
+    } finally {
+      setLoading(false);
+    }
+  }, [router]);
+
+  useEffect(() => { load(); }, [load]);
+
+  async function submitSign() {
+    setError(null);
+    if (!ackSupply || !ackMin || !ackInstall) {
+      setError("You must acknowledge all three requirements.");
+      return;
+    }
+    if (!typedName.trim()) { setError("Type your full legal name."); return; }
+    if (!consent) { setError("You must consent to conducting business electronically."); return; }
+    setSaving(true);
+    const res = await fetch("/api/coffee/agreement/sign", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({
+        typed_name: typedName.trim(),
+        consent_esign: true,
+        customer_name: customerName.trim(),
+        customer_address: customerAddress.trim(),
+        num_machines: Number(numMachines) || 1,
+        authorized_representative_name: authRepName.trim(),
+        authorized_representative_title: authRepTitle.trim(),
+        ack_exclusive_supply: ackSupply,
+        ack_minimum_purchase: ackMin,
+        ack_installation_maintenance: ackInstall,
+      }),
+    });
+    setSaving(false);
+    if (!res.ok) {
+      setError((await res.json().catch(() => ({}))).error || "Failed to sign");
+      return;
+    }
+    await load();
+  }
+
+  if (loading) {
+    return <div className="min-h-[60vh] flex items-center justify-center"><Loader2 className="h-6 w-6 animate-spin text-green-primary" /></div>;
+  }
+
+  const status = agreement?.status;
+  const alreadyExecuted = status === "fully_executed" || status === "legacy_approved";
+  const pendingCountersign = status === "provider_signed_pending_company_countersign";
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
+      <Link href="/coffee" className="flex items-center gap-1.5 text-sm text-gray-500 hover:text-green-primary mb-4">
+        <ArrowLeft className="h-4 w-4" /> Back to Coffee Shop
+      </Link>
+
+      <div className="flex items-center gap-3 mb-6">
+        <div className="rounded-xl bg-emerald-100 p-2">
+          <Coffee className="h-5 w-5 text-emerald-700" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">{template?.title || "Coffee Supply Agreement"}</h1>
+          <p className="text-sm text-gray-500">Version {template?.version} · Effective {template?.effective_date}</p>
+        </div>
+      </div>
+
+      {status === "legacy_approved" && (
+        <div className="mb-4 rounded-2xl border border-blue-200 bg-blue-50 p-4">
+          <p className="text-sm font-semibold text-blue-900 mb-1 flex items-center gap-2">
+            <ShieldCheck className="h-4 w-4" /> Grandfathered
+          </p>
+          <p className="text-sm text-blue-800">
+            You&apos;re able to order today under the old application-form acknowledgment.
+            Please sign the current version below at your convenience so we have a full
+            signed record on file.
+          </p>
+        </div>
+      )}
+
+      {alreadyExecuted && status === "fully_executed" && (
+        <div className="mb-4 rounded-2xl border border-emerald-200 bg-emerald-50 p-4">
+          <p className="text-sm font-semibold text-emerald-900 mb-1 flex items-center gap-2">
+            <CheckCircle2 className="h-4 w-4" /> Fully executed
+          </p>
+          <p className="text-sm text-emerald-800">
+            Signed by you and countersigned by Apex AI Vending. You&apos;re good to order.
+          </p>
+        </div>
+      )}
+
+      {pendingCountersign && (
+        <div className="mb-4 rounded-2xl border border-amber-200 bg-amber-50 p-4">
+          <p className="text-sm font-semibold text-amber-900 mb-1 flex items-center gap-2">
+            <AlertCircle className="h-4 w-4" /> Awaiting countersignature
+          </p>
+          <p className="text-sm text-amber-800">
+            You signed on {agreement?.provider_signed_at ? new Date(agreement.provider_signed_at).toLocaleString() : "recently"}.
+            Apex AI Vending will countersign shortly — you&apos;ll be able to place orders once that clears.
+          </p>
+        </div>
+      )}
+
+      {/* Agreement content */}
+      <div className="rounded-2xl border border-gray-200 bg-white p-6 mb-6 max-h-[500px] overflow-y-auto">
+        <div className="prose prose-sm max-w-none" dangerouslySetInnerHTML={{ __html: template?.content_html || "" }} />
+      </div>
+
+      {/* Sign form — hidden if already executed */}
+      {!alreadyExecuted && (
+        <div className="rounded-2xl border border-gray-200 bg-white p-6 space-y-4">
+          <h2 className="text-lg font-semibold text-gray-900">Signature block</h2>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div>
+              <label className="block text-xs font-medium text-gray-700 mb-1">Customer name (business)</label>
+              <input
+                type="text"
+                value={customerName}
+                onChange={(e) => setCustomerName(e.target.value)}
+                disabled={pendingCountersign}
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-gray-700 mb-1">Number of machines</label>
+              <input
+                type="number"
+                min={1}
+                value={numMachines}
+                onChange={(e) => setNumMachines(e.target.value)}
+                disabled={pendingCountersign}
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-gray-700 mb-1">Customer address</label>
+            <input
+              type="text"
+              value={customerAddress}
+              onChange={(e) => setCustomerAddress(e.target.value)}
+              placeholder="Street, City, State ZIP"
+              disabled={pendingCountersign}
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+            />
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div>
+              <label className="block text-xs font-medium text-gray-700 mb-1">Authorized representative</label>
+              <input
+                type="text"
+                value={authRepName}
+                onChange={(e) => setAuthRepName(e.target.value)}
+                disabled={pendingCountersign}
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-gray-700 mb-1">Title</label>
+              <input
+                type="text"
+                value={authRepTitle}
+                onChange={(e) => setAuthRepTitle(e.target.value)}
+                placeholder="Owner, Director, Manager…"
+                disabled={pendingCountersign}
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2 border-t border-gray-100 pt-4">
+            <p className="text-xs font-semibold text-gray-700 uppercase tracking-wide">Acknowledgments</p>
+            <label className="flex items-start gap-2 text-sm text-gray-700">
+              <input
+                type="checkbox"
+                checked={ackSupply}
+                onChange={(e) => setAckSupply(e.target.checked)}
+                disabled={pendingCountersign}
+                className="mt-0.5"
+              />
+              <span>I agree to the <strong>exclusive supply requirement</strong> — beverage products for the Equipment come from Apex AI Vending only.</span>
+            </label>
+            <label className="flex items-start gap-2 text-sm text-gray-700">
+              <input
+                type="checkbox"
+                checked={ackMin}
+                onChange={(e) => setAckMin(e.target.checked)}
+                disabled={pendingCountersign}
+                className="mt-0.5"
+              />
+              <span>I acknowledge the <strong>minimum purchase requirement</strong> of $200/machine/month in beverage supplies.</span>
+            </label>
+            <label className="flex items-start gap-2 text-sm text-gray-700">
+              <input
+                type="checkbox"
+                checked={ackInstall}
+                onChange={(e) => setAckInstall(e.target.checked)}
+                disabled={pendingCountersign}
+                className="mt-0.5"
+              />
+              <span>I acknowledge <strong>installation, service, and day-to-day upkeep</strong> responsibilities as set out in section 8.</span>
+            </label>
+          </div>
+
+          <div className="border-t border-gray-100 pt-4 space-y-3">
+            <div>
+              <label className="block text-xs font-medium text-gray-700 mb-1">Type your full legal name to sign</label>
+              <input
+                type="text"
+                value={typedName}
+                onChange={(e) => setTypedName(e.target.value)}
+                disabled={pendingCountersign}
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm font-serif italic"
+              />
+            </div>
+            <label className="flex items-start gap-2 text-sm text-gray-700">
+              <input
+                type="checkbox"
+                checked={consent}
+                onChange={(e) => setConsent(e.target.checked)}
+                disabled={pendingCountersign}
+                className="mt-0.5"
+              />
+              <span>
+                I consent to conducting this transaction electronically. My typed name above is a valid electronic
+                signature under the E-SIGN Act and applicable state law.
+              </span>
+            </label>
+          </div>
+
+          {error && (
+            <div className="flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+              <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
+              <span>{error}</span>
+            </div>
+          )}
+
+          <button
+            onClick={submitSign}
+            disabled={saving || pendingCountersign}
+            className="w-full inline-flex items-center justify-center gap-2 rounded-xl bg-emerald-600 hover:bg-emerald-700 px-6 py-3 text-sm font-semibold text-white cursor-pointer disabled:opacity-50"
+          >
+            {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <CheckCircle2 className="h-4 w-4" />}
+            {pendingCountersign ? "Signed — waiting on countersign" : "Sign Agreement"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/coffee/page.tsx
+++ b/src/app/coffee/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
-import { Search, ShoppingCart, Coffee, Lock, Loader2, X, AlertCircle, BookOpen } from "lucide-react";
+import { Search, ShoppingCart, Coffee, Lock, Loader2, X, AlertCircle, BookOpen, FileSignature } from "lucide-react";
 import { createBrowserClient } from "@/lib/supabase";
 import type { Profile } from "@/lib/types";
 import CoffeeCartDrawer from "@/app/components/CoffeeCartDrawer";
@@ -56,6 +56,7 @@ export default function CoffeeMarketplacePage() {
   const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
   const [guides, setGuides] = useState<Guide[]>([]);
   const [selectedGuide, setSelectedGuide] = useState<Guide | null>(null);
+  const [agreementStatus, setAgreementStatus] = useState<string | null>(null);
 
   useEffect(() => {
     const supabase = createBrowserClient();
@@ -70,6 +71,21 @@ export default function CoffeeMarketplacePage() {
           if (res.ok) {
             const data = await res.json();
             setProfile(data);
+            // If the operator is already coffee-enabled, fetch their coffee
+            // supply agreement status so the banner + button gates can
+            // reflect it. Non-enabled users don't need this (they'll hit
+            // the "Apply for Coffee Services" CTA instead).
+            if (data.coffee_access_enabled) {
+              try {
+                const aRes = await fetch("/api/coffee/agreement", {
+                  headers: { Authorization: `Bearer ${session.access_token}` },
+                });
+                if (aRes.ok) {
+                  const a = await aRes.json();
+                  setAgreementStatus(a.agreement?.status || null);
+                }
+              } catch {}
+            }
           }
         } catch {}
       }
@@ -176,6 +192,10 @@ export default function CoffeeMarketplacePage() {
   }
 
   const coffeeEnabled = !!profile?.coffee_access_enabled;
+  const agreementSigned = agreementStatus === "fully_executed" || agreementStatus === "legacy_approved";
+  const agreementLegacy = agreementStatus === "legacy_approved";
+  const agreementPending = agreementStatus === "provider_signed_pending_company_countersign";
+  const needsAgreementSign = coffeeEnabled && agreementStatus !== null && !agreementSigned && !agreementPending;
 
   function stockBadge(status: string) {
     switch (status) {
@@ -281,6 +301,69 @@ export default function CoffeeMarketplacePage() {
                 className="flex-shrink-0 rounded-xl bg-green-600 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-green-700"
               >
                 Apply for Coffee Services
+              </Link>
+            </div>
+          </div>
+        )}
+
+        {needsAgreementSign && (
+          <div className="mb-8 rounded-2xl border border-emerald-800 bg-emerald-900/30 p-6">
+            <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex items-start gap-3">
+                <FileSignature className="mt-0.5 h-5 w-5 flex-shrink-0 text-emerald-400" />
+                <div>
+                  <p className="font-semibold text-white">Sign the Equipment Loan &amp; Beverage Supply Agreement</p>
+                  <p className="mt-1 text-sm text-gray-300">
+                    Your account is approved, but orders can&apos;t be placed until the agreement is signed
+                    and countersigned. Only takes a minute.
+                  </p>
+                </div>
+              </div>
+              <Link
+                href="/coffee/agreement"
+                className="flex-shrink-0 rounded-xl bg-emerald-600 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-emerald-700"
+              >
+                Sign Agreement
+              </Link>
+            </div>
+          </div>
+        )}
+
+        {agreementPending && (
+          <div className="mb-8 rounded-2xl border border-amber-700 bg-amber-900/30 p-6">
+            <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex items-start gap-3">
+                <AlertCircle className="mt-0.5 h-5 w-5 flex-shrink-0 text-amber-400" />
+                <div>
+                  <p className="font-semibold text-white">Agreement awaiting Apex AI countersign</p>
+                  <p className="mt-1 text-sm text-gray-300">
+                    You&apos;ve signed. We&apos;ll countersign shortly — orders open up automatically once
+                    that clears.
+                  </p>
+                </div>
+              </div>
+              <Link
+                href="/coffee/agreement"
+                className="flex-shrink-0 rounded-xl bg-amber-600 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-amber-700"
+              >
+                View Agreement
+              </Link>
+            </div>
+          </div>
+        )}
+
+        {agreementLegacy && (
+          <div className="mb-6 rounded-xl border border-blue-800 bg-blue-900/30 p-4">
+            <div className="flex items-center justify-between gap-3">
+              <p className="text-sm text-gray-300">
+                Please sign the current Equipment Loan &amp; Beverage Supply Agreement when you have a moment —
+                you can keep ordering in the meantime.
+              </p>
+              <Link
+                href="/coffee/agreement"
+                className="flex-shrink-0 rounded-lg bg-blue-600 px-4 py-2 text-xs font-semibold text-white hover:bg-blue-700"
+              >
+                Sign
               </Link>
             </div>
           </div>

--- a/src/lib/coffeeEmail.ts
+++ b/src/lib/coffeeEmail.ts
@@ -158,6 +158,10 @@ export async function sendCoffeeOrderNotification(params: OrderNotificationParam
   return getResend().emails.send({
     from: FROM_EMAIL,
     to: FULFILLMENT_EMAIL,
+    // CC the admin inbox so James sees every order come through in
+    // addition to the fulfillment mailbox. Falls through gracefully if
+    // both env vars point at the same address.
+    cc: ADMIN_EMAIL && ADMIN_EMAIL !== FULFILLMENT_EMAIL ? [ADMIN_EMAIL] : undefined,
     subject: `New Coffee Order: ${orderNumber} from ${operatorName}`,
     html,
   });

--- a/src/lib/placementAgreements.ts
+++ b/src/lib/placementAgreements.ts
@@ -212,12 +212,14 @@ export async function countersignAsAdmin(args: CountersignArgs): Promise<UserAgr
     .single();
   if (error) throw error;
 
-  // Mirror onto placement_partners for the legacy admin surface — turns
-  // any partner into fully-active once countersigned.
-  await supabaseAdmin
-    .from("placement_partners")
-    .update({ agreement_signed_at: nowIso, updated_at: nowIso })
-    .eq("id", current.user_id);
+  // Mirror onto placement_partners ONLY for the PPA type — coffee_supply
+  // (or any future type) shouldn't touch the marketplace partner row.
+  if (current.agreement_type === "placement_provider") {
+    await supabaseAdmin
+      .from("placement_partners")
+      .update({ agreement_signed_at: nowIso, updated_at: nowIso })
+      .eq("id", current.user_id);
+  }
 
   await audit(args.agreementId, args.adminUserId, "countersigned", current.status, "fully_executed", {
     countersigner: args.adminNameSnapshot,
@@ -369,6 +371,33 @@ export async function requireExecutedPlacementProviderAgreement(userId: string):
   return null;
 }
 
+/**
+ * requireExecutedCoffeeSupplyAgreement — mirror guard for the Equipment
+ * Loan & Beverage Supply Agreement. Blocks coffee checkout until the
+ * operator has signed and Vending Connector has countersigned (or the
+ * operator was grandfathered as legacy_approved during migration 117).
+ */
+export async function requireExecutedCoffeeSupplyAgreement(userId: string): Promise<string | null> {
+  const agreement = await getUserAgreement(userId, "coffee_supply");
+  if (!agreement) {
+    return "Sign the Equipment Loan & Beverage Supply Agreement to place orders.";
+  }
+  const ok: AgreementStatus[] = ["fully_executed", "legacy_approved"];
+  if (!ok.includes(agreement.status)) {
+    if (agreement.status === "provider_signed_pending_company_countersign") {
+      return "Your Equipment Loan & Beverage Supply Agreement is awaiting Apex AI countersignature.";
+    }
+    if (agreement.status === "correction_requested") {
+      return "Your Equipment Loan & Beverage Supply Agreement needs correction — please re-sign the corrected version.";
+    }
+    if (agreement.status === "declined") {
+      return "Your Equipment Loan & Beverage Supply Agreement was declined. Contact support.";
+    }
+    return "Equipment Loan & Beverage Supply Agreement not fully executed.";
+  }
+  return null;
+}
+
 // ─── Audit helper ──────────────────────────────────────────────────
 
 export async function audit(
@@ -453,7 +482,12 @@ function escapeHtml(s: string): string {
 // ─── Storage helper ─────────────────────────────────────────────────
 
 export async function persistExecutedDocument(agreement: UserAgreement, html: string): Promise<string> {
-  const path = `placement-providers/${agreement.user_id}/${agreement.agreement_version}/${agreement.id}.html`;
+  // Path segment is derived from agreement_type so new types (coffee_supply,
+  // etc.) live under their own prefix without colliding with PPA docs.
+  const typeSegment = agreement.agreement_type === "placement_provider"
+    ? "placement-providers"
+    : agreement.agreement_type.replace(/_/g, "-");
+  const path = `${typeSegment}/${agreement.user_id}/${agreement.agreement_version}/${agreement.id}.html`;
   const { error } = await supabaseAdmin
     .storage
     .from("user-agreements")

--- a/supabase/migrations/117_coffee_supply_agreement.sql
+++ b/supabase/migrations/117_coffee_supply_agreement.sql
@@ -1,0 +1,132 @@
+-- Coffee Supply Agreement — real signable template.
+--
+-- Reuses the generic agreement_templates + user_agreements + audit tables
+-- established for the Placement Provider Agreement in migration 115. The
+-- signing UX + state machine + admin countersign flow are shared.
+--
+-- The checkbox on the coffee application form was never a real agreement.
+-- This migration seeds the real Equipment Loan & Beverage Supply Agreement
+-- as version 1 (agreement_type='coffee_supply') and grants legacy_approved
+-- to every operator who was already coffee_access_enabled so we don't
+-- immediately block them from ordering. The banner + admin dashboard will
+-- prompt legacy users to sign the real one at their convenience.
+
+-- ─── Seed coffee_supply v1 ─────────────────────────────────────────
+-- Content mirrors the source PDF. Coffee-specific form fields (customer
+-- name, address, number of machines, authorized-representative name/title,
+-- and the three acknowledgments) are captured on user_agreements.metadata
+-- at sign time — no schema change to user_agreements is required because
+-- metadata is already jsonb.
+INSERT INTO agreement_templates (
+  agreement_type, version, title, effective_date, is_active, content_html, content_hash
+) VALUES (
+  'coffee_supply',
+  1,
+  'Apex AI Vending — Equipment Loan & Beverage Supply Agreement',
+  CURRENT_DATE,
+  true,
+  $$
+  <h1>Apex AI Vending — Equipment Loan &amp; Beverage Supply Agreement</h1>
+  <p><em>the apex of retail innovation</em></p>
+
+  <h2>1. Parties</h2>
+  <p>This Equipment Loan and Beverage Supply Agreement ("Agreement") is entered into by and between Apex AI Vending ("Company") and the Customer identified on the signature page below.</p>
+
+  <h2>2. Term</h2>
+  <p>The initial term of this Agreement shall be five (5) years from the Effective Date, automatically renewing for successive one (1) year terms unless terminated by either party with thirty (30) days written notice.</p>
+
+  <h2>3. Equipment Loan</h2>
+  <p>Company agrees to provide Customer with beverage vending equipment ("Equipment") at no charge, subject to the terms and conditions of this Agreement. The number of machines is specified on the signature page below.</p>
+
+  <h2>4. Shipping</h2>
+  <p>Company shall arrange and pay for shipping of Equipment to Customer location. Customer shall be responsible for receiving and placing Equipment at designated location.</p>
+
+  <h2>5. Exclusive Product &amp; Supply Requirement</h2>
+  <p>Customer agrees to purchase all beverage products for use in the Equipment exclusively from Company. Customer shall not use any third-party products in the Equipment without prior written consent from Company.</p>
+
+  <h2>6. Minimum Purchase Requirement</h2>
+  <p>Customer agrees to purchase a minimum of Two Hundred Dollars ($200.00) per machine per month in beverage supplies from Company. Failure to meet this requirement may result in termination of this Agreement and removal of Equipment.</p>
+
+  <h2>7. Product Usage Compliance</h2>
+  <p>Customer shall use Company-supplied products in accordance with all applicable health, safety, and food service regulations. Customer shall maintain proper storage conditions for all beverage products.</p>
+
+  <h2>8. Installation, Service &amp; Maintenance</h2>
+  <p>Company shall provide initial installation of Equipment at no cost. Company shall provide routine maintenance and repairs. Customer shall notify Company promptly of any Equipment malfunction. Customer acknowledges responsibility for day-to-day cleaning and basic upkeep of Equipment.</p>
+
+  <h2>9. Pricing</h2>
+  <p>Company shall provide Customer with current pricing for all beverage products. Prices are subject to change with thirty (30) days written notice. Customer shall pay all invoices within thirty (30) days of receipt.</p>
+
+  <h2>10. Default</h2>
+  <p>Either party shall be in default if they fail to perform any material obligation under this Agreement and such failure continues for thirty (30) days after written notice. Upon default, the non-defaulting party may terminate this Agreement and pursue all available legal remedies.</p>
+
+  <h2>11. Early Termination / Buyout</h2>
+  <p>Customer may terminate this Agreement early by paying a buyout fee of Two Thousand Dollars ($2,000.00) per machine. Upon payment of the buyout fee, Customer may either return the Equipment or purchase it at fair market value.</p>
+
+  <h2>12. Equipment Removal</h2>
+  <p>Upon termination of this Agreement, Company shall have the right to remove all Equipment from Customer premises within thirty (30) days. Customer shall provide reasonable access for Equipment removal and shall not impede or delay such removal.</p>
+
+  <h2>13. Limitation of Liability</h2>
+  <p>IN NO EVENT SHALL EITHER PARTY BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES. COMPANY'S TOTAL LIABILITY UNDER THIS AGREEMENT SHALL NOT EXCEED THE AMOUNTS PAID BY CUSTOMER IN THE TWELVE (12) MONTHS PRECEDING THE CLAIM.</p>
+
+  <h2>14. Governing Law</h2>
+  <p>This Agreement shall be governed by and construed in accordance with the laws of the State in which the Equipment is located, without regard to conflict of law principles.</p>
+
+  <h2>15. Entire Agreement</h2>
+  <p>This Agreement constitutes the entire agreement between the parties concerning the subject matter hereof and supersedes all prior agreements, understandings, negotiations, and discussions, whether oral or written.</p>
+
+  <h2>Acknowledgments</h2>
+  <p>The Customer acknowledges each of the following by checking the corresponding boxes on the signature page:</p>
+  <ul>
+    <li>Customer agrees to the exclusive supply requirement.</li>
+    <li>Customer acknowledges the minimum purchase requirement.</li>
+    <li>Customer acknowledges responsibility for installation and maintenance obligations described in this Agreement.</li>
+  </ul>
+
+  <h2>Electronic Records &amp; Signatures</h2>
+  <p>The parties consent to conduct this transaction electronically. A typed name below constitutes a valid electronic signature under the E-SIGN Act and applicable state law.</p>
+  $$,
+  md5(random()::text || clock_timestamp()::text)
+) ON CONFLICT (agreement_type, version) DO NOTHING;
+
+-- ─── Backfill: existing coffee-access operators get legacy_approved ─
+-- Every operator whose profile shows coffee_agreement_signed=true and
+-- coffee_access_enabled=true today had informally acknowledged the previous
+-- checkbox. We stamp a legacy_approved user_agreements row referencing the
+-- new template so they can keep ordering while we prompt them to sign the
+-- real one. Idempotent — the composite unique key protects against
+-- double-inserts.
+DO $$
+DECLARE
+  coffee_template_id uuid;
+BEGIN
+  SELECT id INTO coffee_template_id
+    FROM agreement_templates
+    WHERE agreement_type = 'coffee_supply' AND version = 1
+    LIMIT 1;
+
+  IF coffee_template_id IS NULL THEN
+    RAISE NOTICE 'coffee_supply v1 template missing — skipping backfill';
+    RETURN;
+  END IF;
+
+  INSERT INTO user_agreements (
+    user_id, agreement_template_id, agreement_type, agreement_version,
+    status, admin_override_reason, countersigned_at
+  )
+  SELECT
+    p.id,
+    coffee_template_id,
+    'coffee_supply',
+    1,
+    'legacy_approved',
+    'Backfilled from pre-workflow coffee_agreement_signed flag on migration 117',
+    now()
+  FROM profiles p
+  WHERE p.coffee_agreement_signed = true
+    AND p.coffee_access_enabled = true
+    AND NOT EXISTS (
+      SELECT 1 FROM user_agreements ua
+      WHERE ua.user_id = p.id
+        AND ua.agreement_template_id = coffee_template_id
+    );
+END $$;


### PR DESCRIPTION
Replaces the checkbox-on-application-form fake with the actual Equipment Loan & Beverage Supply Agreement. Operators must sign + Apex AI must countersign before any coffee order can be placed.

* Migration 117 — seeds agreement_templates row for coffee_supply v1 (real HTML from the PDF). Backfills legacy_approved user_agreements rows for every operator with coffee_agreement_signed=true so existing approved operators are grandfathered and can keep ordering while we prompt them to sign the real one.

* Type-agnostic countersign — placementAgreements.countersignAsAdmin now only mirrors to placement_partners for placement_provider agreements; coffee_supply doesn't touch that table. persistExecutedDocument path is derived from agreement_type. The admin countersign API uses the agreement's own type instead of a hardcoded "placement_provider" so the same route handles both PPA and coffee agreements.

* requireExecutedCoffeeSupplyAgreement — the hard gate. POST /api/coffee/checkout returns 403 { sign_url: '/coffee/agreement' } until the operator has fully_executed or legacy_approved status.

* /api/coffee/agreement (GET) + /api/coffee/agreement/sign (POST) — fetches template + prefills from the coffee application; sign accepts the coffee-specific fields (customer name/address, num_machines, authorized rep name/title, 3 acknowledgment checkboxes, typed sig, e-sign consent) and captures them on user_agreements.metadata. Notifies admin so they know to countersign.

* /coffee/agreement — virtual signing page. Renders the template HTML in a scroll container, the coffee-specific form, the three acknowledgment checkboxes, typed-name signature box, e-sign consent. Shows waiting-for-countersign state after submit and grandfathered banner for legacy_approved rows.

* /coffee shop page — surface three banners: needs-sign (approved but not signed), pending-countersign (signed but awaiting Apex AI), legacy-nudge (grandfathered, can still order but should sign the current version). Each links to /coffee/agreement.

* /admin/coffee/agreements — countersign queue driven by /api/admin/marketplace/agreements?type=coffee_supply. Shows the customer name, address, num machines, and authorized rep from the agreement metadata alongside the standard status + signed/countersigned columns.

* sendCoffeeOrderNotification now CCs COFFEE_ADMIN_EMAIL so James sees every order in addition to the fulfillment mailbox.