### PR TITLE
Admin coffee_access_enabled overrides agreement gate

### DIFF
--- a/src/app/api/coffee/checkout/route.ts
+++ b/src/app/api/coffee/checkout/route.ts
@@ -17,15 +17,24 @@ export async function POST(req: NextRequest) {
       return forbiddenResponse();
     }
 
-    // Real Equipment Loan & Beverage Supply Agreement gate — must be fully
-    // executed (or grandfathered legacy_approved) before any order can be
-    // placed. Returns a clear "sign here" message when it isn't.
-    const agreementBlock = await requireExecutedCoffeeSupplyAgreement(user.id);
-    if (agreementBlock) {
-      return NextResponse.json(
-        { error: agreementBlock, sign_url: "/coffee/agreement" },
-        { status: 403 },
-      );
+    // Admin-grant override: the admin's coffee_access_enabled flag is the
+    // authoritative permission today. The Equipment Loan & Beverage Supply
+    // Agreement is prompted on the shop + checkout page as a nudge, but
+    // NOT enforced at payment time — that would strand admin-approved
+    // operators who haven't signed yet.
+    //
+    // Flip the env var COFFEE_AGREEMENT_ENFORCED=true to turn the hard
+    // gate back on once every active operator has signed. The full guard
+    // infrastructure (template, sign flow, countersign queue) is already
+    // wired — this flag is the only switch.
+    if (process.env.COFFEE_AGREEMENT_ENFORCED === "true") {
+      const agreementBlock = await requireExecutedCoffeeSupplyAgreement(user.id);
+      if (agreementBlock) {
+        return NextResponse.json(
+          { error: agreementBlock, sign_url: "/coffee/agreement" },
+          { status: 403 },
+        );
+      }
     }
 
     const body = await req.json();

--- a/src/app/coffee/checkout/page.tsx
+++ b/src/app/coffee/checkout/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense } from "react";
 import Link from "next/link";
-import { Loader2, ShoppingCart, ArrowLeft, AlertCircle, CreditCard } from "lucide-react";
+import { Loader2, ShoppingCart, ArrowLeft, AlertCircle, CreditCard, FileSignature } from "lucide-react";
 import { createBrowserClient } from "@/lib/supabase";
 import type { Profile } from "@/lib/types";
 
@@ -42,6 +42,7 @@ function CheckoutContent() {
   const [items, setItems] = useState<CartItem[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
+  const [agreementStatus, setAgreementStatus] = useState<string | null>(null);
 
   const [form, setForm] = useState({
     shipping_business_name: "",
@@ -90,6 +91,20 @@ function CheckoutContent() {
             router.push("/coffee/apply");
             return;
           }
+
+          // Fetch coffee supply agreement status so we can offer an
+          // inline "sign the agreement" panel above the form. Admin's
+          // coffee_access_enabled grant is the authoritative permission —
+          // this is a nudge, not a block. Ignore errors quietly.
+          try {
+            const aRes = await fetch("/api/coffee/agreement", {
+              headers: { Authorization: `Bearer ${session.access_token}` },
+            });
+            if (aRes.ok) {
+              const a = await aRes.json();
+              setAgreementStatus(a.agreement?.status || null);
+            }
+          } catch {}
           setForm((prev) => ({
             ...prev,
             shipping_business_name: data.company_name || "",
@@ -250,6 +265,41 @@ function CheckoutContent() {
         <div className="mt-4 flex items-center gap-2 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
           <AlertCircle className="h-4 w-4 flex-shrink-0" />
           {error}
+        </div>
+      )}
+
+      {agreementStatus !== null &&
+        agreementStatus !== "fully_executed" &&
+        agreementStatus !== "legacy_approved" &&
+        agreementStatus !== "provider_signed_pending_company_countersign" && (
+        <div className="mt-4 rounded-2xl border border-emerald-200 bg-emerald-50 p-4">
+          <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-start gap-3">
+              <FileSignature className="mt-0.5 h-5 w-5 flex-shrink-0 text-emerald-700" />
+              <div>
+                <p className="font-semibold text-emerald-900">Sign the Equipment Loan &amp; Beverage Supply Agreement</p>
+                <p className="mt-0.5 text-sm text-emerald-800">
+                  You can complete this order today, but please sign the agreement so we have your
+                  record on file. Takes about a minute.
+                </p>
+              </div>
+            </div>
+            <Link
+              href="/coffee/agreement"
+              className="inline-flex flex-shrink-0 items-center gap-1.5 rounded-xl bg-emerald-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-emerald-700"
+            >
+              Sign Now
+            </Link>
+          </div>
+        </div>
+      )}
+
+      {agreementStatus === "provider_signed_pending_company_countersign" && (
+        <div className="mt-4 rounded-2xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+          <p className="flex items-center gap-2 font-semibold">
+            <AlertCircle className="h-4 w-4" /> Agreement awaiting Apex AI countersignature
+          </p>
+          <p className="mt-1 text-xs">You&apos;ve signed. Apex AI will countersign shortly — your order will still process today.</p>
         </div>
       )}
 

--- a/src/app/coffee/page.tsx
+++ b/src/app/coffee/page.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import { Search, ShoppingCart, Coffee, Lock, Loader2, X, AlertCircle, BookOpen, FileSignature } from "lucide-react";
 import { createBrowserClient } from "@/lib/supabase";
 import type { Profile } from "@/lib/types";
@@ -41,7 +40,6 @@ interface Product {
 }
 
 export default function CoffeeMarketplacePage() {
-  const router = useRouter();
   const [token, setToken] = useState("");
   const [profile, setProfile] = useState<Profile | null>(null);
   const [loading, setLoading] = useState(true);
@@ -73,36 +71,21 @@ export default function CoffeeMarketplacePage() {
           if (res.ok) {
             const data = await res.json();
             setProfile(data);
-            // If the operator is already coffee-enabled, verify their
-            // coffee supply agreement is executed. Anything short of
-            // fully_executed / legacy_approved / pending-countersign gets
-            // auto-redirected to /coffee/agreement so the sign flow is
-            // the first thing they see.
-            //
-            // Fail-safe: if the fetch errors (e.g. template not yet seeded
-            // on this env), we still redirect. Better to land the operator
-            // on the sign page — where any real error is surfaced clearly —
-            // than to let them hit an opaque 403 at checkout.
+            // If the operator is already coffee-enabled, fetch their
+            // coffee supply agreement status so the banner can offer the
+            // sign flow. Admin's coffee_access_enabled grant is the
+            // authoritative permission — we don't redirect or block
+            // browsing here, just surface the sign CTA prominently.
             if (data.coffee_access_enabled) {
-              let status: string | null = null;
-              let fetchOk = false;
               try {
                 const aRes = await fetch("/api/coffee/agreement", {
                   headers: { Authorization: `Bearer ${session.access_token}` },
                 });
                 if (aRes.ok) {
-                  fetchOk = true;
                   const a = await aRes.json();
-                  status = a.agreement?.status || null;
-                  setAgreementStatus(status);
+                  setAgreementStatus(a.agreement?.status || null);
                 }
               } catch {}
-              const okStates = ["fully_executed", "legacy_approved", "provider_signed_pending_company_countersign"];
-              const canBrowse = fetchOk && okStates.includes(status || "");
-              if (!canBrowse) {
-                router.replace("/coffee/agreement");
-                return;
-              }
             }
           }
         } catch {}


### PR DESCRIPTION
Admin's coffee_access_enabled grant is now the authoritative permission for checkout. The Equipment Loan & Beverage Supply Agreement is prompted prominently on the shop and at checkout, but no longer blocks payment.

* Checkout guard — the requireExecutedCoffeeSupplyAgreement check is now wrapped in a COFFEE_AGREEMENT_ENFORCED=true env flag. Default OFF. Approved operators without a signed agreement can complete orders today; flip the flag to re-enable the hard gate once everyone's signed. All the sign / countersign / audit infrastructure stays put.

* /coffee shop — dropped the auto-redirect to /coffee/agreement. The three existing banners (needs sign / pending countersign / legacy nudge) stay so the sign flow is still one click away. Operators can browse and order without being bounced off the shop.

* /coffee/checkout — fetches the agreement status on load and renders an inline "Sign the Equipment Loan & Beverage Supply Agreement" panel above the form when the caller is unsigned. Doesn't block submit — just offers the sign flow at the moment of payment, which is exactly when the reminder lands hardest.