### PR TITLE
Coffee checkout clears cart at order commit, not payment landing

### DIFF
--- a/src/app/api/coffee/checkout/route.ts
+++ b/src/app/api/coffee/checkout/route.ts
@@ -160,6 +160,18 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: itemsError.message }, { status: 500 });
     }
 
+    // Clear the cart as soon as the order + items are committed. Payment
+    // hasn't landed yet — but the order lives in awaiting_payment with the
+    // invoice/checkout URL, so if the customer bounces before paying they
+    // can still complete payment from /coffee/orders. Meanwhile the cart
+    // is empty for their next order (previous behavior only cleared cart
+    // on paid webhook, which meant QB customers who bounced before paying
+    // saw stale items on their next visit).
+    await supabaseAdmin
+      .from("coffee_cart_items")
+      .delete()
+      .eq("user_id", user.id);
+
     // Fire "order placed" emails immediately at checkout submission so the
     // buyer and fulfillment mailbox both see it right away — invoice link
     // follows on the same page. handleCoffeeOrderCompleted fires a second


### PR DESCRIPTION
Customers who placed a coffee order and came back to place a second one were seeing their previously-purchased items still in the cart. Root cause: POST /api/coffee/checkout only cleared the cart when handleCoffeeOrderCompleted ran — which fires from the QB/Stripe webhook after payment lands. For QB flows the webhook often lags or never sees the payment, and for any flow where the customer bounces before paying, the cart stayed populated.

Fix: clear coffee_cart_items right after coffee_orders + coffee_order_items insert successfully, before we hand the customer off to QB/Stripe. The order lives in awaiting_payment with the invoice/checkout link on the order-detail page, so a bounced customer can still complete payment from /coffee/orders. Meanwhile the cart is empty for their next order.

This mirrors what the legacy POST /api/coffee/orders route was already doing — the newer checkout route just didn't clear the cart at order-commit time.