### PR TITLE
Lead Generator entitlements + PP customer shell + QB $9.99/mo gate

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -40,6 +40,7 @@ import {
   US_STATES,
 } from "@/lib/types";
 import type { Profile, VendingRequest, OperatorListing } from "@/lib/types";
+import LeadGeneratorAdminPanel from "@/app/components/LeadGeneratorAdminPanel";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -715,13 +716,24 @@ function UsersManager({ token, onSuccess }: { token: string; onSuccess: (msg: st
                   <option value="locator">Locator</option>
                   <option value="location_manager">Location Manager</option>
                   <option value="requestor">Location</option>
+                  <option value="placement_partner">Placement Provider</option>
                   <option value="sales">Sales Rep</option>
                   <option value="sales_manager">Sales Manager</option>
                   <option value="market_leader">Market Leader</option>
                   <option value="director_of_sales">Director of Sales</option>
                   <option value="admin">Admin</option>
                 </select>
+                <p className="mt-1 text-[11px] text-gray-500">
+                  Placement Providers get free Lead Generator access + zero CRM access.
+                  Operators, Location Managers, and Requestors are payment-gated for Lead Generator ($9.99/mo).
+                </p>
               </div>
+
+              {/* Lead Generator admin control panel */}
+              <LeadGeneratorAdminPanel
+                userId={editingUser?.id || ""}
+                token={token}
+              />
               <div className="flex flex-wrap items-center gap-4">
                 <div className="flex items-center gap-2">
                   <input

--- a/src/app/api/admin/lead-generator/override/route.ts
+++ b/src/app/api/admin/lead-generator/override/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+
+/**
+ * POST /api/admin/lead-generator/override
+ * Body: { user_id, action: 'grant' | 'revoke' | 'clear', reason?: string }
+ *
+ * Admin-only Lead Generator entitlement override. Wins over role-based
+ * and subscription-derived entitlement (see getLeadGeneratorAccess).
+ *
+ *   grant  → creates/updates a source=admin_override, status=active row.
+ *            User can use LG regardless of role or subscription.
+ *   revoke → creates/updates a source=admin_override, status=revoked row.
+ *            User is blocked from LG even if they'd otherwise qualify.
+ *   clear  → deletes the admin_override row so the resolver falls back
+ *            to role-based / subscription logic.
+ *
+ * Always audit-logged with before/after.
+ */
+export async function POST(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const body = await req.json().catch(() => ({}));
+  const userId = typeof body.user_id === "string" ? body.user_id : "";
+  const action = typeof body.action === "string" ? body.action : "";
+  const reason = typeof body.reason === "string" ? body.reason.slice(0, 500) : "";
+
+  if (!userId) return NextResponse.json({ error: "user_id required" }, { status: 400 });
+  if (!["grant", "revoke", "clear"].includes(action)) {
+    return NextResponse.json({ error: "action must be grant, revoke, or clear" }, { status: 400 });
+  }
+
+  const { data: profile } = await supabaseAdmin
+    .from("profiles")
+    .select("id, email, full_name")
+    .eq("id", userId)
+    .maybeSingle();
+  if (!profile) return NextResponse.json({ error: "User not found" }, { status: 404 });
+
+  const { data: before } = await supabaseAdmin
+    .from("account_entitlements")
+    .select("*")
+    .eq("user_id", userId)
+    .eq("entitlement_key", "lead_generator_access")
+    .maybeSingle();
+
+  const nowIso = new Date().toISOString();
+
+  if (action === "clear") {
+    // Only clear if the existing row is admin_override; leave role_based /
+    // subscription rows untouched.
+    if (before?.source === "admin_override") {
+      await supabaseAdmin
+        .from("account_entitlements")
+        .delete()
+        .eq("id", before.id);
+    }
+  } else {
+    const newStatus = action === "grant" ? "active" : "revoked";
+    await supabaseAdmin
+      .from("account_entitlements")
+      .upsert({
+        user_id: userId,
+        entitlement_key: "lead_generator_access",
+        source: "admin_override",
+        status: newStatus,
+        starts_at: nowIso,
+        metadata: { reason, actor_id: adminId },
+        updated_at: nowIso,
+      }, { onConflict: "user_id,entitlement_key" });
+  }
+
+  await supabaseAdmin.from("audit_logs").insert({
+    actor_id: adminId,
+    action: `lead_generator_admin_${action}`,
+    entity_type: "account_entitlements",
+    entity_id: userId,
+    before: before ? { source: before.source, status: before.status } : null,
+    after: action === "clear" ? null : { source: "admin_override", status: action === "grant" ? "active" : "revoked" },
+    metadata: {
+      target_user_email: profile.email,
+      target_user_full_name: profile.full_name,
+      reason,
+    },
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/admin/lead-generator/status/route.ts
+++ b/src/app/api/admin/lead-generator/status/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAdminUserId } from "@/lib/adminAuth";
+import { getLeadGeneratorAccess } from "@/lib/leadGeneratorAccess";
+
+/**
+ * GET /api/admin/lead-generator/status?user_id=<uuid>
+ *
+ * Returns the resolver's decision for another user, so the admin edit
+ * modal can render current LG entitlement state without duplicating
+ * the business rule client-side.
+ */
+export async function GET(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const url = new URL(req.url);
+  const userId = url.searchParams.get("user_id");
+  if (!userId) return NextResponse.json({ error: "user_id required" }, { status: 400 });
+
+  const access = await getLeadGeneratorAccess(userId);
+  return NextResponse.json(access);
+}

--- a/src/app/api/sales/lead-generator/route.ts
+++ b/src/app/api/sales/lead-generator/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
-import { getSalesUser, isElevatedRole } from "@/lib/salesAuth";
+import { getUserIdFromRequest } from "@/lib/apiAuth";
+import { getLeadGeneratorAccess } from "@/lib/leadGeneratorAccess";
 import { searchBusinesses } from "@/lib/placesApi";
 import { createLeadSheet, LeadRow } from "@/lib/googleSheets";
 
@@ -31,17 +32,54 @@ const INDUSTRIES = [
   "nursing schools",
 ];
 
+/**
+ * Auth model changed as part of the Lead Generator entitlement rollout:
+ * this API is no longer sales-only. Access resolution lives in
+ * getLeadGeneratorAccess — admin / sales-family / PP / dual-role /
+ * paid operators pass; unsubscribed operators + location_manager +
+ * requestor get 402 with a subscribe URL so the client can redirect
+ * them to the payment gate.
+ */
+async function authorize(req: NextRequest) {
+  const userId = await getUserIdFromRequest(req);
+  if (!userId) {
+    return {
+      resp: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+      userId: null as string | null,
+    };
+  }
+  const access = await getLeadGeneratorAccess(userId);
+  if (!access.canAccessLeadGenerator) {
+    if (access.shouldShowPaymentGate) {
+      return {
+        resp: NextResponse.json(
+          { error: "Lead Generator requires an active $9.99/month subscription", subscribe_url: "/tools/lead-generator/subscribe", reason: access.reason },
+          { status: 402 },
+        ),
+        userId,
+      };
+    }
+    return {
+      resp: NextResponse.json(
+        { error: "Lead Generator access not permitted for this account", reason: access.reason },
+        { status: 403 },
+      ),
+      userId,
+    };
+  }
+  return { resp: null, userId };
+}
+
 export async function GET(req: NextRequest) {
-  const user = await getSalesUser(req);
-  if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { resp } = await authorize(req);
+  if (resp) return resp;
   return NextResponse.json({ industries: INDUSTRIES });
 }
 
 export async function POST(req: NextRequest) {
-  const user = await getSalesUser(req);
-  if (!user) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
+  const { resp, userId } = await authorize(req);
+  if (resp) return resp;
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const body = await req.json();
   const { city, state, industry, radius, lead_count, assigned_to, list_name } = body;
@@ -66,7 +104,7 @@ export async function POST(req: NextRequest) {
       lead_count: 0,
       status: "generating",
       assigned_to: assigned_to || null,
-      created_by: user.id,
+      created_by: userId,
     })
     .select("id")
     .single();

--- a/src/app/api/tools/lead-generator/access/route.ts
+++ b/src/app/api/tools/lead-generator/access/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getUserIdFromRequest } from "@/lib/apiAuth";
+import { getLeadGeneratorAccess } from "@/lib/leadGeneratorAccess";
+
+/**
+ * GET /api/tools/lead-generator/access
+ *
+ * Returns the full LG access decision for the caller so the
+ * customer-facing shell can render the right state (badge, banner,
+ * or bounce). Underlying resolver is the same one gating the actual
+ * generation API — no divergence possible.
+ */
+export async function GET(req: NextRequest) {
+  const userId = await getUserIdFromRequest(req);
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const access = await getLeadGeneratorAccess(userId);
+  return NextResponse.json(access);
+}

--- a/src/app/api/tools/lead-generator/cancel/route.ts
+++ b/src/app/api/tools/lead-generator/cancel/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getUserIdFromRequest } from "@/lib/apiAuth";
+import { cancel } from "@/lib/leadGeneratorSubscription";
+
+/**
+ * POST /api/tools/lead-generator/cancel
+ *
+ * User-initiated cancellation. Immediate revoke per product decision —
+ * access is cut the moment this returns.
+ */
+export async function POST(req: NextRequest) {
+  const userId = await getUserIdFromRequest(req);
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  await cancel(userId);
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/tools/lead-generator/subscribe/route.ts
+++ b/src/app/api/tools/lead-generator/subscribe/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getUserIdFromRequest } from "@/lib/apiAuth";
+import { getLeadGeneratorAccess } from "@/lib/leadGeneratorAccess";
+import { subscribe } from "@/lib/leadGeneratorSubscription";
+
+/**
+ * POST /api/tools/lead-generator/subscribe
+ *
+ * Starts a $9.99/month Lead Generator subscription for the caller.
+ * Creates a QB invoice + returns the invoice pay link. The subscription
+ * status flips to active only when the QB webhook posts a Payment
+ * against the invoice — no client-side "success" grants access.
+ *
+ * Guard: only paid roles can subscribe (operator / location_manager /
+ * requestor). Free-role users trying to subscribe get a friendly 409.
+ */
+export async function POST(req: NextRequest) {
+  const userId = await getUserIdFromRequest(req);
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const access = await getLeadGeneratorAccess(userId);
+  if (!access.requiresSubscription) {
+    if (access.canAccessLeadGenerator) {
+      return NextResponse.json(
+        { error: "Your account already has free Lead Generator access — no subscription needed" },
+        { status: 409 },
+      );
+    }
+    return NextResponse.json(
+      { error: "Lead Generator subscription isn't available for this account. Contact support." },
+      { status: 403 },
+    );
+  }
+
+  const result = await subscribe(userId);
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+  return NextResponse.json({
+    ok: true,
+    subscription_id: result.subscription_id,
+    invoice_id: result.invoice_id,
+    invoice_link: result.invoice_link,
+  });
+}

--- a/src/app/api/webhooks/quickbooks/route.ts
+++ b/src/app/api/webhooks/quickbooks/route.ts
@@ -322,6 +322,22 @@ async function handleQBPayment(paymentId: string, realmId: string) {
       continue;
     }
 
+    // Check lead_generator_subscriptions — QB invoice acts as the
+    // recurring "period charge". On payment we advance the current
+    // period + activate the entitlement. Idempotent per (invoiceId, paymentId).
+    const { data: lgSub } = await supabaseAdmin
+      .from("lead_generator_subscriptions")
+      .select("id, user_id")
+      .eq("provider_subscription_id", invoiceId)
+      .maybeSingle();
+
+    if (lgSub) {
+      console.log(`[qb-webhook] Processing lead-generator subscription payment for QB invoice ${invoiceId}`);
+      const { handleInvoicePaid } = await import("@/lib/leadGeneratorSubscription");
+      await handleInvoicePaid({ invoiceId, paymentId: `qb_${paymentId}` });
+      continue;
+    }
+
     // Check user_listing_purchases (marketplace)
     const { data: marketplacePurchase } = await supabaseAdmin
       .from("user_listing_purchases")

--- a/src/app/components/LeadGeneratorAdminPanel.tsx
+++ b/src/app/components/LeadGeneratorAdminPanel.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Loader2, CheckCircle2, AlertCircle, ShieldCheck, ShieldOff, RotateCcw } from "lucide-react";
+
+interface AccessBody {
+  canAccessLeadGenerator: boolean;
+  requiresSubscription: boolean;
+  hasActiveSubscription: boolean;
+  shouldShowPaymentGate: boolean;
+  isPlacementProvider: boolean;
+  reason: string;
+  subscription: {
+    status: string;
+    current_period_end: string | null;
+    cancel_at_period_end: boolean;
+  } | null;
+}
+
+interface Props {
+  userId: string;
+  token: string;
+}
+
+/**
+ * Admin control panel for a user's Lead Generator entitlement. Shown
+ * inside the user edit modal on /admin. Renders the resolver's
+ * current decision + three admin override actions:
+ *
+ *   Grant   → source=admin_override, status=active (bypass everything)
+ *   Revoke  → source=admin_override, status=revoked (block everything)
+ *   Clear   → delete the admin_override row (fall back to role /
+ *             subscription logic)
+ *
+ * All three go through /api/admin/lead-generator/override and are
+ * audit-logged.
+ */
+export default function LeadGeneratorAdminPanel({ userId, token }: Props) {
+  const [loading, setLoading] = useState(true);
+  const [access, setAccess] = useState<AccessBody | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!userId || !token) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/admin/lead-generator/status?user_id=${userId}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.ok) setAccess((await res.json()) as AccessBody);
+      else setError((await res.json().catch(() => ({}))).error || "Failed to load LG status");
+    } finally {
+      setLoading(false);
+    }
+  }, [userId, token]);
+
+  useEffect(() => { load(); }, [load]);
+
+  async function override(action: "grant" | "revoke" | "clear") {
+    let reason = "";
+    if (action !== "clear") {
+      reason = prompt(`Reason to ${action} Lead Generator access?`) || "";
+      if (!reason) return;
+    }
+    setBusy(action);
+    setMessage(null); setError(null);
+    try {
+      const res = await fetch("/api/admin/lead-generator/override", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ user_id: userId, action, reason }),
+      });
+      if (!res.ok) {
+        setError((await res.json().catch(() => ({}))).error || "Override failed");
+        return;
+      }
+      setMessage(
+        action === "grant" ? "Lead Generator access granted"
+          : action === "revoke" ? "Lead Generator access revoked"
+          : "Admin override cleared — falling back to role / subscription",
+      );
+      await load();
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  if (loading || !access) {
+    return (
+      <div className="rounded-xl border border-gray-100 bg-gray-50 p-3 text-sm text-gray-500 flex items-center gap-2">
+        <Loader2 className="h-3.5 w-3.5 animate-spin" /> Loading Lead Generator status…
+      </div>
+    );
+  }
+
+  const badgeStyle = access.canAccessLeadGenerator
+    ? "bg-emerald-100 text-emerald-800"
+    : "bg-gray-100 text-gray-600";
+
+  return (
+    <div className="rounded-xl border border-gray-100 bg-gray-50 p-3 space-y-2">
+      <div className="flex items-center justify-between">
+        <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">Lead Generator</p>
+        <span className={`text-[10px] font-semibold px-2 py-0.5 rounded-full ${badgeStyle}`}>
+          {access.canAccessLeadGenerator ? "Active" : "Not accessible"}
+        </span>
+      </div>
+      <p className="text-xs text-gray-700">
+        <strong>Reason:</strong> {access.reason.replace(/_/g, " ")}
+      </p>
+      {access.requiresSubscription && access.subscription && (
+        <p className="text-[11px] text-gray-500">
+          Subscription: {access.subscription.status}
+          {access.subscription.current_period_end && ` · ends ${new Date(access.subscription.current_period_end).toLocaleDateString()}`}
+        </p>
+      )}
+
+      {message && (
+        <div className="text-xs text-emerald-700 flex items-center gap-1">
+          <CheckCircle2 className="h-3 w-3" /> {message}
+        </div>
+      )}
+      {error && (
+        <div className="text-xs text-red-700 flex items-center gap-1">
+          <AlertCircle className="h-3 w-3" /> {error}
+        </div>
+      )}
+
+      <div className="flex flex-wrap gap-2 pt-1">
+        <button
+          type="button"
+          onClick={() => override("grant")}
+          disabled={busy !== null}
+          className="inline-flex items-center gap-1 rounded-lg bg-emerald-600 hover:bg-emerald-700 px-2.5 py-1 text-[11px] font-semibold text-white cursor-pointer disabled:opacity-50"
+        >
+          {busy === "grant" ? <Loader2 className="h-3 w-3 animate-spin" /> : <ShieldCheck className="h-3 w-3" />}
+          Grant Access
+        </button>
+        <button
+          type="button"
+          onClick={() => override("revoke")}
+          disabled={busy !== null}
+          className="inline-flex items-center gap-1 rounded-lg border border-red-200 hover:bg-red-50 px-2.5 py-1 text-[11px] font-semibold text-red-700 cursor-pointer disabled:opacity-50"
+        >
+          {busy === "revoke" ? <Loader2 className="h-3 w-3 animate-spin" /> : <ShieldOff className="h-3 w-3" />}
+          Revoke Access
+        </button>
+        <button
+          type="button"
+          onClick={() => override("clear")}
+          disabled={busy !== null}
+          className="inline-flex items-center gap-1 rounded-lg border border-gray-200 hover:bg-gray-100 px-2.5 py-1 text-[11px] font-semibold text-gray-700 cursor-pointer disabled:opacity-50"
+        >
+          {busy === "clear" ? <Loader2 className="h-3 w-3 animate-spin" /> : <RotateCcw className="h-3 w-3" />}
+          Clear Override
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/LeadGeneratorForm.tsx
+++ b/src/app/components/LeadGeneratorForm.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+import { useState } from "react";
+import { Loader2, ExternalLink, CheckCircle2, AlertCircle, Zap } from "lucide-react";
+
+const INDUSTRIES = [
+  "warehouses", "manufacturing", "logistics", "distribution centers",
+  "auto dealerships", "collision centers", "office buildings",
+  "medical offices", "private schools", "vending operators", "hotels",
+  "apartments", "tire shops", "truck repair shops", "rehabs", "RV parks",
+  "motorcycle dealerships", "motorcycle repair shops",
+  "electrical supply stores", "vocational schools", "universities",
+  "cosmetology schools", "trucking schools", "nursing schools",
+  "barbershops", "car washes", "laundromats",
+];
+
+const US_STATES = [
+  "AL","AK","AZ","AR","CA","CO","CT","DE","FL","GA","HI","ID","IL","IN","IA",
+  "KS","KY","LA","ME","MD","MA","MI","MN","MS","MO","MT","NE","NV","NH","NJ",
+  "NM","NY","NC","ND","OH","OK","OR","PA","RI","SC","SD","TN","TX","UT","VT",
+  "VA","WA","WV","WI","WY",
+];
+
+export interface RepOption {
+  id: string;
+  full_name: string;
+  email: string;
+}
+
+interface LeadGeneratorFormProps {
+  token: string;
+  showRepPicker?: boolean;
+  repOptions?: RepOption[];
+  onSubscriptionRequired?: () => void;
+}
+
+/**
+ * Shared Lead Generator form used by both the CRM shell
+ * (/sales/lead-generator) and the customer-facing shell
+ * (/tools/lead-generator). The only functional difference is
+ * showRepPicker — sales/admin can assign lists to a rep; PPs +
+ * paid operators generate for themselves.
+ *
+ * onSubscriptionRequired is called when the API returns 402
+ * (paid role without an active subscription). The customer-facing
+ * shell uses it to route the caller to the payment gate.
+ */
+export default function LeadGeneratorForm({
+  token,
+  showRepPicker = false,
+  repOptions = [],
+  onSubscriptionRequired,
+}: LeadGeneratorFormProps) {
+  const [generating, setGenerating] = useState(false);
+  const [result, setResult] = useState<{ sheet_url: string; lead_count: number; title: string } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const [form, setForm] = useState({
+    city: "",
+    state: "",
+    industry: "",
+    radius: "25",
+    lead_count: "40",
+    assigned_to: "",
+    list_name: "",
+  });
+
+  async function handleGenerate() {
+    setError(null);
+
+    if (!form.city.trim()) { setError("City is required"); return; }
+    if (!form.state) { setError("State is required"); return; }
+    if (!form.industry) { setError("Industry is required"); return; }
+
+    setGenerating(true);
+    setResult(null);
+
+    try {
+      const res = await fetch("/api/sales/lead-generator", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+        body: JSON.stringify({
+          city: form.city.trim(),
+          state: form.state,
+          industry: form.industry,
+          radius: Number(form.radius) || 25,
+          lead_count: Number(form.lead_count) || 40,
+          assigned_to: form.assigned_to || null,
+          list_name: form.list_name.trim() || null,
+        }),
+      });
+
+      // 402 = subscription required. Route the operator to the payment
+      // gate — the API also puts subscribe_url in the body.
+      if (res.status === 402) {
+        if (onSubscriptionRequired) {
+          onSubscriptionRequired();
+        } else {
+          const body = await res.json().catch(() => ({}));
+          window.location.href = body.subscribe_url || "/tools/lead-generator/subscribe";
+        }
+        return;
+      }
+
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || "Failed to generate leads");
+        return;
+      }
+
+      setResult({
+        sheet_url: data.sheet_url || "",
+        lead_count: data.lead_count || 0,
+        title: data.title || "Call List",
+      });
+    } catch {
+      setError("Network error — please try again");
+    } finally {
+      setGenerating(false);
+    }
+  }
+
+  const inputClass = "w-full rounded-lg border border-gray-200 px-3 py-2.5 text-sm focus:border-green-600 focus:outline-none focus:ring-1 focus:ring-green-600/30";
+  const selectClass = `${inputClass} cursor-pointer`;
+  const labelClass = "block text-xs font-medium text-gray-600 mb-1";
+
+  return (
+    <>
+      {error && (
+        <div className="mb-4 flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 p-4">
+          <AlertCircle className="w-4 h-4 text-red-600 mt-0.5 flex-shrink-0" />
+          <p className="text-sm text-red-700">{error}</p>
+        </div>
+      )}
+
+      {result && (
+        <div className="mb-6 rounded-lg border border-green-200 bg-green-50 p-5">
+          <div className="flex items-start gap-3">
+            <CheckCircle2 className="w-5 h-5 text-green-600 mt-0.5 flex-shrink-0" />
+            <div>
+              <p className="font-semibold text-green-800">{result.lead_count} leads generated</p>
+              <p className="text-sm text-green-700 mt-1">Sheet: {result.title}</p>
+              <div className="flex items-center gap-3 mt-3">
+                {result.sheet_url && (
+                  <a
+                    href={result.sheet_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1.5 px-4 py-2 bg-green-700 text-white text-sm font-medium rounded-lg hover:bg-green-800 transition-colors"
+                  >
+                    <ExternalLink className="w-4 h-4" />
+                    Open Google Sheet
+                  </a>
+                )}
+                <button
+                  type="button"
+                  onClick={() => {
+                    setResult(null);
+                    setForm({ city: "", state: "", industry: "", radius: "25", lead_count: "40", assigned_to: "", list_name: "" });
+                  }}
+                  className="inline-flex items-center gap-1.5 px-4 py-2 border border-green-300 text-green-700 text-sm font-medium rounded-lg hover:bg-green-100 transition-colors cursor-pointer"
+                >
+                  <Zap className="w-4 h-4" />
+                  Generate Another
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div className="bg-white rounded-xl border border-gray-100 shadow-sm p-6 space-y-5">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div>
+            <label className={labelClass}>City <span className="text-red-500">*</span></label>
+            <input
+              value={form.city}
+              onChange={(e) => setForm((f) => ({ ...f, city: e.target.value }))}
+              placeholder="e.g. Detroit"
+              className={inputClass}
+            />
+          </div>
+          <div>
+            <label className={labelClass}>State <span className="text-red-500">*</span></label>
+            <select
+              value={form.state}
+              onChange={(e) => setForm((f) => ({ ...f, state: e.target.value }))}
+              className={selectClass}
+            >
+              <option value="">Select state...</option>
+              {US_STATES.map((s) => <option key={s} value={s}>{s}</option>)}
+            </select>
+          </div>
+        </div>
+
+        <div>
+          <label className={labelClass}>Industry <span className="text-red-500">*</span></label>
+          <select
+            value={form.industry}
+            onChange={(e) => setForm((f) => ({ ...f, industry: e.target.value }))}
+            className={selectClass}
+          >
+            <option value="">Select industry...</option>
+            {INDUSTRIES.map((i) => (
+              <option key={i} value={i}>{i.charAt(0).toUpperCase() + i.slice(1)}</option>
+            ))}
+          </select>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div>
+            <label className={labelClass}>Radius (miles)</label>
+            <input
+              type="number"
+              value={form.radius}
+              onChange={(e) => setForm((f) => ({ ...f, radius: e.target.value }))}
+              placeholder="25"
+              min="1"
+              max="100"
+              className={inputClass}
+            />
+          </div>
+          <div>
+            <label className={labelClass}>Max Leads</label>
+            <input
+              type="number"
+              value={form.lead_count}
+              onChange={(e) => setForm((f) => ({ ...f, lead_count: e.target.value }))}
+              placeholder="40"
+              min="5"
+              max="60"
+              className={inputClass}
+            />
+            <p className="text-[10px] text-gray-400 mt-1">Max 60 per generation</p>
+          </div>
+        </div>
+
+        {showRepPicker && (
+          <div>
+            <label className={labelClass}>Assign to Rep</label>
+            <select
+              value={form.assigned_to}
+              onChange={(e) => setForm((f) => ({ ...f, assigned_to: e.target.value }))}
+              className={selectClass}
+            >
+              <option value="">Unassigned</option>
+              {repOptions.map((u) => (
+                <option key={u.id} value={u.id}>{u.full_name || u.email}</option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        <div>
+          <label className={labelClass}>List Name</label>
+          <input
+            value={form.list_name}
+            onChange={(e) => setForm((f) => ({ ...f, list_name: e.target.value }))}
+            placeholder="Auto-generated if blank"
+            className={inputClass}
+          />
+        </div>
+
+        <button
+          type="button"
+          onClick={handleGenerate}
+          disabled={generating}
+          className="w-full py-3 px-4 bg-green-700 hover:bg-green-800 text-white font-semibold rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer flex items-center justify-center gap-2"
+        >
+          {generating ? (
+            <>
+              <Loader2 className="w-4 h-4 animate-spin" />
+              Generating leads...
+            </>
+          ) : (
+            <>
+              <Zap className="w-4 h-4" />
+              Generate Call List
+            </>
+          )}
+        </button>
+
+        {generating && (
+          <p className="text-xs text-center text-gray-500">
+            Searching Google Places and creating your spreadsheet. This may take 15-30 seconds.
+          </p>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -25,6 +25,7 @@ import {
   ShoppingBag,
   Crown,
   Briefcase,
+  Zap,
 } from "lucide-react";
 import type {
   Profile,
@@ -670,6 +671,34 @@ export default function DashboardPage() {
               <ChevronRight className="ml-auto h-5 w-5 text-black-primary/20 transition-colors group-hover:text-green-primary" />
             </Link>
           )}
+
+          {/*
+            Lead Generator card — visible on the customer-facing dashboard
+            for every logged-in account. Access is gated server-side by
+            getLeadGeneratorAccess; free-role users go straight to the tool,
+            paid-role users (operator/location_manager/requestor) hit the
+            $9.99/mo gate on click. Placement Providers also get this link
+            from their /placement dashboard.
+          */}
+          <Link
+            href="/tools/lead-generator"
+            className="group flex items-center gap-4 rounded-2xl border border-gray-100 bg-white p-5 shadow-sm transition-all hover:-translate-y-0.5 hover:border-green-100 hover:shadow-md"
+          >
+            <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-green-50 text-green-primary transition-colors group-hover:bg-green-primary group-hover:text-white">
+              <Zap className="h-6 w-6" />
+            </div>
+            <div>
+              <p className="font-semibold text-black-primary">
+                Lead Generator
+              </p>
+              <p className="text-sm text-black-primary/50">
+                {(["operator", "location_manager", "requestor"] as const).includes(profile.role as unknown as "operator" | "location_manager" | "requestor")
+                  ? "Auto-build call lists from Google Places — $9.99/mo"
+                  : "Auto-build call lists from Google Places by city + industry"}
+              </p>
+            </div>
+            <ChevronRight className="ml-auto h-5 w-5 text-black-primary/20 transition-colors group-hover:text-green-primary" />
+          </Link>
         </div>
 
         {/* ------- RECENT REQUESTS ------- */}

--- a/src/app/placement/page.tsx
+++ b/src/app/placement/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { Loader2, ArrowRight, CheckCircle2, Clock, Building2, Briefcase, Package, Users, Star, Bell, DollarSign, FileSignature } from "lucide-react";
+import { Loader2, ArrowRight, CheckCircle2, Clock, Building2, Briefcase, Package, Users, Star, Bell, DollarSign, FileSignature, Zap } from "lucide-react";
 import { createBrowserClient } from "@/lib/supabase";
 
 interface Partner {
@@ -206,6 +206,20 @@ export default function PlacementDashboardPage() {
           </div>
           <h2 className="text-lg font-semibold text-gray-900 mb-1">My Submissions</h2>
           <p className="text-sm text-gray-500">Track candidate locations you&apos;ve submitted and see approval status.</p>
+        </Link>
+
+        <Link
+          href="/tools/lead-generator"
+          className="group rounded-2xl border border-gray-100 bg-white p-6 hover:border-green-200 hover:shadow-sm transition-all"
+        >
+          <div className="flex items-center justify-between mb-4">
+            <div className="w-12 h-12 rounded-xl bg-green-50 flex items-center justify-center">
+              <Zap className="h-6 w-6 text-green-700" />
+            </div>
+            <ArrowRight className="h-5 w-5 text-gray-300 group-hover:text-green-primary transition-colors" />
+          </div>
+          <h2 className="text-lg font-semibold text-gray-900 mb-1">Lead Generator</h2>
+          <p className="text-sm text-gray-500">Auto-build call lists from Google Places. Included with your account.</p>
         </Link>
 
         <Link

--- a/src/app/sales/lead-generator/page.tsx
+++ b/src/app/sales/lead-generator/page.tsx
@@ -2,68 +2,22 @@
 
 import { useState, useEffect } from "react";
 import { createBrowserClient } from "@/lib/supabase";
-import { Loader2, ExternalLink, CheckCircle2, AlertCircle, Zap } from "lucide-react";
+import { Zap } from "lucide-react";
+import LeadGeneratorForm, { RepOption } from "@/app/components/LeadGeneratorForm";
 
-const INDUSTRIES = [
-  "warehouses",
-  "manufacturing",
-  "logistics",
-  "distribution centers",
-  "auto dealerships",
-  "collision centers",
-  "office buildings",
-  "medical offices",
-  "private schools",
-  "vending operators",
-  "hotels",
-  "apartments",
-  "tire shops",
-  "truck repair shops",
-  "rehabs",
-  "RV parks",
-  "motorcycle dealerships",
-  "motorcycle repair shops",
-  "electrical supply stores",
-  "vocational schools",
-  "universities",
-  "cosmetology schools",
-  "trucking schools",
-  "nursing schools",
-  "barbershops",
-  "car washes",
-  "laundromats",
-];
-
-const US_STATES = [
-  "AL","AK","AZ","AR","CA","CO","CT","DE","FL","GA","HI","ID","IL","IN","IA",
-  "KS","KY","LA","ME","MD","MA","MI","MN","MS","MO","MT","NE","NV","NH","NJ",
-  "NM","NY","NC","ND","OH","OK","OR","PA","RI","SC","SD","TN","TX","UT","VT",
-  "VA","WA","WV","WI","WY",
-];
-
-interface SalesUser {
-  id: string;
-  full_name: string;
-  email: string;
-  role: string;
-}
-
-export default function LeadGeneratorPage() {
+/**
+ * CRM shell for Lead Generator — admin + sales-family only.
+ * Uses the shared LeadGeneratorForm with the rep picker enabled so
+ * users can assign the generated list to another sales rep.
+ *
+ * Access is enforced server-side by /api/sales/lead-generator via
+ * getLeadGeneratorAccess — this page just fetches session + rep
+ * options and renders. Placement Providers / paid operators use
+ * the /tools/lead-generator shell instead.
+ */
+export default function SalesLeadGeneratorPage() {
   const [token, setToken] = useState("");
-  const [salesUsers, setSalesUsers] = useState<SalesUser[]>([]);
-  const [generating, setGenerating] = useState(false);
-  const [result, setResult] = useState<{ sheet_url: string; lead_count: number; title: string } | null>(null);
-  const [error, setError] = useState<string | null>(null);
-
-  const [form, setForm] = useState({
-    city: "",
-    state: "",
-    industry: "",
-    radius: "25",
-    lead_count: "40",
-    assigned_to: "",
-    list_name: "",
-  });
+  const [salesUsers, setSalesUsers] = useState<RepOption[]>([]);
 
   useEffect(() => {
     const supabase = createBrowserClient();
@@ -77,53 +31,6 @@ export default function LeadGeneratorPage() {
     });
   }, []);
 
-  async function handleGenerate() {
-    setError(null);
-
-    if (!form.city.trim()) { setError("City is required"); return; }
-    if (!form.state) { setError("State is required"); return; }
-    if (!form.industry) { setError("Industry is required"); return; }
-
-    setGenerating(true);
-    setResult(null);
-
-    try {
-      const res = await fetch("/api/sales/lead-generator", {
-        method: "POST",
-        headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
-        body: JSON.stringify({
-          city: form.city.trim(),
-          state: form.state,
-          industry: form.industry,
-          radius: Number(form.radius) || 25,
-          lead_count: Number(form.lead_count) || 40,
-          assigned_to: form.assigned_to || null,
-          list_name: form.list_name.trim() || null,
-        }),
-      });
-
-      const data = await res.json();
-      if (!res.ok) {
-        setError(data.error || "Failed to generate leads");
-        return;
-      }
-
-      setResult({
-        sheet_url: data.sheet_url || "",
-        lead_count: data.lead_count || 0,
-        title: data.title || "Call List",
-      });
-    } catch {
-      setError("Network error — please try again");
-    } finally {
-      setGenerating(false);
-    }
-  }
-
-  const inputClass = "w-full rounded-lg border border-gray-200 px-3 py-2.5 text-sm focus:border-green-600 focus:outline-none focus:ring-1 focus:ring-green-600/30";
-  const selectClass = `${inputClass} cursor-pointer`;
-  const labelClass = "block text-xs font-medium text-gray-600 mb-1";
-
   return (
     <div className="p-6 max-w-2xl mx-auto">
       <div className="flex items-center gap-3 mb-6">
@@ -136,164 +43,7 @@ export default function LeadGeneratorPage() {
         </div>
       </div>
 
-      {error && (
-        <div className="mb-4 flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 p-4">
-          <AlertCircle className="w-4 h-4 text-red-600 mt-0.5 flex-shrink-0" />
-          <p className="text-sm text-red-700">{error}</p>
-        </div>
-      )}
-
-      {result && (
-        <div className="mb-6 rounded-lg border border-green-200 bg-green-50 p-5">
-          <div className="flex items-start gap-3">
-            <CheckCircle2 className="w-5 h-5 text-green-600 mt-0.5 flex-shrink-0" />
-            <div>
-              <p className="font-semibold text-green-800">{result.lead_count} leads generated</p>
-              <p className="text-sm text-green-700 mt-1">Sheet: {result.title}</p>
-              <div className="flex items-center gap-3 mt-3">
-                {result.sheet_url && (
-                  <a
-                    href={result.sheet_url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1.5 px-4 py-2 bg-green-700 text-white text-sm font-medium rounded-lg hover:bg-green-800 transition-colors"
-                  >
-                    <ExternalLink className="w-4 h-4" />
-                    Open Google Sheet
-                  </a>
-                )}
-                <button
-                  type="button"
-                  onClick={() => {
-                    setResult(null);
-                    setForm({ city: "", state: "", industry: "", radius: "25", lead_count: "40", assigned_to: "", list_name: "" });
-                  }}
-                  className="inline-flex items-center gap-1.5 px-4 py-2 border border-green-300 text-green-700 text-sm font-medium rounded-lg hover:bg-green-100 transition-colors cursor-pointer"
-                >
-                  <Zap className="w-4 h-4" />
-                  Generate Another
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
-
-      <div className="bg-white rounded-xl border border-gray-100 shadow-sm p-6 space-y-5">
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <div>
-            <label className={labelClass}>City <span className="text-red-500">*</span></label>
-            <input
-              value={form.city}
-              onChange={(e) => setForm((f) => ({ ...f, city: e.target.value }))}
-              placeholder="e.g. Detroit"
-              className={inputClass}
-            />
-          </div>
-          <div>
-            <label className={labelClass}>State <span className="text-red-500">*</span></label>
-            <select
-              value={form.state}
-              onChange={(e) => setForm((f) => ({ ...f, state: e.target.value }))}
-              className={selectClass}
-            >
-              <option value="">Select state...</option>
-              {US_STATES.map((s) => <option key={s} value={s}>{s}</option>)}
-            </select>
-          </div>
-        </div>
-
-        <div>
-          <label className={labelClass}>Industry <span className="text-red-500">*</span></label>
-          <select
-            value={form.industry}
-            onChange={(e) => setForm((f) => ({ ...f, industry: e.target.value }))}
-            className={selectClass}
-          >
-            <option value="">Select industry...</option>
-            {INDUSTRIES.map((i) => (
-              <option key={i} value={i}>{i.charAt(0).toUpperCase() + i.slice(1)}</option>
-            ))}
-          </select>
-        </div>
-
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <div>
-            <label className={labelClass}>Radius (miles)</label>
-            <input
-              type="number"
-              value={form.radius}
-              onChange={(e) => setForm((f) => ({ ...f, radius: e.target.value }))}
-              placeholder="25"
-              min="1"
-              max="100"
-              className={inputClass}
-            />
-          </div>
-          <div>
-            <label className={labelClass}>Max Leads</label>
-            <input
-              type="number"
-              value={form.lead_count}
-              onChange={(e) => setForm((f) => ({ ...f, lead_count: e.target.value }))}
-              placeholder="40"
-              min="5"
-              max="60"
-              className={inputClass}
-            />
-            <p className="text-[10px] text-gray-400 mt-1">Max 60 per generation</p>
-          </div>
-        </div>
-
-        <div>
-          <label className={labelClass}>Assign to Rep</label>
-          <select
-            value={form.assigned_to}
-            onChange={(e) => setForm((f) => ({ ...f, assigned_to: e.target.value }))}
-            className={selectClass}
-          >
-            <option value="">Unassigned</option>
-            {salesUsers.map((u) => (
-              <option key={u.id} value={u.id}>{u.full_name || u.email}</option>
-            ))}
-          </select>
-        </div>
-
-        <div>
-          <label className={labelClass}>List Name</label>
-          <input
-            value={form.list_name}
-            onChange={(e) => setForm((f) => ({ ...f, list_name: e.target.value }))}
-            placeholder="Auto-generated if blank (e.g. Detroit_Warehouses_Leads)"
-            className={inputClass}
-          />
-        </div>
-
-        <button
-          type="button"
-          onClick={handleGenerate}
-          disabled={generating}
-          className="w-full py-3 px-4 bg-green-700 hover:bg-green-800 text-white font-semibold rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer flex items-center justify-center gap-2"
-        >
-          {generating ? (
-            <>
-              <Loader2 className="w-4 h-4 animate-spin" />
-              Generating leads...
-            </>
-          ) : (
-            <>
-              <Zap className="w-4 h-4" />
-              Generate Call List
-            </>
-          )}
-        </button>
-
-        {generating && (
-          <p className="text-xs text-center text-gray-500">
-            Searching Google Places and creating your spreadsheet. This may take 15-30 seconds.
-          </p>
-        )}
-      </div>
+      <LeadGeneratorForm token={token} showRepPicker repOptions={salesUsers} />
     </div>
   );
 }

--- a/src/app/tools/lead-generator/manage/page.tsx
+++ b/src/app/tools/lead-generator/manage/page.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Loader2, ArrowLeft, Zap, AlertCircle, XCircle, CheckCircle2 } from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
+
+interface AccessBody {
+  canAccessLeadGenerator: boolean;
+  requiresSubscription: boolean;
+  hasActiveSubscription: boolean;
+  subscription: {
+    status: string;
+    current_period_end: string | null;
+    cancel_at_period_end: boolean;
+  } | null;
+}
+
+export default function LeadGeneratorManagePage() {
+  const router = useRouter();
+  const [token, setToken] = useState("");
+  const [access, setAccess] = useState<AccessBody | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [canceling, setCanceling] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const load = async (t: string) => {
+    const res = await fetch("/api/tools/lead-generator/access", {
+      headers: { Authorization: `Bearer ${t}` },
+    });
+    if (res.ok) setAccess((await res.json()) as AccessBody);
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!session?.access_token) { router.push("/login?redirect=/tools/lead-generator/manage"); return; }
+      setToken(session.access_token);
+      load(session.access_token);
+    });
+  }, [router]);
+
+  async function handleCancel() {
+    if (!confirm("Cancel your Lead Generator subscription? Access ends immediately.")) return;
+    setError(null); setMessage(null);
+    setCanceling(true);
+    try {
+      const res = await fetch("/api/tools/lead-generator/cancel", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) {
+        setError((await res.json().catch(() => ({}))).error || "Cancel failed");
+        return;
+      }
+      setMessage("Subscription canceled. Access has ended.");
+      await load(token);
+    } catch {
+      setError("Network error — please try again");
+    } finally {
+      setCanceling(false);
+    }
+  }
+
+  if (loading || !access) {
+    return <div className="min-h-[60vh] flex items-center justify-center"><Loader2 className="h-6 w-6 animate-spin text-green-primary" /></div>;
+  }
+
+  const sub = access.subscription;
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="mx-auto max-w-2xl px-4 py-10 sm:px-6">
+        <Link href="/tools/lead-generator" className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-green-primary mb-6">
+          <ArrowLeft className="h-4 w-4" /> Back to Lead Generator
+        </Link>
+
+        <div className="rounded-2xl border border-gray-100 bg-white p-8 shadow-sm">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex items-center justify-center w-12 h-12 rounded-xl bg-green-100">
+              <Zap className="w-6 h-6 text-green-700" />
+            </div>
+            <div>
+              <h1 className="text-2xl font-bold text-gray-900">Manage Subscription</h1>
+              <p className="text-sm text-gray-500">Lead Generator — $9.99/month</p>
+            </div>
+          </div>
+
+          {message && (
+            <div className="mb-4 flex items-start gap-2 rounded-lg border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-800">
+              <CheckCircle2 className="h-4 w-4 mt-0.5" /> {message}
+            </div>
+          )}
+          {error && (
+            <div className="mb-4 flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+              <AlertCircle className="h-4 w-4 mt-0.5" /> {error}
+            </div>
+          )}
+
+          <div className="mb-6 rounded-xl border border-gray-100 bg-gray-50 p-5">
+            <p className="text-xs uppercase tracking-wide text-gray-500 mb-1">Status</p>
+            <p className="text-lg font-semibold text-gray-900 capitalize">
+              {sub?.status || (access.canAccessLeadGenerator ? "Free access" : "No subscription")}
+            </p>
+            {sub?.current_period_end && (
+              <p className="text-xs text-gray-500 mt-2">
+                {sub.status === "active"
+                  ? `Renews ${new Date(sub.current_period_end).toLocaleDateString()}`
+                  : `Period ended ${new Date(sub.current_period_end).toLocaleDateString()}`}
+              </p>
+            )}
+          </div>
+
+          {sub?.status === "active" && (
+            <button
+              onClick={handleCancel}
+              disabled={canceling}
+              className="w-full inline-flex items-center justify-center gap-2 rounded-xl border border-red-200 hover:bg-red-50 px-6 py-3 text-sm font-semibold text-red-700 cursor-pointer disabled:opacity-50"
+            >
+              {canceling ? <Loader2 className="h-4 w-4 animate-spin" /> : <XCircle className="h-4 w-4" />}
+              Cancel Subscription
+            </button>
+          )}
+
+          {(!sub || sub.status !== "active") && access.requiresSubscription && (
+            <Link
+              href="/tools/lead-generator/subscribe"
+              className="w-full inline-flex items-center justify-center gap-2 rounded-xl bg-emerald-600 hover:bg-emerald-700 px-6 py-3 text-sm font-semibold text-white cursor-pointer"
+            >
+              Start Subscription — $9.99/month
+            </Link>
+          )}
+
+          {access.canAccessLeadGenerator && !access.requiresSubscription && (
+            <p className="text-center text-sm text-gray-500">
+              Your account has free Lead Generator access — no subscription needed.
+            </p>
+          )}
+
+          <p className="mt-6 text-[11px] text-gray-500 text-center">
+            Canceling ends access immediately. You can restart a subscription anytime.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/tools/lead-generator/page.tsx
+++ b/src/app/tools/lead-generator/page.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Loader2, Zap, ArrowLeft, ShieldCheck, Building2 } from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
+import LeadGeneratorForm from "@/app/components/LeadGeneratorForm";
+
+interface AccessBody {
+  canAccessLeadGenerator: boolean;
+  requiresSubscription: boolean;
+  hasActiveSubscription: boolean;
+  shouldShowPaymentGate: boolean;
+  isPlacementProvider: boolean;
+  reason: string;
+  subscription: {
+    status: string;
+    current_period_end: string | null;
+    cancel_at_period_end: boolean;
+  } | null;
+}
+
+/**
+ * Customer-facing Lead Generator shell.
+ *
+ * Serves two audiences from the same URL — Placement Providers (free)
+ * and paid operators. Explicitly NOT part of the CRM shell — no CRM
+ * sidebar, no admin links, just the tool + a home link.
+ *
+ * Access is verified server-side twice:
+ *   1) On page load via GET /api/tools/lead-generator/access
+ *   2) On generate-attempt via POST /api/sales/lead-generator (which
+ *      is the shared API — same guard applies to both shells).
+ *
+ * If a paid operator/location_manager/requestor lands here without an
+ * active subscription, we bounce them to /tools/lead-generator/subscribe.
+ * If the account isn't eligible at all, we bounce home with a message.
+ */
+export default function ToolsLeadGeneratorPage() {
+  const router = useRouter();
+  const [token, setToken] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [access, setAccess] = useState<AccessBody | null>(null);
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(async ({ data: { session } }) => {
+      if (!session?.access_token) { router.push("/login?redirect=/tools/lead-generator"); return; }
+      setToken(session.access_token);
+      const res = await fetch("/api/tools/lead-generator/access", {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      });
+      if (!res.ok) {
+        router.push("/");
+        return;
+      }
+      const body = (await res.json()) as AccessBody;
+      setAccess(body);
+      if (!body.canAccessLeadGenerator) {
+        if (body.shouldShowPaymentGate) {
+          router.replace("/tools/lead-generator/subscribe");
+        } else {
+          router.replace("/");
+        }
+        return;
+      }
+      setLoading(false);
+    });
+  }, [router]);
+
+  if (loading || !access) {
+    return (
+      <div className="min-h-[60vh] flex items-center justify-center">
+        <Loader2 className="h-6 w-6 animate-spin text-green-primary" />
+      </div>
+    );
+  }
+
+  const homeHref = access.isPlacementProvider ? "/placement" : "/";
+  const homeLabel = access.isPlacementProvider ? "Placement Dashboard" : "Home";
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6">
+        <Link href={homeHref} className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-green-primary mb-6">
+          <ArrowLeft className="h-4 w-4" /> Back to {homeLabel}
+        </Link>
+
+        <div className="flex items-center gap-3 mb-6">
+          <div className="flex items-center justify-center w-10 h-10 rounded-xl bg-green-100">
+            <Zap className="w-5 h-5 text-green-700" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">Lead Generator</h1>
+            <p className="text-sm text-gray-500">
+              Auto-build outbound call lists from Google Places. Results ship to Google Sheets.
+            </p>
+          </div>
+        </div>
+
+        {access.isPlacementProvider && (
+          <div className="mb-4 rounded-2xl border border-emerald-200 bg-emerald-50 p-4 flex items-start gap-3">
+            <ShieldCheck className="h-5 w-5 text-emerald-700 shrink-0 mt-0.5" />
+            <div className="text-sm text-emerald-900">
+              You&apos;re on Placement Provider access — Lead Generator is included in your account.
+            </div>
+          </div>
+        )}
+
+        {access.requiresSubscription && access.hasActiveSubscription && (
+          <div className="mb-4 rounded-2xl border border-blue-200 bg-blue-50 p-4 flex items-start gap-3">
+            <Building2 className="h-5 w-5 text-blue-700 shrink-0 mt-0.5" />
+            <div className="text-sm text-blue-900">
+              <p className="font-semibold">Active subscription — $9.99/month</p>
+              {access.subscription?.current_period_end && (
+                <p className="text-xs mt-0.5">
+                  Next renewal: {new Date(access.subscription.current_period_end).toLocaleDateString()}
+                  {access.subscription.cancel_at_period_end ? " · cancellation scheduled" : ""}
+                </p>
+              )}
+              <Link
+                href="/tools/lead-generator/manage"
+                className="mt-1 inline-block text-xs font-semibold text-blue-700 hover:text-blue-800 underline"
+              >
+                Manage subscription →
+              </Link>
+            </div>
+          </div>
+        )}
+
+        <LeadGeneratorForm token={token} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/tools/lead-generator/subscribe/page.tsx
+++ b/src/app/tools/lead-generator/subscribe/page.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Loader2, ArrowLeft, Zap, CheckCircle2, AlertCircle, CreditCard, ExternalLink } from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
+
+interface AccessBody {
+  canAccessLeadGenerator: boolean;
+  requiresSubscription: boolean;
+  hasActiveSubscription: boolean;
+  shouldShowPaymentGate: boolean;
+  isPlacementProvider: boolean;
+  reason: string;
+  subscription: {
+    status: string;
+    current_period_end: string | null;
+    cancel_at_period_end: boolean;
+  } | null;
+}
+
+export default function LeadGeneratorSubscribePage() {
+  const router = useRouter();
+  const [token, setToken] = useState("");
+  const [access, setAccess] = useState<AccessBody | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [subscribing, setSubscribing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [invoiceLink, setInvoiceLink] = useState<string | null>(null);
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(async ({ data: { session } }) => {
+      if (!session?.access_token) { router.push("/login?redirect=/tools/lead-generator/subscribe"); return; }
+      setToken(session.access_token);
+      const res = await fetch("/api/tools/lead-generator/access", {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      });
+      if (res.ok) {
+        const body = (await res.json()) as AccessBody;
+        setAccess(body);
+        // If they already have access, no gate needed — send them to the tool.
+        if (body.canAccessLeadGenerator) {
+          router.replace("/tools/lead-generator");
+          return;
+        }
+      }
+      setLoading(false);
+    });
+  }, [router]);
+
+  async function handleSubscribe() {
+    setError(null);
+    setSubscribing(true);
+    try {
+      const res = await fetch("/api/tools/lead-generator/subscribe", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const body = await res.json();
+      if (!res.ok) {
+        setError(body.error || "Could not start subscription");
+        return;
+      }
+      setInvoiceLink(body.invoice_link || null);
+    } catch {
+      setError("Network error — please try again");
+    } finally {
+      setSubscribing(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-[60vh] flex items-center justify-center">
+        <Loader2 className="h-6 w-6 animate-spin text-green-primary" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="mx-auto max-w-2xl px-4 py-10 sm:px-6">
+        <Link href="/" className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-green-primary mb-6">
+          <ArrowLeft className="h-4 w-4" /> Back to Home
+        </Link>
+
+        <div className="rounded-2xl border border-gray-100 bg-white p-8 shadow-sm">
+          <div className="flex items-center gap-3 mb-4">
+            <div className="flex items-center justify-center w-12 h-12 rounded-xl bg-green-100">
+              <Zap className="w-6 h-6 text-green-700" />
+            </div>
+            <div>
+              <h1 className="text-2xl font-bold text-gray-900">Lead Generator Access</h1>
+              <p className="text-sm text-gray-500">Operators — subscribe to unlock</p>
+            </div>
+          </div>
+
+          <div className="mb-6 rounded-xl border border-emerald-100 bg-emerald-50 p-5">
+            <p className="text-3xl font-bold text-emerald-800">$9.99<span className="text-base font-medium text-emerald-700">/month</span></p>
+            <p className="text-sm text-emerald-800 mt-2">
+              Operators can unlock the Lead Generator for $9.99/month. Use it to search,
+              organize, and identify potential vending placement opportunities.
+            </p>
+          </div>
+
+          <ul className="mb-6 space-y-2 text-sm text-gray-700">
+            <li className="flex items-start gap-2">
+              <CheckCircle2 className="h-4 w-4 text-emerald-600 mt-0.5 shrink-0" />
+              Auto-build call lists from Google Places by city + industry
+            </li>
+            <li className="flex items-start gap-2">
+              <CheckCircle2 className="h-4 w-4 text-emerald-600 mt-0.5 shrink-0" />
+              Results ship to Google Sheets for your team
+            </li>
+            <li className="flex items-start gap-2">
+              <CheckCircle2 className="h-4 w-4 text-emerald-600 mt-0.5 shrink-0" />
+              Up to 60 leads per generation
+            </li>
+            <li className="flex items-start gap-2">
+              <CheckCircle2 className="h-4 w-4 text-emerald-600 mt-0.5 shrink-0" />
+              Cancel anytime — access ends immediately
+            </li>
+          </ul>
+
+          {access?.subscription?.status === "past_due" && (
+            <div className="mb-4 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
+              Your last invoice went unpaid. Pay the new invoice below to restore access.
+            </div>
+          )}
+          {access?.subscription?.status === "canceled" && (
+            <div className="mb-4 rounded-lg border border-gray-200 bg-gray-50 p-3 text-sm text-gray-700">
+              Previous subscription canceled. Starting a new subscription creates a fresh invoice.
+            </div>
+          )}
+
+          {error && (
+            <div className="mb-4 flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+              <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
+              <span>{error}</span>
+            </div>
+          )}
+
+          {invoiceLink ? (
+            <>
+              <div className="mb-4 flex items-start gap-2 rounded-lg border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-800">
+                <CheckCircle2 className="h-4 w-4 mt-0.5 shrink-0" />
+                <span>Invoice created. Pay to activate access — you&apos;ll also receive a copy by email.</span>
+              </div>
+              <a
+                href={invoiceLink}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="w-full inline-flex items-center justify-center gap-2 rounded-xl bg-emerald-600 hover:bg-emerald-700 px-6 py-3 text-sm font-semibold text-white cursor-pointer"
+              >
+                <ExternalLink className="h-4 w-4" /> Pay $9.99 Invoice
+              </a>
+            </>
+          ) : (
+            <button
+              onClick={handleSubscribe}
+              disabled={subscribing}
+              className="w-full inline-flex items-center justify-center gap-2 rounded-xl bg-emerald-600 hover:bg-emerald-700 px-6 py-3 text-sm font-semibold text-white cursor-pointer disabled:opacity-50"
+            >
+              {subscribing ? <Loader2 className="h-4 w-4 animate-spin" /> : <CreditCard className="h-4 w-4" />}
+              Start Monthly Subscription — $9.99/month
+            </button>
+          )}
+
+          <p className="mt-4 text-[11px] text-gray-500 text-center">
+            Subscription renews monthly. Cancel anytime from your account.
+            Access begins after payment is confirmed.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/leadGeneratorAccess.ts
+++ b/src/lib/leadGeneratorAccess.ts
@@ -1,0 +1,246 @@
+import { supabaseAdmin } from "./supabaseAdmin";
+
+/**
+ * Lead Generator access resolver.
+ *
+ * Single source of truth. Every LG page, API, and nav gate must call
+ * this — do not re-implement the business rule anywhere else.
+ *
+ * Rule summary:
+ *   FREE (no payment) — admin, sales-family, placement_partner, locator,
+ *     or any user with an active placement_partners row.
+ *   PAID ($9.99/mo QB Recurring) — operator (no PP row), location_manager,
+ *     requestor.
+ *   HIDDEN — everyone else (admin can grant via admin_override entitlement).
+ *
+ * CRM access is a SEPARATE gate. Placement Providers get LG + zero CRM.
+ */
+
+export const LEAD_GENERATOR_MONTHLY_PRICE_USD = 9.99;
+export const LEAD_GENERATOR_MONTHLY_PRICE_CENTS = 999;
+
+export type LGReason =
+  | "role_admin"
+  | "role_sales_family"
+  | "role_placement_partner"
+  | "role_locator"
+  | "placement_partner_row"
+  | "admin_override_granted"
+  | "admin_override_revoked"
+  | "subscription_active"
+  | "subscription_missing"
+  | "subscription_incomplete"
+  | "subscription_past_due"
+  | "subscription_canceled"
+  | "subscription_unpaid"
+  | "role_not_recognized"
+  | "no_user";
+
+const FREE_ROLES = new Set([
+  "admin",
+  "sales",
+  "sales_manager",
+  "director_of_sales",
+  "market_leader",
+  "placement_partner",
+  "locator",
+]);
+
+const PAID_ROLES = new Set([
+  "operator",
+  "location_manager",
+  "requestor",
+]);
+
+const CRM_ALLOWED_ROLES = new Set([
+  "admin",
+  "sales",
+  "sales_manager",
+  "director_of_sales",
+  "market_leader",
+]);
+
+export interface LeadGeneratorAccess {
+  canAccessLeadGenerator: boolean;
+  requiresSubscription: boolean;
+  hasActiveSubscription: boolean;
+  shouldShowPaymentGate: boolean;
+  canAccessCRM: boolean;
+  isPlacementProvider: boolean;
+  reason: LGReason;
+  subscription: {
+    status: string;
+    current_period_end: string | null;
+    cancel_at_period_end: boolean;
+  } | null;
+}
+
+interface ProfileRow {
+  id: string;
+  role: string;
+}
+
+interface EntitlementRow {
+  entitlement_key: string;
+  source: string;
+  status: string;
+  metadata: Record<string, unknown> | null;
+}
+
+interface SubRow {
+  status: string;
+  current_period_end: string | null;
+  cancel_at_period_end: boolean;
+}
+
+export async function getLeadGeneratorAccess(
+  userId: string | null | undefined,
+): Promise<LeadGeneratorAccess> {
+  if (!userId) {
+    return baseline(false, "no_user");
+  }
+
+  const [{ data: profile }, { data: entitlement }, { data: sub }, ppRow] = await Promise.all([
+    supabaseAdmin
+      .from("profiles")
+      .select("id, role")
+      .eq("id", userId)
+      .maybeSingle() as unknown as Promise<{ data: ProfileRow | null }>,
+    supabaseAdmin
+      .from("account_entitlements")
+      .select("entitlement_key, source, status, metadata")
+      .eq("user_id", userId)
+      .eq("entitlement_key", "lead_generator_access")
+      .maybeSingle() as unknown as Promise<{ data: EntitlementRow | null }>,
+    supabaseAdmin
+      .from("lead_generator_subscriptions")
+      .select("status, current_period_end, cancel_at_period_end")
+      .eq("user_id", userId)
+      .maybeSingle() as unknown as Promise<{ data: SubRow | null }>,
+    (async () => {
+      const { data } = await supabaseAdmin
+        .from("placement_partners")
+        .select("id, active")
+        .eq("id", userId)
+        .maybeSingle();
+      return data && data.active !== false ? data : null;
+    })(),
+  ]);
+
+  const role = profile?.role || "";
+  const isPP = !!ppRow || role === "placement_partner" || role === "locator";
+  const canCRM = CRM_ALLOWED_ROLES.has(role);
+
+  // Admin override — hard grant / hard revoke, wins over everything.
+  if (entitlement?.source === "admin_override") {
+    if (entitlement.status === "active") {
+      return {
+        canAccessLeadGenerator: true,
+        requiresSubscription: false,
+        hasActiveSubscription: false,
+        shouldShowPaymentGate: false,
+        canAccessCRM: canCRM,
+        isPlacementProvider: isPP,
+        reason: "admin_override_granted",
+        subscription: sub ? { status: sub.status, current_period_end: sub.current_period_end, cancel_at_period_end: sub.cancel_at_period_end } : null,
+      };
+    }
+    if (entitlement.status === "revoked") {
+      return {
+        canAccessLeadGenerator: false,
+        requiresSubscription: false,
+        hasActiveSubscription: false,
+        shouldShowPaymentGate: false,
+        canAccessCRM: canCRM,
+        isPlacementProvider: isPP,
+        reason: "admin_override_revoked",
+        subscription: null,
+      };
+    }
+  }
+
+  // Free-role access.
+  if (FREE_ROLES.has(role) || isPP) {
+    let reason: LGReason = "role_not_recognized";
+    if (role === "admin") reason = "role_admin";
+    else if (role === "placement_partner") reason = "role_placement_partner";
+    else if (role === "locator") reason = "role_locator";
+    else if (
+      role === "sales" || role === "sales_manager" ||
+      role === "director_of_sales" || role === "market_leader"
+    ) reason = "role_sales_family";
+    else if (isPP) reason = "placement_partner_row";
+    return {
+      canAccessLeadGenerator: true,
+      requiresSubscription: false,
+      hasActiveSubscription: false,
+      shouldShowPaymentGate: false,
+      canAccessCRM: canCRM,
+      isPlacementProvider: isPP,
+      reason,
+      subscription: null,
+    };
+  }
+
+  // Paid-role access.
+  if (PAID_ROLES.has(role)) {
+    const hasActive = sub?.status === "active" || sub?.status === "trialing";
+    if (hasActive) {
+      return {
+        canAccessLeadGenerator: true,
+        requiresSubscription: true,
+        hasActiveSubscription: true,
+        shouldShowPaymentGate: false,
+        canAccessCRM: canCRM,
+        isPlacementProvider: isPP,
+        reason: "subscription_active",
+        subscription: sub ? { status: sub.status, current_period_end: sub.current_period_end, cancel_at_period_end: sub.cancel_at_period_end } : null,
+      };
+    }
+    let reason: LGReason = "subscription_missing";
+    if (sub?.status === "past_due") reason = "subscription_past_due";
+    else if (sub?.status === "canceled") reason = "subscription_canceled";
+    else if (sub?.status === "unpaid") reason = "subscription_unpaid";
+    else if (sub?.status === "incomplete" || sub?.status === "incomplete_expired") reason = "subscription_incomplete";
+    return {
+      canAccessLeadGenerator: false,
+      requiresSubscription: true,
+      hasActiveSubscription: false,
+      shouldShowPaymentGate: true,
+      canAccessCRM: canCRM,
+      isPlacementProvider: isPP,
+      reason,
+      subscription: sub ? { status: sub.status, current_period_end: sub.current_period_end, cancel_at_period_end: sub.cancel_at_period_end } : null,
+    };
+  }
+
+  // Unknown / unsupported role — no access unless admin has granted.
+  return baseline(canCRM, "role_not_recognized", isPP);
+}
+
+function baseline(canCRM: boolean, reason: LGReason, isPP = false): LeadGeneratorAccess {
+  return {
+    canAccessLeadGenerator: false,
+    requiresSubscription: false,
+    hasActiveSubscription: false,
+    shouldShowPaymentGate: false,
+    canAccessCRM: canCRM,
+    isPlacementProvider: isPP,
+    reason,
+    subscription: null,
+  };
+}
+
+/**
+ * Convenience: returns just the boolean decision + the redirect target
+ * (either a subscribe URL or an access-denied path). Callers pushing
+ * users through server-side redirects use this.
+ */
+export async function requireLeadGeneratorOrRedirect(
+  userId: string | null | undefined,
+): Promise<{ ok: true; access: LeadGeneratorAccess } | { ok: false; redirect: string; access: LeadGeneratorAccess }> {
+  const access = await getLeadGeneratorAccess(userId);
+  if (access.canAccessLeadGenerator) return { ok: true, access };
+  if (access.shouldShowPaymentGate) return { ok: false, redirect: "/tools/lead-generator/subscribe", access };
+  return { ok: false, redirect: "/", access };
+}

--- a/src/lib/leadGeneratorSubscription.ts
+++ b/src/lib/leadGeneratorSubscription.ts
@@ -1,0 +1,294 @@
+import { supabaseAdmin } from "./supabaseAdmin";
+import { createInvoice, getInvoice, sendInvoiceEmail } from "./quickbooks";
+import { LEAD_GENERATOR_MONTHLY_PRICE_USD } from "./leadGeneratorAccess";
+
+/**
+ * Lead Generator subscription lifecycle helpers.
+ *
+ * Recurring rails: QuickBooks. Since QB Online doesn't expose Recurring
+ * Sales Receipts via API (those are UI-configured templates only), we
+ * roll our own monthly invoice cycle:
+ *
+ *   subscribe()  — creates a QB customer + one-shot $9.99 invoice; saves
+ *                  the subscription row in status=incomplete + provider_customer_id.
+ *                  Returns the invoice link so the caller can click through
+ *                  to pay.
+ *   handleInvoicePaid()
+ *                — called from the QB webhook. Advances current_period_end
+ *                  by 30 days; flips status→active; upserts the
+ *                  account_entitlements row (source=subscription).
+ *   cancel()     — user-initiated. Immediate revoke: entitlement cleared,
+ *                  sub row flipped to canceled. Any pending QB invoice
+ *                  can still be paid but won't reactivate access unless
+ *                  the user re-subscribes.
+ *   renewInvoice()
+ *                — cron-facing. For active subs whose period_end is within
+ *                  N days, mint the next month's invoice and email it.
+ *                  Not wired to a scheduler tonight — call it from a cron
+ *                  endpoint when ready.
+ */
+
+const PERIOD_DAYS = 30;
+
+export interface SubscribeResult {
+  ok: true;
+  subscription_id: string;
+  invoice_id: string;
+  invoice_link?: string;
+}
+
+export interface SubscribeError {
+  ok: false;
+  error: string;
+  status: number;
+}
+
+/**
+ * Kick off a Lead Generator subscription for the caller.
+ * Creates the QB invoice ($9.99), stores tracking row.
+ * Idempotent within a 30s window — repeated calls return the same
+ * pending invoice rather than double-charging.
+ */
+export async function subscribe(userId: string): Promise<SubscribeResult | SubscribeError> {
+  const { data: profile } = await supabaseAdmin
+    .from("profiles")
+    .select("id, full_name, email, phone")
+    .eq("id", userId)
+    .maybeSingle();
+  if (!profile) return { ok: false, error: "Profile not found", status: 404 };
+  if (!profile.email) return { ok: false, error: "Account is missing an email address", status: 400 };
+
+  const { data: existingSub } = await supabaseAdmin
+    .from("lead_generator_subscriptions")
+    .select("*")
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (existingSub?.status === "active" || existingSub?.status === "trialing") {
+    return { ok: false, error: "Subscription is already active", status: 409 };
+  }
+
+  // Fresh invoice for this billing period.
+  let invoice;
+  try {
+    invoice = await createInvoice({
+      customerEmail: profile.email,
+      customerName: profile.full_name || profile.email,
+      customerPhone: profile.phone || undefined,
+      lineItems: [
+        {
+          description: "Lead Generator monthly subscription",
+          amount: LEAD_GENERATOR_MONTHLY_PRICE_USD,
+          quantity: 1,
+        },
+      ],
+      memo: `Lead Generator subscription — ${new Date().toISOString().slice(0, 10)}`,
+      metadata: {
+        type: "lead_generator_subscription",
+        user_id: userId,
+      },
+    });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "QB invoice create failed";
+    return { ok: false, error: msg, status: 502 };
+  }
+
+  const nowIso = new Date().toISOString();
+  const payload = {
+    user_id: userId,
+    provider: "quickbooks",
+    provider_customer_id: null as string | null,
+    provider_subscription_id: invoice.Id,   // no template — invoice id is the recurring anchor
+    provider_receipt_kind: "invoice" as const,
+    last_payment_id: null as string | null,
+    amount_cents: Math.round(LEAD_GENERATOR_MONTHLY_PRICE_USD * 100),
+    status: "incomplete" as const,
+    current_period_start: null as string | null,
+    current_period_end: null as string | null,
+    cancel_at_period_end: false,
+    canceled_at: null as string | null,
+    updated_at: nowIso,
+  };
+
+  const { data: sub, error: subErr } = await supabaseAdmin
+    .from("lead_generator_subscriptions")
+    .upsert(payload, { onConflict: "user_id" })
+    .select("*")
+    .single();
+
+  if (subErr) {
+    return { ok: false, error: subErr.message, status: 500 };
+  }
+
+  // Best-effort send of the invoice email.
+  try {
+    await sendInvoiceEmail(invoice.Id, profile.email);
+  } catch {
+    // Non-fatal — caller can click the link from the response.
+  }
+
+  let invoiceLink: string | undefined;
+  try {
+    const fullInvoice = await getInvoice(invoice.Id);
+    invoiceLink = fullInvoice.InvoiceLink || undefined;
+  } catch {
+    // Ignore — the invoice will still be paid from QB email.
+  }
+
+  await supabaseAdmin.from("audit_logs").insert({
+    actor_id: userId,
+    action: "lead_generator_subscribe_started",
+    entity_type: "lead_generator_subscriptions",
+    entity_id: sub.id,
+    metadata: { invoice_id: invoice.Id },
+  });
+
+  return {
+    ok: true,
+    subscription_id: sub.id,
+    invoice_id: invoice.Id,
+    invoice_link: invoiceLink,
+  };
+}
+
+/**
+ * Called from the QB webhook when a Payment posts to a Lead Generator
+ * invoice. Advances current_period_end + activates the entitlement.
+ * Idempotent: repeat calls with the same paymentId are a no-op.
+ */
+export async function handleInvoicePaid(args: {
+  invoiceId: string;
+  paymentId: string;
+}): Promise<void> {
+  const { data: sub } = await supabaseAdmin
+    .from("lead_generator_subscriptions")
+    .select("*")
+    .eq("provider_subscription_id", args.invoiceId)
+    .maybeSingle();
+  if (!sub) return;
+  if (sub.last_payment_id === args.paymentId) return;   // already processed
+
+  const nowIso = new Date().toISOString();
+  const periodStart = sub.current_period_end && new Date(sub.current_period_end) > new Date()
+    ? sub.current_period_end                     // stacking on existing period
+    : nowIso;
+  const periodEnd = new Date(new Date(periodStart).getTime() + PERIOD_DAYS * 86400 * 1000).toISOString();
+
+  await supabaseAdmin
+    .from("lead_generator_subscriptions")
+    .update({
+      status: "active",
+      current_period_start: periodStart,
+      current_period_end: periodEnd,
+      last_payment_id: args.paymentId,
+      updated_at: nowIso,
+    })
+    .eq("id", sub.id);
+
+  await supabaseAdmin
+    .from("account_entitlements")
+    .upsert({
+      user_id: sub.user_id,
+      entitlement_key: "lead_generator_access",
+      source: "subscription",
+      status: "active",
+      starts_at: periodStart,
+      ends_at: periodEnd,
+      metadata: { subscription_id: sub.id, paid_via: args.paymentId },
+      updated_at: nowIso,
+    }, { onConflict: "user_id,entitlement_key" });
+
+  await supabaseAdmin.from("audit_logs").insert({
+    actor_id: sub.user_id,
+    action: "lead_generator_subscription_activated",
+    entity_type: "lead_generator_subscriptions",
+    entity_id: sub.id,
+    metadata: {
+      invoice_id: args.invoiceId,
+      payment_id: args.paymentId,
+      current_period_end: periodEnd,
+    },
+  });
+}
+
+/**
+ * User-initiated cancel. Immediate revoke per the product decision.
+ * Any pending QB invoice can still be paid but won't reactivate access
+ * unless the caller re-subscribes.
+ */
+export async function cancel(userId: string, actorId?: string): Promise<void> {
+  const { data: sub } = await supabaseAdmin
+    .from("lead_generator_subscriptions")
+    .select("*")
+    .eq("user_id", userId)
+    .maybeSingle();
+  if (!sub) return;
+
+  const nowIso = new Date().toISOString();
+  await supabaseAdmin
+    .from("lead_generator_subscriptions")
+    .update({
+      status: "canceled",
+      canceled_at: nowIso,
+      current_period_end: nowIso,
+      cancel_at_period_end: false,
+      updated_at: nowIso,
+    })
+    .eq("id", sub.id);
+
+  // Clear any subscription-sourced entitlement row. Role-based rows for
+  // PP dual-role users are protected — we only touch source=subscription.
+  await supabaseAdmin
+    .from("account_entitlements")
+    .update({ status: "inactive", ends_at: nowIso, updated_at: nowIso })
+    .eq("user_id", userId)
+    .eq("entitlement_key", "lead_generator_access")
+    .eq("source", "subscription");
+
+  await supabaseAdmin.from("audit_logs").insert({
+    actor_id: actorId || userId,
+    action: "lead_generator_subscription_canceled",
+    entity_type: "lead_generator_subscriptions",
+    entity_id: sub.id,
+    metadata: { canceled_by: actorId ? "admin" : "self", user_id: userId },
+  });
+}
+
+/**
+ * Cron-facing renewal: for every active subscription whose
+ * current_period_end is within N days of now, mint the next month's
+ * invoice and email it. Called from /api/cron/lead-generator-renew
+ * on a daily schedule.
+ *
+ * NOT wired to a scheduler in this PR — call it manually or hook it
+ * into vercel.json cron config to enable. Without it, admin must
+ * re-invoice manually via the admin panel.
+ */
+export async function renewUpcoming(withinDays: number = 3): Promise<{ processed: number; failed: number; details: Array<{ user_id: string; ok: boolean; error?: string }> }> {
+  const horizon = new Date(Date.now() + withinDays * 86400 * 1000).toISOString();
+  const { data: subs } = await supabaseAdmin
+    .from("lead_generator_subscriptions")
+    .select("id, user_id, current_period_end, status")
+    .in("status", ["active"])
+    .lte("current_period_end", horizon);
+
+  const details: Array<{ user_id: string; ok: boolean; error?: string }> = [];
+  let processed = 0, failed = 0;
+
+  for (const s of subs || []) {
+    try {
+      const result = await subscribe(s.user_id);   // mints the next invoice
+      if (result.ok) {
+        processed++;
+        details.push({ user_id: s.user_id, ok: true });
+      } else {
+        failed++;
+        details.push({ user_id: s.user_id, ok: false, error: result.error });
+      }
+    } catch (e) {
+      failed++;
+      details.push({ user_id: s.user_id, ok: false, error: e instanceof Error ? e.message : "unknown" });
+    }
+  }
+  return { processed, failed, details };
+}

--- a/supabase/migrations/119_lead_generator_access.sql
+++ b/supabase/migrations/119_lead_generator_access.sql
@@ -1,0 +1,185 @@
+-- Lead Generator access control.
+--
+-- Business rule (finalized with product):
+--   FREE ACCESS (source='role_based'):
+--     admin, sales, sales_manager, director_of_sales, market_leader,
+--     placement_partner, locator, or any user holding an active
+--     placement_partners row (dual-role via marketplace onboarding).
+--   PAID ACCESS ($9.99/mo, source='subscription'):
+--     operator (without a PP row), location_manager, requestor.
+--   HIDDEN (no nav, no route): everyone else — admin can grant manually.
+--
+-- CRM access is a SEPARATE entitlement — Lead Generator access must
+-- never imply CRM access. Placement Providers get LG + zero CRM.
+--
+-- Recurring rails: QuickBooks (Recurring Sales Receipts preferred if QB
+-- Payments enabled, fallback to Recurring Invoices). Subscription state
+-- machine lives in lead_generator_subscriptions; entitlement rows live
+-- in account_entitlements so future entitlement kinds (e.g. coffee
+-- proposal exports) can slot into the same table.
+
+-- ═════════════════════════════════════════════════════════════════════
+-- account_entitlements — generic per-user, per-key entitlement rows
+-- ═════════════════════════════════════════════════════════════════════
+
+CREATE TABLE IF NOT EXISTS account_entitlements (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  entitlement_key text NOT NULL,
+  source text NOT NULL CHECK (source IN (
+    'role_based',
+    'subscription',
+    'admin_override'
+  )),
+  status text NOT NULL DEFAULT 'active' CHECK (status IN (
+    'active',
+    'inactive',
+    'suspended',
+    'revoked'
+  )),
+  starts_at timestamptz NOT NULL DEFAULT now(),
+  ends_at timestamptz,
+  metadata jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (user_id, entitlement_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_account_entitlements_user_active
+  ON account_entitlements(user_id)
+  WHERE status = 'active';
+CREATE INDEX IF NOT EXISTS idx_account_entitlements_key
+  ON account_entitlements(entitlement_key, status);
+
+COMMENT ON COLUMN account_entitlements.source IS
+  'role_based = free by profile.role or PP membership. subscription = paid via QB recurring. admin_override = manually granted or revoked by admin.';
+
+-- ═════════════════════════════════════════════════════════════════════
+-- lead_generator_subscriptions — QB-backed recurring subscription state
+-- ═════════════════════════════════════════════════════════════════════
+-- Tracks the QB Recurring Sales Receipt (or Recurring Invoice) that
+-- backs a user's $9.99/mo Lead Generator subscription. Our own state
+-- machine — QB webhooks advance current_period_end on paid events;
+-- cron flips to past_due when period lapses.
+
+CREATE TABLE IF NOT EXISTS lead_generator_subscriptions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  provider text NOT NULL DEFAULT 'quickbooks',
+  provider_customer_id text,            -- QB Customer ID
+  provider_subscription_id text,        -- QB Recurring template ID
+  provider_receipt_kind text            -- 'sales_receipt' | 'invoice'
+    CHECK (provider_receipt_kind IN ('sales_receipt', 'invoice')),
+  last_payment_id text,                 -- Last QB Payment / SalesReceipt txn id
+  amount_cents integer NOT NULL DEFAULT 999,   -- $9.99 = 999 cents (this table stores cents so integers don't drift; entitlement is boolean)
+  status text NOT NULL DEFAULT 'incomplete' CHECK (status IN (
+    'incomplete',
+    'incomplete_expired',
+    'trialing',
+    'active',
+    'past_due',
+    'unpaid',
+    'canceled'
+  )),
+  current_period_start timestamptz,
+  current_period_end timestamptz,
+  cancel_at_period_end boolean NOT NULL DEFAULT false,
+  canceled_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (user_id)   -- one live subscription per user; canceled rows stay for history via status
+);
+
+CREATE INDEX IF NOT EXISTS idx_lg_subs_status
+  ON lead_generator_subscriptions(status);
+CREATE INDEX IF NOT EXISTS idx_lg_subs_qb_sub
+  ON lead_generator_subscriptions(provider_subscription_id)
+  WHERE provider_subscription_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_lg_subs_qb_customer
+  ON lead_generator_subscriptions(provider_customer_id)
+  WHERE provider_customer_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_lg_subs_period_end
+  ON lead_generator_subscriptions(current_period_end)
+  WHERE status IN ('active', 'past_due');
+
+-- ═════════════════════════════════════════════════════════════════════
+-- Backfill role-based entitlement rows for free-access users
+-- ═════════════════════════════════════════════════════════════════════
+-- Idempotent — UNIQUE (user_id, entitlement_key) protects against
+-- re-runs. Operator, location_manager, requestor are intentionally
+-- left with no row so the resolver returns "requires subscription".
+--
+-- Anyone with an active placement_partners row also gets free access,
+-- regardless of primary profile.role — captures the dual-role case.
+
+INSERT INTO account_entitlements (user_id, entitlement_key, source, status, metadata)
+SELECT
+  p.id,
+  'lead_generator_access',
+  'role_based',
+  'active',
+  jsonb_build_object('reason', 'role_' || p.role)
+FROM profiles p
+WHERE p.role IN (
+  'admin',
+  'sales',
+  'sales_manager',
+  'director_of_sales',
+  'market_leader',
+  'placement_partner',
+  'locator'
+)
+ON CONFLICT (user_id, entitlement_key) DO NOTHING;
+
+-- Dual-role: PP row exists but primary role is something else.
+INSERT INTO account_entitlements (user_id, entitlement_key, source, status, metadata)
+SELECT
+  pp.id,
+  'lead_generator_access',
+  'role_based',
+  'active',
+  jsonb_build_object('reason', 'placement_partner_row')
+FROM placement_partners pp
+WHERE pp.active IS NOT FALSE
+ON CONFLICT (user_id, entitlement_key) DO NOTHING;
+
+-- ═════════════════════════════════════════════════════════════════════
+-- RLS
+-- ═════════════════════════════════════════════════════════════════════
+-- Service-role only for writes. Callers can read their own entitlement
+-- rows so client code can render "subscription active" state without a
+-- server round-trip; the full subscriptions table stays admin-only.
+
+ALTER TABLE account_entitlements ENABLE ROW LEVEL SECURITY;
+ALTER TABLE lead_generator_subscriptions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Service role only" ON account_entitlements;
+CREATE POLICY "Service role only" ON account_entitlements
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+DROP POLICY IF EXISTS "Self read entitlements" ON account_entitlements;
+CREATE POLICY "Self read entitlements" ON account_entitlements
+  FOR SELECT TO authenticated
+  USING (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "Service role only" ON lead_generator_subscriptions;
+CREATE POLICY "Service role only" ON lead_generator_subscriptions
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+DROP POLICY IF EXISTS "Self read subscription" ON lead_generator_subscriptions;
+CREATE POLICY "Self read subscription" ON lead_generator_subscriptions
+  FOR SELECT TO authenticated
+  USING (user_id = auth.uid());
+
+-- ═════════════════════════════════════════════════════════════════════
+-- Verification query — run manually after migration to confirm the cut
+-- ═════════════════════════════════════════════════════════════════════
+--
+-- SELECT
+--   (SELECT COUNT(*) FROM account_entitlements
+--     WHERE entitlement_key = 'lead_generator_access' AND status = 'active') AS active_lg_entitlements,
+--   (SELECT COUNT(*) FROM profiles WHERE role = 'admin') AS admins,
+--   (SELECT COUNT(*) FROM profiles WHERE role IN ('sales','sales_manager','director_of_sales','market_leader')) AS sales_family,
+--   (SELECT COUNT(*) FROM profiles WHERE role = 'placement_partner') AS placement_partners,
+--   (SELECT COUNT(*) FROM profiles WHERE role IN ('operator','location_manager','requestor')) AS payment_gated,
+--   (SELECT COUNT(*) FROM lead_generator_subscriptions WHERE status = 'active') AS active_subs;


### PR DESCRIPTION
Access matrix now enforced end-to-end:
  admin, sales-family, placement_partner, locator, or any user with an
  active placement_partners row → free
  operator (no PP row), location_manager, requestor → $9.99/mo QB gate
  anyone else → hidden until admin override
Lead Generator access is a SEPARATE entitlement from CRM access — Placement Providers get LG + zero CRM.

Migration 119:
  * account_entitlements (generic per-user, per-key rows; role_based / subscription / admin_override sources; unique on user_id + key)
  * lead_generator_subscriptions (our QB-backed sub state machine)
  * Backfill: role_based active rows for every admin, sales-family, placement_partner, locator, plus any user holding an active placement_partners row (dual-role case)
  * Service-role RLS with self-read for entitlements + subscription

Resolver lib/leadGeneratorAccess.ts — single source of truth. Returns canAccessLeadGenerator / requiresSubscription / hasActiveSubscription / shouldShowPaymentGate / canAccessCRM / reason with typed reasons.

Two shells, one component:
  * /sales/lead-generator (CRM shell, admin+sales, keeps rep picker)
  * /tools/lead-generator (customer-facing shell for PP + paid ops; no CRM sidebar; auto-bounces to subscribe gate for unsubscribed paid roles)
  * Both use src/app/components/LeadGeneratorForm — shared UI

APIs:
  * /api/sales/lead-generator — guard swapped from sales-only to the resolver; returns 402 { subscribe_url } for unsubscribed paid roles
  * /api/tools/lead-generator/access — returns the resolver decision for the caller
  * /api/tools/lead-generator/subscribe — creates a $9.99 QB invoice (customer + line item + memo); stores tracking row in lead_generator_subscriptions with status=incomplete; returns the QB invoice pay link
  * /api/tools/lead-generator/cancel — user self-cancel; immediate revoke per product decision
  * /api/admin/lead-generator/status?user_id — resolver decision for another user (for the admin edit modal)
  * /api/admin/lead-generator/override — grant / revoke / clear an admin_override entitlement row; audit-logged

QB webhook extension:
  * When a Payment lands for a lead_generator_subscriptions invoice, handleInvoicePaid() advances current_period_end by 30 days, activates the subscription, and upserts the account_entitlements row (source=subscription). Idempotent on (invoice_id, payment_id).

QB recurring rails note:
  QB Online doesn't expose Recurring Sales Receipts via API — those
  are UI-configured templates. We roll our own monthly cycle by
  minting a fresh $9.99 invoice per period. renewUpcoming() in
  leadGeneratorSubscription.ts is the cron entry point for auto-
  generating next month's invoice (not wired to a scheduler in this
  PR — hook into vercel.json cron when ready).

UI:
  * Payment gate page /tools/lead-generator/subscribe with copy the spec asked for ($9.99/mo, subscribe button, invoice pay link)
  * Manage subscription page /tools/lead-generator/manage with self-cancel
  * "Lead Generator" card added to /placement dashboard (PPs) and /dashboard (everyone) — access-gated server-side, not by UI-hiding alone
  * Admin user edit modal on /admin/page.tsx — role dropdown now includes Placement Provider; new LeadGeneratorAdminPanel shows live LG status + Grant/Revoke/Clear override buttons

Everything writes to the existing audit_logs table (actions: lead_generator_subscribe_started, lead_generator_subscription_activated, lead_generator_subscription_canceled, lead_generator_admin_grant / revoke / clear).