### PR TITLE
Fail-safe coffee agreement prompt on shop + checkout

### DIFF
--- a/src/app/coffee/checkout/page.tsx
+++ b/src/app/coffee/checkout/page.tsx
@@ -184,7 +184,14 @@ function CheckoutContent() {
           setError("Failed to create payment session");
         }
       } else {
-        const data = await res.json();
+        const data = await res.json().catch(() => ({}));
+        // Coffee Supply Agreement not fully executed — the API returned a
+        // sign_url. Route the operator to the agreement so they can sign
+        // right now instead of leaving them stuck on a raw error.
+        if (res.status === 403 && data.sign_url) {
+          window.location.href = data.sign_url;
+          return;
+        }
         setError(data.error || "Failed to process checkout");
       }
     } catch {

--- a/src/app/coffee/page.tsx
+++ b/src/app/coffee/page.tsx
@@ -73,28 +73,36 @@ export default function CoffeeMarketplacePage() {
           if (res.ok) {
             const data = await res.json();
             setProfile(data);
-            // If the operator is already coffee-enabled, fetch their coffee
-            // supply agreement status. Users who haven't signed the agreement
-            // yet get auto-redirected to /coffee/agreement so the sign flow
-            // is the first thing they see — no need to click through a
-            // banner. Users mid-flow (already-signed-pending-countersign,
-            // legacy-approved) stay on the shop with a banner instead.
+            // If the operator is already coffee-enabled, verify their
+            // coffee supply agreement is executed. Anything short of
+            // fully_executed / legacy_approved / pending-countersign gets
+            // auto-redirected to /coffee/agreement so the sign flow is
+            // the first thing they see.
+            //
+            // Fail-safe: if the fetch errors (e.g. template not yet seeded
+            // on this env), we still redirect. Better to land the operator
+            // on the sign page — where any real error is surfaced clearly —
+            // than to let them hit an opaque 403 at checkout.
             if (data.coffee_access_enabled) {
+              let status: string | null = null;
+              let fetchOk = false;
               try {
                 const aRes = await fetch("/api/coffee/agreement", {
                   headers: { Authorization: `Bearer ${session.access_token}` },
                 });
                 if (aRes.ok) {
+                  fetchOk = true;
                   const a = await aRes.json();
-                  const status = a.agreement?.status || null;
+                  status = a.agreement?.status || null;
                   setAgreementStatus(status);
-                  const needsInitialSign = ["not_started", "draft", "correction_requested", "declined"].includes(status || "");
-                  if (needsInitialSign) {
-                    router.replace("/coffee/agreement");
-                    return;
-                  }
                 }
               } catch {}
+              const okStates = ["fully_executed", "legacy_approved", "provider_signed_pending_company_countersign"];
+              const canBrowse = fetchOk && okStates.includes(status || "");
+              if (!canBrowse) {
+                router.replace("/coffee/agreement");
+                return;
+              }
             }
           }
         } catch {}


### PR DESCRIPTION
Users were getting blocked at payment without ever being offered the agreement — most likely path: migration 117 hadn't run yet on that environment, so /api/coffee/agreement returned 500, the fetch failed silently, no redirect fired, and checkout returned a raw 403 with no CTA to sign.

Two fixes so the sign flow always surfaces:

* /coffee shop page — redirect to /coffee/agreement whenever we can't positively confirm the caller has an executed (fully_executed, legacy_approved, or pending countersign) agreement. Fetch errors, unknown statuses, and truly-unsigned states all send them to the sign page, where any real problem is surfaced clearly instead of hiding under a silent failure.

* /coffee/checkout — when POST /api/coffee/checkout returns 403 with sign_url in the body (the checkout guard's response shape), the browser is redirected to that URL immediately. Operators trying to pay while unsigned now get taken straight to the agreement instead of stuck on the checkout page reading an error.