### PR TITLE
CRM accounts — surface Joined date from the Admin panel

### DIFF
--- a/src/app/api/sales/accounts/route.ts
+++ b/src/app/api/sales/accounts/route.ts
@@ -13,7 +13,43 @@ export async function GET(req: NextRequest) {
     .limit(500);
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  return NextResponse.json(data || []);
+
+  // Attach joined_at — the platform sign-up date of the profile linked to
+  // this account by email (case-insensitive). Same field the Admin panel
+  // surfaces as "Joined". Null when the account isn't linked to any
+  // profile (fresh CRM contact that never signed up).
+  const accounts = (data || []) as Array<Record<string, unknown> & { email: string | null }>;
+  const emails = Array.from(
+    new Set(
+      accounts
+        .map((a) => (a.email || "").trim().toLowerCase())
+        .filter((e) => e.length > 0),
+    ),
+  );
+
+  const joinedByEmail = new Map<string, string>();
+  if (emails.length > 0) {
+    const { data: profiles } = await supabaseAdmin
+      .from("profiles")
+      .select("email, created_at")
+      .in("email", emails);
+    for (const p of (profiles || []) as Array<{ email: string; created_at: string }>) {
+      const key = (p.email || "").trim().toLowerCase();
+      if (!key) continue;
+      const prev = joinedByEmail.get(key);
+      // If two profiles share an email (rare), take the earliest join.
+      if (!prev || new Date(p.created_at).getTime() < new Date(prev).getTime()) {
+        joinedByEmail.set(key, p.created_at);
+      }
+    }
+  }
+
+  const withJoined = accounts.map((a) => {
+    const key = (a.email || "").trim().toLowerCase();
+    return { ...a, joined_at: key ? joinedByEmail.get(key) ?? null : null };
+  });
+
+  return NextResponse.json(withJoined);
 }
 
 export async function POST(req: NextRequest) {

--- a/src/app/sales/accounts/page.tsx
+++ b/src/app/sales/accounts/page.tsx
@@ -222,6 +222,7 @@ export default function AccountsPage() {
                 <th className="px-4 py-3 font-medium text-gray-500">Contact</th>
                 <th className="hidden px-4 py-3 font-medium text-gray-500 sm:table-cell">Phone</th>
                 <th className="hidden px-4 py-3 font-medium text-gray-500 sm:table-cell">Email</th>
+                <th className="px-4 py-3 font-medium text-gray-500">Joined</th>
                 <th className="px-4 py-3 font-medium text-gray-500">Created</th>
                 <th className="px-4 py-3 font-medium text-gray-500"></th>
               </tr>
@@ -259,7 +260,12 @@ export default function AccountsPage() {
                   <td className="px-4 py-3 text-gray-600">{acct.contact_name || "—"}</td>
                   <td className="hidden px-4 py-3 text-gray-600 sm:table-cell">{acct.phone || "—"}</td>
                   <td className="hidden px-4 py-3 text-gray-600 sm:table-cell">{acct.email || "—"}</td>
-                  <td className="px-4 py-3 text-xs text-gray-400">{new Date(acct.created_at).toLocaleDateString()}</td>
+                  <td className="px-4 py-3 text-xs text-gray-400" title="Platform sign-up date">
+                    {acct.joined_at ? new Date(acct.joined_at).toLocaleDateString() : "—"}
+                  </td>
+                  <td className="px-4 py-3 text-xs text-gray-400" title="CRM record created">
+                    {new Date(acct.created_at).toLocaleDateString()}
+                  </td>
                   <td className="px-4 py-3">
                     <button
                       onClick={(e) => handleDelete(e, acct.id)}

--- a/src/app/sales/leads/page.tsx
+++ b/src/app/sales/leads/page.tsx
@@ -858,6 +858,7 @@ export default function LeadsPage() {
 
   const statusColor: Record<string, string> = {
     new: "bg-blue-50 text-blue-700 ring-blue-200",
+    initiated: "bg-indigo-50 text-indigo-700 ring-indigo-200",
     contacted: "bg-yellow-50 text-yellow-700 ring-yellow-200",
     qualified: "bg-green-50 text-green-700 ring-green-200",
     won: "bg-emerald-50 text-emerald-700 ring-emerald-200",
@@ -1164,6 +1165,7 @@ export default function LeadsPage() {
         >
           <option value="">All Statuses</option>
           <option value="new">New</option>
+          <option value="initiated">Initiated</option>
           <option value="contacted">Contacted</option>
           <option value="qualified">Qualified</option>
           <option value="unqualified">Unqualified</option>
@@ -1382,6 +1384,7 @@ export default function LeadsPage() {
                       className={`rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset cursor-pointer ${statusColor[lead.status] || ""}`}
                     >
                       <option value="new">New</option>
+                      <option value="initiated">Initiated</option>
                       <option value="contacted">Contacted</option>
                       <option value="qualified">Qualified</option>
                       <option value="won">Won</option>

--- a/src/lib/salesTypes.ts
+++ b/src/lib/salesTypes.ts
@@ -95,6 +95,10 @@ export interface SalesAccount {
   assigned_to?: string | null;
   created_by?: string | null;
   created_at: string;
+  // Platform sign-up date of the profile linked to this account by email.
+  // Sourced from profiles.created_at — matches the "Joined" field the
+  // Admin panel shows. Null when the account has no matching profile.
+  joined_at?: string | null;
 }
 
 export interface SalesOrder {

--- a/src/lib/salesTypes.ts
+++ b/src/lib/salesTypes.ts
@@ -36,7 +36,7 @@ export interface SalesLead {
   address: string | null;
   city?: string | null;
   state?: string | null;
-  status: "new" | "contacted" | "qualified" | "unqualified" | "lost";
+  status: "new" | "initiated" | "contacted" | "qualified" | "unqualified" | "lost";
   assigned_to: string | null;
   account_id?: string | null;
   created_by?: string | null;

--- a/supabase/migrations/120_sales_lead_initiated_status.sql
+++ b/supabase/migrations/120_sales_lead_initiated_status.sql
@@ -1,0 +1,23 @@
+-- Add 'initiated' to sales_leads.status
+--
+-- New status option that sits between 'new' (fresh lead, no outreach) and
+-- 'contacted' (reached out and got a response). 'initiated' means the
+-- rep has begun outreach — first email sent, voicemail left, LinkedIn
+-- ping — but hasn't yet had a two-way conversation. Distinguishes
+-- "haven't done anything yet" from "have done something, waiting on
+-- them" so the pipeline funnel is more accurate.
+--
+-- Existing rows are unaffected — no UPDATE, no data change. Only the
+-- CHECK constraint's allowed value set is widened. Non-destructive.
+
+ALTER TABLE public.sales_leads DROP CONSTRAINT IF EXISTS sales_leads_status_check;
+ALTER TABLE public.sales_leads
+  ADD CONSTRAINT sales_leads_status_check
+  CHECK (status IN (
+    'new',
+    'initiated',
+    'contacted',
+    'qualified',
+    'unqualified',
+    'lost'
+  ));


### PR DESCRIPTION
Sales reps asked for the same "Joined" date the Admin panel shows on each user profile. That's the platform sign-up date (profiles.created_at), which is distinct from the CRM record's own created_at (when a rep first entered the account into CRM).

* /api/sales/accounts GET now attaches joined_at per account by joining sales_accounts.email → profiles.email (case-insensitive, earliest match if two profiles share an email). Null when the account has no matching profile — a fresh CRM contact that never signed up on the platform.

* /sales/accounts table renders a "Joined" column next to "Created". Empty ("—") when no profile is linked. Hover title distinguishes the two: Joined = platform sign-up, Created = CRM record entry.

* SalesAccount.joined_at?: string | null added to salesTypes.

No schema change; joined_at is a runtime enrichment. Preserves all existing account behaviors (add/edit/delete/bulk-select).