### PR TITLE
Agreements — include/exclude toggle on the Operator section

### DIFF
--- a/src/app/api/sales/agreements/[id]/route.ts
+++ b/src/app/api/sales/agreements/[id]/route.ts
@@ -118,6 +118,7 @@ export async function PATCH(
     "internal_notes",
     "customer_notes",
     // Section toggles & auto-invoice
+    "include_operator",
     "include_equipment",
     "include_location_services",
     "include_shipping_storage",

--- a/src/app/sales/agreements/[id]/page.tsx
+++ b/src/app/sales/agreements/[id]/page.tsx
@@ -80,6 +80,7 @@ interface Agreement {
   total_due_prior_to_procurement: number;
   payment_due_date: string | null;
   payment_method_notes: string | null;
+  include_operator: boolean;
   include_equipment: boolean;
   include_location_services: boolean;
   include_shipping_storage: boolean;
@@ -186,6 +187,7 @@ type FormData = {
   contract_expiration_date: string;
   internal_notes: string;
   customer_notes: string;
+  include_operator: boolean;
   include_equipment: boolean;
   include_location_services: boolean;
   include_shipping_storage: boolean;
@@ -285,6 +287,7 @@ function agreementToForm(ag: Agreement): FormData {
     contract_expiration_date: ag.contract_expiration_date || "",
     internal_notes: ag.internal_notes || "",
     customer_notes: ag.customer_notes || "",
+    include_operator: ag.include_operator !== false,
     include_equipment: ag.include_equipment !== false,
     include_location_services: ag.include_location_services !== false,
     include_shipping_storage: ag.include_shipping_storage !== false,
@@ -457,6 +460,7 @@ function StandaloneAgreementEditor() {
       contract_expiration_date: form.contract_expiration_date || null,
       internal_notes: form.internal_notes,
       customer_notes: form.customer_notes,
+      include_operator: form.include_operator,
       include_equipment: form.include_equipment,
       include_location_services: form.include_location_services,
       include_shipping_storage: form.include_shipping_storage,
@@ -945,24 +949,45 @@ function StandaloneAgreementEditor() {
             />
           )}
 
-          {agreement.agreement_type !== "location_placement" && (
-          <>
-          {/* Operator Information */}
-          <div className="rounded-xl border border-gray-200 bg-white p-5">
-            <h3 className="text-sm font-semibold text-gray-900 flex items-center gap-2 mb-4">
-              <Building2 className="h-4 w-4 text-gray-400" /> Operator Information
-            </h3>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <InputField label="Company Name" value={form.operator_company_name} onChange={(v) => updateField("operator_company_name", v)} disabled={isReadOnly} required />
-              <InputField label="Legal Name / Contact" value={form.operator_legal_name} onChange={(v) => updateField("operator_legal_name", v)} disabled={isReadOnly} required />
-              <InputField label="Email" type="email" value={form.operator_email} onChange={(v) => updateField("operator_email", v)} disabled={isReadOnly} required />
-              <InputField label="Phone" type="tel" value={form.operator_phone} onChange={(v) => updateField("operator_phone", v)} disabled={isReadOnly} />
-              <InputField label="Billing Address" value={form.operator_billing_address} onChange={(v) => updateField("operator_billing_address", v)} disabled={isReadOnly} />
-              <InputField label="Delivery Address" value={form.operator_delivery_address} onChange={(v) => updateField("operator_delivery_address", v)} disabled={isReadOnly} />
-              <InputField label="Title" value={form.operator_title} onChange={(v) => updateField("operator_title", v)} disabled={isReadOnly} />
+          {/*
+            Operator Information — now toggle-able. Turned OFF lets admin
+            save the agreement without an operator attached (the "add the
+            operator later" flow). Required-field markers only fire when
+            the section is included. Location Placement agreements often
+            start without an operator matched, so the toggle defaults ON
+            but is expected to be flipped OFF for that case.
+          */}
+          <div className={`rounded-xl border bg-white p-5 ${form.include_operator ? "border-gray-200" : "border-gray-200 opacity-60"}`}>
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-sm font-semibold text-gray-900 flex items-center gap-2">
+                <Building2 className="h-4 w-4 text-gray-400" /> Operator Information
+              </h3>
+              <SectionToggle
+                included={form.include_operator}
+                onChange={(v) => updateBool("include_operator", v)}
+                disabled={isReadOnly}
+              />
             </div>
+            {form.include_operator ? (
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <InputField label="Company Name" value={form.operator_company_name} onChange={(v) => updateField("operator_company_name", v)} disabled={isReadOnly} required />
+                <InputField label="Legal Name / Contact" value={form.operator_legal_name} onChange={(v) => updateField("operator_legal_name", v)} disabled={isReadOnly} required />
+                <InputField label="Email" type="email" value={form.operator_email} onChange={(v) => updateField("operator_email", v)} disabled={isReadOnly} required />
+                <InputField label="Phone" type="tel" value={form.operator_phone} onChange={(v) => updateField("operator_phone", v)} disabled={isReadOnly} />
+                <InputField label="Billing Address" value={form.operator_billing_address} onChange={(v) => updateField("operator_billing_address", v)} disabled={isReadOnly} />
+                <InputField label="Delivery Address" value={form.operator_delivery_address} onChange={(v) => updateField("operator_delivery_address", v)} disabled={isReadOnly} />
+                <InputField label="Title" value={form.operator_title} onChange={(v) => updateField("operator_title", v)} disabled={isReadOnly} />
+              </div>
+            ) : (
+              <p className="text-xs text-gray-500">
+                Operator not attached yet — the agreement will save without one, and you can toggle
+                this section back on later to fill in operator details.
+              </p>
+            )}
           </div>
 
+          {agreement.agreement_type !== "location_placement" && (
+          <>
           {/* Equipment Purchase */}
           <div className={`rounded-xl border bg-white p-5 ${form.include_equipment ? "border-gray-200" : "border-gray-200 opacity-60"}`}>
             <div className="flex items-center justify-between mb-4">

--- a/supabase/migrations/121_agreement_include_operator_toggle.sql
+++ b/supabase/migrations/121_agreement_include_operator_toggle.sql
@@ -1,0 +1,19 @@
+-- Optional Operator section on agreements
+--
+-- Adds an include/exclude toggle for the Operator Information block on
+-- purchase_agreements, mirroring the existing pattern for
+-- include_equipment, include_location_services, include_shipping_storage
+-- (migration 090) and include_placement_terms / include_compensation
+-- (migration 092).
+--
+-- Rationale: for location placement agreements, admin often builds the
+-- contract before an operator has been matched. Being able to exclude
+-- the operator section lets the agreement stand on its own and the
+-- operator info be attached later.
+--
+-- Default TRUE preserves existing equipment agreements — they always
+-- required operator info. Admin can flip it off per-agreement when
+-- appropriate.
+
+ALTER TABLE purchase_agreements
+  ADD COLUMN IF NOT EXISTS include_operator boolean DEFAULT true;


### PR DESCRIPTION
Admins often build a location placement agreement before an operator has been matched. Adding a SectionToggle to the Operator Information block lets them save the agreement without operator info and attach the operator later — the same include/exclude pattern already used for Equipment / Location Services / Shipping / Payment.

* Migration 121 — ALTER purchase_agreements ADD COLUMN include_operator boolean DEFAULT true. Default true preserves existing equipment agreements (operator info was always required there); admin flips off on location placement agreements when the operator isn't attached yet.

* /api/sales/agreements/[id] PATCH allowlist now accepts include_operator so the editor can save the toggle state.

* /sales/agreements/[id] editor:
  - AgreementDetail + FormState + load + save all carry include_operator.
  - Operator Information card wrapped with SectionToggle in its header, matching Equipment / Location Services / Shipping / Payment.
  - When toggled off, the card body collapses to a small "operator not attached yet — you can toggle back on later" note. Required-field markers only apply when the section is included.
  - Dropped the previous agreement_type !== "location_placement" guard on the operator card only; equipment / services / shipping / payment sections stay hidden on location placement agreements as before.