### PR TITLE
Account-level coffee pricing tiers

### DIFF
--- a/src/app/admin/coffee/tier-prices/page.tsx
+++ b/src/app/admin/coffee/tier-prices/page.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { Loader2, ArrowLeft, DollarSign, CheckCircle2, AlertCircle, Save } from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
+
+interface Tier {
+  id: string;
+  tier_key: string;
+  name: string;
+  sort_order: number;
+}
+
+interface PriceCell {
+  price: number;
+  shipping_cost: number;
+  updated_at: string | null;
+  updated_by: string | null;
+}
+
+interface Row {
+  product_id: string;
+  product_name: string;
+  product_sku: string;
+  base_price: number;
+  base_shipping_cost: number;
+  active: boolean;
+  prices: Record<string, PriceCell>;
+}
+
+interface Draft {
+  price: string;
+  shipping_cost: string;
+}
+
+export default function AdminCoffeeTierPricesPage() {
+  const router = useRouter();
+  const [token, setToken] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [tiers, setTiers] = useState<Tier[]>([]);
+  const [rows, setRows] = useState<Row[]>([]);
+  const [drafts, setDrafts] = useState<Record<string, Draft>>({}); // key: productId:tierId
+  const [saving, setSaving] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+
+  const load = useCallback(async (t: string) => {
+    setLoading(true);
+    const res = await fetch("/api/admin/coffee/tier-prices", {
+      headers: { Authorization: `Bearer ${t}` },
+    });
+    if (res.ok) {
+      const body = await res.json();
+      setTiers(body.tiers || []);
+      setRows(body.rows || []);
+    } else {
+      setError((await res.json().catch(() => ({}))).error || "Failed to load tier prices");
+    }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!session?.access_token) { router.push("/login?redirect=/admin/coffee/tier-prices"); return; }
+      setToken(session.access_token);
+      load(session.access_token);
+    });
+  }, [router, load]);
+
+  function cellKey(productId: string, tierId: string) {
+    return `${productId}:${tierId}`;
+  }
+
+  function draftFor(productId: string, tierId: string, cell: PriceCell | undefined): Draft {
+    const key = cellKey(productId, tierId);
+    const d = drafts[key];
+    if (d) return d;
+    return {
+      price: cell ? String(cell.price) : "",
+      shipping_cost: cell ? String(cell.shipping_cost) : "",
+    };
+  }
+
+  function updateDraft(productId: string, tierId: string, field: keyof Draft, value: string) {
+    setDrafts((prev) => {
+      const key = cellKey(productId, tierId);
+      const cell = rows.find((r) => r.product_id === productId)?.prices[tierId];
+      const base = prev[key] || {
+        price: cell ? String(cell.price) : "",
+        shipping_cost: cell ? String(cell.shipping_cost) : "",
+      };
+      return { ...prev, [key]: { ...base, [field]: value } };
+    });
+  }
+
+  async function saveCell(productId: string, tierId: string) {
+    setMessage(null); setError(null);
+    const draft = drafts[cellKey(productId, tierId)];
+    if (!draft) return;
+    const priceNum = Number(draft.price);
+    const shipNum = draft.shipping_cost === "" ? null : Number(draft.shipping_cost);
+    if (!Number.isFinite(priceNum) || priceNum < 0) {
+      setError("Price must be a non-negative number.");
+      return;
+    }
+    if (shipNum !== null && (!Number.isFinite(shipNum) || shipNum < 0)) {
+      setError("Shipping must be a non-negative number.");
+      return;
+    }
+    setSaving(cellKey(productId, tierId));
+    const res = await fetch("/api/admin/coffee/tier-prices", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({
+        product_id: productId,
+        pricing_tier_id: tierId,
+        price: priceNum,
+        shipping_cost: shipNum,
+      }),
+    });
+    setSaving(null);
+    if (!res.ok) {
+      setError((await res.json().catch(() => ({}))).error || "Save failed");
+      return;
+    }
+    setMessage("Saved. Only this tier / product cell was changed.");
+    // Clear draft + reload so we pick up updated_at
+    setDrafts((prev) => {
+      const next = { ...prev };
+      delete next[cellKey(productId, tierId)];
+      return next;
+    });
+    load(token);
+  }
+
+  const filteredRows = search.trim()
+    ? rows.filter((r) => {
+        const s = search.trim().toLowerCase();
+        return r.product_name.toLowerCase().includes(s) || (r.product_sku || "").toLowerCase().includes(s);
+      })
+    : rows;
+
+  if (loading) {
+    return <div className="flex min-h-[60vh] items-center justify-center"><Loader2 className="h-6 w-6 animate-spin text-emerald-600" /></div>;
+  }
+
+  return (
+    <div className="p-6 max-w-7xl mx-auto">
+      <Link href="/admin/coffee" className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-emerald-600 mb-4">
+        <ArrowLeft className="h-4 w-4" /> Coffee Admin
+      </Link>
+
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
+          <DollarSign className="h-6 w-6 text-emerald-600" /> Coffee Pricing Tiers
+        </h1>
+        <p className="text-sm text-gray-500 mt-1 max-w-3xl">
+          Each product carries one price per tier. Editing a single cell — say Tier 2 — leaves
+          Tier 1 and Tier 3 untouched. Every change is written to the admin audit log with the
+          before / after values.
+        </p>
+      </div>
+
+      {message && (
+        <div className="mb-4 flex items-start gap-2 rounded-xl border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-700">
+          <CheckCircle2 className="h-4 w-4 mt-0.5" /> {message}
+        </div>
+      )}
+      {error && (
+        <div className="mb-4 flex items-start gap-2 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          <AlertCircle className="h-4 w-4 mt-0.5" /> {error}
+        </div>
+      )}
+
+      <div className="mb-4 flex items-center gap-3">
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search by product name or SKU…"
+          className="flex-1 rounded-xl border border-gray-200 px-4 py-2 text-sm"
+        />
+        <span className="text-xs text-gray-500 whitespace-nowrap">
+          {filteredRows.length} of {rows.length} products
+        </span>
+      </div>
+
+      <div className="rounded-2xl border border-gray-100 bg-white overflow-x-auto">
+        <table className="w-full text-sm min-w-[900px]">
+          <thead>
+            <tr className="text-xs text-gray-500 border-b border-gray-100 bg-gray-50">
+              <th className="text-left py-2 px-3 font-medium">Product</th>
+              <th className="text-right py-2 px-3 font-medium">Base</th>
+              {tiers.map((t) => (
+                <th key={t.id} className="text-left py-2 px-3 font-medium">
+                  {t.name}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {filteredRows.map((r) => (
+              <tr key={r.product_id} className="border-b border-gray-50 align-top">
+                <td className="py-3 px-3">
+                  <p className="font-medium text-gray-900">{r.product_name}</p>
+                  <p className="text-[11px] text-gray-400">{r.product_sku}</p>
+                  {!r.active && <span className="text-[10px] text-red-600 uppercase">Inactive</span>}
+                </td>
+                <td className="py-3 px-3 text-right text-xs text-gray-500 whitespace-nowrap">
+                  <p>${r.base_price.toFixed(2)}</p>
+                  <p className="text-gray-400">+${r.base_shipping_cost.toFixed(2)} ship</p>
+                </td>
+                {tiers.map((t) => {
+                  const cell = r.prices[t.id];
+                  const draft = draftFor(r.product_id, t.id, cell);
+                  const key = cellKey(r.product_id, t.id);
+                  const dirty = !!drafts[key];
+                  return (
+                    <td key={t.id} className="py-3 px-3">
+                      <div className="flex flex-col gap-1">
+                        <label className="text-[10px] text-gray-500">Price</label>
+                        <div className="flex items-center gap-1">
+                          <span className="text-xs text-gray-400">$</span>
+                          <input
+                            type="number"
+                            min={0}
+                            step="0.01"
+                            value={draft.price}
+                            onChange={(e) => updateDraft(r.product_id, t.id, "price", e.target.value)}
+                            className={`w-24 rounded-lg border px-2 py-1 text-sm ${dirty ? "border-emerald-400 bg-emerald-50" : "border-gray-200"}`}
+                          />
+                        </div>
+                        <label className="text-[10px] text-gray-500 mt-1">Shipping</label>
+                        <div className="flex items-center gap-1">
+                          <span className="text-xs text-gray-400">$</span>
+                          <input
+                            type="number"
+                            min={0}
+                            step="0.01"
+                            value={draft.shipping_cost}
+                            onChange={(e) => updateDraft(r.product_id, t.id, "shipping_cost", e.target.value)}
+                            className={`w-24 rounded-lg border px-2 py-1 text-sm ${dirty ? "border-emerald-400 bg-emerald-50" : "border-gray-200"}`}
+                          />
+                        </div>
+                        <button
+                          onClick={() => saveCell(r.product_id, t.id)}
+                          disabled={!dirty || saving === key}
+                          className="mt-2 inline-flex items-center justify-center gap-1 rounded-lg bg-emerald-600 hover:bg-emerald-700 px-2 py-1 text-[11px] font-semibold text-white disabled:opacity-40"
+                        >
+                          {saving === key ? <Loader2 className="h-3 w-3 animate-spin" /> : <Save className="h-3 w-3" />}
+                          Save {t.name}
+                        </button>
+                        {cell?.updated_at && (
+                          <p className="text-[10px] text-gray-400 mt-1">
+                            Updated {new Date(cell.updated_at).toLocaleDateString()}
+                          </p>
+                        )}
+                      </div>
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+            {filteredRows.length === 0 && (
+              <tr>
+                <td colSpan={2 + tiers.length} className="text-center text-sm text-gray-500 py-8">
+                  No products match your search.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -222,7 +222,8 @@ function UsersManager({ token, onSuccess }: { token: string; onSuccess: (msg: st
   const [search, setSearch] = useState("");
   const [roleFilter, setRoleFilter] = useState("");
   const [editingUser, setEditingUser] = useState<Profile | null>(null);
-  const [editForm, setEditForm] = useState({ role: "", verified: false, featured: false, coffee_access_enabled: false, full_name: "", email: "", company_name: "", phone: "", address: "", city: "", state: "", zip: "" });
+  const [editForm, setEditForm] = useState({ role: "", verified: false, featured: false, coffee_access_enabled: false, coffee_pricing_tier_id: "", full_name: "", email: "", company_name: "", phone: "", address: "", city: "", state: "", zip: "" });
+  const [coffeeTiers, setCoffeeTiers] = useState<Array<{ id: string; tier_key: string; name: string }>>([]);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState("");
   const [deleteTarget, setDeleteTarget] = useState<Profile | null>(null);
@@ -254,6 +255,23 @@ function UsersManager({ token, onSuccess }: { token: string; onSuccess: (msg: st
     fetchUsers();
   }, [fetchUsers]);
 
+  // Load coffee pricing tiers once so the edit modal's tier dropdown
+  // has its options ready. Reads through the public "authenticated"
+  // policy on coffee_pricing_tiers — no admin route needed.
+  useEffect(() => {
+    (async () => {
+      try {
+        const supabase = (await import("@/lib/supabase")).createBrowserClient();
+        const { data } = await supabase
+          .from("coffee_pricing_tiers")
+          .select("id, tier_key, name")
+          .eq("is_active", true)
+          .order("sort_order");
+        setCoffeeTiers((data as Array<{ id: string; tier_key: string; name: string }>) || []);
+      } catch {}
+    })();
+  }, []);
+
   function openEdit(user: Profile) {
     setEditingUser(user);
     setEditForm({
@@ -261,6 +279,7 @@ function UsersManager({ token, onSuccess }: { token: string; onSuccess: (msg: st
       verified: user.verified,
       featured: user.featured,
       coffee_access_enabled: !!user.coffee_access_enabled,
+      coffee_pricing_tier_id: (user as unknown as { coffee_pricing_tier_id?: string | null }).coffee_pricing_tier_id || "",
       full_name: user.full_name,
       email: user.email,
       company_name: user.company_name || "",
@@ -293,13 +312,20 @@ function UsersManager({ token, onSuccess }: { token: string; onSuccess: (msg: st
     setSaving(true);
     setSaveError("");
     try {
+      // Empty string on the tier dropdown means "unassigned" → null so
+      // the FK check on the API side treats it as clearing rather than
+      // rejecting an invalid uuid.
+      const payload = {
+        ...editForm,
+        coffee_pricing_tier_id: editForm.coffee_pricing_tier_id || null,
+      };
       const res = await fetch(`/api/admin/users/${editingUser.id}`, {
         method: "PATCH",
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${token}`,
         },
-        body: JSON.stringify(editForm),
+        body: JSON.stringify(payload),
       });
       if (res.ok) {
         setEditingUser(null);
@@ -733,6 +759,23 @@ function UsersManager({ token, onSuccess }: { token: string; onSuccess: (msg: st
                     Coffee Access
                   </label>
                 </div>
+              </div>
+              <div>
+                <label className="mb-1 block text-sm font-medium text-black-primary">Coffee Pricing Tier</label>
+                <select
+                  value={editForm.coffee_pricing_tier_id}
+                  onChange={(e) => setEditForm((f) => ({ ...f, coffee_pricing_tier_id: e.target.value }))}
+                  className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm focus:border-green-primary focus:outline-none focus:ring-1 focus:ring-green-primary"
+                >
+                  <option value="">Unassigned (defaults to Tier 1)</option>
+                  {coffeeTiers.map((t) => (
+                    <option key={t.id} value={t.id}>{t.name}</option>
+                  ))}
+                </select>
+                <p className="mt-1 text-[11px] text-gray-500">
+                  Controls the price this operator sees + pays for coffee products.
+                  <Link href="/admin/coffee/tier-prices" className="ml-1 text-green-primary hover:underline">Edit tier prices →</Link>
+                </p>
               </div>
               <hr className="border-gray-100" />
               <p className="text-xs font-medium text-black-primary/50 uppercase tracking-wide">Location Info</p>

--- a/src/app/api/admin/coffee/tier-prices/route.ts
+++ b/src/app/api/admin/coffee/tier-prices/route.ts
@@ -1,0 +1,151 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+
+/**
+ * GET /api/admin/coffee/tier-prices
+ *
+ * Returns the full tier-price matrix:
+ *   tiers  — [{id, tier_key, name, sort_order}, ...] active only
+ *   rows   — [{
+ *     product_id, product_name, product_sku, base_price, base_shipping_cost,
+ *     prices: { <tier_id>: { price, shipping_cost, updated_at, updated_by }},
+ *   }, ...]
+ * for the admin grid UI. Base price is included so admin can compare
+ * tier prices against the legacy coffee_products.price fallback.
+ */
+export async function GET(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const [{ data: tiers }, { data: products }, { data: tierPrices }] = await Promise.all([
+    supabaseAdmin
+      .from("coffee_pricing_tiers")
+      .select("id, tier_key, name, sort_order")
+      .eq("is_active", true)
+      .order("sort_order"),
+    supabaseAdmin
+      .from("coffee_products")
+      .select("id, name, sku, price, shipping_cost, active, sort_order")
+      .order("sort_order"),
+    supabaseAdmin
+      .from("coffee_product_tier_prices")
+      .select("product_id, pricing_tier_id, price, shipping_cost, updated_at, updated_by"),
+  ]);
+
+  const rows = (products || []).map((p) => {
+    const prices: Record<string, {
+      price: number;
+      shipping_cost: number;
+      updated_at: string | null;
+      updated_by: string | null;
+    }> = {};
+    for (const tp of tierPrices || []) {
+      if (tp.product_id === p.id) {
+        prices[tp.pricing_tier_id as string] = {
+          price: Number(tp.price),
+          shipping_cost: Number(tp.shipping_cost || 0),
+          updated_at: tp.updated_at,
+          updated_by: tp.updated_by,
+        };
+      }
+    }
+    return {
+      product_id: p.id,
+      product_name: p.name,
+      product_sku: p.sku,
+      base_price: Number(p.price),
+      base_shipping_cost: Number(p.shipping_cost || 0),
+      active: p.active !== false,
+      prices,
+    };
+  });
+
+  return NextResponse.json({ tiers: tiers || [], rows });
+}
+
+/**
+ * PATCH /api/admin/coffee/tier-prices
+ * Body: { product_id, pricing_tier_id, price, shipping_cost? }
+ *
+ * Upserts one (product_id, pricing_tier_id) cell. Editing Tier 2
+ * leaves Tier 1 and Tier 3 rows untouched — the unique constraint
+ * enforces cell-level isolation. Audit-logs the change with before/after.
+ */
+export async function PATCH(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const body = await req.json().catch(() => ({}));
+  const productId = typeof body.product_id === "string" ? body.product_id : "";
+  const tierId = typeof body.pricing_tier_id === "string" ? body.pricing_tier_id : "";
+  const priceRaw = Number(body.price);
+  const shippingCostRaw = body.shipping_cost !== undefined && body.shipping_cost !== null
+    ? Number(body.shipping_cost)
+    : null;
+
+  if (!productId) return NextResponse.json({ error: "product_id is required" }, { status: 400 });
+  if (!tierId) return NextResponse.json({ error: "pricing_tier_id is required" }, { status: 400 });
+  if (!Number.isFinite(priceRaw) || priceRaw < 0) {
+    return NextResponse.json({ error: "price must be a non-negative number" }, { status: 400 });
+  }
+  if (shippingCostRaw !== null && (!Number.isFinite(shippingCostRaw) || shippingCostRaw < 0)) {
+    return NextResponse.json({ error: "shipping_cost must be a non-negative number" }, { status: 400 });
+  }
+
+  // Validate FKs exist so we return a clean 400 instead of a cryptic 500.
+  const [{ data: product }, { data: tier }] = await Promise.all([
+    supabaseAdmin.from("coffee_products").select("id, name, sku").eq("id", productId).maybeSingle(),
+    supabaseAdmin.from("coffee_pricing_tiers").select("id, tier_key, name").eq("id", tierId).maybeSingle(),
+  ]);
+  if (!product) return NextResponse.json({ error: "Unknown product" }, { status: 400 });
+  if (!tier) return NextResponse.json({ error: "Unknown pricing tier" }, { status: 400 });
+
+  const { data: before } = await supabaseAdmin
+    .from("coffee_product_tier_prices")
+    .select("id, price, shipping_cost")
+    .eq("product_id", productId)
+    .eq("pricing_tier_id", tierId)
+    .maybeSingle();
+
+  const nowIso = new Date().toISOString();
+  const payload: Record<string, unknown> = {
+    product_id: productId,
+    pricing_tier_id: tierId,
+    price: priceRaw,
+    updated_at: nowIso,
+    updated_by: adminId,
+  };
+  if (shippingCostRaw !== null) payload.shipping_cost = shippingCostRaw;
+
+  const { data: after, error } = await supabaseAdmin
+    .from("coffee_product_tier_prices")
+    .upsert(payload, { onConflict: "product_id,pricing_tier_id" })
+    .select("id, product_id, pricing_tier_id, price, shipping_cost, updated_at, updated_by")
+    .single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  await supabaseAdmin.from("audit_logs").insert({
+    actor_id: adminId,
+    action: before ? "coffee_tier_price_updated" : "coffee_tier_price_created",
+    entity_type: "coffee_product_tier_prices",
+    entity_id: after.id,
+    before: before
+      ? { price: Number(before.price), shipping_cost: Number(before.shipping_cost || 0) }
+      : null,
+    after: {
+      price: Number(after.price),
+      shipping_cost: Number(after.shipping_cost || 0),
+    },
+    metadata: {
+      product_id: productId,
+      product_name: product.name,
+      product_sku: product.sku,
+      pricing_tier_id: tierId,
+      tier_key: tier.tier_key,
+      tier_name: tier.name,
+    },
+  });
+
+  return NextResponse.json({ ok: true, row: after });
+}

--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -22,6 +22,7 @@ export async function PATCH(
       "full_name", "email", "role", "company_name", "phone",
       "website", "bio", "address", "city", "state", "zip", "country",
       "verified", "featured", "coffee_access_enabled", "locator_status",
+      "coffee_pricing_tier_id",
     ];
     const updates: Record<string, unknown> = {};
     for (const field of allowedFields) {
@@ -30,6 +31,29 @@ export async function PATCH(
 
     if (Object.keys(updates).length === 0) {
       return NextResponse.json({ error: "No valid fields to update" }, { status: 400 });
+    }
+
+    // Track the previous coffee_pricing_tier_id for audit-log write.
+    let previousTierId: string | null = null;
+    if ("coffee_pricing_tier_id" in updates) {
+      const { data: existing } = await supabaseAdmin
+        .from("profiles")
+        .select("coffee_pricing_tier_id")
+        .eq("id", id)
+        .maybeSingle();
+      previousTierId = (existing?.coffee_pricing_tier_id as string | null) || null;
+
+      // Validate the new tier id if non-null.
+      if (updates.coffee_pricing_tier_id) {
+        const { data: tier } = await supabaseAdmin
+          .from("coffee_pricing_tiers")
+          .select("id, tier_key, name")
+          .eq("id", updates.coffee_pricing_tier_id as string)
+          .maybeSingle();
+        if (!tier) {
+          return NextResponse.json({ error: "Unknown coffee pricing tier" }, { status: 400 });
+        }
+      }
     }
 
     // When admin removes featured status, cancel the Stripe subscription and clear the ID
@@ -85,6 +109,37 @@ export async function PATCH(
         .from("operator_listings")
         .update({ featured: updates.featured as boolean })
         .eq("operator_id", id);
+    }
+
+    // Audit log — coffee pricing tier assignment / reassignment.
+    if ("coffee_pricing_tier_id" in updates) {
+      const newTierId = (updates.coffee_pricing_tier_id as string | null) || null;
+      if (newTierId !== previousTierId) {
+        const tierIds = [previousTierId, newTierId].filter((v): v is string => !!v);
+        const { data: tierRows } = tierIds.length > 0
+          ? await supabaseAdmin
+              .from("coffee_pricing_tiers")
+              .select("id, tier_key, name")
+              .in("id", tierIds)
+          : { data: [] as Array<{ id: string; tier_key: string; name: string }> };
+        const byId = new Map((tierRows || []).map((t) => [t.id, t]));
+        await supabaseAdmin.from("audit_logs").insert({
+          actor_id: adminId,
+          action: "coffee_account_tier_reassigned",
+          entity_type: "profiles",
+          entity_id: id,
+          before: previousTierId
+            ? { coffee_pricing_tier_id: previousTierId, tier: byId.get(previousTierId) || null }
+            : { coffee_pricing_tier_id: null },
+          after: newTierId
+            ? { coffee_pricing_tier_id: newTierId, tier: byId.get(newTierId) || null }
+            : { coffee_pricing_tier_id: null },
+          metadata: {
+            user_email: data?.email || null,
+            user_full_name: data?.full_name || null,
+          },
+        });
+      }
     }
 
     return NextResponse.json(data);

--- a/src/app/api/coffee/cart/route.ts
+++ b/src/app/api/coffee/cart/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { getCoffeeUser, forbiddenResponse } from "@/lib/coffeeAuth";
+import { resolveCoffeeProductsPricing } from "@/lib/coffeePricing";
 
 export async function GET(req: NextRequest) {
   try {
@@ -19,7 +20,32 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ error: error.message }, { status: 500 });
     }
 
-    return NextResponse.json({ items: data || [] });
+    // Overwrite the joined product's price + shipping_cost with the
+    // caller's tier-resolved values. The cart itself stores only
+    // quantity + product_id — pricing is always live, so no cart
+    // migration is needed when tiers change.
+    const items = (data || []) as Array<Record<string, unknown> & {
+      product_id: string;
+      coffee_products: { id: string; price: number; shipping_cost: number } & Record<string, unknown>;
+    }>;
+    if (items.length > 0) {
+      const priced = await resolveCoffeeProductsPricing({
+        productIds: items.map((i) => i.product_id),
+        userId: user.id,
+      });
+      for (const item of items) {
+        const r = priced.get(item.product_id);
+        if (r && item.coffee_products) {
+          item.coffee_products = {
+            ...item.coffee_products,
+            price: r.price,
+            shipping_cost: r.shipping_cost,
+          };
+        }
+      }
+    }
+
+    return NextResponse.json({ items });
   } catch (e) {
     const msg = e instanceof Error ? e.message : "Unknown error";
     return NextResponse.json({ error: msg }, { status: 500 });

--- a/src/app/api/coffee/checkout/route.ts
+++ b/src/app/api/coffee/checkout/route.ts
@@ -6,6 +6,7 @@ import { isQuickBooks } from "@/lib/paymentProvider";
 import { createInvoice, sendInvoiceEmail, getInvoice } from "@/lib/quickbooks";
 import { sendCoffeeOrderNotification, sendCoffeeOrderConfirmation } from "@/lib/coffeeEmail";
 import { requireExecutedCoffeeSupplyAgreement } from "@/lib/placementAgreements";
+import { resolveCoffeeProductsPricing } from "@/lib/coffeePricing";
 
 export async function POST(req: NextRequest) {
   try {
@@ -90,21 +91,32 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "All items in your cart are unavailable" }, { status: 400 });
     }
 
+    // Resolve every line's unit price against the operator's coffee
+    // pricing tier — the joined coffee_products.price is only used as
+    // a bootstrap fallback. Snapshot the resolved pricing_tier_id on
+    // the order line so historical orders stay correct after admin
+    // edits tier prices later.
+    const productIds = validItems.map((i: Record<string, unknown>) => (i.coffee_products as Record<string, unknown>).id as string);
+    const priced = await resolveCoffeeProductsPricing({ productIds, userId: user.id });
+
     const orderNumber = `VC-${Date.now()}`;
 
     const orderItems = validItems.map((item: Record<string, unknown>) => {
       const product = item.coffee_products as Record<string, unknown>;
-      const unitPrice = Number(product.price);
-      const shippingCost = Number(product.shipping_cost || 0);
+      const productId = product.id as string;
+      const resolved = priced.get(productId);
+      const unitPrice = resolved ? resolved.price : Number(product.price);
+      const shippingCost = resolved ? resolved.shipping_cost : Number(product.shipping_cost || 0);
       const quantity = Number(item.quantity);
       return {
-        product_id: product.id as string,
+        product_id: productId,
         product_name: product.name as string,
         product_sku: product.sku as string,
         quantity,
         unit_price: unitPrice,
         shipping_cost: shippingCost,
         line_total: (unitPrice + shippingCost) * quantity,
+        pricing_tier_id: resolved?.pricing_tier_id || null,
       };
     });
 

--- a/src/app/api/coffee/orders/route.ts
+++ b/src/app/api/coffee/orders/route.ts
@@ -5,6 +5,7 @@ import {
   sendCoffeeOrderNotification,
   sendCoffeeOrderConfirmation,
 } from "@/lib/coffeeEmail";
+import { resolveCoffeeProductsPricing } from "@/lib/coffeePricing";
 
 export async function GET(req: NextRequest) {
   try {
@@ -92,19 +93,28 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "All items in your cart are unavailable" }, { status: 400 });
     }
 
+    // Same tier resolution + snapshot as /api/coffee/checkout — both
+    // write paths must produce equivalent lines so admin editing a
+    // tier price never causes divergent behavior between them.
+    const productIds = validItems.map((i: Record<string, unknown>) => (i.coffee_products as Record<string, unknown>).id as string);
+    const priced = await resolveCoffeeProductsPricing({ productIds, userId: user.id });
+
     const orderNumber = `VC-${Date.now()}`;
 
     const orderItems = validItems.map((item: Record<string, unknown>) => {
       const product = item.coffee_products as Record<string, unknown>;
-      const unitPrice = Number(product.price);
+      const productId = product.id as string;
+      const resolved = priced.get(productId);
+      const unitPrice = resolved ? resolved.price : Number(product.price);
       const quantity = Number(item.quantity);
       return {
-        product_id: product.id as string,
+        product_id: productId,
         product_name: product.name as string,
         product_sku: product.sku as string,
         quantity,
         unit_price: unitPrice,
         line_total: unitPrice * quantity,
+        pricing_tier_id: resolved?.pricing_tier_id || null,
       };
     });
 

--- a/src/app/api/coffee/products/route.ts
+++ b/src/app/api/coffee/products/route.ts
@@ -1,6 +1,19 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getUserIdFromRequest } from "@/lib/apiAuth";
+import { resolveCoffeeProductsPricing } from "@/lib/coffeePricing";
 
+/**
+ * GET /api/coffee/products — public shopper feed.
+ *
+ * Prices returned to the caller are resolved against the caller's
+ * coffee pricing tier via resolveCoffeeProductsPricing. Unauth
+ * callers, or accounts with no tier assigned, resolve to Tier 1.
+ *
+ * The response shape is unchanged — `price` and `shipping_cost` on
+ * each row are overwritten with the tier-resolved values. Downstream
+ * clients (shop page, cart drawer) don't need to change.
+ */
 export async function GET(req: NextRequest) {
   try {
     const { searchParams } = new URL(req.url);
@@ -33,12 +46,28 @@ export async function GET(req: NextRequest) {
     }
 
     const { data, error } = await query;
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
-    if (error) {
-      return NextResponse.json({ error: error.message }, { status: 500 });
-    }
+    const rows = data || [];
+    const userId = await getUserIdFromRequest(req);
+    const priced = await resolveCoffeeProductsPricing({
+      productIds: rows.map((r: { id: string }) => r.id),
+      userId,
+    });
 
-    return NextResponse.json({ products: data || [] });
+    const products = rows.map((r: Record<string, unknown>) => {
+      const resolved = priced.get(r.id as string);
+      if (!resolved) return r;
+      return {
+        ...r,
+        price: resolved.price,
+        shipping_cost: resolved.shipping_cost,
+        pricing_tier_id: resolved.pricing_tier_id,
+        pricing_tier_key: resolved.tier_key,
+      };
+    });
+
+    return NextResponse.json({ products });
   } catch (e) {
     const msg = e instanceof Error ? e.message : "Unknown error";
     return NextResponse.json({ error: msg }, { status: 500 });

--- a/src/lib/coffeePricing.ts
+++ b/src/lib/coffeePricing.ts
@@ -1,0 +1,217 @@
+import { supabaseAdmin } from "./supabaseAdmin";
+
+/**
+ * Coffee product pricing resolver — the single source of truth for
+ * what price a given account sees / pays for a given coffee product.
+ *
+ * Fallback chain:
+ *   1. Active tier price for the account's assigned tier
+ *   2. Active Tier 1 price (the default/floor)
+ *   3. coffee_products.price (bootstrap fallback for products with no
+ *      tier prices seeded yet — shouldn't happen post-migration 118)
+ *   4. 0 (last-resort — flagged as fallback_used=true)
+ *
+ * Money is Postgres NUMERIC → JS number here. That matches the rest of
+ * the coffee stack; Stripe/QB integrations convert to cents at the
+ * boundary (Math.round(x * 100)).
+ */
+
+export interface ResolvedPricing {
+  product_id: string;
+  pricing_tier_id: string | null;
+  tier_key: string | null;
+  tier_name: string | null;
+  price: number;
+  shipping_cost: number;
+  currency: "USD";
+  fallback_used: boolean;
+  fallback_reason: string | null;
+}
+
+interface TierRow {
+  id: string;
+  tier_key: string;
+  name: string;
+}
+
+interface TierPriceRow {
+  product_id: string;
+  pricing_tier_id: string;
+  price: number;
+  shipping_cost: number;
+}
+
+interface ProductBaseRow {
+  id: string;
+  price: number;
+  shipping_cost: number;
+}
+
+/**
+ * Look up the caller's active pricing tier row. Nullable — a user with
+ * no assignment is treated as Tier 1 downstream by the resolver.
+ */
+export async function getUserPricingTier(userId: string | null | undefined): Promise<TierRow | null> {
+  if (!userId) return null;
+  const { data } = await supabaseAdmin
+    .from("profiles")
+    .select("coffee_pricing_tier_id, coffee_pricing_tier:coffee_pricing_tier_id(id, tier_key, name, is_active)")
+    .eq("id", userId)
+    .maybeSingle();
+  const tier = (data?.coffee_pricing_tier as unknown as (TierRow & { is_active: boolean }) | null) || null;
+  if (!tier || tier.is_active === false) return null;
+  return { id: tier.id, tier_key: tier.tier_key, name: tier.name };
+}
+
+/**
+ * Fetch the active Tier 1 row so the resolver can fall back when a
+ * caller either has no assigned tier or is missing a price for their
+ * assigned tier.
+ */
+export async function getTierOneRow(): Promise<TierRow | null> {
+  const { data } = await supabaseAdmin
+    .from("coffee_pricing_tiers")
+    .select("id, tier_key, name")
+    .eq("tier_key", "tier_1")
+    .eq("is_active", true)
+    .maybeSingle();
+  return (data as TierRow) || null;
+}
+
+/**
+ * Batch pricing resolver — hydrate a map of {product_id → ResolvedPricing}
+ * for the given user in a fixed number of queries regardless of list
+ * length. Use this from every list surface (products endpoint, cart,
+ * checkout, admin previews, receipts).
+ */
+export async function resolveCoffeeProductsPricing(args: {
+  productIds: string[];
+  userId?: string | null;
+}): Promise<Map<string, ResolvedPricing>> {
+  const out = new Map<string, ResolvedPricing>();
+  const productIds = Array.from(new Set(args.productIds.filter(Boolean)));
+  if (productIds.length === 0) return out;
+
+  const [userTier, tierOne, productBaseResp, tierPriceResp] = await Promise.all([
+    getUserPricingTier(args.userId ?? null),
+    getTierOneRow(),
+    supabaseAdmin
+      .from("coffee_products")
+      .select("id, price, shipping_cost")
+      .in("id", productIds),
+    supabaseAdmin
+      .from("coffee_product_tier_prices")
+      .select("product_id, pricing_tier_id, price, shipping_cost")
+      .in("product_id", productIds)
+      .eq("is_active", true),
+  ]);
+
+  const effectiveTier = userTier || tierOne;
+  const bases = new Map<string, ProductBaseRow>(
+    ((productBaseResp.data || []) as ProductBaseRow[]).map((p) => [p.id, p]),
+  );
+  const tierPrices = new Map<string, TierPriceRow>();
+  for (const row of (tierPriceResp.data || []) as TierPriceRow[]) {
+    tierPrices.set(`${row.product_id}:${row.pricing_tier_id}`, row);
+  }
+
+  for (const pid of productIds) {
+    const base = bases.get(pid);
+    if (!base) {
+      // Product row missing — shouldn't happen, but never throw here;
+      // callers include invalid ids sometimes (deleted while cart open).
+      out.set(pid, {
+        product_id: pid,
+        pricing_tier_id: null,
+        tier_key: null,
+        tier_name: null,
+        price: 0,
+        shipping_cost: 0,
+        currency: "USD",
+        fallback_used: true,
+        fallback_reason: "product-not-found",
+      });
+      continue;
+    }
+
+    // Preferred: the user's tier price
+    if (effectiveTier) {
+      const priced = tierPrices.get(`${pid}:${effectiveTier.id}`);
+      if (priced) {
+        const isFallback = !!(userTier && effectiveTier.tier_key === "tier_1" && !args.userId);
+        out.set(pid, {
+          product_id: pid,
+          pricing_tier_id: effectiveTier.id,
+          tier_key: effectiveTier.tier_key,
+          tier_name: effectiveTier.name,
+          price: Number(priced.price),
+          shipping_cost: Number(priced.shipping_cost),
+          currency: "USD",
+          fallback_used: !userTier,
+          fallback_reason: !userTier ? "no-tier-assigned-defaulted-tier-1" : null,
+        });
+        continue;
+      }
+    }
+
+    // Fallback 1: Tier 1 price if user tier had no row
+    if (tierOne) {
+      const t1 = tierPrices.get(`${pid}:${tierOne.id}`);
+      if (t1) {
+        out.set(pid, {
+          product_id: pid,
+          pricing_tier_id: tierOne.id,
+          tier_key: tierOne.tier_key,
+          tier_name: tierOne.name,
+          price: Number(t1.price),
+          shipping_cost: Number(t1.shipping_cost),
+          currency: "USD",
+          fallback_used: true,
+          fallback_reason: userTier
+            ? `no-price-for-${userTier.tier_key}-fell-back-tier-1`
+            : "no-tier-assigned-defaulted-tier-1",
+        });
+        continue;
+      }
+    }
+
+    // Fallback 2: bootstrap product.price
+    out.set(pid, {
+      product_id: pid,
+      pricing_tier_id: null,
+      tier_key: null,
+      tier_name: null,
+      price: Number(base.price),
+      shipping_cost: Number(base.shipping_cost || 0),
+      currency: "USD",
+      fallback_used: true,
+      fallback_reason: "no-tier-prices-defined-using-product-base",
+    });
+  }
+
+  return out;
+}
+
+/**
+ * Single-product convenience wrapper. Prefer resolveCoffeeProductsPricing
+ * when you have more than one product in hand.
+ */
+export async function resolveCoffeeProductPricing(args: {
+  productId: string;
+  userId?: string | null;
+}): Promise<ResolvedPricing> {
+  const map = await resolveCoffeeProductsPricing({ productIds: [args.productId], userId: args.userId });
+  const hit = map.get(args.productId);
+  if (hit) return hit;
+  return {
+    product_id: args.productId,
+    pricing_tier_id: null,
+    tier_key: null,
+    tier_name: null,
+    price: 0,
+    shipping_cost: 0,
+    currency: "USD",
+    fallback_used: true,
+    fallback_reason: "product-not-found",
+  };
+}

--- a/supabase/migrations/118_coffee_pricing_tiers.sql
+++ b/supabase/migrations/118_coffee_pricing_tiers.sql
@@ -1,0 +1,144 @@
+-- Account-level coffee pricing tiers.
+--
+-- Every coffee-enabled operator (a row in profiles with
+-- coffee_access_enabled=true) belongs to exactly one pricing tier.
+-- Each coffee product carries a price + shipping cost per tier.
+-- Admin can edit any single (product, tier) cell without disturbing
+-- the other two.
+--
+-- Money type: NUMERIC (matches the rest of the coffee stack —
+-- coffee_products.price, coffee_orders.subtotal/total, and
+-- coffee_order_items.unit_price are all numeric today). Postgres
+-- NUMERIC is arbitrary-precision decimal, not floating point, so the
+-- "no floats" invariant is satisfied.
+--
+-- Rollout is zero-downtime: tier prices for existing products are
+-- backfilled to the current product.price so the resolver falls
+-- through to sensible values on day one.
+
+-- ═════════════════════════════════════════════════════════════════════
+-- 1. Pricing tiers
+-- ═════════════════════════════════════════════════════════════════════
+
+CREATE TABLE IF NOT EXISTS coffee_pricing_tiers (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tier_key text UNIQUE NOT NULL CHECK (tier_key ~ '^tier_[0-9]+$'),
+  name text NOT NULL,
+  description text,
+  is_active boolean NOT NULL DEFAULT true,
+  sort_order int NOT NULL DEFAULT 0,
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_coffee_pricing_tiers_active_sort
+  ON coffee_pricing_tiers(is_active, sort_order);
+
+INSERT INTO coffee_pricing_tiers (tier_key, name, description, sort_order)
+VALUES
+  ('tier_1', 'Tier 1', 'Standard / new operator pricing', 1),
+  ('tier_2', 'Tier 2', 'Preferred pricing', 2),
+  ('tier_3', 'Tier 3', 'Volume / partner pricing', 3)
+ON CONFLICT (tier_key) DO NOTHING;
+
+-- ═════════════════════════════════════════════════════════════════════
+-- 2. Per-product / per-tier prices
+-- ═════════════════════════════════════════════════════════════════════
+
+CREATE TABLE IF NOT EXISTS coffee_product_tier_prices (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  product_id uuid NOT NULL REFERENCES coffee_products(id) ON DELETE CASCADE,
+  pricing_tier_id uuid NOT NULL REFERENCES coffee_pricing_tiers(id) ON DELETE RESTRICT,
+  price numeric NOT NULL CHECK (price >= 0),
+  shipping_cost numeric NOT NULL DEFAULT 0 CHECK (shipping_cost >= 0),
+  is_active boolean NOT NULL DEFAULT true,
+  updated_by uuid REFERENCES profiles(id),
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now(),
+  UNIQUE (product_id, pricing_tier_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_coffee_product_tier_prices_product
+  ON coffee_product_tier_prices(product_id)
+  WHERE is_active = true;
+CREATE INDEX IF NOT EXISTS idx_coffee_product_tier_prices_tier
+  ON coffee_product_tier_prices(pricing_tier_id)
+  WHERE is_active = true;
+
+-- ═════════════════════════════════════════════════════════════════════
+-- 3. Account tier assignment
+-- ═════════════════════════════════════════════════════════════════════
+-- Nullable — null means "resolver falls through to Tier 1", which is
+-- how new accounts default without a hard-set. Admin can promote later.
+
+ALTER TABLE profiles
+  ADD COLUMN IF NOT EXISTS coffee_pricing_tier_id uuid
+    REFERENCES coffee_pricing_tiers(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_profiles_coffee_pricing_tier
+  ON profiles(coffee_pricing_tier_id)
+  WHERE coffee_pricing_tier_id IS NOT NULL;
+
+-- ═════════════════════════════════════════════════════════════════════
+-- 4. Historical snapshot on order lines
+-- ═════════════════════════════════════════════════════════════════════
+-- coffee_order_items already snapshots product_name, product_sku,
+-- unit_price. Add pricing_tier_id so admin can trace which tier's
+-- price a historical order actually paid.
+
+ALTER TABLE coffee_order_items
+  ADD COLUMN IF NOT EXISTS pricing_tier_id uuid
+    REFERENCES coffee_pricing_tiers(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_coffee_order_items_pricing_tier
+  ON coffee_order_items(pricing_tier_id)
+  WHERE pricing_tier_id IS NOT NULL;
+
+-- ═════════════════════════════════════════════════════════════════════
+-- 5. Backfill product×tier prices
+-- ═════════════════════════════════════════════════════════════════════
+-- For every existing coffee_products row, create Tier 1 / Tier 2 /
+-- Tier 3 price rows mirroring the current product.price and
+-- shipping_cost. Admin adjusts T2/T3 downward later — day-one behavior
+-- is a no-op: every tier resolves to the same price the shop shows
+-- today.
+--
+-- Idempotent: the unique (product_id, pricing_tier_id) constraint
+-- + ON CONFLICT DO NOTHING protects against re-runs.
+
+INSERT INTO coffee_product_tier_prices (product_id, pricing_tier_id, price, shipping_cost)
+SELECT
+  p.id,
+  t.id,
+  p.price,
+  COALESCE(p.shipping_cost, 0)
+FROM coffee_products p
+CROSS JOIN coffee_pricing_tiers t
+ON CONFLICT (product_id, pricing_tier_id) DO NOTHING;
+
+-- ═════════════════════════════════════════════════════════════════════
+-- 6. RLS
+-- ═════════════════════════════════════════════════════════════════════
+-- All writes are admin-mediated via API routes using supabaseAdmin
+-- (service role). Public reads are also mediated — the resolver is a
+-- server-side helper that never exposes the full price matrix to
+-- non-admin callers. So the tables are service-role-only, plus an
+-- authenticated read policy on tier metadata (so the admin UI's
+-- profile-edit modal can populate its tier dropdown without a
+-- separate route).
+
+ALTER TABLE coffee_pricing_tiers ENABLE ROW LEVEL SECURITY;
+ALTER TABLE coffee_product_tier_prices ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Service role only" ON coffee_pricing_tiers;
+CREATE POLICY "Service role only" ON coffee_pricing_tiers
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+DROP POLICY IF EXISTS "Anyone reads active tiers" ON coffee_pricing_tiers;
+CREATE POLICY "Anyone reads active tiers" ON coffee_pricing_tiers
+  FOR SELECT TO authenticated
+  USING (is_active = true);
+
+DROP POLICY IF EXISTS "Service role only" ON coffee_product_tier_prices;
+CREATE POLICY "Service role only" ON coffee_product_tier_prices
+  FOR ALL TO service_role USING (true) WITH CHECK (true);


### PR DESCRIPTION
Every coffee operator now belongs to exactly one pricing tier (Tier 1 / Tier 2 / Tier 3). Each coffee product carries a price + shipping cost per tier. Admin can edit any single (product, tier) cell without touching the other two. Historical orders keep the price they actually paid via a pricing_tier_id snapshot on coffee_order_items.

Migration 118:
  * coffee_pricing_tiers (id, tier_key, name, description, is_active, sort_order) — seeded Tier 1 / Tier 2 / Tier 3
  * coffee_product_tier_prices (product_id, pricing_tier_id, price, shipping_cost, updated_by, timestamps) with UNIQUE (product_id, pricing_tier_id) — that constraint is what makes single-cell edits safe
  * profiles.coffee_pricing_tier_id — nullable FK; null resolves to Tier 1
  * coffee_order_items.pricing_tier_id — nullable FK, snapshot at order time
  * Backfill: cross-joins every coffee_products × coffee_pricing_tiers to seed all three tiers from the current product.price + shipping_cost. Day-one shopper price is identical to before; admin adjusts T2/T3 as needed
  * Service-role-only RLS, plus an authenticated read policy on tier metadata so the admin edit modal can populate its dropdown

Money type: numeric (matches the rest of the coffee stack — coffee_products, coffee_orders, coffee_order_items are all numeric). Postgres NUMERIC is arbitrary-precision decimal, not floating point, so the "no floats" invariant is satisfied. Stripe/QB integrations already convert to cents at the boundary via Math.round(x * 100).

Resolver: src/lib/coffeePricing.ts
  * resolveCoffeeProductsPricing({productIds, userId}) — batch, N+3 queries regardless of list size
  * Fallback chain: user's tier → Tier 1 → coffee_products.price → 0
  * Returns fallback_used + fallback_reason so admin surfaces can flag missing prices

Wired into every price-flowing surface:
  * /api/coffee/products — remaps price + shipping_cost per row, plus adds pricing_tier_id + pricing_tier_key to the payload
  * /api/coffee/cart GET — remaps joined coffee_products price + shipping
  * /api/coffee/checkout POST — resolver drives unit_price; snapshots pricing_tier_id on every coffee_order_items row
  * /api/coffee/orders POST (legacy path) — same treatment so both write paths behave consistently

Admin surfaces:
  * New tier-prices grid at /admin/coffee/tier-prices — product × 3 tiers, inline per-cell edit with dirty-state highlighting, save per cell
  * GET/PATCH /api/admin/coffee/tier-prices — validates non-negative numerics, FK exists checks, writes audit_logs
  * profiles.coffee_pricing_tier_id added to /api/admin/users/[id] PATCH allowlist with FK validation + audit-log write on reassign
  * Tier dropdown added to the user edit modal on /admin/page.tsx with an "Edit tier prices →" link to the grid

Audit logs: coffee_tier_price_created, coffee_tier_price_updated, coffee_account_tier_reassigned actions — all captured on audit_logs with before/after jsonb and product/tier metadata. Reuses the existing table established by migration 105.

Preserves existing behavior:
  * Shopper page, cart drawer, checkout page render unchanged (the same product.price field just resolves to a tier-aware value)
  * coffee_pricing_proposals stays untouched — it's an operator's "quote my downstream customer" tool, orthogonal to tier pricing
  * Existing orders keep the unit_price they were written with; new orders write pricing_tier_id alongside so admin can trace which tier a historical order paid