### PR TITLE
Get Your Own Vending Website — customer intake wizard + admin queue

### DIFF
--- a/src/app/admin/website-requests/[id]/page.tsx
+++ b/src/app/admin/website-requests/[id]/page.tsx
@@ -1,0 +1,415 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import { Loader2, ArrowLeft, Globe, MessageSquare, Send, CheckCircle2, AlertCircle, Download, ExternalLink } from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
+
+interface DetailRequest {
+  id: string;
+  status: string;
+  business_name: string | null;
+  primary_contact: string | null;
+  phone: string | null;
+  email: string | null;
+  business_address: string | null;
+  years_in_business: string | null;
+  business_story: string | null;
+  mission_values: string | null;
+  brand_primary_color: string | null;
+  brand_secondary_color: string | null;
+  preferred_style: string | null;
+  tagline: string | null;
+  primary_services: string[] | null;
+  industries_served: string[] | null;
+  geographic_market: Record<string, unknown> | null;
+  homepage_message: string | null;
+  about_content: string | null;
+  services_content: string | null;
+  primary_cta: string | null;
+  primary_cta_custom: string | null;
+  inquiry_email: string | null;
+  public_phone: string | null;
+  business_hours: string | null;
+  domain_status: string | null;
+  current_domain: string | null;
+  domain_registrar: string | null;
+  business_email: string | null;
+  existing_website: string | null;
+  integrations: Array<{ key: string; notes?: string }> | null;
+  requested_features: Array<{ key: string; notes?: string }> | null;
+  launch_checklist: Record<string, boolean> | null;
+  legal_pages_needed: string[] | null;
+  submitted_at: string | null;
+  created_at: string;
+  updated_at: string;
+  user: { id: string; full_name: string | null; email: string | null; role: string; company_name: string | null } | null;
+  assignee: { id: string; full_name: string | null; email: string | null } | null;
+}
+
+interface Media {
+  id: string;
+  kind: string;
+  file_name: string | null;
+  external_url: string | null;
+  caption: string | null;
+  mime_type: string | null;
+  signed_url: string | null;
+  created_at: string;
+}
+
+interface Activity {
+  id: string;
+  event_type: string;
+  visibility: "public" | "internal";
+  previous_status: string | null;
+  new_status: string | null;
+  message: string | null;
+  metadata: Record<string, unknown> | null;
+  created_at: string;
+  actor: { id: string; full_name: string | null; email: string | null } | null;
+}
+
+const STATUSES = [
+  "submitted", "under_review", "needs_information",
+  "approved_for_build", "in_development", "client_review",
+  "ready_to_launch", "launched", "cancelled",
+];
+
+export default function AdminWebsiteRequestDetailPage() {
+  const router = useRouter();
+  const { id } = useParams<{ id: string }>();
+  const [token, setToken] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [request, setRequest] = useState<DetailRequest | null>(null);
+  const [media, setMedia] = useState<Media[]>([]);
+  const [activity, setActivity] = useState<Activity[]>([]);
+  const [saving, setSaving] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [noteText, setNoteText] = useState("");
+  const [infoRequestText, setInfoRequestText] = useState("");
+
+  const load = useCallback(async (t: string) => {
+    setLoading(true);
+    const res = await fetch(`/api/admin/website-requests/${id}`, {
+      headers: { Authorization: `Bearer ${t}` },
+    });
+    if (res.ok) {
+      const body = await res.json();
+      setRequest(body.request);
+      setMedia(body.media || []);
+      setActivity(body.activity || []);
+    }
+    setLoading(false);
+  }, [id]);
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!session?.access_token) { router.push(`/login?redirect=/admin/website-requests/${id}`); return; }
+      setToken(session.access_token);
+      load(session.access_token);
+    });
+  }, [router, id, load]);
+
+  async function changeStatus(nextStatus: string) {
+    setError(null); setMessage(null); setSaving("status");
+    const res = await fetch(`/api/admin/website-requests/${id}/status`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ status: nextStatus }),
+    });
+    setSaving(null);
+    if (!res.ok) {
+      setError((await res.json().catch(() => ({}))).error || "Status update failed");
+      return;
+    }
+    setMessage(`Status updated to ${nextStatus.replace(/_/g, " ")}`);
+    await load(token);
+  }
+
+  async function addNote(visibility: "internal" | "public") {
+    if (!noteText.trim()) return;
+    setError(null); setMessage(null); setSaving("note");
+    const res = await fetch(`/api/admin/website-requests/${id}/note`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ message: noteText, visibility }),
+    });
+    setSaving(null);
+    if (!res.ok) {
+      setError((await res.json().catch(() => ({}))).error || "Note failed");
+      return;
+    }
+    setNoteText("");
+    setMessage(visibility === "internal" ? "Internal note added" : "Public note added");
+    await load(token);
+  }
+
+  async function requestInfo() {
+    if (!infoRequestText.trim()) return;
+    setError(null); setMessage(null); setSaving("info");
+    const res = await fetch(`/api/admin/website-requests/${id}/request-info`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ message: infoRequestText }),
+    });
+    setSaving(null);
+    if (!res.ok) {
+      setError((await res.json().catch(() => ({}))).error || "Request-info failed");
+      return;
+    }
+    setInfoRequestText("");
+    setMessage("Needs-info request sent to customer");
+    await load(token);
+  }
+
+  if (loading || !request) {
+    return <div className="min-h-[60vh] flex items-center justify-center"><Loader2 className="h-6 w-6 animate-spin text-green-primary" /></div>;
+  }
+
+  return (
+    <div className="p-6 max-w-6xl mx-auto">
+      <Link href="/admin/website-requests" className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-green-primary mb-4">
+        <ArrowLeft className="h-4 w-4" /> All Requests
+      </Link>
+
+      <div className="flex items-start justify-between mb-6">
+        <div className="flex items-center gap-3">
+          <div className="w-10 h-10 rounded-xl bg-green-100 flex items-center justify-center">
+            <Globe className="h-5 w-5 text-green-700" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">{request.business_name || "Untitled Request"}</h1>
+            <p className="text-sm text-gray-500">
+              {request.user?.full_name || "—"} &lt;{request.user?.email}&gt; · updated {new Date(request.updated_at).toLocaleString()}
+            </p>
+          </div>
+        </div>
+        <span className="rounded-full bg-blue-100 text-blue-800 px-3 py-1 text-xs font-semibold">
+          {request.status.replace(/_/g, " ")}
+        </span>
+      </div>
+
+      {message && (
+        <div className="mb-4 flex items-start gap-2 rounded-xl border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-800">
+          <CheckCircle2 className="h-4 w-4 mt-0.5" /> {message}
+        </div>
+      )}
+      {error && (
+        <div className="mb-4 flex items-start gap-2 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          <AlertCircle className="h-4 w-4 mt-0.5" /> {error}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Left column — intake summary */}
+        <div className="lg:col-span-2 space-y-4">
+          <Card title="Business">
+            <Row label="Contact" v={request.primary_contact} />
+            <Row label="Email" v={request.email} />
+            <Row label="Phone" v={request.phone} />
+            <Row label="Address" v={request.business_address} />
+            <Row label="Years" v={request.years_in_business} />
+            <Block label="Story" v={request.business_story} />
+            <Block label="Mission" v={request.mission_values} />
+          </Card>
+          <Card title="Brand">
+            <Row label="Style" v={request.preferred_style} />
+            <div className="flex items-center gap-3 text-sm">
+              <span className="text-gray-500 w-40 shrink-0">Colors</span>
+              <div className="flex items-center gap-2">
+                {request.brand_primary_color && (
+                  <span className="inline-flex items-center gap-1"><span className="w-5 h-5 rounded border border-gray-200" style={{ background: request.brand_primary_color }} />{request.brand_primary_color}</span>
+                )}
+                {request.brand_secondary_color && (
+                  <span className="inline-flex items-center gap-1"><span className="w-5 h-5 rounded border border-gray-200" style={{ background: request.brand_secondary_color }} />{request.brand_secondary_color}</span>
+                )}
+              </div>
+            </div>
+            <Row label="Tagline" v={request.tagline} />
+          </Card>
+          <Card title="Products & Customer">
+            <Row label="Services" v={(request.primary_services || []).join(", ")} />
+            <Row label="Industries" v={(request.industries_served || []).join(", ")} />
+            <Row label="Geo (JSON)" v={JSON.stringify(request.geographic_market || {})} />
+          </Card>
+          <Card title="Content">
+            <Block label="Hero" v={request.homepage_message} />
+            <Block label="About" v={request.about_content} />
+            <Block label="Services" v={request.services_content} />
+            <Row label="Primary CTA" v={request.primary_cta === "custom" ? request.primary_cta_custom : request.primary_cta} />
+          </Card>
+          <Card title="Contact">
+            <Row label="Public Email" v={request.inquiry_email} />
+            <Row label="Public Phone" v={request.public_phone} />
+            <Row label="Hours" v={request.business_hours} />
+          </Card>
+          <Card title="Domain & Tech">
+            <Row label="Owns Domain" v={request.domain_status} />
+            <Row label="Domain" v={request.current_domain} />
+            <Row label="Registrar" v={request.domain_registrar} />
+            <Row label="Business Email" v={request.business_email} />
+            <Row label="Existing Site" v={request.existing_website} />
+            <Row label="Integrations" v={(request.integrations || []).map((i) => i.key).join(", ")} />
+          </Card>
+          <Card title="Features">
+            <Row label="Requested" v={(request.requested_features || []).map((f) => f.key).join(", ")} />
+          </Card>
+          <Card title="Launch Checklist">
+            <ul className="text-sm text-gray-700">
+              {Object.entries(request.launch_checklist || {}).map(([k, v]) => (
+                <li key={k} className="flex items-center gap-2">
+                  <CheckCircle2 className={`h-3.5 w-3.5 ${v ? "text-emerald-600" : "text-gray-300"}`} />
+                  <span>{k.replace(/_/g, " ")}</span>
+                </li>
+              ))}
+            </ul>
+            {(request.legal_pages_needed || []).length > 0 && (
+              <p className="text-xs text-gray-500 mt-2">Legal: {(request.legal_pages_needed || []).join(", ")}</p>
+            )}
+          </Card>
+          <Card title={`Media (${media.length})`}>
+            {media.length === 0 ? (
+              <p className="text-sm text-gray-500">No uploads.</p>
+            ) : (
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+                {media.map((m) => (
+                  <div key={m.id} className="rounded-lg border border-gray-100 overflow-hidden bg-white">
+                    {m.kind === "video_link" ? (
+                      <a href={m.external_url || "#"} target="_blank" rel="noreferrer" className="block p-3 text-xs text-green-primary hover:underline break-all">
+                        <ExternalLink className="inline h-3 w-3 mr-1" /> {m.external_url}
+                      </a>
+                    ) : m.signed_url ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <a href={m.signed_url} target="_blank" rel="noreferrer" className="block group">
+                        {m.mime_type?.startsWith("video/") ? (
+                          <div className="aspect-square flex items-center justify-center bg-gray-50 text-xs text-gray-500">Video</div>
+                        ) : (
+                          <img src={m.signed_url} alt={m.file_name || ""} className="aspect-square w-full object-cover" />
+                        )}
+                        <div className="p-1 text-[10px] text-gray-500 truncate flex items-center gap-1">
+                          <Download className="h-3 w-3" />
+                          <span className="uppercase text-[9px]">{m.kind}</span>
+                          <span className="truncate">{m.file_name}</span>
+                        </div>
+                      </a>
+                    ) : null}
+                  </div>
+                ))}
+              </div>
+            )}
+          </Card>
+        </div>
+
+        {/* Right column — controls + activity */}
+        <div className="space-y-4">
+          <Card title="Status">
+            <select
+              value={request.status}
+              onChange={(e) => changeStatus(e.target.value)}
+              disabled={saving === "status"}
+              className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm"
+            >
+              {STATUSES.map((s) => (
+                <option key={s} value={s}>{s.replace(/_/g, " ")}</option>
+              ))}
+            </select>
+          </Card>
+
+          <Card title="Request more information">
+            <p className="text-xs text-gray-500 mb-2">Sends a public message + flips status to Needs Information.</p>
+            <textarea
+              value={infoRequestText}
+              onChange={(e) => setInfoRequestText(e.target.value)}
+              rows={3}
+              placeholder="What do you need from them?"
+              className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm"
+            />
+            <button
+              onClick={requestInfo}
+              disabled={saving === "info" || !infoRequestText.trim()}
+              className="mt-2 w-full inline-flex items-center justify-center gap-1.5 rounded-lg bg-amber-600 hover:bg-amber-700 px-3 py-2 text-xs font-semibold text-white disabled:opacity-50"
+            >
+              {saving === "info" ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Send className="h-3.5 w-3.5" />}
+              Send Needs-Info Request
+            </button>
+          </Card>
+
+          <Card title="Notes">
+            <textarea
+              value={noteText}
+              onChange={(e) => setNoteText(e.target.value)}
+              rows={3}
+              placeholder="Note for the team or the customer"
+              className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm"
+            />
+            <div className="flex gap-2 mt-2">
+              <button
+                onClick={() => addNote("internal")}
+                disabled={saving === "note" || !noteText.trim()}
+                className="flex-1 inline-flex items-center justify-center gap-1.5 rounded-lg border border-gray-200 bg-white hover:bg-gray-50 px-3 py-2 text-xs font-semibold text-gray-700 disabled:opacity-50"
+              >
+                <MessageSquare className="h-3.5 w-3.5" /> Internal
+              </button>
+              <button
+                onClick={() => addNote("public")}
+                disabled={saving === "note" || !noteText.trim()}
+                className="flex-1 inline-flex items-center justify-center gap-1.5 rounded-lg bg-blue-600 hover:bg-blue-700 px-3 py-2 text-xs font-semibold text-white disabled:opacity-50"
+              >
+                <Send className="h-3.5 w-3.5" /> Public
+              </button>
+            </div>
+          </Card>
+
+          <Card title="Activity">
+            <ol className="space-y-3">
+              {activity.map((a) => (
+                <li key={a.id} className="text-xs">
+                  <div className="flex items-center justify-between">
+                    <span className={`font-semibold ${a.visibility === "internal" ? "text-gray-700" : "text-blue-700"}`}>
+                      {a.event_type.replace(/_/g, " ")}
+                      {a.visibility === "internal" && <span className="ml-1 text-[9px] text-gray-400 uppercase">Internal</span>}
+                    </span>
+                    <span className="text-gray-400">{new Date(a.created_at).toLocaleString()}</span>
+                  </div>
+                  {a.message && <p className="text-gray-600 mt-0.5 whitespace-pre-wrap">{a.message}</p>}
+                  {a.actor && <p className="text-gray-400 mt-0.5">{a.actor.full_name || a.actor.email}</p>}
+                </li>
+              ))}
+            </ol>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Card({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-2xl border border-gray-100 bg-white p-4">
+      <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-2">{title}</p>
+      <div className="space-y-1">{children}</div>
+    </div>
+  );
+}
+
+function Row({ label, v }: { label: string; v: string | null | undefined }) {
+  return (
+    <div className="flex items-start gap-3 text-sm">
+      <span className="w-40 text-gray-500 shrink-0">{label}</span>
+      <span className="flex-1 text-gray-900 break-words">{v || <span className="text-gray-300">—</span>}</span>
+    </div>
+  );
+}
+
+function Block({ label, v }: { label: string; v: string | null | undefined }) {
+  return (
+    <div className="text-sm">
+      <p className="text-xs text-gray-500 mb-0.5">{label}</p>
+      <p className="text-gray-900 whitespace-pre-wrap">{v || <span className="text-gray-300">—</span>}</p>
+    </div>
+  );
+}

--- a/src/app/admin/website-requests/page.tsx
+++ b/src/app/admin/website-requests/page.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { Loader2, Globe, Filter, Search, ExternalLink } from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
+
+interface Row {
+  id: string;
+  status: string;
+  business_name: string | null;
+  primary_contact: string | null;
+  email: string | null;
+  current_domain: string | null;
+  existing_website: string | null;
+  updated_at: string;
+  submitted_at: string | null;
+  assigned_to: string | null;
+  user: { id: string; full_name: string | null; email: string | null; role: string } | null;
+}
+
+const STATUS_STYLES: Record<string, string> = {
+  draft: "bg-gray-100 text-gray-700",
+  submitted: "bg-blue-100 text-blue-800",
+  under_review: "bg-blue-100 text-blue-800",
+  needs_information: "bg-amber-100 text-amber-800",
+  approved_for_build: "bg-emerald-100 text-emerald-800",
+  in_development: "bg-emerald-100 text-emerald-800",
+  client_review: "bg-purple-100 text-purple-800",
+  ready_to_launch: "bg-purple-100 text-purple-800",
+  launched: "bg-green-100 text-green-800",
+  cancelled: "bg-red-100 text-red-700",
+};
+
+const FILTERS = [
+  { key: "", label: "All" },
+  { key: "submitted", label: "Submitted" },
+  { key: "under_review", label: "Under Review" },
+  { key: "needs_information", label: "Needs Info" },
+  { key: "approved_for_build", label: "Approved" },
+  { key: "in_development", label: "In Development" },
+  { key: "client_review", label: "Client Review" },
+  { key: "ready_to_launch", label: "Ready to Launch" },
+  { key: "launched", label: "Launched" },
+  { key: "cancelled", label: "Cancelled" },
+];
+
+export default function AdminWebsiteRequestsPage() {
+  const router = useRouter();
+  const [token, setToken] = useState("");
+  const [rows, setRows] = useState<Row[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [status, setStatus] = useState("");
+  const [q, setQ] = useState("");
+
+  const load = useCallback(async (t: string) => {
+    setLoading(true);
+    const params = new URLSearchParams();
+    if (status) params.set("status", status);
+    if (q.trim()) params.set("q", q.trim());
+    const res = await fetch(`/api/admin/website-requests?${params}`, {
+      headers: { Authorization: `Bearer ${t}` },
+    });
+    if (res.ok) setRows((await res.json()).requests || []);
+    setLoading(false);
+  }, [status, q]);
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!session?.access_token) { router.push("/login?redirect=/admin/website-requests"); return; }
+      setToken(session.access_token);
+      load(session.access_token);
+    });
+  }, [router, load]);
+
+  useEffect(() => { if (token) load(token); }, [token, load]);
+
+  return (
+    <div className="p-6 max-w-6xl mx-auto">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
+          <Globe className="h-6 w-6 text-green-600" /> Website Requests
+        </h1>
+        <p className="text-sm text-gray-500 mt-1">
+          Customer-submitted website intakes — review, request more info, approve, and manage status
+          through launch.
+        </p>
+      </div>
+
+      <div className="mb-4 flex flex-col sm:flex-row gap-2">
+        <div className="flex items-center gap-2 flex-wrap">
+          <Filter className="h-4 w-4 text-gray-400" />
+          {FILTERS.map((f) => (
+            <button
+              key={f.key}
+              onClick={() => setStatus(f.key)}
+              className={`rounded-lg px-3 py-1.5 text-xs font-medium cursor-pointer ${status === f.key ? "bg-green-100 text-green-700" : "bg-gray-100 text-gray-500 hover:bg-gray-200"}`}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+        <div className="flex-1 flex items-center gap-2">
+          <Search className="h-4 w-4 text-gray-400" />
+          <input
+            type="text"
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="Search business / contact / email"
+            className="flex-1 rounded-xl border border-gray-200 px-3 py-2 text-sm"
+          />
+        </div>
+      </div>
+
+      <div className="rounded-2xl border border-gray-100 bg-white">
+        {loading ? (
+          <div className="p-8 flex justify-center"><Loader2 className="h-5 w-5 animate-spin text-green-primary" /></div>
+        ) : rows.length === 0 ? (
+          <p className="p-8 text-sm text-gray-500 text-center">No requests match the current filter.</p>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-xs text-gray-500 border-b border-gray-100">
+                <th className="text-left py-2 px-3 font-medium">Business</th>
+                <th className="text-left py-2 px-3 font-medium">Contact</th>
+                <th className="text-left py-2 px-3 font-medium">Domain</th>
+                <th className="text-left py-2 px-3 font-medium">Status</th>
+                <th className="text-left py-2 px-3 font-medium">Submitted</th>
+                <th className="text-left py-2 px-3 font-medium">Updated</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => (
+                <tr key={r.id} className="border-b border-gray-50 last:border-b-0 hover:bg-gray-50/50 cursor-pointer" onClick={() => router.push(`/admin/website-requests/${r.id}`)}>
+                  <td className="py-2 px-3">
+                    <p className="font-medium text-gray-900">{r.business_name || <span className="text-gray-400">Untitled</span>}</p>
+                    <p className="text-[11px] text-gray-500">{r.user?.email}</p>
+                  </td>
+                  <td className="py-2 px-3 text-gray-700">
+                    <p>{r.primary_contact}</p>
+                    <p className="text-[11px] text-gray-400">{r.email}</p>
+                  </td>
+                  <td className="py-2 px-3 text-xs text-gray-500">
+                    {r.current_domain || r.existing_website ? (
+                      <a href={r.current_domain ? `https://${r.current_domain}` : r.existing_website!} target="_blank" rel="noreferrer" onClick={(e) => e.stopPropagation()} className="inline-flex items-center gap-1 text-green-primary hover:underline">
+                        {r.current_domain || r.existing_website}
+                        <ExternalLink className="h-3 w-3" />
+                      </a>
+                    ) : "—"}
+                  </td>
+                  <td className="py-2 px-3">
+                    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold ${STATUS_STYLES[r.status] || "bg-gray-100 text-gray-600"}`}>
+                      {r.status.replace(/_/g, " ")}
+                    </span>
+                  </td>
+                  <td className="py-2 px-3 text-xs text-gray-500">{r.submitted_at ? new Date(r.submitted_at).toLocaleDateString() : "—"}</td>
+                  <td className="py-2 px-3 text-xs text-gray-500">{new Date(r.updated_at).toLocaleDateString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/admin/website-requests/[id]/assign/route.ts
+++ b/src/app/api/admin/website-requests/[id]/assign/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+
+/**
+ * POST /api/admin/website-requests/[id]/assign
+ * Body: { user_id?: string }  — pass null to unassign
+ *
+ * Records the change on activity so team handoffs are auditable.
+ */
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id } = await params;
+
+  const body = await req.json().catch(() => ({}));
+  const targetId = typeof body.user_id === "string" && body.user_id ? body.user_id : null;
+
+  const { data: existing } = await supabaseAdmin
+    .from("website_requests")
+    .select("id, assigned_to")
+    .eq("id", id)
+    .maybeSingle();
+  if (!existing) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  if (targetId) {
+    const { data: user } = await supabaseAdmin
+      .from("profiles")
+      .select("id, full_name, email")
+      .eq("id", targetId)
+      .maybeSingle();
+    if (!user) return NextResponse.json({ error: "Unknown assignee" }, { status: 400 });
+  }
+
+  const { data: updated, error } = await supabaseAdmin
+    .from("website_requests")
+    .update({ assigned_to: targetId, updated_at: new Date().toISOString() })
+    .eq("id", id)
+    .select("*")
+    .single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  await supabaseAdmin.from("website_request_activity").insert({
+    request_id: id,
+    actor_id: adminId,
+    event_type: "assigned",
+    visibility: "internal",
+    message: targetId ? `Assigned to ${targetId}` : "Unassigned",
+    metadata: { previous_assignee: existing.assigned_to, new_assignee: targetId },
+  });
+
+  return NextResponse.json({ request: updated });
+}

--- a/src/app/api/admin/website-requests/[id]/note/route.ts
+++ b/src/app/api/admin/website-requests/[id]/note/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+
+/**
+ * POST /api/admin/website-requests/[id]/note
+ * Body: { message, visibility?: 'internal' | 'public' }
+ *
+ * Internal notes never surface to the customer; public notes appear on
+ * their timeline (used for "requesting more info" style comments).
+ */
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id } = await params;
+
+  const body = await req.json().catch(() => ({}));
+  const message = typeof body.message === "string" ? body.message.trim().slice(0, 4000) : "";
+  const visibility = body.visibility === "public" ? "public" : "internal";
+  if (!message) return NextResponse.json({ error: "message is required" }, { status: 400 });
+
+  const { data: request } = await supabaseAdmin
+    .from("website_requests")
+    .select("id")
+    .eq("id", id)
+    .maybeSingle();
+  if (!request) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const { data, error } = await supabaseAdmin
+    .from("website_request_activity")
+    .insert({
+      request_id: id,
+      actor_id: adminId,
+      event_type: "note_added",
+      visibility,
+      message,
+    })
+    .select("*")
+    .single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ activity: data });
+}

--- a/src/app/api/admin/website-requests/[id]/request-info/route.ts
+++ b/src/app/api/admin/website-requests/[id]/request-info/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+import { sendWebsiteRequestNotification } from "@/lib/websiteRequestEmail";
+
+/**
+ * POST /api/admin/website-requests/[id]/request-info
+ * Body: { message }
+ *
+ * Flips the request to needs_information + records a public activity
+ * entry with the admin's message so the customer knows exactly what
+ * they need to provide. Fires the needs_information notification.
+ */
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id } = await params;
+
+  const body = await req.json().catch(() => ({}));
+  const message = typeof body.message === "string" ? body.message.trim().slice(0, 4000) : "";
+  if (!message) return NextResponse.json({ error: "message is required" }, { status: 400 });
+
+  const { data: existing } = await supabaseAdmin
+    .from("website_requests")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+  if (!existing) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const nowIso = new Date().toISOString();
+  const { data: updated, error } = await supabaseAdmin
+    .from("website_requests")
+    .update({ status: "needs_information", updated_at: nowIso })
+    .eq("id", id)
+    .select("*")
+    .single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  await supabaseAdmin.from("website_request_activity").insert({
+    request_id: id,
+    actor_id: adminId,
+    event_type: "info_requested",
+    visibility: "public",
+    previous_status: existing.status,
+    new_status: "needs_information",
+    message,
+  });
+
+  try {
+    await sendWebsiteRequestNotification({
+      event: "needs_information",
+      request: updated,
+    });
+  } catch (e) {
+    console.error("[admin.request-info] notification failed:", e);
+  }
+
+  return NextResponse.json({ request: updated });
+}

--- a/src/app/api/admin/website-requests/[id]/route.ts
+++ b/src/app/api/admin/website-requests/[id]/route.ts
@@ -1,0 +1,100 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+import { signedMediaUrl, CUSTOMER_EDITABLE_SCALARS, CUSTOMER_EDITABLE_JSONB } from "@/lib/websiteRequests";
+
+/**
+ * GET /api/admin/website-requests/[id]
+ * PATCH /api/admin/website-requests/[id]
+ *
+ * Admin gets the full request row + media (with fresh signed URLs) +
+ * full activity log (both public and internal entries).
+ *
+ * PATCH accepts any customer-editable field (so admin can correct
+ * intake on behalf of the customer) plus admin-only fields
+ * assigned_to. Status changes and internal notes go through their
+ * dedicated routes so the activity log stays clean.
+ */
+
+const ADMIN_ONLY_EDITABLE = new Set(["assigned_to"]);
+const CUSTOMER_KEYS = new Set<string>([...CUSTOMER_EDITABLE_SCALARS, ...CUSTOMER_EDITABLE_JSONB]);
+
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id } = await params;
+
+  const [{ data: request }, { data: media }, { data: activity }] = await Promise.all([
+    supabaseAdmin
+      .from("website_requests")
+      .select(`*, user:user_id(id, full_name, email, role, phone, company_name), assignee:assigned_to(id, full_name, email)`)
+      .eq("id", id)
+      .maybeSingle(),
+    supabaseAdmin
+      .from("website_request_media")
+      .select("*")
+      .eq("request_id", id)
+      .order("sort_order"),
+    supabaseAdmin
+      .from("website_request_activity")
+      .select(`*, actor:actor_id(id, full_name, email)`)
+      .eq("request_id", id)
+      .order("created_at", { ascending: false }),
+  ]);
+
+  if (!request) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const mediaWithUrls = await Promise.all(
+    (media || []).map(async (m) => ({
+      ...m,
+      signed_url: m.file_path ? await signedMediaUrl(m.file_path, 900) : null,
+    })),
+  );
+
+  return NextResponse.json({
+    request,
+    media: mediaWithUrls,
+    activity: activity || [],
+  });
+}
+
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id } = await params;
+
+  const body = await req.json().catch(() => ({}));
+  const patch: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(body)) {
+    if (CUSTOMER_KEYS.has(k) || ADMIN_ONLY_EDITABLE.has(k)) patch[k] = v;
+  }
+  if (Object.keys(patch).length === 0) {
+    return NextResponse.json({ error: "No editable fields in body" }, { status: 400 });
+  }
+
+  const { data: before } = await supabaseAdmin
+    .from("website_requests")
+    .select("id")
+    .eq("id", id)
+    .maybeSingle();
+  if (!before) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const { data: updated, error } = await supabaseAdmin
+    .from("website_requests")
+    .update({ ...patch, updated_at: new Date().toISOString() })
+    .eq("id", id)
+    .select("*")
+    .single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  await supabaseAdmin.from("website_request_activity").insert({
+    request_id: id,
+    actor_id: adminId,
+    event_type: "edited",
+    visibility: "internal",
+    message: "Admin edited intake",
+    metadata: { fields: Object.keys(patch) },
+  });
+
+  return NextResponse.json({ request: updated });
+}

--- a/src/app/api/admin/website-requests/[id]/status/route.ts
+++ b/src/app/api/admin/website-requests/[id]/status/route.ts
@@ -1,0 +1,88 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+import { sendWebsiteRequestNotification } from "@/lib/websiteRequestEmail";
+
+const ALLOWED_STATUSES = new Set([
+  "draft",
+  "submitted",
+  "under_review",
+  "needs_information",
+  "approved_for_build",
+  "in_development",
+  "client_review",
+  "ready_to_launch",
+  "launched",
+  "cancelled",
+]);
+
+const NOTIFIABLE = new Set([
+  "needs_information",
+  "approved_for_build",
+  "in_development",
+  "client_review",
+  "ready_to_launch",
+  "launched",
+]);
+
+/**
+ * POST /api/admin/website-requests/[id]/status
+ * Body: { status, message? }
+ *
+ * Transitions the request status. Records a public activity entry so
+ * the customer sees the change on their own view + optionally kicks a
+ * notification email (idempotent per (request_id, status) inside
+ * sendWebsiteRequestNotification).
+ */
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id } = await params;
+
+  const body = await req.json().catch(() => ({}));
+  const nextStatus = typeof body.status === "string" ? body.status : "";
+  const message = typeof body.message === "string" ? body.message.slice(0, 1000) : "";
+
+  if (!ALLOWED_STATUSES.has(nextStatus)) {
+    return NextResponse.json({ error: "Invalid status" }, { status: 400 });
+  }
+
+  const { data: existing } = await supabaseAdmin
+    .from("website_requests")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+  if (!existing) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const nowIso = new Date().toISOString();
+  const { data: updated, error } = await supabaseAdmin
+    .from("website_requests")
+    .update({ status: nextStatus, updated_at: nowIso })
+    .eq("id", id)
+    .select("*")
+    .single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  await supabaseAdmin.from("website_request_activity").insert({
+    request_id: id,
+    actor_id: adminId,
+    event_type: "status_changed",
+    visibility: "public",
+    previous_status: existing.status,
+    new_status: nextStatus,
+    message: message || null,
+  });
+
+  if (NOTIFIABLE.has(nextStatus)) {
+    try {
+      await sendWebsiteRequestNotification({
+        event: nextStatus as Parameters<typeof sendWebsiteRequestNotification>[0]["event"],
+        request: updated,
+      });
+    } catch (e) {
+      console.error("[admin.status] notification failed:", e);
+    }
+  }
+
+  return NextResponse.json({ request: updated });
+}

--- a/src/app/api/admin/website-requests/route.ts
+++ b/src/app/api/admin/website-requests/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+
+/**
+ * GET /api/admin/website-requests
+ *
+ * Admin queue with filter/search. Returns request rows joined with the
+ * submitting profile (name/email) so the list view can render account
+ * context without a follow-up hop.
+ *
+ * Query params:
+ *   status      — optional status filter
+ *   assigned_to — optional user id (or "unassigned")
+ *   q           — free-text search over business_name / primary_contact / email
+ *   limit       — 1..200 (default 100)
+ */
+export async function GET(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const url = new URL(req.url);
+  const status = url.searchParams.get("status");
+  const assignedTo = url.searchParams.get("assigned_to");
+  const q = (url.searchParams.get("q") || "").trim();
+  const limit = Math.max(1, Math.min(200, Number(url.searchParams.get("limit") || 100)));
+
+  let query = supabaseAdmin
+    .from("website_requests")
+    .select(`
+      id, status, business_name, primary_contact, email, phone,
+      current_domain, existing_website, assigned_to, submitted_at, created_at, updated_at,
+      user:user_id(id, full_name, email, role)
+    `)
+    .order("updated_at", { ascending: false })
+    .limit(limit);
+
+  if (status) query = query.eq("status", status);
+  if (assignedTo === "unassigned") query = query.is("assigned_to", null);
+  else if (assignedTo) query = query.eq("assigned_to", assignedTo);
+  if (q) {
+    const s = q.replace(/[%,]/g, "");
+    query = query.or(`business_name.ilike.%${s}%,primary_contact.ilike.%${s}%,email.ilike.%${s}%`);
+  }
+
+  const { data, error } = await query;
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ requests: data || [] });
+}

--- a/src/app/api/website-requests/[id]/media/[mediaId]/route.ts
+++ b/src/app/api/website-requests/[id]/media/[mediaId]/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getUserIdFromRequest } from "@/lib/apiAuth";
+
+/**
+ * DELETE /api/website-requests/[id]/media/[mediaId]
+ * Remove an uploaded asset (also deletes the bucket file). Only the
+ * owner can delete, and only while the request is still editable.
+ */
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string; mediaId: string }> },
+) {
+  const userId = await getUserIdFromRequest(req);
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const { id, mediaId } = await params;
+
+  const { data: request } = await supabaseAdmin
+    .from("website_requests")
+    .select("id, user_id, status, logo_media_id")
+    .eq("id", id)
+    .eq("user_id", userId)
+    .maybeSingle();
+  if (!request) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  if (request.status !== "draft" && request.status !== "needs_information") {
+    return NextResponse.json({ error: "Request is not editable" }, { status: 409 });
+  }
+
+  const { data: media } = await supabaseAdmin
+    .from("website_request_media")
+    .select("*")
+    .eq("id", mediaId)
+    .eq("request_id", id)
+    .maybeSingle();
+  if (!media) return NextResponse.json({ error: "Media not found" }, { status: 404 });
+
+  if (media.file_path) {
+    await supabaseAdmin.storage.from("website-request-media").remove([media.file_path]).catch(() => {});
+  }
+  await supabaseAdmin.from("website_request_media").delete().eq("id", mediaId);
+
+  // If we just deleted the logo, clear the FK so the wizard doesn't
+  // dangle-render a preview.
+  if (request.logo_media_id === mediaId) {
+    await supabaseAdmin
+      .from("website_requests")
+      .update({ logo_media_id: null, updated_at: new Date().toISOString() })
+      .eq("id", id);
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/website-requests/[id]/media/route.ts
+++ b/src/app/api/website-requests/[id]/media/route.ts
@@ -1,0 +1,133 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getUserIdFromRequest } from "@/lib/apiAuth";
+import { signedMediaUrl } from "@/lib/websiteRequests";
+
+/**
+ * POST /api/website-requests/[id]/media
+ * multipart/form-data:
+ *   file       — File
+ *   kind       — 'logo'|'staff'|'location'|'machine'|'product'|'video'|'testimonial'
+ *   caption    — optional
+ *
+ * OR JSON body for video_link:
+ *   { kind: 'video_link', external_url, caption? }
+ *
+ * File uploads land in the private website-request-media bucket.
+ * Returns the media row + a fresh signed_url so the wizard can render
+ * the preview immediately.
+ */
+
+const MAX_BYTES = 15 * 1024 * 1024;   // 15 MB per file
+const ALLOWED_IMAGE_MIME = new Set(["image/png", "image/jpeg", "image/webp", "image/gif", "image/svg+xml"]);
+const ALLOWED_VIDEO_MIME = new Set(["video/mp4", "video/quicktime", "video/webm"]);
+const IMAGE_KINDS = new Set(["logo", "staff", "location", "machine", "product", "testimonial"]);
+
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const userId = await getUserIdFromRequest(req);
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const { id } = await params;
+
+  const { data: request } = await supabaseAdmin
+    .from("website_requests")
+    .select("id, user_id, status")
+    .eq("id", id)
+    .eq("user_id", userId)
+    .maybeSingle();
+  if (!request) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  if (request.status !== "draft" && request.status !== "needs_information") {
+    return NextResponse.json({ error: "Request is not editable" }, { status: 409 });
+  }
+
+  const contentType = req.headers.get("content-type") || "";
+
+  // Video link branch — JSON body, no file.
+  if (contentType.includes("application/json")) {
+    const body = await req.json().catch(() => ({}));
+    if (body.kind !== "video_link") {
+      return NextResponse.json({ error: "kind must be 'video_link' for JSON body" }, { status: 400 });
+    }
+    const url = typeof body.external_url === "string" ? body.external_url.trim() : "";
+    if (!/^https?:\/\//i.test(url)) {
+      return NextResponse.json({ error: "external_url must be a valid https URL" }, { status: 400 });
+    }
+    const { data, error } = await supabaseAdmin
+      .from("website_request_media")
+      .insert({
+        request_id: id,
+        kind: "video_link",
+        external_url: url,
+        caption: typeof body.caption === "string" ? body.caption.trim() : null,
+        uploaded_by: userId,
+      })
+      .select("*")
+      .single();
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ media: data });
+  }
+
+  const fd = await req.formData();
+  const file = fd.get("file");
+  const kind = String(fd.get("kind") || "");
+  const caption = String(fd.get("caption") || "").trim() || null;
+
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: "file is required" }, { status: 400 });
+  }
+  if (!IMAGE_KINDS.has(kind) && kind !== "video") {
+    return NextResponse.json({ error: "invalid kind" }, { status: 400 });
+  }
+  if (file.size > MAX_BYTES) {
+    return NextResponse.json({ error: "File exceeds 15 MB" }, { status: 413 });
+  }
+  const mime = file.type || "application/octet-stream";
+  if (kind === "video" && !ALLOWED_VIDEO_MIME.has(mime)) {
+    return NextResponse.json({ error: `Unsupported video type: ${mime}` }, { status: 415 });
+  }
+  if (kind !== "video" && !ALLOWED_IMAGE_MIME.has(mime)) {
+    return NextResponse.json({ error: `Unsupported image type: ${mime}` }, { status: 415 });
+  }
+
+  const ext = file.name.split(".").pop() || (mime.split("/")[1] || "bin");
+  const safeName = file.name.replace(/[^\w.\-]/g, "_").slice(-80);
+  const path = `${userId}/${id}/${kind}/${Date.now()}-${Math.random().toString(36).slice(2, 8)}-${safeName}`;
+  const buffer = Buffer.from(await file.arrayBuffer());
+
+  const { error: uploadErr } = await supabaseAdmin
+    .storage
+    .from("website-request-media")
+    .upload(path, buffer, { contentType: mime, upsert: false });
+  if (uploadErr) return NextResponse.json({ error: uploadErr.message }, { status: 500 });
+
+  const { data: mediaRow, error: insertErr } = await supabaseAdmin
+    .from("website_request_media")
+    .insert({
+      request_id: id,
+      kind,
+      file_path: path,
+      file_name: file.name,
+      file_size_bytes: file.size,
+      mime_type: mime,
+      caption,
+      uploaded_by: userId,
+      sort_order: Date.now(),
+    })
+    .select("*")
+    .single();
+  if (insertErr) {
+    // Best-effort cleanup — orphaned bucket file otherwise
+    await supabaseAdmin.storage.from("website-request-media").remove([path]).catch(() => {});
+    return NextResponse.json({ error: insertErr.message }, { status: 500 });
+  }
+
+  // If this was a logo, stamp the FK on the parent request.
+  if (kind === "logo") {
+    await supabaseAdmin
+      .from("website_requests")
+      .update({ logo_media_id: mediaRow.id, updated_at: new Date().toISOString() })
+      .eq("id", id);
+  }
+
+  const signed = await signedMediaUrl(path);
+  return NextResponse.json({ media: { ...mediaRow, signed_url: signed } });
+}

--- a/src/app/api/website-requests/[id]/route.ts
+++ b/src/app/api/website-requests/[id]/route.ts
@@ -1,0 +1,110 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getUserIdFromRequest } from "@/lib/apiAuth";
+import { sanitizeCustomerPatch, signedMediaUrl } from "@/lib/websiteRequests";
+
+/**
+ * GET /api/website-requests/[id]   — own draft/request + media + public activity
+ * PATCH /api/website-requests/[id] — save/autosave (only customer-editable fields)
+ * DELETE /api/website-requests/[id] — delete own DRAFT only; submitted requests
+ *                                     cannot be deleted (customer requests
+ *                                     cancellation from admin instead).
+ */
+
+async function ownedRequest(userId: string, id: string) {
+  const { data } = await supabaseAdmin
+    .from("website_requests")
+    .select("*")
+    .eq("id", id)
+    .eq("user_id", userId)
+    .maybeSingle();
+  return data;
+}
+
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const userId = await getUserIdFromRequest(req);
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const { id } = await params;
+
+  const request = await ownedRequest(userId, id);
+  if (!request) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const [{ data: media }, { data: activity }] = await Promise.all([
+    supabaseAdmin
+      .from("website_request_media")
+      .select("*")
+      .eq("request_id", id)
+      .order("sort_order"),
+    supabaseAdmin
+      .from("website_request_activity")
+      .select("*")
+      .eq("request_id", id)
+      .eq("visibility", "public")
+      .order("created_at", { ascending: false }),
+  ]);
+
+  // Sign urls for media so private assets can render in the wizard
+  const mediaWithUrls = await Promise.all(
+    (media || []).map(async (m) => ({
+      ...m,
+      signed_url: m.file_path ? await signedMediaUrl(m.file_path) : null,
+    })),
+  );
+
+  return NextResponse.json({
+    request,
+    media: mediaWithUrls,
+    activity: activity || [],
+  });
+}
+
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const userId = await getUserIdFromRequest(req);
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const { id } = await params;
+
+  const existing = await ownedRequest(userId, id);
+  if (!existing) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  // Once submitted, the customer can't silently edit — they'd need admin
+  // to switch it back to draft or to Needs Information.
+  if (existing.status !== "draft" && existing.status !== "needs_information") {
+    return NextResponse.json(
+      { error: "Request is no longer editable. Contact support to make changes." },
+      { status: 409 },
+    );
+  }
+
+  const body = await req.json().catch(() => ({}));
+  const patch = sanitizeCustomerPatch(body);
+  if (Object.keys(patch).length === 0) {
+    return NextResponse.json({ error: "No editable fields in body" }, { status: 400 });
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from("website_requests")
+    .update({ ...patch, updated_at: new Date().toISOString() })
+    .eq("id", id)
+    .select("*")
+    .single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ request: data });
+}
+
+export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const userId = await getUserIdFromRequest(req);
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const { id } = await params;
+
+  const existing = await ownedRequest(userId, id);
+  if (!existing) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  if (existing.status !== "draft") {
+    return NextResponse.json(
+      { error: "Only drafts can be deleted. Request cancellation from support instead." },
+      { status: 409 },
+    );
+  }
+
+  await supabaseAdmin.from("website_requests").delete().eq("id", id);
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/website-requests/[id]/submit/route.ts
+++ b/src/app/api/website-requests/[id]/submit/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getUserIdFromRequest } from "@/lib/apiAuth";
+import { validateSubmit } from "@/lib/websiteRequests";
+import { sendWebsiteRequestNotification } from "@/lib/websiteRequestEmail";
+
+/**
+ * POST /api/website-requests/[id]/submit
+ *
+ * Flip a draft (or a needs_information response) into `submitted`. Runs
+ * server-side validation of the minimum required fields + content
+ * ownership acknowledgment. On success, fires customer confirmation +
+ * admin notification.
+ */
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const userId = await getUserIdFromRequest(req);
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const { id } = await params;
+
+  const { data: existing } = await supabaseAdmin
+    .from("website_requests")
+    .select("*")
+    .eq("id", id)
+    .eq("user_id", userId)
+    .maybeSingle();
+  if (!existing) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  if (existing.status !== "draft" && existing.status !== "needs_information") {
+    return NextResponse.json({ error: `Cannot submit from status "${existing.status}"` }, { status: 409 });
+  }
+
+  const validation = validateSubmit(existing);
+  if (!validation.ok) {
+    return NextResponse.json(
+      { error: "Missing required fields", missing: validation.missing },
+      { status: 400 },
+    );
+  }
+
+  const nowIso = new Date().toISOString();
+  const { data: updated, error } = await supabaseAdmin
+    .from("website_requests")
+    .update({
+      status: "submitted",
+      submitted_at: existing.submitted_at || nowIso,
+      updated_at: nowIso,
+    })
+    .eq("id", id)
+    .select("*")
+    .single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  await supabaseAdmin.from("website_request_activity").insert({
+    request_id: id,
+    actor_id: userId,
+    event_type: "submitted",
+    visibility: "public",
+    previous_status: existing.status,
+    new_status: "submitted",
+    message: existing.status === "needs_information"
+      ? "Resubmitted with additional information"
+      : "Submitted for review",
+  });
+
+  // Fire-and-forget notifications; a Resend failure shouldn't block the submit.
+  try {
+    await sendWebsiteRequestNotification({
+      event: "submitted",
+      request: updated,
+    });
+  } catch (e) {
+    console.error("[website-request.submit] notification failed:", e);
+  }
+
+  return NextResponse.json({ ok: true, request: updated });
+}

--- a/src/app/api/website-requests/route.ts
+++ b/src/app/api/website-requests/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getUserIdFromRequest } from "@/lib/apiAuth";
+
+/**
+ * GET /api/website-requests — list the caller's own website requests.
+ * POST /api/website-requests — create a new draft, prefilling from the
+ * caller's profile so the wizard opens with sensible defaults.
+ */
+
+export async function GET(req: NextRequest) {
+  const userId = await getUserIdFromRequest(req);
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { data, error } = await supabaseAdmin
+    .from("website_requests")
+    .select("id, status, business_name, updated_at, submitted_at, created_at")
+    .eq("user_id", userId)
+    .order("updated_at", { ascending: false });
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ requests: data || [] });
+}
+
+export async function POST(req: NextRequest) {
+  const userId = await getUserIdFromRequest(req);
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { data: profile } = await supabaseAdmin
+    .from("profiles")
+    .select("full_name, email, phone, company_name, address, city, state, zip")
+    .eq("id", userId)
+    .maybeSingle();
+
+  const composedAddress = [
+    profile?.address,
+    profile?.city,
+    profile?.state,
+    profile?.zip,
+  ].filter(Boolean).join(", ") || null;
+
+  const { data, error } = await supabaseAdmin
+    .from("website_requests")
+    .insert({
+      user_id: userId,
+      status: "draft",
+      business_name: profile?.company_name || null,
+      primary_contact: profile?.full_name || null,
+      email: profile?.email || null,
+      phone: profile?.phone || null,
+      business_address: composedAddress,
+      inquiry_email: profile?.email || null,
+      public_phone: profile?.phone || null,
+      business_email: profile?.email || null,
+      lead_delivery_destination: "email",
+      lead_delivery_email: profile?.email || null,
+    })
+    .select("*")
+    .single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  await supabaseAdmin.from("website_request_activity").insert({
+    request_id: data.id,
+    actor_id: userId,
+    event_type: "created",
+    visibility: "internal",
+    new_status: "draft",
+    message: "Draft created",
+  });
+
+  return NextResponse.json({ request: data }, { status: 201 });
+}

--- a/src/app/components/website-builder/WizardBrandStep.tsx
+++ b/src/app/components/website-builder/WizardBrandStep.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { Loader2, Upload, Trash2, ImageIcon, Plus, X } from "lucide-react";
+import { TextField, TextArea, ColorField, ChipToggle } from "./fields";
+import type { StepProps, WebsiteRequestMedia } from "./types";
+
+const STYLES = [
+  { value: "modern", label: "Modern" },
+  { value: "corporate", label: "Corporate" },
+  { value: "premium", label: "Premium" },
+  { value: "minimal", label: "Minimal" },
+  { value: "bold", label: "Bold" },
+  { value: "friendly", label: "Friendly" },
+  { value: "tech_forward", label: "Tech-forward" },
+  { value: "other", label: "Other" },
+] as const;
+
+interface Props extends StepProps {
+  media: WebsiteRequestMedia[];
+  token: string;
+  onMediaChange: () => void;
+}
+
+/**
+ * Step 2 — Brand. Logo upload + brand colors + preferred style + tagline
+ * + inspiration sites. The logo lives in the shared media table with
+ * kind='logo'; the parent request row keeps a logo_media_id FK so the
+ * media step can render the same asset without a re-upload.
+ */
+export default function WizardBrandStep({
+  request, updateField, isReadOnly, media, token, onMediaChange,
+}: Props) {
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const fileRef = useRef<HTMLInputElement | null>(null);
+
+  const logo = media.find((m) => m.kind === "logo");
+  const style = request.preferred_style as (typeof STYLES)[number]["value"] | null;
+  const inspiration = request.inspiration_sites || [];
+
+  async function uploadLogo(file: File) {
+    setError(null);
+    setUploading(true);
+    const fd = new FormData();
+    fd.append("file", file);
+    fd.append("kind", "logo");
+    const res = await fetch(`/api/website-requests/${request.id}/media`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+      body: fd,
+    });
+    setUploading(false);
+    if (!res.ok) {
+      setError((await res.json().catch(() => ({}))).error || "Upload failed");
+      return;
+    }
+    onMediaChange();
+  }
+
+  async function deleteLogo() {
+    if (!logo) return;
+    if (!confirm("Remove the current logo?")) return;
+    await fetch(`/api/website-requests/${request.id}/media/${logo.id}`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    onMediaChange();
+  }
+
+  function updateInspiration(next: typeof inspiration) {
+    updateField("inspiration_sites", next);
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-lg font-semibold text-gray-900">Branding</h2>
+        <p className="text-sm text-gray-500 mt-1">
+          Logo, colors, style. Uploads are private — only you and the Vending Connector team see them.
+        </p>
+      </div>
+
+      {/* Logo upload */}
+      <div>
+        <label className="block text-xs font-medium text-gray-700 mb-1">Logo</label>
+        <div className="flex flex-wrap items-center gap-3">
+          {logo?.signed_url ? (
+            <div className="relative">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={logo.signed_url} alt="Logo preview" className="h-24 w-24 object-contain rounded-lg border border-gray-200 bg-gray-50" />
+              {!isReadOnly && (
+                <button
+                  onClick={deleteLogo}
+                  className="absolute -top-2 -right-2 bg-white border border-gray-200 rounded-full p-1 hover:bg-red-50 hover:border-red-200"
+                  aria-label="Remove logo"
+                >
+                  <X className="h-3.5 w-3.5 text-red-600" />
+                </button>
+              )}
+            </div>
+          ) : (
+            <div className="h-24 w-24 rounded-lg border-2 border-dashed border-gray-200 flex items-center justify-center bg-gray-50">
+              <ImageIcon className="h-8 w-8 text-gray-300" />
+            </div>
+          )}
+          {!isReadOnly && (
+            <>
+              <button
+                type="button"
+                onClick={() => fileRef.current?.click()}
+                disabled={uploading}
+                className="inline-flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-4 py-2 text-sm font-medium hover:bg-gray-50 cursor-pointer disabled:opacity-50"
+              >
+                {uploading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Upload className="h-4 w-4" />}
+                {logo ? "Replace Logo" : "Upload Logo"}
+              </button>
+              <input
+                ref={fileRef}
+                type="file"
+                accept="image/png,image/jpeg,image/webp,image/svg+xml"
+                className="hidden"
+                onChange={(e) => { const f = e.target.files?.[0]; if (f) void uploadLogo(f); e.currentTarget.value = ""; }}
+              />
+            </>
+          )}
+        </div>
+        {error && <p className="text-xs text-red-600 mt-1">{error}</p>}
+      </div>
+
+      {/* Colors */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <ColorField label="Primary Color" value={request.brand_primary_color} onChange={(v) => updateField("brand_primary_color", v)} disabled={isReadOnly} />
+        <ColorField label="Secondary Color" value={request.brand_secondary_color} onChange={(v) => updateField("brand_secondary_color", v)} disabled={isReadOnly} />
+      </div>
+
+      {/* Preferred style */}
+      <ChipToggle
+        label="Preferred Style"
+        options={STYLES as unknown as Array<{ value: string; label: string }>}
+        selected={style ? [style] : []}
+        onChange={(next) => updateField("preferred_style", next[next.length - 1] || null)}
+        disabled={isReadOnly}
+        hint="Pick the one that best fits your brand — we can mix and match."
+      />
+
+      {style === "other" && (
+        <TextField
+          label="Describe your style"
+          value={request.preferred_style_other}
+          onChange={(v) => updateField("preferred_style_other", v)}
+          disabled={isReadOnly}
+        />
+      )}
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <TextField label="Fonts (optional)" value={request.fonts} onChange={(v) => updateField("fonts", v)} disabled={isReadOnly} placeholder="e.g. Inter, Poppins" />
+        <TextField label="Tagline (optional)" value={request.tagline} onChange={(v) => updateField("tagline", v)} disabled={isReadOnly} placeholder="e.g. Smart vending, effortlessly." />
+      </div>
+
+      {/* Inspiration sites */}
+      <div>
+        <label className="block text-xs font-medium text-gray-700 mb-1">Websites / Competitors You Like</label>
+        <p className="text-[11px] text-gray-500 mb-2">Add URLs of sites whose look you like, with a short note about what specifically caught your eye.</p>
+        <div className="space-y-2">
+          {inspiration.map((row, i) => (
+            <div key={i} className="flex gap-2">
+              <input
+                type="url"
+                value={row.url}
+                onChange={(e) => {
+                  const next = [...inspiration];
+                  next[i] = { ...next[i], url: e.target.value };
+                  updateInspiration(next);
+                }}
+                placeholder="https://example.com"
+                disabled={isReadOnly}
+                className="flex-1 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-600 focus:outline-none disabled:bg-gray-50"
+              />
+              <input
+                type="text"
+                value={row.note || ""}
+                onChange={(e) => {
+                  const next = [...inspiration];
+                  next[i] = { ...next[i], note: e.target.value };
+                  updateInspiration(next);
+                }}
+                placeholder="What you like about it"
+                disabled={isReadOnly}
+                className="flex-1 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-green-600 focus:outline-none disabled:bg-gray-50"
+              />
+              {!isReadOnly && (
+                <button
+                  type="button"
+                  onClick={() => updateInspiration(inspiration.filter((_, x) => x !== i))}
+                  className="rounded-lg p-2 text-gray-400 hover:text-red-600 hover:bg-red-50"
+                  aria-label="Remove"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              )}
+            </div>
+          ))}
+          {!isReadOnly && (
+            <button
+              type="button"
+              onClick={() => updateInspiration([...inspiration, { url: "", note: "" }])}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-dashed border-gray-300 px-3 py-2 text-xs font-medium text-gray-600 hover:bg-gray-50"
+            >
+              <Plus className="h-3.5 w-3.5" /> Add Site
+            </button>
+          )}
+        </div>
+      </div>
+
+      <TextArea label="Notes for the design team (optional)" value={request.additional_notes} onChange={(v) => updateField("additional_notes", v)} disabled={isReadOnly} rows={3} placeholder="Anything else about the brand direction?" />
+    </div>
+  );
+}

--- a/src/app/components/website-builder/WizardBusinessStep.tsx
+++ b/src/app/components/website-builder/WizardBusinessStep.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { TextField, TextArea } from "./fields";
+import type { StepProps } from "./types";
+
+/**
+ * Step 1 — Business overview. Prefilled from the caller's profile on
+ * draft creation (see POST /api/website-requests); the customer can
+ * override anything here for the website context without changing
+ * their platform account.
+ */
+export default function WizardBusinessStep({ request, updateField, isReadOnly }: StepProps) {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-lg font-semibold text-gray-900">Business Overview</h2>
+        <p className="text-sm text-gray-500 mt-1">
+          The basics — how customers reach you and what makes your business tick. We&rsquo;ve
+          prefilled anything we already had on file; edit any of it for your website.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <TextField label="Business Name" value={request.business_name} onChange={(v) => updateField("business_name", v)} disabled={isReadOnly} required />
+        <TextField label="Primary Contact" value={request.primary_contact} onChange={(v) => updateField("primary_contact", v)} disabled={isReadOnly} required />
+        <TextField label="Phone" type="tel" value={request.phone} onChange={(v) => updateField("phone", v)} disabled={isReadOnly} required />
+        <TextField label="Email" type="email" value={request.email} onChange={(v) => updateField("email", v)} disabled={isReadOnly} required />
+      </div>
+
+      <TextField
+        label="Business Address"
+        value={request.business_address}
+        onChange={(v) => updateField("business_address", v)}
+        disabled={isReadOnly}
+        required
+      />
+
+      <TextField
+        label="Years in Business"
+        value={request.years_in_business}
+        onChange={(v) => updateField("years_in_business", v)}
+        disabled={isReadOnly}
+        placeholder="e.g. 5 years"
+      />
+
+      <TextArea
+        label="Business Story"
+        value={request.business_story}
+        onChange={(v) => updateField("business_story", v)}
+        disabled={isReadOnly}
+        placeholder="Tell us how your business started and what makes it unique."
+        rows={4}
+      />
+
+      <TextArea
+        label="Mission / Values"
+        value={request.mission_values}
+        onChange={(v) => updateField("mission_values", v)}
+        disabled={isReadOnly}
+        placeholder="What do you stand for? What matters to your team?"
+        rows={3}
+      />
+    </div>
+  );
+}

--- a/src/app/components/website-builder/WizardContactStep.tsx
+++ b/src/app/components/website-builder/WizardContactStep.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { Trash2, Plus, Info } from "lucide-react";
+import { TextField, TextArea, Checkbox } from "./fields";
+import type { StepProps } from "./types";
+
+const AVAILABLE_FIELDS = [
+  { key: "name", label: "Name", kind: "text" },
+  { key: "company", label: "Company", kind: "text" },
+  { key: "email", label: "Email", kind: "email" },
+  { key: "phone", label: "Phone", kind: "tel" },
+  { key: "address", label: "Address", kind: "text" },
+  { key: "city", label: "City", kind: "text" },
+  { key: "state", label: "State", kind: "text" },
+  { key: "zip", label: "ZIP", kind: "text" },
+  { key: "business_type", label: "Business Type", kind: "text" },
+  { key: "employee_count", label: "Employee Count", kind: "number" },
+  { key: "foot_traffic", label: "Estimated Daily Foot Traffic", kind: "number" },
+  { key: "service_requested", label: "Service Requested", kind: "text" },
+  { key: "message", label: "Message", kind: "textarea" },
+] as const;
+
+/**
+ * Step 6 — Contact & Lead Capture. The customer configures the contact
+ * form fields they want on their website + where new leads should be
+ * delivered.
+ *
+ * SECURITY: Only email delivery is offered in v1. Routing to the CRM
+ * would require the caller to have CRM permission, which we deliberately
+ * do not check here — Lead Generator access ≠ CRM access. The
+ * lead_delivery_destination column supports 'crm' for future work but
+ * the UI locks it to email.
+ */
+export default function WizardContactStep({ request, updateField, isReadOnly }: StepProps) {
+  const fields = request.contact_form_fields || [];
+  const enabledKeys = new Set(fields.map((f) => f.key));
+
+  function toggleField(key: string, label: string, kind: string) {
+    if (isReadOnly) return;
+    if (enabledKeys.has(key)) {
+      updateField("contact_form_fields", fields.filter((f) => f.key !== key));
+    } else {
+      updateField("contact_form_fields", [...fields, { key, label, kind, required: false }]);
+    }
+  }
+
+  function toggleRequired(key: string) {
+    if (isReadOnly) return;
+    updateField(
+      "contact_form_fields",
+      fields.map((f) => (f.key === key ? { ...f, required: !f.required } : f)),
+    );
+  }
+
+  const customFields = fields.filter((f) => !AVAILABLE_FIELDS.some((a) => a.key === f.key));
+
+  function addCustom() {
+    if (isReadOnly) return;
+    const label = prompt("Custom field label?");
+    if (!label) return;
+    const key = label.toLowerCase().replace(/[^\w]/g, "_").replace(/^_+|_+$/g, "").slice(0, 40) || `custom_${fields.length}`;
+    updateField("contact_form_fields", [...fields, { key, label, kind: "text", required: false }]);
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-lg font-semibold text-gray-900">Contact &amp; Lead Capture</h2>
+        <p className="text-sm text-gray-500 mt-1">
+          How customers reach you, and what your website contact form asks them.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <TextField label="Public Inquiry Email" type="email" value={request.inquiry_email} onChange={(v) => updateField("inquiry_email", v)} disabled={isReadOnly} required />
+        <TextField label="Public Phone Number" type="tel" value={request.public_phone} onChange={(v) => updateField("public_phone", v)} disabled={isReadOnly} required />
+      </div>
+
+      <TextArea label="Business Hours" value={request.business_hours} onChange={(v) => updateField("business_hours", v)} disabled={isReadOnly} rows={2} placeholder="e.g. Mon–Fri 8a–6p, closed weekends" />
+
+      {/* Contact form field builder */}
+      <div>
+        <label className="block text-xs font-medium text-gray-700 mb-1">Contact Form Fields</label>
+        <p className="text-[11px] text-gray-500 mb-2">Pick what to ask on your website form. Toggle Required per field.</p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+          {AVAILABLE_FIELDS.map((f) => {
+            const on = enabledKeys.has(f.key);
+            const row = fields.find((x) => x.key === f.key);
+            return (
+              <div key={f.key} className={`rounded-lg border p-3 ${on ? "border-emerald-200 bg-emerald-50/40" : "border-gray-200 bg-white"}`}>
+                <label className="flex items-center gap-2 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={on}
+                    onChange={() => toggleField(f.key, f.label, f.kind)}
+                    disabled={isReadOnly}
+                    className="h-4 w-4 rounded border-gray-300 text-green-600"
+                  />
+                  <span className="text-sm text-gray-800">{f.label}</span>
+                </label>
+                {on && (
+                  <label className="flex items-center gap-2 mt-2 pl-6 text-[11px] text-gray-600 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={!!row?.required}
+                      onChange={() => toggleRequired(f.key)}
+                      disabled={isReadOnly}
+                      className="h-3.5 w-3.5 rounded border-gray-300 text-green-600"
+                    />
+                    Required
+                  </label>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        {customFields.length > 0 && (
+          <div className="mt-3 space-y-2">
+            <p className="text-[11px] font-semibold text-gray-500 uppercase">Custom Fields</p>
+            {customFields.map((f) => (
+              <div key={f.key} className="flex items-center gap-2 rounded-lg border border-gray-200 bg-white p-2 text-sm">
+                <span className="flex-1">{f.label}</span>
+                <label className="text-[11px] text-gray-500 flex items-center gap-1">
+                  <input
+                    type="checkbox"
+                    checked={f.required}
+                    onChange={() => toggleRequired(f.key)}
+                    disabled={isReadOnly}
+                    className="h-3.5 w-3.5 rounded"
+                  /> Required
+                </label>
+                {!isReadOnly && (
+                  <button
+                    type="button"
+                    onClick={() => updateField("contact_form_fields", fields.filter((x) => x.key !== f.key))}
+                    className="p-1 text-gray-400 hover:text-red-600"
+                    aria-label="Remove"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {!isReadOnly && (
+          <button
+            type="button"
+            onClick={addCustom}
+            className="mt-2 inline-flex items-center gap-1.5 rounded-lg border border-dashed border-gray-300 px-3 py-2 text-xs font-medium text-gray-600 hover:bg-gray-50"
+          >
+            <Plus className="h-3.5 w-3.5" /> Add Custom Field
+          </button>
+        )}
+      </div>
+
+      {/* Lead delivery */}
+      <div>
+        <label className="block text-xs font-medium text-gray-700 mb-1">Where should new website leads be delivered?</label>
+        <div className="rounded-xl border border-gray-100 bg-gray-50 p-4">
+          <Checkbox
+            label="Email"
+            checked={request.lead_delivery_destination !== "crm"}
+            onChange={() => updateField("lead_delivery_destination", "email")}
+            disabled={isReadOnly}
+          />
+          <div className="mt-3 pl-6">
+            <TextField
+              label="Delivery email address"
+              type="email"
+              value={request.lead_delivery_email}
+              onChange={(v) => updateField("lead_delivery_email", v)}
+              disabled={isReadOnly || request.lead_delivery_destination === "crm"}
+              placeholder="leads@yourdomain.com"
+            />
+          </div>
+          <div className="mt-4 flex items-start gap-2 rounded-lg bg-blue-50 border border-blue-100 p-3 text-xs text-blue-800">
+            <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+            <span>
+              CRM routing is a separate integration we roll out per-account. Contact your admin
+              to enable it — the wizard defaults to email delivery so no CRM permissions are
+              granted through this form.
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/website-builder/WizardContentStep.tsx
+++ b/src/app/components/website-builder/WizardContentStep.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { Trash2, Plus } from "lucide-react";
+import { TextField, TextArea, RadioGroup } from "./fields";
+import type { StepProps } from "./types";
+
+const CTA_OPTIONS = [
+  { value: "request_free_service", label: "Request Free Vending Service" },
+  { value: "request_quote", label: "Request a Quote" },
+  { value: "get_a_machine", label: "Get a Machine" },
+  { value: "schedule_consultation", label: "Schedule a Consultation" },
+  { value: "contact_us", label: "Contact Us" },
+  { value: "custom", label: "Custom" },
+] as const;
+
+/**
+ * Step 4 — Website Content. Hero, about, services copy, testimonials
+ * (dynamic list), FAQs (dynamic list), CTAs.
+ */
+export default function WizardContentStep({ request, updateField, isReadOnly }: StepProps) {
+  const testimonials = request.testimonials || [];
+  const faqs = request.faqs || [];
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-lg font-semibold text-gray-900">Website Content</h2>
+        <p className="text-sm text-gray-500 mt-1">
+          The words on the page. We&rsquo;ll polish these; rough drafts are fine.
+        </p>
+      </div>
+
+      <TextArea label="Homepage Message / Hero Message" value={request.homepage_message} onChange={(v) => updateField("homepage_message", v)} disabled={isReadOnly} required rows={3} placeholder="One-sentence pitch — what do you do, for whom?" />
+
+      <TextArea label="About Us" value={request.about_content} onChange={(v) => updateField("about_content", v)} disabled={isReadOnly} rows={5} placeholder="A short story about the company. Team, history, mission." />
+
+      <TextArea label="Services Content" value={request.services_content} onChange={(v) => updateField("services_content", v)} disabled={isReadOnly} rows={5} placeholder="Rough copy for your services page." />
+
+      <RadioGroup
+        label="Gallery Needed?"
+        options={[{ value: "yes", label: "Yes" }, { value: "no", label: "No" }]}
+        value={request.gallery_needed === true ? "yes" : request.gallery_needed === false ? "no" : null}
+        onChange={(v) => updateField("gallery_needed", v === "yes")}
+        disabled={isReadOnly}
+      />
+
+      {/* Testimonials */}
+      <div>
+        <label className="block text-xs font-medium text-gray-700 mb-1">Testimonials</label>
+        <p className="text-[11px] text-gray-500 mb-2">Add real quotes from customers. We&rsquo;ll ask you to confirm permission at submit.</p>
+        <div className="space-y-3">
+          {testimonials.map((t, i) => (
+            <div key={i} className="rounded-xl border border-gray-100 bg-gray-50 p-3 space-y-2">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                <input
+                  type="text"
+                  value={t.name}
+                  onChange={(e) => {
+                    const next = [...testimonials];
+                    next[i] = { ...next[i], name: e.target.value };
+                    updateField("testimonials", next);
+                  }}
+                  placeholder="Customer / company name"
+                  disabled={isReadOnly}
+                  className="rounded-lg border border-gray-200 px-3 py-2 text-sm bg-white disabled:bg-gray-100"
+                />
+                <input
+                  type="text"
+                  value={t.role || ""}
+                  onChange={(e) => {
+                    const next = [...testimonials];
+                    next[i] = { ...next[i], role: e.target.value };
+                    updateField("testimonials", next);
+                  }}
+                  placeholder="Role/title (optional)"
+                  disabled={isReadOnly}
+                  className="rounded-lg border border-gray-200 px-3 py-2 text-sm bg-white disabled:bg-gray-100"
+                />
+              </div>
+              <div className="flex gap-2">
+                <textarea
+                  value={t.quote}
+                  onChange={(e) => {
+                    const next = [...testimonials];
+                    next[i] = { ...next[i], quote: e.target.value };
+                    updateField("testimonials", next);
+                  }}
+                  placeholder="The quote"
+                  disabled={isReadOnly}
+                  rows={2}
+                  className="flex-1 rounded-lg border border-gray-200 px-3 py-2 text-sm bg-white disabled:bg-gray-100"
+                />
+                {!isReadOnly && (
+                  <button
+                    type="button"
+                    onClick={() => updateField("testimonials", testimonials.filter((_, x) => x !== i))}
+                    className="rounded-lg p-2 text-gray-400 hover:text-red-600 hover:bg-red-50"
+                    aria-label="Remove"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                )}
+              </div>
+            </div>
+          ))}
+          {!isReadOnly && (
+            <button
+              type="button"
+              onClick={() => updateField("testimonials", [...testimonials, { name: "", quote: "", role: "" }])}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-dashed border-gray-300 px-3 py-2 text-xs font-medium text-gray-600 hover:bg-gray-50"
+            >
+              <Plus className="h-3.5 w-3.5" /> Add Testimonial
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* FAQs */}
+      <div>
+        <label className="block text-xs font-medium text-gray-700 mb-1">FAQs</label>
+        <p className="text-[11px] text-gray-500 mb-2">Common questions your customers ask.</p>
+        <div className="space-y-3">
+          {faqs.map((f, i) => (
+            <div key={i} className="rounded-xl border border-gray-100 bg-gray-50 p-3 space-y-2">
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  value={f.question}
+                  onChange={(e) => {
+                    const next = [...faqs];
+                    next[i] = { ...next[i], question: e.target.value };
+                    updateField("faqs", next);
+                  }}
+                  placeholder="Question"
+                  disabled={isReadOnly}
+                  className="flex-1 rounded-lg border border-gray-200 px-3 py-2 text-sm bg-white disabled:bg-gray-100"
+                />
+                {!isReadOnly && (
+                  <button
+                    type="button"
+                    onClick={() => updateField("faqs", faqs.filter((_, x) => x !== i))}
+                    className="rounded-lg p-2 text-gray-400 hover:text-red-600 hover:bg-red-50"
+                    aria-label="Remove"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                )}
+              </div>
+              <textarea
+                value={f.answer}
+                onChange={(e) => {
+                  const next = [...faqs];
+                  next[i] = { ...next[i], answer: e.target.value };
+                  updateField("faqs", next);
+                }}
+                placeholder="Answer"
+                disabled={isReadOnly}
+                rows={2}
+                className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm bg-white disabled:bg-gray-100"
+              />
+            </div>
+          ))}
+          {!isReadOnly && (
+            <button
+              type="button"
+              onClick={() => updateField("faqs", [...faqs, { question: "", answer: "" }])}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-dashed border-gray-300 px-3 py-2 text-xs font-medium text-gray-600 hover:bg-gray-50"
+            >
+              <Plus className="h-3.5 w-3.5" /> Add FAQ
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* CTAs */}
+      <RadioGroup
+        label="Primary Call-to-Action"
+        options={CTA_OPTIONS as unknown as Array<{ value: string; label: string }>}
+        value={request.primary_cta}
+        onChange={(v) => updateField("primary_cta", v)}
+        disabled={isReadOnly}
+      />
+      {request.primary_cta === "custom" && (
+        <TextField
+          label="Custom CTA text"
+          value={request.primary_cta_custom}
+          onChange={(v) => updateField("primary_cta_custom", v)}
+          disabled={isReadOnly}
+          required
+        />
+      )}
+      <TextField label="Optional Secondary CTA" value={request.secondary_cta} onChange={(v) => updateField("secondary_cta", v)} disabled={isReadOnly} placeholder="e.g. Learn More" />
+    </div>
+  );
+}

--- a/src/app/components/website-builder/WizardDomainStep.tsx
+++ b/src/app/components/website-builder/WizardDomainStep.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { Trash2, Plus, ShieldAlert } from "lucide-react";
+import { TextField, RadioGroup, ChipToggle } from "./fields";
+import type { StepProps } from "./types";
+
+const INTEGRATION_OPTIONS = [
+  { value: "google_analytics", label: "Google Analytics" },
+  { value: "meta_pixel", label: "Meta Pixel" },
+  { value: "google_business", label: "Google Business Profile" },
+  { value: "crm", label: "CRM" },
+  { value: "scheduling", label: "Scheduling" },
+  { value: "payments", label: "Payment processing" },
+  { value: "newsletter", label: "Newsletter / email marketing" },
+  { value: "other", label: "Other" },
+];
+
+/**
+ * Step 7 — Domain & Technology.
+ *
+ * SECURITY RULE (spec section 9): NEVER ask for passwords, API secrets,
+ * registrar credentials, etc. in free-text fields here. This step
+ * captures which systems the customer uses — the operations team wires
+ * credentials through a separate secure channel later.
+ */
+export default function WizardDomainStep({ request, updateField, isReadOnly }: StepProps) {
+  const integrations = request.integrations || [];
+  const selectedKeys = new Set(integrations.map((i) => i.key));
+  const status = request.domain_status;
+
+  function toggleIntegration(key: string) {
+    if (isReadOnly) return;
+    if (selectedKeys.has(key)) {
+      updateField("integrations", integrations.filter((i) => i.key !== key));
+    } else {
+      updateField("integrations", [...integrations, { key, notes: "" }]);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-lg font-semibold text-gray-900">Domain &amp; Technology</h2>
+        <p className="text-sm text-gray-500 mt-1">
+          What we&rsquo;ll build the site on. Zero passwords or API keys go in here — our team
+          reaches out separately for any secure credential exchange.
+        </p>
+      </div>
+
+      <div className="rounded-lg border border-amber-100 bg-amber-50 p-3 flex items-start gap-2 text-xs text-amber-900">
+        <ShieldAlert className="h-4 w-4 mt-0.5 shrink-0" />
+        <span>
+          Never share passwords, API secrets, or credentials in this form. If we need any,
+          we&rsquo;ll set up a secure exchange separately.
+        </span>
+      </div>
+
+      <RadioGroup
+        label="Do you currently own a domain?"
+        options={[
+          { value: "yes", label: "Yes" },
+          { value: "no", label: "No" },
+          { value: "not_sure", label: "Not sure" },
+        ]}
+        value={status}
+        onChange={(v) => updateField("domain_status", v)}
+        disabled={isReadOnly}
+      />
+
+      {status === "yes" && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <TextField
+            label="Current Domain"
+            value={request.current_domain}
+            onChange={(v) => updateField("current_domain", v)}
+            disabled={isReadOnly}
+            placeholder="e.g. yourbusiness.com"
+          />
+          <TextField
+            label="Domain Registrar (optional)"
+            value={request.domain_registrar}
+            onChange={(v) => updateField("domain_registrar", v)}
+            disabled={isReadOnly}
+            placeholder="e.g. GoDaddy, Namecheap"
+            hint="Name of the company where the domain is registered — no login details."
+          />
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <TextField
+          label="Business Email"
+          type="email"
+          value={request.business_email}
+          onChange={(v) => updateField("business_email", v)}
+          disabled={isReadOnly}
+          placeholder="you@yourbusiness.com"
+        />
+        <TextField
+          label="Existing Website URL"
+          value={request.existing_website}
+          onChange={(v) => updateField("existing_website", v)}
+          disabled={isReadOnly}
+          placeholder="https://…"
+        />
+      </div>
+
+      <div>
+        <ChipToggle
+          label="Special Integrations"
+          options={INTEGRATION_OPTIONS}
+          selected={integrations.map((i) => i.key)}
+          onChange={(next) => {
+            const nextSet = new Set(next);
+            const merged: Array<{ key: string; notes?: string }> = [];
+            for (const key of next) {
+              const existing = integrations.find((i) => i.key === key);
+              merged.push(existing || { key, notes: "" });
+            }
+            updateField("integrations", merged.filter((i) => nextSet.has(i.key)));
+          }}
+          disabled={isReadOnly}
+          hint="Pick anything you already use — we'll wire it up during build."
+        />
+        {integrations.length > 0 && (
+          <div className="mt-3 space-y-2">
+            {integrations.map((it) => (
+              <div key={it.key} className="flex items-center gap-2 rounded-lg border border-gray-100 bg-white p-2">
+                <span className="text-sm font-medium text-gray-800 w-40 shrink-0">
+                  {INTEGRATION_OPTIONS.find((o) => o.value === it.key)?.label || it.key}
+                </span>
+                <input
+                  type="text"
+                  value={it.notes || ""}
+                  onChange={(e) => updateField(
+                    "integrations",
+                    integrations.map((x) => (x.key === it.key ? { ...x, notes: e.target.value } : x)),
+                  )}
+                  placeholder="Notes (property ID, account name, etc. — no secrets)"
+                  disabled={isReadOnly}
+                  className="flex-1 rounded-lg border border-gray-200 px-3 py-2 text-sm bg-white disabled:bg-gray-50"
+                />
+                {!isReadOnly && (
+                  <button
+                    type="button"
+                    onClick={() => toggleIntegration(it.key)}
+                    className="p-1 text-gray-400 hover:text-red-600"
+                    aria-label="Remove"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/website-builder/WizardFeaturesStep.tsx
+++ b/src/app/components/website-builder/WizardFeaturesStep.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { TextField, TextArea, Checkbox } from "./fields";
+import type { StepProps } from "./types";
+
+const FEATURES = [
+  { key: "photo_gallery", label: "Photo Gallery" },
+  { key: "testimonials", label: "Customer Reviews / Testimonials" },
+  { key: "google_maps", label: "Google Maps / Service Area" },
+  { key: "online_payments", label: "Online Payments" },
+  { key: "appointment_booking", label: "Appointment Booking" },
+  { key: "blog", label: "Blog / News" },
+  { key: "newsletter", label: "Newsletter Signup" },
+  { key: "lead_forms", label: "Lead Generation Forms" },
+  { key: "social_links", label: "Social Media Links" },
+  { key: "google_analytics", label: "Google Analytics" },
+  { key: "meta_pixel", label: "Meta Pixel" },
+  { key: "seo_setup", label: "SEO Setup" },
+  { key: "google_business", label: "Google Business Integration" },
+  { key: "other", label: "Other" },
+];
+
+/**
+ * Step 8 — Features Requested. Checklist of website features. Selecting
+ * "Online Payments" reveals a conditional follow-up. "Other" reveals a
+ * free-text field per spec.
+ */
+export default function WizardFeaturesStep({ request, updateField, isReadOnly }: StepProps) {
+  const selected = request.requested_features || [];
+  const selectedKeys = new Set(selected.map((f) => f.key));
+
+  function toggle(key: string) {
+    if (isReadOnly) return;
+    if (selectedKeys.has(key)) {
+      updateField("requested_features", selected.filter((f) => f.key !== key));
+    } else {
+      updateField("requested_features", [...selected, { key, notes: "" }]);
+    }
+  }
+
+  function updateNote(key: string, value: string) {
+    if (isReadOnly) return;
+    updateField(
+      "requested_features",
+      selected.map((f) => (f.key === key ? { ...f, notes: value } : f)),
+    );
+  }
+
+  const onlinePayments = selected.find((f) => f.key === "online_payments");
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-lg font-semibold text-gray-900">Features Requested</h2>
+        <p className="text-sm text-gray-500 mt-1">
+          Everything you&rsquo;d like to include. Toggle a feature and add notes if you have
+          specifics.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+        {FEATURES.map((f) => {
+          const on = selectedKeys.has(f.key);
+          const row = selected.find((x) => x.key === f.key);
+          return (
+            <div key={f.key} className={`rounded-xl border p-3 ${on ? "border-emerald-200 bg-emerald-50/40" : "border-gray-200 bg-white"}`}>
+              <Checkbox
+                label={f.label}
+                checked={on}
+                onChange={() => toggle(f.key)}
+                disabled={isReadOnly}
+              />
+              {on && (
+                <input
+                  type="text"
+                  value={row?.notes || ""}
+                  onChange={(e) => updateNote(f.key, e.target.value)}
+                  placeholder="Notes (optional)"
+                  disabled={isReadOnly}
+                  className="mt-2 w-full rounded-lg border border-gray-200 px-3 py-1.5 text-xs bg-white disabled:bg-gray-50"
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {selectedKeys.has("other") && (
+        <TextField
+          label="Describe other feature"
+          value={request.requested_features_other}
+          onChange={(v) => updateField("requested_features_other", v)}
+          disabled={isReadOnly}
+          placeholder="What else should we build?"
+        />
+      )}
+
+      {onlinePayments && (
+        <TextArea
+          label="What do customers need to pay for?"
+          value={onlinePayments.notes || ""}
+          onChange={(v) => updateNote("online_payments", v)}
+          disabled={isReadOnly}
+          rows={2}
+          placeholder="e.g. Vending service deposits, coffee subscriptions, invoices."
+        />
+      )}
+    </div>
+  );
+}

--- a/src/app/components/website-builder/WizardLaunchStep.tsx
+++ b/src/app/components/website-builder/WizardLaunchStep.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { Info } from "lucide-react";
+import { TextField, TextArea, Checkbox, ChipToggle } from "./fields";
+import type { StepProps } from "./types";
+
+const CHECKLIST = [
+  { key: "own_domain", label: "Own Domain" },
+  { key: "logo_ready", label: "Logo Ready" },
+  { key: "brand_colors", label: "Brand Colors Selected" },
+  { key: "photos_ready", label: "Photos Ready" },
+  { key: "copy_ready", label: "Website Copy / Content Ready" },
+  { key: "contact_confirmed", label: "Contact Information Confirmed" },
+  { key: "services_confirmed", label: "Services Confirmed" },
+  { key: "service_area_confirmed", label: "Service Area Confirmed" },
+  { key: "testimonials_available", label: "Testimonials Available" },
+  { key: "legal_pages_needed", label: "Legal Pages Needed" },
+];
+
+const LEGAL_PAGES = [
+  { value: "privacy_policy", label: "Privacy Policy" },
+  { value: "terms_of_use", label: "Terms of Use" },
+  { value: "cookie_notice", label: "Cookie Notice" },
+  { value: "accessibility_statement", label: "Accessibility Statement" },
+  { value: "other", label: "Other" },
+];
+
+/**
+ * Step 9 — Launch Readiness. Checklist + legal-pages picker with
+ * conditional disclosure of the free-text field when "Other" is picked.
+ * Notes explicitly disclaim legal advice per spec section 11.
+ */
+export default function WizardLaunchStep({ request, updateField, isReadOnly }: StepProps) {
+  const checklist = request.launch_checklist || {};
+  const legalPages = request.legal_pages_needed || [];
+  const legalPagesEnabled = checklist.legal_pages_needed === true;
+
+  function toggleChecklist(key: string, value: boolean) {
+    if (isReadOnly) return;
+    updateField("launch_checklist", { ...checklist, [key]: value });
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-lg font-semibold text-gray-900">Launch Readiness</h2>
+        <p className="text-sm text-gray-500 mt-1">
+          Where are we today? Anything unchecked is fine — we&rsquo;ll help you close the gap.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+        {CHECKLIST.map((c) => (
+          <div key={c.key} className="rounded-xl border border-gray-100 bg-white p-3">
+            <Checkbox
+              label={c.label}
+              checked={!!checklist[c.key]}
+              onChange={(v) => toggleChecklist(c.key, v)}
+              disabled={isReadOnly}
+            />
+          </div>
+        ))}
+      </div>
+
+      {legalPagesEnabled && (
+        <div>
+          <ChipToggle
+            label="Which legal pages?"
+            options={LEGAL_PAGES}
+            selected={legalPages}
+            onChange={(next) => updateField("legal_pages_needed", next)}
+            disabled={isReadOnly}
+          />
+          {legalPages.includes("other") && (
+            <div className="mt-2">
+              <TextField
+                label="Describe other legal page"
+                value={request.legal_pages_other}
+                onChange={(v) => updateField("legal_pages_other", v)}
+                disabled={isReadOnly}
+              />
+            </div>
+          )}
+          <div className="mt-3 flex items-start gap-2 rounded-lg bg-blue-50 border border-blue-100 p-3 text-xs text-blue-800">
+            <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+            <span>
+              Legal-page templates we provide are starting points — not legal advice. We
+              recommend having your attorney review the finished copy.
+            </span>
+          </div>
+        </div>
+      )}
+
+      <TextArea label="Additional Ideas" value={request.additional_notes} onChange={(v) => updateField("additional_notes", v)} disabled={isReadOnly} rows={3} placeholder="Anything else you'd like to see?" />
+      <TextArea label="Special Requests" value={request.special_requests} onChange={(v) => updateField("special_requests", v)} disabled={isReadOnly} rows={3} />
+      <TextArea label="Website Inspiration (in addition to Brand step)" value={request.website_inspiration} onChange={(v) => updateField("website_inspiration", v)} disabled={isReadOnly} rows={3} />
+      <TextArea label="Future Plans" value={request.future_plans} onChange={(v) => updateField("future_plans", v)} disabled={isReadOnly} rows={3} placeholder="What's on the roadmap for your business?" />
+      <TextArea label="Anything Else We Should Know" value={request.anything_else} onChange={(v) => updateField("anything_else", v)} disabled={isReadOnly} rows={3} />
+    </div>
+  );
+}

--- a/src/app/components/website-builder/WizardMediaStep.tsx
+++ b/src/app/components/website-builder/WizardMediaStep.tsx
@@ -1,0 +1,297 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { Loader2, Upload, Trash2, Image as ImageIcon, Video, Plus, ExternalLink } from "lucide-react";
+import { TextField } from "./fields";
+import type { StepProps, WebsiteRequestMedia } from "./types";
+
+interface Props extends StepProps {
+  media: WebsiteRequestMedia[];
+  token: string;
+  onMediaChange: () => void;
+}
+
+const KINDS = [
+  { key: "staff", label: "Staff Photos", accept: "image/*", description: "Team headshots and group photos." },
+  { key: "location", label: "Location / Project Photos", accept: "image/*", description: "Installed machines in the wild." },
+  { key: "machine", label: "Machine Photos", accept: "image/*", description: "Product shots of your machines." },
+  { key: "product", label: "Product Photos", accept: "image/*", description: "Snacks, drinks, coffee — whatever you stock." },
+  { key: "video", label: "Videos", accept: "video/mp4,video/quicktime,video/webm", description: "Short clips (MP4/MOV/WEBM, ≤ 15 MB)." },
+] as const;
+
+const SOCIAL_KEYS = [
+  { key: "facebook", label: "Facebook" },
+  { key: "instagram", label: "Instagram" },
+  { key: "linkedin", label: "LinkedIn" },
+  { key: "tiktok", label: "TikTok" },
+  { key: "youtube", label: "YouTube" },
+  { key: "other", label: "Other" },
+];
+
+/**
+ * Step 5 — Media. Organized upload sections per media kind + a
+ * video-link block (URLs for YouTube/Vimeo) + social profile URLs.
+ * Logo is shown as a reference if it was uploaded in Branding — we
+ * don't ask twice.
+ */
+export default function WizardMediaStep({ request, isReadOnly, media, token, onMediaChange, updateField }: Props) {
+  const logo = media.find((m) => m.kind === "logo");
+  const socialLinks = request.social_links || {};
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-lg font-semibold text-gray-900">Photos &amp; Media</h2>
+        <p className="text-sm text-gray-500 mt-1">
+          The more real photos we have, the better your site looks. Uploads are private —
+          only you and the Vending Connector team see them until launch.
+        </p>
+      </div>
+
+      {logo && (
+        <div className="rounded-xl border border-emerald-200 bg-emerald-50/50 p-4 flex items-center gap-3">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          {logo.signed_url && <img src={logo.signed_url} alt="Logo" className="h-14 w-14 object-contain rounded-lg border border-white bg-white" />}
+          <div className="text-sm text-emerald-900">
+            <p className="font-medium">Logo already uploaded from Branding step</p>
+            <p className="text-xs text-emerald-800">Head back to Brand to replace it.</p>
+          </div>
+        </div>
+      )}
+
+      {KINDS.map((k) => (
+        <MediaSection
+          key={k.key}
+          kind={k.key}
+          label={k.label}
+          description={k.description}
+          accept={k.accept}
+          media={media.filter((m) => m.kind === k.key)}
+          requestId={request.id}
+          token={token}
+          onChange={onMediaChange}
+          disabled={isReadOnly}
+        />
+      ))}
+
+      {/* Video links */}
+      <VideoLinkSection
+        media={media.filter((m) => m.kind === "video_link")}
+        requestId={request.id}
+        token={token}
+        onChange={onMediaChange}
+        disabled={isReadOnly}
+      />
+
+      {/* Social links */}
+      <div>
+        <label className="block text-xs font-medium text-gray-700 mb-2">Social Links</label>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+          {SOCIAL_KEYS.map((s) => (
+            <TextField
+              key={s.key}
+              label={s.label}
+              value={socialLinks[s.key] || ""}
+              onChange={(v) => updateField("social_links", { ...socialLinks, [s.key]: v })}
+              disabled={isReadOnly}
+              placeholder={`https://${s.key === "other" ? "example.com" : `${s.key}.com/your-page`}`}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MediaSection({ kind, label, description, accept, media, requestId, token, onChange, disabled }: {
+  kind: string;
+  label: string;
+  description: string;
+  accept: string;
+  media: WebsiteRequestMedia[];
+  requestId: string;
+  token: string;
+  onChange: () => void;
+  disabled: boolean;
+}) {
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  async function upload(files: FileList) {
+    setError(null);
+    setUploading(true);
+    for (const file of Array.from(files)) {
+      const fd = new FormData();
+      fd.append("file", file);
+      fd.append("kind", kind);
+      const res = await fetch(`/api/website-requests/${requestId}/media`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+        body: fd,
+      });
+      if (!res.ok) {
+        setError((await res.json().catch(() => ({}))).error || `Upload failed for ${file.name}`);
+        break;
+      }
+    }
+    setUploading(false);
+    onChange();
+  }
+
+  async function del(id: string) {
+    if (!confirm("Remove this file?")) return;
+    await fetch(`/api/website-requests/${requestId}/media/${id}`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    onChange();
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-1">
+        <label className="block text-sm font-medium text-gray-800">{label}</label>
+        <span className="text-[11px] text-gray-500">{media.length} {media.length === 1 ? "file" : "files"}</span>
+      </div>
+      <p className="text-[11px] text-gray-500 mb-2">{description}</p>
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
+        {media.map((m) => (
+          <div key={m.id} className="relative group rounded-xl border border-gray-100 bg-white overflow-hidden">
+            {m.mime_type?.startsWith("video/") ? (
+              <div className="aspect-square flex items-center justify-center bg-gray-50">
+                <Video className="h-8 w-8 text-gray-400" />
+              </div>
+            ) : m.signed_url ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={m.signed_url} alt={m.caption || m.file_name || ""} className="aspect-square w-full object-cover" />
+            ) : (
+              <div className="aspect-square flex items-center justify-center bg-gray-50">
+                <ImageIcon className="h-8 w-8 text-gray-400" />
+              </div>
+            )}
+            <div className="p-2 text-[11px] text-gray-600 truncate">{m.file_name}</div>
+            {!disabled && (
+              <button
+                type="button"
+                onClick={() => del(m.id)}
+                className="absolute top-1 right-1 bg-white/90 border border-gray-200 rounded-full p-1 opacity-0 group-hover:opacity-100 transition-opacity"
+                aria-label="Delete"
+              >
+                <Trash2 className="h-3.5 w-3.5 text-red-600" />
+              </button>
+            )}
+          </div>
+        ))}
+        {!disabled && (
+          <button
+            type="button"
+            onClick={() => inputRef.current?.click()}
+            disabled={uploading}
+            className="aspect-square rounded-xl border-2 border-dashed border-gray-200 flex flex-col items-center justify-center text-xs text-gray-500 hover:bg-gray-50 disabled:opacity-50"
+          >
+            {uploading ? <Loader2 className="h-6 w-6 animate-spin" /> : <Upload className="h-6 w-6 mb-1" />}
+            {uploading ? "Uploading…" : "Add"}
+          </button>
+        )}
+      </div>
+      <input
+        ref={inputRef}
+        type="file"
+        multiple
+        accept={accept}
+        className="hidden"
+        onChange={(e) => { if (e.target.files?.length) void upload(e.target.files); e.currentTarget.value = ""; }}
+      />
+      {error && <p className="text-xs text-red-600 mt-1">{error}</p>}
+    </div>
+  );
+}
+
+function VideoLinkSection({ media, requestId, token, onChange, disabled }: {
+  media: WebsiteRequestMedia[];
+  requestId: string;
+  token: string;
+  onChange: () => void;
+  disabled: boolean;
+}) {
+  const [url, setUrl] = useState("");
+  const [caption, setCaption] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function add() {
+    setError(null);
+    if (!/^https?:\/\//i.test(url)) { setError("Enter a valid https URL"); return; }
+    setBusy(true);
+    const res = await fetch(`/api/website-requests/${requestId}/media`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ kind: "video_link", external_url: url, caption }),
+    });
+    setBusy(false);
+    if (!res.ok) {
+      setError((await res.json().catch(() => ({}))).error || "Add failed");
+      return;
+    }
+    setUrl("");
+    setCaption("");
+    onChange();
+  }
+
+  async function del(id: string) {
+    if (!confirm("Remove this video link?")) return;
+    await fetch(`/api/website-requests/${requestId}/media/${id}`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    onChange();
+  }
+
+  return (
+    <div>
+      <label className="block text-sm font-medium text-gray-800 mb-1">Video Links (YouTube / Vimeo)</label>
+      <p className="text-[11px] text-gray-500 mb-2">Paste URLs of videos you&rsquo;d like embedded. We&rsquo;ll handle the player.</p>
+      <div className="space-y-2 mb-3">
+        {media.map((m) => (
+          <div key={m.id} className="flex items-center gap-2 rounded-lg border border-gray-100 bg-white p-2">
+            <a href={m.external_url || "#"} target="_blank" rel="noreferrer" className="flex-1 text-sm text-green-primary truncate hover:underline">
+              <ExternalLink className="inline h-3.5 w-3.5 mr-1" /> {m.external_url}
+            </a>
+            {m.caption && <span className="text-[11px] text-gray-500 truncate max-w-[40%]">{m.caption}</span>}
+            {!disabled && (
+              <button type="button" onClick={() => del(m.id)} className="p-1 text-gray-400 hover:text-red-600" aria-label="Remove"><Trash2 className="h-3.5 w-3.5" /></button>
+            )}
+          </div>
+        ))}
+      </div>
+      {!disabled && (
+        <div className="flex flex-col sm:flex-row gap-2">
+          <input
+            type="url"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            placeholder="https://youtube.com/…"
+            className="flex-1 rounded-lg border border-gray-200 px-3 py-2 text-sm"
+          />
+          <input
+            type="text"
+            value={caption}
+            onChange={(e) => setCaption(e.target.value)}
+            placeholder="Caption (optional)"
+            className="flex-1 rounded-lg border border-gray-200 px-3 py-2 text-sm"
+          />
+          <button
+            type="button"
+            onClick={add}
+            disabled={busy}
+            className="inline-flex items-center gap-1.5 rounded-lg bg-green-primary hover:bg-green-hover px-3 py-2 text-sm font-semibold text-white disabled:opacity-50"
+          >
+            {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />} Add
+          </button>
+        </div>
+      )}
+      {error && <p className="text-xs text-red-600 mt-1">{error}</p>}
+    </div>
+  );
+}

--- a/src/app/components/website-builder/WizardProductsStep.tsx
+++ b/src/app/components/website-builder/WizardProductsStep.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { Trash2, Plus } from "lucide-react";
+import { TextField, TextArea, ChipToggle } from "./fields";
+import type { StepProps } from "./types";
+
+const SERVICES = [
+  { value: "ai_vending", label: "AI Vending" },
+  { value: "traditional_vending", label: "Traditional Vending" },
+  { value: "micro_markets", label: "Micro Markets" },
+  { value: "office_coffee", label: "Office Coffee Service" },
+  { value: "pantry", label: "Pantry Service" },
+  { value: "healthy_vending", label: "Healthy Vending" },
+  { value: "beverage", label: "Beverage Service" },
+  { value: "custom", label: "Custom / Other" },
+];
+
+const INDUSTRIES = [
+  { value: "offices", label: "Offices" },
+  { value: "manufacturing", label: "Manufacturing" },
+  { value: "warehouses", label: "Warehouses" },
+  { value: "healthcare", label: "Healthcare" },
+  { value: "schools", label: "Schools" },
+  { value: "apartments", label: "Apartments" },
+  { value: "hotels", label: "Hotels" },
+  { value: "gyms", label: "Gyms" },
+  { value: "auto_dealerships", label: "Auto Dealerships" },
+  { value: "government", label: "Government" },
+  { value: "retail", label: "Retail" },
+  { value: "other", label: "Other" },
+];
+
+/**
+ * Step 3 — Products, Services & Target Customer. Consolidated per spec:
+ * services + revenue drivers + differentiators + industries + geography
+ * in one logical block.
+ */
+export default function WizardProductsStep({ request, updateField, isReadOnly }: StepProps) {
+  const selectedServices = request.primary_services || [];
+  const selectedIndustries = request.industries_served || [];
+  const drivers = request.revenue_drivers || [];
+  const geo = request.geographic_market || {};
+
+  function updateGeo(patch: Partial<typeof geo>) {
+    updateField("geographic_market", { ...geo, ...patch });
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-lg font-semibold text-gray-900">Products, Services &amp; Target Customer</h2>
+        <p className="text-sm text-gray-500 mt-1">
+          What you offer, what makes you win, and who you serve.
+        </p>
+      </div>
+
+      <ChipToggle
+        label="Primary Services"
+        options={SERVICES}
+        selected={selectedServices}
+        onChange={(next) => updateField("primary_services", next)}
+        disabled={isReadOnly}
+      />
+      {selectedServices.includes("custom") && (
+        <TextField
+          label="Describe your custom service"
+          value={request.primary_services_other}
+          onChange={(v) => updateField("primary_services_other", v)}
+          disabled={isReadOnly}
+        />
+      )}
+
+      {/* Revenue drivers */}
+      <div>
+        <label className="block text-xs font-medium text-gray-700 mb-1">Top 3 Revenue Drivers</label>
+        <p className="text-[11px] text-gray-500 mb-2">The services/products that bring in most of your revenue.</p>
+        <div className="space-y-3">
+          {drivers.map((d, i) => (
+            <div key={i} className="rounded-xl border border-gray-100 bg-gray-50 p-3 space-y-2">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                <input
+                  type="text"
+                  value={d.name}
+                  onChange={(e) => {
+                    const next = [...drivers];
+                    next[i] = { ...next[i], name: e.target.value };
+                    updateField("revenue_drivers", next);
+                  }}
+                  placeholder="Product / service name"
+                  disabled={isReadOnly}
+                  className="rounded-lg border border-gray-200 px-3 py-2 text-sm bg-white disabled:bg-gray-100"
+                />
+                <input
+                  type="text"
+                  value={d.pricing || ""}
+                  onChange={(e) => {
+                    const next = [...drivers];
+                    next[i] = { ...next[i], pricing: e.target.value };
+                    updateField("revenue_drivers", next);
+                  }}
+                  placeholder="Pricing (optional)"
+                  disabled={isReadOnly}
+                  className="rounded-lg border border-gray-200 px-3 py-2 text-sm bg-white disabled:bg-gray-100"
+                />
+              </div>
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  value={d.description || ""}
+                  onChange={(e) => {
+                    const next = [...drivers];
+                    next[i] = { ...next[i], description: e.target.value };
+                    updateField("revenue_drivers", next);
+                  }}
+                  placeholder="Short description"
+                  disabled={isReadOnly}
+                  className="flex-1 rounded-lg border border-gray-200 px-3 py-2 text-sm bg-white disabled:bg-gray-100"
+                />
+                {!isReadOnly && (
+                  <button
+                    type="button"
+                    onClick={() => updateField("revenue_drivers", drivers.filter((_, x) => x !== i))}
+                    className="rounded-lg p-2 text-gray-400 hover:text-red-600 hover:bg-red-50"
+                    aria-label="Remove"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                )}
+              </div>
+            </div>
+          ))}
+          {!isReadOnly && drivers.length < 5 && (
+            <button
+              type="button"
+              onClick={() => updateField("revenue_drivers", [...drivers, { name: "", description: "", pricing: "" }])}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-dashed border-gray-300 px-3 py-2 text-xs font-medium text-gray-600 hover:bg-gray-50"
+            >
+              <Plus className="h-3.5 w-3.5" /> Add Revenue Driver
+            </button>
+          )}
+        </div>
+      </div>
+
+      <TextArea label="Pricing Notes" value={request.pricing_notes} onChange={(v) => updateField("pricing_notes", v)} disabled={isReadOnly} rows={3} placeholder="Anything specific about how you price?" />
+
+      <TextArea label="Why Customers Choose You" value={request.differentiators} onChange={(v) => updateField("differentiators", v)} disabled={isReadOnly} rows={3} placeholder="Your key differentiators / value proposition." />
+
+      <ChipToggle
+        label="Industries Served"
+        options={INDUSTRIES}
+        selected={selectedIndustries}
+        onChange={(next) => updateField("industries_served", next)}
+        disabled={isReadOnly}
+      />
+      {selectedIndustries.includes("other") && (
+        <TextField
+          label="Describe other industries"
+          value={request.industries_served_other}
+          onChange={(v) => updateField("industries_served_other", v)}
+          disabled={isReadOnly}
+        />
+      )}
+
+      {/* Geographic market */}
+      <div>
+        <label className="block text-xs font-medium text-gray-700 mb-1">Primary Geographic Market</label>
+        <p className="text-[11px] text-gray-500 mb-2">Where you serve — comma-separate multiple values in each field.</p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+          <input
+            type="text"
+            value={(geo.cities || []).join(", ")}
+            onChange={(e) => updateGeo({ cities: e.target.value.split(",").map((s) => s.trim()).filter(Boolean) })}
+            placeholder="Cities (e.g. Denver, Aurora)"
+            disabled={isReadOnly}
+            className="rounded-lg border border-gray-200 px-3 py-2 text-sm bg-white disabled:bg-gray-50"
+          />
+          <input
+            type="text"
+            value={(geo.states || []).join(", ")}
+            onChange={(e) => updateGeo({ states: e.target.value.split(",").map((s) => s.trim().toUpperCase()).filter(Boolean) })}
+            placeholder="States (e.g. CO, WY)"
+            disabled={isReadOnly}
+            className="rounded-lg border border-gray-200 px-3 py-2 text-sm bg-white disabled:bg-gray-50"
+          />
+          <input
+            type="text"
+            value={(geo.counties || []).join(", ")}
+            onChange={(e) => updateGeo({ counties: e.target.value.split(",").map((s) => s.trim()).filter(Boolean) })}
+            placeholder="Counties / regions (optional)"
+            disabled={isReadOnly}
+            className="rounded-lg border border-gray-200 px-3 py-2 text-sm bg-white disabled:bg-gray-50"
+          />
+          <input
+            type="number"
+            value={geo.radius_miles ?? ""}
+            onChange={(e) => updateGeo({ radius_miles: e.target.value ? Number(e.target.value) : null })}
+            placeholder="Service radius (miles)"
+            disabled={isReadOnly}
+            min={0}
+            className="rounded-lg border border-gray-200 px-3 py-2 text-sm bg-white disabled:bg-gray-50"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/website-builder/WizardReviewStep.tsx
+++ b/src/app/components/website-builder/WizardReviewStep.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import { CheckCircle2, Pencil, Send, Loader2 } from "lucide-react";
+import { Checkbox } from "./fields";
+import type { WebsiteRequest, WebsiteRequestMedia, WebsiteRequestActivity } from "./types";
+
+interface Props {
+  request: WebsiteRequest;
+  media: WebsiteRequestMedia[];
+  activity: WebsiteRequestActivity[];
+  updateField: (key: string, value: unknown) => void;
+  isReadOnly: boolean;
+  onEditStep: (key: string) => void;
+  onSubmit: () => void;
+  submitting: boolean;
+}
+
+/**
+ * Step 10 — Review. Shows every section with an Edit shortcut back to
+ * the relevant step, plus the required content-ownership acknowledgment
+ * and the final Submit button.
+ */
+export default function WizardReviewStep({
+  request, media, activity, updateField, isReadOnly, onEditStep, onSubmit, submitting,
+}: Props) {
+  const alreadySubmitted = request.status !== "draft" && request.status !== "needs_information";
+  const mediaByKind = media.reduce<Record<string, WebsiteRequestMedia[]>>((acc, m) => {
+    (acc[m.kind] ||= []).push(m);
+    return acc;
+  }, {});
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-lg font-semibold text-gray-900">Review &amp; Submit</h2>
+        <p className="text-sm text-gray-500 mt-1">
+          Look everything over. Use the Edit buttons to jump back and tweak.
+        </p>
+      </div>
+
+      <Section title="Business" onEdit={() => onEditStep("business")}>
+        <Row label="Business" value={request.business_name} />
+        <Row label="Contact" value={request.primary_contact} />
+        <Row label="Email" value={request.email} />
+        <Row label="Phone" value={request.phone} />
+        <Row label="Address" value={request.business_address} />
+        <Row label="Years in Business" value={request.years_in_business} />
+        <Block label="Business Story" value={request.business_story} />
+        <Block label="Mission / Values" value={request.mission_values} />
+      </Section>
+
+      <Section title="Brand" onEdit={() => onEditStep("brand")}>
+        <Row label="Style" value={request.preferred_style || request.preferred_style_other} />
+        <Row label="Primary Color" value={request.brand_primary_color} />
+        <Row label="Secondary Color" value={request.brand_secondary_color} />
+        <Row label="Fonts" value={request.fonts} />
+        <Row label="Tagline" value={request.tagline} />
+        <Row label="Inspiration Sites" value={(request.inspiration_sites || []).map((s) => s.url).filter(Boolean).join(", ") || null} />
+      </Section>
+
+      <Section title="Products &amp; Customer" onEdit={() => onEditStep("products")}>
+        <Row label="Services" value={(request.primary_services || []).join(", ") || null} />
+        <Row label="Industries" value={(request.industries_served || []).join(", ") || null} />
+        <Row label="Cities" value={(request.geographic_market?.cities || []).join(", ") || null} />
+        <Row label="States" value={(request.geographic_market?.states || []).join(", ") || null} />
+        <Row label="Radius (mi)" value={request.geographic_market?.radius_miles?.toString() || null} />
+        <Row label="Revenue Drivers" value={(request.revenue_drivers || []).map((d) => d.name).filter(Boolean).join(", ") || null} />
+        <Block label="Differentiators" value={request.differentiators} />
+      </Section>
+
+      <Section title="Content" onEdit={() => onEditStep("content")}>
+        <Block label="Hero Message" value={request.homepage_message} />
+        <Block label="About" value={request.about_content} />
+        <Row label="Gallery Needed" value={request.gallery_needed == null ? null : request.gallery_needed ? "Yes" : "No"} />
+        <Row label="Testimonials" value={String((request.testimonials || []).length)} />
+        <Row label="FAQs" value={String((request.faqs || []).length)} />
+        <Row label="Primary CTA" value={request.primary_cta === "custom" ? request.primary_cta_custom : request.primary_cta} />
+        <Row label="Secondary CTA" value={request.secondary_cta} />
+      </Section>
+
+      <Section title="Media" onEdit={() => onEditStep("media")}>
+        <Row label="Logo" value={mediaByKind.logo?.length ? "Uploaded" : "—"} />
+        <Row label="Staff Photos" value={String(mediaByKind.staff?.length || 0)} />
+        <Row label="Location Photos" value={String(mediaByKind.location?.length || 0)} />
+        <Row label="Machine Photos" value={String(mediaByKind.machine?.length || 0)} />
+        <Row label="Product Photos" value={String(mediaByKind.product?.length || 0)} />
+        <Row label="Videos" value={String(mediaByKind.video?.length || 0)} />
+        <Row label="Video Links" value={String(mediaByKind.video_link?.length || 0)} />
+      </Section>
+
+      <Section title="Contact" onEdit={() => onEditStep("contact")}>
+        <Row label="Public Email" value={request.inquiry_email} />
+        <Row label="Public Phone" value={request.public_phone} />
+        <Row label="Business Hours" value={request.business_hours} />
+        <Row label="Form Fields" value={(request.contact_form_fields || []).map((f) => f.label).join(", ") || null} />
+        <Row label="Lead Delivery" value={`Email → ${request.lead_delivery_email || "not set"}`} />
+      </Section>
+
+      <Section title="Domain &amp; Tech" onEdit={() => onEditStep("domain")}>
+        <Row label="Owns Domain" value={request.domain_status} />
+        <Row label="Domain" value={request.current_domain} />
+        <Row label="Registrar" value={request.domain_registrar} />
+        <Row label="Business Email" value={request.business_email} />
+        <Row label="Existing Website" value={request.existing_website} />
+        <Row label="Integrations" value={(request.integrations || []).map((i) => i.key).join(", ") || null} />
+      </Section>
+
+      <Section title="Features" onEdit={() => onEditStep("features")}>
+        <Row label="Requested" value={(request.requested_features || []).map((f) => f.key).join(", ") || null} />
+      </Section>
+
+      <Section title="Launch Checklist" onEdit={() => onEditStep("launch")}>
+        <ul className="text-sm text-gray-700 space-y-1">
+          {Object.entries(request.launch_checklist || {}).map(([k, v]) => (
+            <li key={k} className="flex items-center gap-2">
+              <CheckCircle2 className={`h-4 w-4 ${v ? "text-emerald-600" : "text-gray-300"}`} />
+              <span>{k.replace(/_/g, " ")}</span>
+            </li>
+          ))}
+        </ul>
+        {(request.legal_pages_needed || []).length > 0 && (
+          <p className="mt-2 text-xs text-gray-500">
+            Legal pages: {(request.legal_pages_needed || []).join(", ")}
+          </p>
+        )}
+      </Section>
+
+      {activity.length > 0 && (
+        <Section title="Activity">
+          <ul className="text-xs text-gray-600 space-y-1">
+            {activity.map((a) => (
+              <li key={a.id}>
+                <span className="text-gray-400">{new Date(a.created_at).toLocaleString()}</span> — {a.message || a.event_type}
+              </li>
+            ))}
+          </ul>
+        </Section>
+      )}
+
+      <div className="rounded-xl border border-amber-200 bg-amber-50 p-4">
+        <Checkbox
+          label="I confirm the information submitted is accurate and I have permission to use the uploaded logos, images, testimonials, and other content."
+          checked={request.content_ownership_acknowledged}
+          onChange={(v) => updateField("content_ownership_acknowledged", v)}
+          disabled={isReadOnly}
+        />
+      </div>
+
+      {!alreadySubmitted && (
+        <button
+          type="button"
+          onClick={onSubmit}
+          disabled={submitting || !request.content_ownership_acknowledged}
+          className="w-full inline-flex items-center justify-center gap-2 rounded-xl bg-green-primary hover:bg-green-hover px-6 py-3.5 text-sm font-semibold text-white cursor-pointer disabled:opacity-50"
+        >
+          {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
+          {request.status === "needs_information" ? "Resubmit Website Request" : "Submit Website Request"}
+        </button>
+      )}
+    </div>
+  );
+}
+
+function Section({ title, children, onEdit }: { title: string; children: React.ReactNode; onEdit?: () => void }) {
+  return (
+    <div className="rounded-xl border border-gray-100 bg-white p-4">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-sm font-semibold text-gray-900" dangerouslySetInnerHTML={{ __html: title }} />
+        {onEdit && (
+          <button
+            type="button"
+            onClick={onEdit}
+            className="inline-flex items-center gap-1 text-xs text-green-primary hover:text-green-hover"
+          >
+            <Pencil className="h-3 w-3" /> Edit
+          </button>
+        )}
+      </div>
+      <div className="space-y-1">{children}</div>
+    </div>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string | null | undefined }) {
+  return (
+    <div className="flex items-start gap-3 text-sm">
+      <span className="w-40 text-gray-500 shrink-0">{label}</span>
+      <span className="flex-1 text-gray-900">{value || <span className="text-gray-300">—</span>}</span>
+    </div>
+  );
+}
+
+function Block({ label, value }: { label: string; value: string | null | undefined }) {
+  return (
+    <div className="text-sm">
+      <p className="text-xs text-gray-500 mb-0.5">{label}</p>
+      <p className="text-gray-900 whitespace-pre-wrap">{value || <span className="text-gray-300">—</span>}</p>
+    </div>
+  );
+}

--- a/src/app/components/website-builder/fields.tsx
+++ b/src/app/components/website-builder/fields.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+/**
+ * Shared inputs for the website-builder wizard. Same base styling as
+ * agreement editor for consistency; each accepts a value + onChange +
+ * disabled flag so read-only mode drops in cleanly.
+ */
+
+import React from "react";
+
+const baseInput = "w-full rounded-lg border border-gray-200 px-3 py-2.5 text-sm focus:border-green-600 focus:outline-none focus:ring-1 focus:ring-green-600/30 disabled:bg-gray-50 disabled:text-gray-500";
+const labelCls = "block text-xs font-medium text-gray-700 mb-1";
+const hintCls = "text-[11px] text-gray-500 mt-1";
+
+export function Label({ children, hint }: { children: React.ReactNode; hint?: string }) {
+  return (
+    <div>
+      <label className={labelCls}>{children}</label>
+      {hint && <p className={hintCls}>{hint}</p>}
+    </div>
+  );
+}
+
+export function TextField(props: {
+  label: string;
+  value: string | null;
+  onChange: (v: string) => void;
+  disabled?: boolean;
+  placeholder?: string;
+  hint?: string;
+  type?: string;
+  required?: boolean;
+}) {
+  const { label, value, onChange, disabled, placeholder, hint, type = "text", required } = props;
+  return (
+    <div>
+      <label className={labelCls}>{label}{required && <span className="text-red-500"> *</span>}</label>
+      <input
+        type={type}
+        value={value || ""}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        disabled={disabled}
+        className={baseInput}
+      />
+      {hint && <p className={hintCls}>{hint}</p>}
+    </div>
+  );
+}
+
+export function TextArea(props: {
+  label: string;
+  value: string | null;
+  onChange: (v: string) => void;
+  disabled?: boolean;
+  placeholder?: string;
+  hint?: string;
+  rows?: number;
+  required?: boolean;
+}) {
+  const { label, value, onChange, disabled, placeholder, hint, rows = 4, required } = props;
+  return (
+    <div>
+      <label className={labelCls}>{label}{required && <span className="text-red-500"> *</span>}</label>
+      <textarea
+        value={value || ""}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        disabled={disabled}
+        rows={rows}
+        className={baseInput}
+      />
+      {hint && <p className={hintCls}>{hint}</p>}
+    </div>
+  );
+}
+
+export function ColorField(props: {
+  label: string;
+  value: string | null;
+  onChange: (v: string) => void;
+  disabled?: boolean;
+}) {
+  const { label, value, onChange, disabled } = props;
+  return (
+    <div>
+      <label className={labelCls}>{label}</label>
+      <div className="flex items-center gap-2">
+        <input
+          type="color"
+          value={value || "#16a34a"}
+          onChange={(e) => onChange(e.target.value)}
+          disabled={disabled}
+          className="h-10 w-14 rounded border border-gray-200 cursor-pointer disabled:cursor-not-allowed"
+        />
+        <input
+          type="text"
+          value={value || ""}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder="#16a34a"
+          disabled={disabled}
+          className={baseInput}
+        />
+      </div>
+    </div>
+  );
+}
+
+export function ChipToggle<T extends string>(props: {
+  label: string;
+  options: Array<{ value: T; label: string }>;
+  selected: T[];
+  onChange: (next: T[]) => void;
+  disabled?: boolean;
+  hint?: string;
+}) {
+  const { label, options, selected, onChange, disabled, hint } = props;
+  function toggle(v: T) {
+    if (disabled) return;
+    if (selected.includes(v)) onChange(selected.filter((x) => x !== v));
+    else onChange([...selected, v]);
+  }
+  return (
+    <div>
+      <label className={labelCls}>{label}</label>
+      <div className="flex flex-wrap gap-2">
+        {options.map((o) => {
+          const on = selected.includes(o.value);
+          return (
+            <button
+              key={o.value}
+              type="button"
+              onClick={() => toggle(o.value)}
+              disabled={disabled}
+              className={`rounded-full border px-3 py-1.5 text-xs font-medium cursor-pointer disabled:cursor-not-allowed ${on
+                ? "border-green-600 bg-green-50 text-green-800"
+                : "border-gray-200 bg-white text-gray-700 hover:bg-gray-50"
+                }`}
+            >
+              {o.label}
+            </button>
+          );
+        })}
+      </div>
+      {hint && <p className={hintCls}>{hint}</p>}
+    </div>
+  );
+}
+
+export function RadioGroup<T extends string>(props: {
+  label: string;
+  options: Array<{ value: T; label: string }>;
+  value: T | null;
+  onChange: (v: T) => void;
+  disabled?: boolean;
+}) {
+  const { label, options, value, onChange, disabled } = props;
+  return (
+    <div>
+      <label className={labelCls}>{label}</label>
+      <div className="flex flex-wrap gap-2">
+        {options.map((o) => (
+          <button
+            key={o.value}
+            type="button"
+            onClick={() => !disabled && onChange(o.value)}
+            disabled={disabled}
+            className={`rounded-full border px-3 py-1.5 text-xs font-medium cursor-pointer disabled:cursor-not-allowed ${value === o.value
+              ? "border-green-600 bg-green-50 text-green-800"
+              : "border-gray-200 bg-white text-gray-700 hover:bg-gray-50"
+              }`}
+          >
+            {o.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function Checkbox(props: {
+  label: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  disabled?: boolean;
+  hint?: string;
+}) {
+  const { label, checked, onChange, disabled, hint } = props;
+  return (
+    <label className={`flex items-start gap-2 text-sm ${disabled ? "opacity-60" : "cursor-pointer"}`}>
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        disabled={disabled}
+        className="mt-0.5 h-4 w-4 rounded border-gray-300 text-green-600 focus:ring-green-500"
+      />
+      <span className="flex-1">
+        <span className="block text-gray-800">{label}</span>
+        {hint && <span className={hintCls}>{hint}</span>}
+      </span>
+    </label>
+  );
+}

--- a/src/app/components/website-builder/types.ts
+++ b/src/app/components/website-builder/types.ts
@@ -1,0 +1,116 @@
+export interface WebsiteRequest {
+  id: string;
+  user_id: string;
+  status: string;
+  assigned_to: string | null;
+
+  business_name: string | null;
+  primary_contact: string | null;
+  phone: string | null;
+  email: string | null;
+  business_address: string | null;
+  years_in_business: string | null;
+  business_story: string | null;
+  mission_values: string | null;
+
+  logo_media_id: string | null;
+  brand_primary_color: string | null;
+  brand_secondary_color: string | null;
+  preferred_style: string | null;
+  preferred_style_other: string | null;
+  fonts: string | null;
+  tagline: string | null;
+  inspiration_sites: Array<{ url: string; note?: string }> | null;
+
+  primary_services: string[] | null;
+  primary_services_other: string | null;
+  revenue_drivers: Array<{ name: string; description?: string; pricing?: string }> | null;
+  pricing_notes: string | null;
+  differentiators: string | null;
+  industries_served: string[] | null;
+  industries_served_other: string | null;
+  geographic_market: {
+    cities?: string[];
+    states?: string[];
+    counties?: string[];
+    radius_miles?: number | null;
+  } | null;
+
+  homepage_message: string | null;
+  about_content: string | null;
+  services_content: string | null;
+  gallery_needed: boolean | null;
+  testimonials: Array<{ name: string; quote: string; role?: string; image_media_id?: string | null }> | null;
+  faqs: Array<{ question: string; answer: string }> | null;
+  primary_cta: string | null;
+  primary_cta_custom: string | null;
+  secondary_cta: string | null;
+
+  social_links: Record<string, string> | null;
+
+  inquiry_email: string | null;
+  public_phone: string | null;
+  business_hours: string | null;
+  contact_form_fields: Array<{ key: string; label: string; required: boolean; kind: string }> | null;
+  lead_delivery_destination: "email" | "crm" | null;
+  lead_delivery_email: string | null;
+
+  domain_status: "yes" | "no" | "not_sure" | null;
+  current_domain: string | null;
+  domain_registrar: string | null;
+  business_email: string | null;
+  existing_website: string | null;
+  integrations: Array<{ key: string; notes?: string }> | null;
+
+  requested_features: Array<{ key: string; notes?: string }> | null;
+  requested_features_other: string | null;
+
+  launch_checklist: Record<string, boolean> | null;
+  legal_pages_needed: string[] | null;
+  legal_pages_other: string | null;
+
+  additional_notes: string | null;
+  special_requests: string | null;
+  website_inspiration: string | null;
+  future_plans: string | null;
+  anything_else: string | null;
+
+  content_ownership_acknowledged: boolean;
+  submitted_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface WebsiteRequestMedia {
+  id: string;
+  request_id: string;
+  kind: "logo" | "staff" | "location" | "machine" | "product" | "video" | "video_link" | "testimonial";
+  file_path: string | null;
+  file_name: string | null;
+  file_size_bytes: number | null;
+  mime_type: string | null;
+  external_url: string | null;
+  caption: string | null;
+  sort_order: number;
+  signed_url: string | null;
+  created_at: string;
+}
+
+export interface WebsiteRequestActivity {
+  id: string;
+  request_id: string;
+  actor_id: string | null;
+  event_type: string;
+  visibility: "public" | "internal";
+  previous_status: string | null;
+  new_status: string | null;
+  message: string | null;
+  metadata: Record<string, unknown> | null;
+  created_at: string;
+}
+
+export interface StepProps {
+  request: WebsiteRequest;
+  updateField: (key: string, value: unknown) => void;
+  isReadOnly: boolean;
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -26,6 +26,7 @@ import {
   Crown,
   Briefcase,
   Zap,
+  Globe,
 } from "lucide-react";
 import type {
   Profile,
@@ -695,6 +696,30 @@ export default function DashboardPage() {
                 {(["operator", "location_manager", "requestor"] as const).includes(profile.role as unknown as "operator" | "location_manager" | "requestor")
                   ? "Auto-build call lists from Google Places — $9.99/mo"
                   : "Auto-build call lists from Google Places by city + industry"}
+              </p>
+            </div>
+            <ChevronRight className="ml-auto h-5 w-5 text-black-primary/20 transition-colors group-hover:text-green-primary" />
+          </Link>
+
+          {/*
+            Get Your Own Vending Website — customer-facing intake for a
+            managed website build. Available to every logged-in account.
+            No CRM permission is granted through this route; the wizard's
+            own guards keep customer data isolated to their own account.
+          */}
+          <Link
+            href="/website-builder"
+            className="group flex items-center gap-4 rounded-2xl border border-gray-100 bg-white p-5 shadow-sm transition-all hover:-translate-y-0.5 hover:border-green-100 hover:shadow-md"
+          >
+            <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-green-50 text-green-primary transition-colors group-hover:bg-green-primary group-hover:text-white">
+              <Globe className="h-6 w-6" />
+            </div>
+            <div>
+              <p className="font-semibold text-black-primary">
+                Get Your Own Vending Website
+              </p>
+              <p className="text-sm text-black-primary/50">
+                Guided intake — our team builds a website tailored to your vending business
               </p>
             </div>
             <ChevronRight className="ml-auto h-5 w-5 text-black-primary/20 transition-colors group-hover:text-green-primary" />

--- a/src/app/website-builder/[id]/page.tsx
+++ b/src/app/website-builder/[id]/page.tsx
@@ -1,0 +1,305 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import {
+  Loader2, ArrowLeft, ArrowRight, Save, CheckCircle2, AlertCircle,
+  Globe, Building2, Palette, Package, FileText, Image as ImageIcon,
+  Mail, Server, Sparkles, ListChecks, Send,
+} from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
+import WizardBusinessStep from "@/app/components/website-builder/WizardBusinessStep";
+import WizardBrandStep from "@/app/components/website-builder/WizardBrandStep";
+import WizardProductsStep from "@/app/components/website-builder/WizardProductsStep";
+import WizardContentStep from "@/app/components/website-builder/WizardContentStep";
+import WizardMediaStep from "@/app/components/website-builder/WizardMediaStep";
+import WizardContactStep from "@/app/components/website-builder/WizardContactStep";
+import WizardDomainStep from "@/app/components/website-builder/WizardDomainStep";
+import WizardFeaturesStep from "@/app/components/website-builder/WizardFeaturesStep";
+import WizardLaunchStep from "@/app/components/website-builder/WizardLaunchStep";
+import WizardReviewStep from "@/app/components/website-builder/WizardReviewStep";
+import type {
+  WebsiteRequest, WebsiteRequestMedia, WebsiteRequestActivity,
+} from "@/app/components/website-builder/types";
+
+const STEPS = [
+  { key: "business", label: "Business", icon: Building2 },
+  { key: "brand", label: "Brand", icon: Palette },
+  { key: "products", label: "Products & Customers", icon: Package },
+  { key: "content", label: "Website Content", icon: FileText },
+  { key: "media", label: "Media", icon: ImageIcon },
+  { key: "contact", label: "Contact & Leads", icon: Mail },
+  { key: "domain", label: "Domain & Tech", icon: Server },
+  { key: "features", label: "Features", icon: Sparkles },
+  { key: "launch", label: "Launch Readiness", icon: ListChecks },
+  { key: "review", label: "Review & Submit", icon: Send },
+] as const;
+
+export default function WebsiteBuilderWizard() {
+  const router = useRouter();
+  const { id } = useParams<{ id: string }>();
+  const [token, setToken] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState<"idle" | "saving" | "saved" | "error">("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [stepIndex, setStepIndex] = useState(0);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitMissing, setSubmitMissing] = useState<string[]>([]);
+  const [request, setRequest] = useState<WebsiteRequest | null>(null);
+  const [media, setMedia] = useState<WebsiteRequestMedia[]>([]);
+  const [activity, setActivity] = useState<WebsiteRequestActivity[]>([]);
+
+  const dirtyRef = useRef<Record<string, unknown>>({});
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const reload = useCallback(async (t: string) => {
+    const res = await fetch(`/api/website-requests/${id}`, {
+      headers: { Authorization: `Bearer ${t}` },
+    });
+    if (!res.ok) {
+      setError((await res.json().catch(() => ({}))).error || "Failed to load");
+      return null;
+    }
+    const body = await res.json();
+    setRequest(body.request);
+    setMedia(body.media || []);
+    setActivity(body.activity || []);
+    return body;
+  }, [id]);
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(async ({ data: { session } }) => {
+      if (!session?.access_token) { router.push(`/login?redirect=/website-builder/${id}`); return; }
+      setToken(session.access_token);
+      await reload(session.access_token);
+      setLoading(false);
+    });
+  }, [router, id, reload]);
+
+  /**
+   * Autosave: whenever a step calls updateField, we merge into dirtyRef
+   * and debounce a PATCH. Step changes flush immediately so back/forward
+   * navigation always saves.
+   */
+  const flush = useCallback(async () => {
+    const patch = { ...dirtyRef.current };
+    dirtyRef.current = {};
+    if (Object.keys(patch).length === 0) return;
+    setSaving("saving");
+    const res = await fetch(`/api/website-requests/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify(patch),
+    });
+    if (!res.ok) {
+      setSaving("error");
+      setError((await res.json().catch(() => ({}))).error || "Save failed");
+      return;
+    }
+    const body = await res.json();
+    setRequest(body.request);
+    setSaving("saved");
+    setTimeout(() => setSaving("idle"), 1500);
+  }, [id, token]);
+
+  const updateField = useCallback((key: string, value: unknown) => {
+    setRequest((prev) => (prev ? { ...prev, [key]: value } : prev));
+    dirtyRef.current[key] = value;
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => { void flush(); }, 800);
+  }, [flush]);
+
+  const goToStep = useCallback(async (nextIndex: number) => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    await flush();
+    setStepIndex(Math.max(0, Math.min(STEPS.length - 1, nextIndex)));
+  }, [flush]);
+
+  async function handleSubmit() {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    await flush();
+    setSubmitting(true);
+    setSubmitMissing([]);
+    setError(null);
+    const res = await fetch(`/api/website-requests/${id}/submit`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    setSubmitting(false);
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      if (Array.isArray(body.missing)) setSubmitMissing(body.missing);
+      setError(body.error || "Submission failed");
+      return;
+    }
+    await reload(token);
+  }
+
+  const currentStep = STEPS[stepIndex];
+  const isReadOnly = useMemo(() => {
+    if (!request) return true;
+    return request.status !== "draft" && request.status !== "needs_information";
+  }, [request]);
+
+  if (loading || !request) {
+    return <div className="min-h-[60vh] flex items-center justify-center"><Loader2 className="h-6 w-6 animate-spin text-green-primary" /></div>;
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="mx-auto max-w-5xl px-4 py-8 sm:px-6">
+        <Link href="/website-builder" className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-green-primary mb-4">
+          <ArrowLeft className="h-4 w-4" /> Back to Requests
+        </Link>
+
+        <div className="flex items-center gap-3 mb-6">
+          <div className="w-10 h-10 rounded-xl bg-green-100 flex items-center justify-center">
+            <Globe className="h-5 w-5 text-green-700" />
+          </div>
+          <div className="flex-1">
+            <h1 className="text-2xl font-bold text-gray-900">{request.business_name || "Your Website Request"}</h1>
+            <p className="text-sm text-gray-500">
+              Step {stepIndex + 1} of {STEPS.length} — {currentStep.label}
+            </p>
+          </div>
+          <div className="text-xs text-gray-400 whitespace-nowrap">
+            {saving === "saving" && (<><Loader2 className="inline h-3 w-3 animate-spin mr-1" /> Saving…</>)}
+            {saving === "saved" && (<><CheckCircle2 className="inline h-3 w-3 mr-1 text-emerald-600" /> Saved</>)}
+            {saving === "error" && (<><AlertCircle className="inline h-3 w-3 mr-1 text-red-500" /> Save error</>)}
+          </div>
+        </div>
+
+        {request.status === "needs_information" && (
+          <div className="mb-6 rounded-2xl border border-amber-200 bg-amber-50 p-4">
+            <p className="text-sm font-semibold text-amber-900 flex items-center gap-2">
+              <AlertCircle className="h-4 w-4" /> Action Required
+            </p>
+            <p className="text-xs text-amber-800 mt-1">
+              Our team requested additional information on this request. Update the relevant sections
+              and resubmit when ready.
+            </p>
+          </div>
+        )}
+
+        {isReadOnly && request.status !== "needs_information" && (
+          <div className="mb-6 rounded-2xl border border-blue-200 bg-blue-50 p-4">
+            <p className="text-sm font-semibold text-blue-900">This request has been submitted</p>
+            <p className="text-xs text-blue-800 mt-1">
+              Current status: <strong>{request.status.replace(/_/g, " ")}</strong>. Contact support
+              to make changes.
+            </p>
+          </div>
+        )}
+
+        {/* Progress rail */}
+        <div className="mb-6 grid grid-cols-5 sm:grid-cols-10 gap-1">
+          {STEPS.map((s, i) => (
+            <button
+              key={s.key}
+              type="button"
+              onClick={() => void goToStep(i)}
+              className={`h-2 rounded-full transition-colors ${i <= stepIndex ? "bg-green-primary" : "bg-gray-200 hover:bg-gray-300"}`}
+              title={s.label}
+              aria-label={`Go to step ${i + 1}: ${s.label}`}
+            />
+          ))}
+        </div>
+
+        {error && (
+          <div className="mb-4 flex items-start gap-2 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+            <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
+            <div className="flex-1">
+              <p>{error}</p>
+              {submitMissing.length > 0 && (
+                <ul className="mt-1 list-disc list-inside text-xs">
+                  {submitMissing.map((m) => <li key={m}>{m}</li>)}
+                </ul>
+              )}
+            </div>
+          </div>
+        )}
+
+        <div className="rounded-2xl border border-gray-100 bg-white p-6 sm:p-8">
+          {currentStep.key === "business" && (
+            <WizardBusinessStep request={request} updateField={updateField} isReadOnly={isReadOnly} />
+          )}
+          {currentStep.key === "brand" && (
+            <WizardBrandStep
+              request={request} updateField={updateField} isReadOnly={isReadOnly}
+              media={media} token={token} onMediaChange={() => reload(token)}
+            />
+          )}
+          {currentStep.key === "products" && (
+            <WizardProductsStep request={request} updateField={updateField} isReadOnly={isReadOnly} />
+          )}
+          {currentStep.key === "content" && (
+            <WizardContentStep request={request} updateField={updateField} isReadOnly={isReadOnly} />
+          )}
+          {currentStep.key === "media" && (
+            <WizardMediaStep
+              request={request} isReadOnly={isReadOnly}
+              media={media} token={token} onMediaChange={() => reload(token)}
+              updateField={updateField}
+            />
+          )}
+          {currentStep.key === "contact" && (
+            <WizardContactStep request={request} updateField={updateField} isReadOnly={isReadOnly} />
+          )}
+          {currentStep.key === "domain" && (
+            <WizardDomainStep request={request} updateField={updateField} isReadOnly={isReadOnly} />
+          )}
+          {currentStep.key === "features" && (
+            <WizardFeaturesStep request={request} updateField={updateField} isReadOnly={isReadOnly} />
+          )}
+          {currentStep.key === "launch" && (
+            <WizardLaunchStep request={request} updateField={updateField} isReadOnly={isReadOnly} />
+          )}
+          {currentStep.key === "review" && (
+            <WizardReviewStep
+              request={request} media={media} activity={activity}
+              updateField={updateField} isReadOnly={isReadOnly}
+              onEditStep={(k) => {
+                const idx = STEPS.findIndex((s) => s.key === k);
+                if (idx >= 0) void goToStep(idx);
+              }}
+              onSubmit={handleSubmit}
+              submitting={submitting}
+            />
+          )}
+        </div>
+
+        <div className="mt-6 flex items-center justify-between">
+          <button
+            type="button"
+            onClick={() => void goToStep(stepIndex - 1)}
+            disabled={stepIndex === 0}
+            className="inline-flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-4 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-40 cursor-pointer"
+          >
+            <ArrowLeft className="h-4 w-4" /> Back
+          </button>
+          <button
+            type="button"
+            onClick={() => void flush()}
+            disabled={saving === "saving"}
+            className="inline-flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-4 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-40 cursor-pointer"
+          >
+            <Save className="h-4 w-4" /> Save Draft
+          </button>
+          {stepIndex < STEPS.length - 1 ? (
+            <button
+              type="button"
+              onClick={() => void goToStep(stepIndex + 1)}
+              className="inline-flex items-center gap-2 rounded-xl bg-green-primary hover:bg-green-hover px-5 py-2.5 text-sm font-semibold text-white cursor-pointer"
+            >
+              Save & Continue <ArrowRight className="h-4 w-4" />
+            </button>
+          ) : (
+            <div className="w-32" />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/website-builder/page.tsx
+++ b/src/app/website-builder/page.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Loader2, Globe, Plus, ArrowRight, Clock, CheckCircle2, AlertCircle } from "lucide-react";
+import { createBrowserClient } from "@/lib/supabase";
+
+interface RequestListItem {
+  id: string;
+  status: string;
+  business_name: string | null;
+  updated_at: string;
+  submitted_at: string | null;
+  created_at: string;
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  draft: "Draft",
+  submitted: "Submitted",
+  under_review: "Under Review",
+  needs_information: "Action Required",
+  approved_for_build: "Approved for Build",
+  in_development: "In Development",
+  client_review: "Client Review",
+  ready_to_launch: "Ready to Launch",
+  launched: "Launched",
+  cancelled: "Cancelled",
+};
+
+const STATUS_STYLES: Record<string, string> = {
+  draft: "bg-gray-100 text-gray-700",
+  submitted: "bg-blue-100 text-blue-700",
+  under_review: "bg-blue-100 text-blue-700",
+  needs_information: "bg-amber-100 text-amber-800",
+  approved_for_build: "bg-emerald-100 text-emerald-800",
+  in_development: "bg-emerald-100 text-emerald-800",
+  client_review: "bg-purple-100 text-purple-800",
+  ready_to_launch: "bg-purple-100 text-purple-800",
+  launched: "bg-green-100 text-green-800",
+  cancelled: "bg-red-100 text-red-700",
+};
+
+/**
+ * Landing for "Get Your Own Vending Website". Lists the caller's own
+ * requests + a "start new" CTA. New drafts create through POST and
+ * redirect straight into the wizard so the customer sees prefilled
+ * fields on step 1.
+ */
+export default function WebsiteBuilderIndex() {
+  const router = useRouter();
+  const [token, setToken] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [creating, setCreating] = useState(false);
+  const [requests, setRequests] = useState<RequestListItem[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(async ({ data: { session } }) => {
+      if (!session?.access_token) { router.push("/login?redirect=/website-builder"); return; }
+      setToken(session.access_token);
+      const res = await fetch("/api/website-requests", {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      });
+      if (res.ok) {
+        const body = await res.json();
+        setRequests(body.requests || []);
+      }
+      setLoading(false);
+    });
+  }, [router]);
+
+  async function createDraft() {
+    setError(null);
+    setCreating(true);
+    const res = await fetch("/api/website-requests", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    setCreating(false);
+    if (!res.ok) {
+      setError((await res.json().catch(() => ({}))).error || "Could not create draft");
+      return;
+    }
+    const body = await res.json();
+    router.push(`/website-builder/${body.request.id}`);
+  }
+
+  if (loading) {
+    return <div className="min-h-[60vh] flex items-center justify-center"><Loader2 className="h-6 w-6 animate-spin text-green-primary" /></div>;
+  }
+
+  const currentDraft = requests.find((r) => r.status === "draft" || r.status === "needs_information");
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="mx-auto max-w-3xl px-4 py-10 sm:px-6">
+        <div className="flex items-center gap-3 mb-6">
+          <div className="w-12 h-12 rounded-2xl bg-green-100 flex items-center justify-center">
+            <Globe className="h-6 w-6 text-green-700" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">Get Your Own Vending Website</h1>
+            <p className="text-sm text-gray-500">A guided intake so our team can build your site — takes about 15 minutes.</p>
+          </div>
+        </div>
+
+        {error && (
+          <div className="mb-4 flex items-start gap-2 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+            <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" /> {error}
+          </div>
+        )}
+
+        {currentDraft ? (
+          <div className="mb-6 rounded-2xl border border-emerald-200 bg-white p-5">
+            <p className="text-sm font-semibold text-emerald-800 mb-1">
+              {currentDraft.status === "needs_information" ? "Action required on your request" : "Continue your draft"}
+            </p>
+            <p className="text-xs text-gray-500 mb-3">
+              {currentDraft.business_name || "Untitled"} · saved {new Date(currentDraft.updated_at).toLocaleString()}
+            </p>
+            <Link
+              href={`/website-builder/${currentDraft.id}`}
+              className="inline-flex items-center gap-2 rounded-xl bg-green-primary hover:bg-green-hover px-5 py-2.5 text-sm font-semibold text-white"
+            >
+              Resume <ArrowRight className="h-4 w-4" />
+            </Link>
+          </div>
+        ) : (
+          <div className="mb-6 rounded-2xl border border-gray-200 bg-white p-5">
+            <p className="text-sm text-gray-700 mb-3">
+              Ready to start? Our team uses your intake to build a website tailored to your vending
+              business — branding, content, features, everything.
+            </p>
+            <button
+              onClick={createDraft}
+              disabled={creating}
+              className="inline-flex items-center gap-2 rounded-xl bg-green-primary hover:bg-green-hover px-5 py-2.5 text-sm font-semibold text-white cursor-pointer disabled:opacity-50"
+            >
+              {creating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
+              Start New Website Request
+            </button>
+          </div>
+        )}
+
+        {requests.length > 0 && (
+          <div className="rounded-2xl border border-gray-100 bg-white">
+            <div className="p-4 border-b border-gray-100">
+              <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">Your Requests</p>
+            </div>
+            <ul className="divide-y divide-gray-50">
+              {requests.map((r) => (
+                <li key={r.id}>
+                  <Link
+                    href={`/website-builder/${r.id}`}
+                    className="flex items-center gap-3 p-4 hover:bg-gray-50/50"
+                  >
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-medium text-gray-900 truncate">{r.business_name || "Untitled request"}</p>
+                      <p className="text-xs text-gray-500 flex items-center gap-1.5">
+                        <Clock className="h-3 w-3" /> Updated {new Date(r.updated_at).toLocaleDateString()}
+                      </p>
+                    </div>
+                    <span className={`text-[10px] font-semibold px-2 py-0.5 rounded-full ${STATUS_STYLES[r.status] || "bg-gray-100 text-gray-600"}`}>
+                      {STATUS_LABELS[r.status] || r.status}
+                    </span>
+                    {r.status === "launched" && <CheckCircle2 className="h-4 w-4 text-green-600" />}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/websiteRequestEmail.ts
+++ b/src/lib/websiteRequestEmail.ts
@@ -1,0 +1,202 @@
+import { Resend } from "resend";
+import { supabaseAdmin } from "./supabaseAdmin";
+
+/**
+ * Website Request notifications — piggybacks on Resend + the same FROM
+ * address the rest of the app uses. Idempotent per (request_id, event)
+ * so status transitions don't double-fire on retries.
+ */
+
+const FROM = process.env.FROM_EMAIL || "receipts@bytebitevending.com";
+const ADMIN_INBOX = process.env.WEBSITE_ADMIN_EMAIL
+  || process.env.COFFEE_ADMIN_EMAIL
+  || "james@apexaivending.com";
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "https://vendingconnector.com";
+
+type NotificationEvent =
+  | "submitted"
+  | "needs_information"
+  | "approved_for_build"
+  | "in_development"
+  | "client_review"
+  | "ready_to_launch"
+  | "launched";
+
+interface RequestSlim {
+  id: string;
+  business_name?: string | null;
+  primary_contact?: string | null;
+  email?: string | null;
+}
+
+function h(s: string | null | undefined): string {
+  return String(s ?? "").replace(/[&<>"']/g, (c) => ({
+    "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;",
+  }[c] as string));
+}
+
+/**
+ * Idempotency check — look at website_request_activity to see whether
+ * we've already logged this same event/status pair. Prevents Resend
+ * duplicates on webhook / retry storms.
+ */
+async function alreadySent(requestId: string, event: NotificationEvent): Promise<boolean> {
+  const { data } = await supabaseAdmin
+    .from("website_request_activity")
+    .select("id")
+    .eq("request_id", requestId)
+    .eq("event_type", `notified_${event}`)
+    .limit(1);
+  return (data || []).length > 0;
+}
+
+async function markSent(requestId: string, event: NotificationEvent, meta?: Record<string, unknown>) {
+  await supabaseAdmin.from("website_request_activity").insert({
+    request_id: requestId,
+    event_type: `notified_${event}`,
+    visibility: "internal",
+    metadata: meta || null,
+  });
+}
+
+/**
+ * Copy library — one per supported event. Keep marketing tone friendly
+ * and match the spec verbatim where the user gave copy.
+ */
+function copyFor(event: NotificationEvent, req: RequestSlim): {
+  customerSubject: string;
+  customerHtml: string;
+  adminSubject: string;
+  adminHtml: string;
+} {
+  const businessName = req.business_name || "your business";
+  const contactName = req.primary_contact || "there";
+  const link = `${APP_URL}/website-builder/${req.id}`;
+  const adminLink = `${APP_URL}/admin/website-requests/${req.id}`;
+
+  switch (event) {
+    case "submitted":
+      return {
+        customerSubject: "We Received Your Website Request",
+        customerHtml: shell(`
+          <p>Hi ${h(contactName)},</p>
+          <p>Thanks for submitting your vending website information. Our team has received your
+          request and will review your business information, branding, content, and requested
+          features. We&rsquo;ll contact you if anything else is needed.</p>
+          <p><a href="${h(link)}" style="color:#16a34a;">View your request</a></p>
+        `),
+        adminSubject: `New website request — ${businessName}`,
+        adminHtml: shell(`
+          <p><strong>${h(businessName)}</strong> submitted a new website request.</p>
+          <p>Primary contact: ${h(contactName)} &lt;${h(req.email || "")}&gt;</p>
+          <p><a href="${h(adminLink)}" style="color:#16a34a;">Open in admin</a></p>
+        `),
+      };
+    case "needs_information":
+      return {
+        customerSubject: "Action needed on your website request",
+        customerHtml: shell(`
+          <p>Hi ${h(contactName)},</p>
+          <p>We need a little more information to keep building your vending website.
+          Open your request to see what&rsquo;s outstanding and reply.</p>
+          <p><a href="${h(link)}" style="color:#16a34a;">Open your request</a></p>
+        `),
+        adminSubject: `Needs-info sent — ${businessName}`,
+        adminHtml: shell(`<p>Sent a needs-info request to ${h(contactName)} for <strong>${h(businessName)}</strong>.</p>`),
+      };
+    case "approved_for_build":
+      return {
+        customerSubject: "Your website request is approved for build",
+        customerHtml: shell(`
+          <p>Hi ${h(contactName)},</p>
+          <p>Good news — we&rsquo;ve approved <strong>${h(businessName)}</strong> for build. Our
+          team is starting your site now. We&rsquo;ll reach out with a client review when the
+          first draft is ready.</p>
+        `),
+        adminSubject: `Approved for build — ${businessName}`,
+        adminHtml: shell(`<p>Marked <strong>${h(businessName)}</strong> approved for build.</p>`),
+      };
+    case "in_development":
+      return {
+        customerSubject: "Your website is in development",
+        customerHtml: shell(`<p>Hi ${h(contactName)},</p><p>Your website is officially in development. We&rsquo;ll invite you to review a draft as soon as it&rsquo;s ready.</p>`),
+        adminSubject: `In development — ${businessName}`,
+        adminHtml: shell(`<p>${h(businessName)} moved to In Development.</p>`),
+      };
+    case "client_review":
+      return {
+        customerSubject: "Your website draft is ready to review",
+        customerHtml: shell(`
+          <p>Hi ${h(contactName)},</p>
+          <p>Your website draft for <strong>${h(businessName)}</strong> is ready for your review.
+          Open your request for the preview link and next steps.</p>
+          <p><a href="${h(link)}" style="color:#16a34a;">Open your request</a></p>
+        `),
+        adminSubject: `Client review sent — ${businessName}`,
+        adminHtml: shell(`<p>Sent client review link to ${h(contactName)} for <strong>${h(businessName)}</strong>.</p>`),
+      };
+    case "ready_to_launch":
+      return {
+        customerSubject: "Your website is ready to launch",
+        customerHtml: shell(`<p>Hi ${h(contactName)},</p><p>Everything looks good on our side — your website is ready to launch. We&rsquo;ll confirm the go-live time with you.</p>`),
+        adminSubject: `Ready to launch — ${businessName}`,
+        adminHtml: shell(`<p>${h(businessName)} marked Ready to Launch.</p>`),
+      };
+    case "launched":
+      return {
+        customerSubject: "Your website is live",
+        customerHtml: shell(`<p>Hi ${h(contactName)},</p><p>Your new vending website is live. Congrats! We&rsquo;ll follow up soon with performance tips.</p>`),
+        adminSubject: `Launched — ${businessName}`,
+        adminHtml: shell(`<p>${h(businessName)} launched.</p>`),
+      };
+  }
+}
+
+function shell(body: string): string {
+  return `
+    <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:560px;margin:0 auto;padding:24px;color:#111;">
+      <div style="margin-bottom:20px;"><strong style="color:#16a34a;font-size:20px;">Vending Connector</strong></div>
+      ${body}
+      <hr style="border:none;border-top:1px solid #e5e7eb;margin:20px 0;">
+      <p style="color:#9ca3af;font-size:11px;">Vending Connector · vendingconnector.com</p>
+    </div>
+  `;
+}
+
+export async function sendWebsiteRequestNotification(args: {
+  event: NotificationEvent;
+  request: RequestSlim;
+  skipAdmin?: boolean;
+  skipCustomer?: boolean;
+}): Promise<void> {
+  const { event, request } = args;
+  if (await alreadySent(request.id, event)) return;
+
+  const resend = new Resend(process.env.RESEND_API_KEY);
+  const copy = copyFor(event, request);
+
+  const sends: Promise<unknown>[] = [];
+  if (!args.skipCustomer && request.email) {
+    sends.push(resend.emails.send({
+      from: FROM,
+      to: request.email,
+      subject: copy.customerSubject,
+      html: copy.customerHtml,
+    }));
+  }
+  if (!args.skipAdmin) {
+    sends.push(resend.emails.send({
+      from: FROM,
+      to: ADMIN_INBOX,
+      subject: copy.adminSubject,
+      html: copy.adminHtml,
+    }));
+  }
+  try {
+    await Promise.all(sends);
+    await markSent(request.id, event);
+  } catch (e) {
+    // Don't mark sent on failure — retry on next status transition.
+    console.error("[websiteRequestEmail] send failed:", e);
+  }
+}

--- a/src/lib/websiteRequests.ts
+++ b/src/lib/websiteRequests.ts
@@ -1,0 +1,128 @@
+import { supabaseAdmin } from "./supabaseAdmin";
+
+/**
+ * Shared allowlist + helpers for website intake requests.
+ *
+ * The wizard has 10 steps × dozens of fields; rather than list them in
+ * every API route, this module owns the single source of truth for what
+ * the customer can update on their draft. Admin edits use a superset
+ * (see admin route).
+ */
+
+// Scalar text/enum/boolean columns the customer can set through the wizard.
+export const CUSTOMER_EDITABLE_SCALARS = [
+  // Business
+  "business_name", "primary_contact", "phone", "email", "business_address",
+  "years_in_business", "business_story", "mission_values",
+  // Brand
+  "brand_primary_color", "brand_secondary_color",
+  "preferred_style", "preferred_style_other",
+  "fonts", "tagline",
+  // Products
+  "primary_services_other",
+  "pricing_notes", "differentiators",
+  "industries_served_other",
+  // Content
+  "homepage_message", "about_content", "services_content",
+  "gallery_needed",
+  "primary_cta", "primary_cta_custom", "secondary_cta",
+  // Contact
+  "inquiry_email", "public_phone", "business_hours",
+  "lead_delivery_destination", "lead_delivery_email",
+  // Domain
+  "domain_status", "current_domain", "domain_registrar",
+  "business_email", "existing_website",
+  // Features
+  "requested_features_other",
+  // Launch
+  "legal_pages_other",
+  // Notes
+  "additional_notes", "special_requests", "website_inspiration",
+  "future_plans", "anything_else",
+  // Ack
+  "content_ownership_acknowledged",
+] as const;
+
+// JSONB columns the customer can set — arrays/objects assembled client-side.
+export const CUSTOMER_EDITABLE_JSONB = [
+  "inspiration_sites",
+  "primary_services",
+  "revenue_drivers",
+  "industries_served",
+  "geographic_market",
+  "testimonials",
+  "faqs",
+  "social_links",
+  "contact_form_fields",
+  "integrations",
+  "requested_features",
+  "launch_checklist",
+  "legal_pages_needed",
+] as const;
+
+export type WebsiteRequestPatch = Partial<Record<
+  (typeof CUSTOMER_EDITABLE_SCALARS)[number] | (typeof CUSTOMER_EDITABLE_JSONB)[number],
+  unknown
+>>;
+
+const SCALAR_SET = new Set<string>(CUSTOMER_EDITABLE_SCALARS);
+const JSONB_SET = new Set<string>(CUSTOMER_EDITABLE_JSONB);
+
+/**
+ * Pluck only the keys the customer is allowed to write. Anything else in
+ * the body is silently dropped — no leakage of admin-only fields (status,
+ * assigned_to, submitted_at, etc.) via a rogue PATCH.
+ */
+export function sanitizeCustomerPatch(body: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(body)) {
+    if (SCALAR_SET.has(k) || JSONB_SET.has(k)) out[k] = v;
+  }
+  return out;
+}
+
+/**
+ * Validation for the FINAL submit — draft PATCH is loose (any subset is
+ * fine while the customer is still filling it out).
+ */
+export interface SubmitValidation {
+  ok: boolean;
+  missing: string[];
+}
+
+export function validateSubmit(row: Record<string, unknown>): SubmitValidation {
+  const required: Array<[string, string]> = [
+    ["business_name", "Business name"],
+    ["primary_contact", "Primary contact"],
+    ["email", "Business email"],
+    ["phone", "Phone"],
+    ["business_address", "Business address"],
+    ["homepage_message", "Homepage message"],
+    ["primary_cta", "Primary call-to-action"],
+    ["inquiry_email", "Public inquiry email"],
+    ["public_phone", "Public phone"],
+  ];
+  const missing: string[] = [];
+  for (const [key, label] of required) {
+    const v = row[key];
+    if (v == null || (typeof v === "string" && !v.trim())) missing.push(label);
+  }
+  if (row.content_ownership_acknowledged !== true) {
+    missing.push("Content ownership acknowledgment");
+  }
+  return { ok: missing.length === 0, missing };
+}
+
+/**
+ * Signed URL for a private media asset. Short-lived so links can't be
+ * shared long-term — admin re-generates when opening the detail page.
+ */
+export async function signedMediaUrl(filePath: string, expiresInSec = 600): Promise<string | null> {
+  if (!filePath) return null;
+  const { data, error } = await supabaseAdmin
+    .storage
+    .from("website-request-media")
+    .createSignedUrl(filePath, expiresInSec);
+  if (error || !data?.signedUrl) return null;
+  return data.signedUrl;
+}

--- a/supabase/migrations/122_website_requests.sql
+++ b/supabase/migrations/122_website_requests.sql
@@ -1,0 +1,256 @@
+-- Get Your Own Vending Website — intake wizard schema.
+--
+-- Customer-facing multi-step website builder. Each account can hold
+-- one live draft + a history of submitted requests. Media (logo, staff
+-- photos, machine photos, videos) live in their own table with signed-URL
+-- delivery so private assets don't leak. Status transitions + admin
+-- notes/requests land on website_request_activity for a durable
+-- timeline visible either to the customer (public entries) or admin
+-- only (internal entries).
+--
+-- Model choice: flat columns for the top-level scalars every
+-- website needs (business_name, primary_contact, email, etc.) and JSONB
+-- for structured lists (testimonials, faqs, revenue_drivers, social_links,
+-- integrations, requested_features, launch_checklist, contact_form_fields,
+-- inspiration_sites). Keeps queries fast on the scalars, keeps the schema
+-- extensible without 20 child tables, and future-proofs the shape for
+-- AI-driven website generation.
+--
+-- Additive migration — new tables, new bucket, new policies. No changes
+-- to existing tables. Safe on live data.
+
+-- ═════════════════════════════════════════════════════════════════════
+-- website_requests
+-- ═════════════════════════════════════════════════════════════════════
+
+CREATE TABLE IF NOT EXISTS website_requests (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+
+  -- Status matches the spec exactly.
+  status text NOT NULL DEFAULT 'draft' CHECK (status IN (
+    'draft',
+    'submitted',
+    'under_review',
+    'needs_information',
+    'approved_for_build',
+    'in_development',
+    'client_review',
+    'ready_to_launch',
+    'launched',
+    'cancelled'
+  )),
+
+  -- Admin assignment
+  assigned_to uuid REFERENCES profiles(id) ON DELETE SET NULL,
+
+  -- Step 1: Business
+  business_name text,
+  primary_contact text,
+  phone text,
+  email text,
+  business_address text,
+  years_in_business text,
+  business_story text,
+  mission_values text,
+
+  -- Step 2: Brand
+  logo_media_id uuid,                       -- FK filled after media upload; kept nullable for wizard flow
+  brand_primary_color text,
+  brand_secondary_color text,
+  preferred_style text,                     -- 'modern' | 'corporate' | ... | 'other'
+  preferred_style_other text,
+  fonts text,
+  tagline text,
+  inspiration_sites jsonb DEFAULT '[]'::jsonb,   -- [{url, note}]
+
+  -- Step 3: Products, Services & Target Customer
+  primary_services jsonb DEFAULT '[]'::jsonb,    -- ['ai_vending', 'micro_markets', ...]
+  primary_services_other text,
+  revenue_drivers jsonb DEFAULT '[]'::jsonb,     -- [{name, description, pricing}]
+  pricing_notes text,
+  differentiators text,
+  industries_served jsonb DEFAULT '[]'::jsonb,   -- ['offices', 'manufacturing', ...]
+  industries_served_other text,
+  geographic_market jsonb DEFAULT '{}'::jsonb,   -- {cities: [], states: [], counties: [], radius_miles: null}
+
+  -- Step 4: Website Content
+  homepage_message text,
+  about_content text,
+  services_content text,
+  gallery_needed boolean,
+  testimonials jsonb DEFAULT '[]'::jsonb,        -- [{name, quote, role, image_media_id}]
+  faqs jsonb DEFAULT '[]'::jsonb,                -- [{question, answer}]
+  primary_cta text,                              -- preset key or free text via primary_cta_custom
+  primary_cta_custom text,
+  secondary_cta text,
+
+  -- Step 5: Media handled by website_request_media rows; social links here.
+  social_links jsonb DEFAULT '{}'::jsonb,        -- {facebook, instagram, linkedin, tiktok, youtube, other}
+
+  -- Step 6: Contact & Lead Capture
+  inquiry_email text,
+  public_phone text,
+  business_hours text,
+  contact_form_fields jsonb DEFAULT '[]'::jsonb, -- [{key, label, required, kind}]
+  lead_delivery_destination text DEFAULT 'email' CHECK (lead_delivery_destination IN ('email', 'crm')),
+  lead_delivery_email text,
+
+  -- Step 7: Domain & Technology
+  --   NO password / API secret / registrar credential fields — enforced by omission.
+  --   Sensitive credentials, if ever needed, go through a separate secure workflow.
+  domain_status text CHECK (domain_status IN ('yes', 'no', 'not_sure') OR domain_status IS NULL),
+  current_domain text,
+  domain_registrar text,
+  business_email text,
+  existing_website text,
+  integrations jsonb DEFAULT '[]'::jsonb,        -- [{key, notes}]
+
+  -- Step 8: Features Requested
+  requested_features jsonb DEFAULT '[]'::jsonb,  -- [{key, notes}]
+  requested_features_other text,
+
+  -- Step 9: Launch Readiness
+  launch_checklist jsonb DEFAULT '{}'::jsonb,    -- {own_domain: bool, logo_ready: bool, ...}
+  legal_pages_needed jsonb DEFAULT '[]'::jsonb,  -- ['privacy_policy', 'terms_of_use', ...]
+  legal_pages_other text,
+
+  -- Step 10: Additional Notes
+  additional_notes text,
+  special_requests text,
+  website_inspiration text,
+  future_plans text,
+  anything_else text,
+
+  -- Submission acknowledgment
+  content_ownership_acknowledged boolean NOT NULL DEFAULT false,
+  submitted_at timestamptz,
+
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_website_requests_user
+  ON website_requests(user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_website_requests_status
+  ON website_requests(status, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_website_requests_assigned
+  ON website_requests(assigned_to, status)
+  WHERE assigned_to IS NOT NULL;
+
+-- ═════════════════════════════════════════════════════════════════════
+-- website_request_media
+-- ═════════════════════════════════════════════════════════════════════
+-- One row per uploaded asset. `kind` distinguishes the section it
+-- belongs to (logo/staff/location/machine/product/video_link) so the
+-- wizard can render each section's uploads separately.
+
+CREATE TABLE IF NOT EXISTS website_request_media (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  request_id uuid NOT NULL REFERENCES website_requests(id) ON DELETE CASCADE,
+  kind text NOT NULL CHECK (kind IN (
+    'logo',
+    'staff',
+    'location',
+    'machine',
+    'product',
+    'video',
+    'video_link',
+    'testimonial'
+  )),
+  file_path text,                    -- storage bucket path; null for video_link entries
+  file_name text,
+  file_size_bytes integer,
+  mime_type text,
+  external_url text,                 -- for kind='video_link'
+  caption text,
+  sort_order integer NOT NULL DEFAULT 0,
+  uploaded_by uuid REFERENCES profiles(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_website_request_media_request
+  ON website_request_media(request_id, kind, sort_order);
+
+-- Now the FK back-link from website_requests.logo_media_id
+ALTER TABLE website_requests
+  ADD CONSTRAINT website_requests_logo_media_fk
+  FOREIGN KEY (logo_media_id) REFERENCES website_request_media(id) ON DELETE SET NULL;
+
+-- ═════════════════════════════════════════════════════════════════════
+-- website_request_activity
+-- ═════════════════════════════════════════════════════════════════════
+-- Status transitions, admin internal notes, request-info messages,
+-- assignment changes. `visibility` gates whether the customer sees an
+-- entry ('public') or only admin does ('internal').
+
+CREATE TABLE IF NOT EXISTS website_request_activity (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  request_id uuid NOT NULL REFERENCES website_requests(id) ON DELETE CASCADE,
+  actor_id uuid REFERENCES profiles(id) ON DELETE SET NULL,
+  event_type text NOT NULL,          -- 'status_changed', 'note_added', 'info_requested', 'assigned', 'submitted', 'edited'
+  visibility text NOT NULL DEFAULT 'internal' CHECK (visibility IN ('public', 'internal')),
+  previous_status text,
+  new_status text,
+  message text,
+  metadata jsonb,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_website_request_activity_request
+  ON website_request_activity(request_id, created_at DESC);
+
+-- ═════════════════════════════════════════════════════════════════════
+-- Storage bucket
+-- ═════════════════════════════════════════════════════════════════════
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('website-request-media', 'website-request-media', false)
+ON CONFLICT (id) DO NOTHING;
+
+-- ═════════════════════════════════════════════════════════════════════
+-- RLS
+-- ═════════════════════════════════════════════════════════════════════
+-- All writes flow through the API (service role). Callers get self-read
+-- so client code can render its own draft without an extra server hop.
+
+ALTER TABLE website_requests ENABLE ROW LEVEL SECURITY;
+ALTER TABLE website_request_media ENABLE ROW LEVEL SECURITY;
+ALTER TABLE website_request_activity ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Service role only" ON website_requests;
+CREATE POLICY "Service role only" ON website_requests
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+DROP POLICY IF EXISTS "Self read requests" ON website_requests;
+CREATE POLICY "Self read requests" ON website_requests
+  FOR SELECT TO authenticated
+  USING (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "Service role only" ON website_request_media;
+CREATE POLICY "Service role only" ON website_request_media
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+DROP POLICY IF EXISTS "Self read media" ON website_request_media;
+CREATE POLICY "Self read media" ON website_request_media
+  FOR SELECT TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM website_requests r
+    WHERE r.id = website_request_media.request_id
+      AND r.user_id = auth.uid()
+  ));
+
+DROP POLICY IF EXISTS "Service role only" ON website_request_activity;
+CREATE POLICY "Service role only" ON website_request_activity
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+DROP POLICY IF EXISTS "Self read activity public" ON website_request_activity;
+CREATE POLICY "Self read activity public" ON website_request_activity
+  FOR SELECT TO authenticated
+  USING (
+    visibility = 'public'
+    AND EXISTS (
+      SELECT 1 FROM website_requests r
+      WHERE r.id = website_request_activity.request_id
+        AND r.user_id = auth.uid()
+    )
+  );


### PR DESCRIPTION
New end-to-end feature: a 10-step guided wizard that collects everything our team needs to build a customer's website, with admin management, notifications, and full account isolation.

Migration 122:
  * website_requests — one row per intake; flat columns for scalars, JSONB for lists (testimonials, faqs, revenue_drivers, integrations, requested_features, launch_checklist, contact_form_fields, etc.)
  * website_request_media — kinded uploads (logo/staff/location/machine/ product/video/video_link/testimonial). Private bucket 'website-request-media' with signed-URL delivery.
  * website_request_activity — durable timeline. `visibility` gates whether the customer sees an entry ('public') or admin only ('internal').
  * Status: draft → submitted → under_review → needs_information → approved_for_build → in_development → client_review → ready_to_launch → launched (or cancelled).
  * Self-scoped RLS + service-role writes.

Customer routes:
  * POST /api/website-requests           — create draft (prefilled from profile)
  * GET  /api/website-requests           — list own
  * GET  /api/website-requests/[id]      — draft + media (signed URLs) + public activity
  * PATCH /api/website-requests/[id]     — save/autosave (allowlisted fields only)
  * DELETE /api/website-requests/[id]    — draft only
  * POST /api/website-requests/[id]/submit  — validate + flip to submitted
  * POST /api/website-requests/[id]/media   — multipart upload; JSON body for video_link
  * DELETE /api/website-requests/[id]/media/[mediaId]

Wizard UI:
  * /website-builder — landing (existing requests + Start New)
  * /website-builder/[id] — 10-step wizard, progress rail, debounced autosave, back/save/continue, read-only when submitted, "Action Required" banner when status is needs_information
  * Steps: Business, Brand (+ logo upload), Products & Customers, Content (testimonials/faqs/CTAs), Media (kinded uploads + social), Contact (form builder + email delivery), Domain (with NO password/ secret fields), Features, Launch Readiness, Review & Submit
  * Shared LeadGeneratorForm-style component patterns; consistent green-primary design system

Admin surfaces:
  * /admin/website-requests           — queue with status filter + search
  * /admin/website-requests/[id]      — full submission view with signed-
    URL media, status dropdown, needs-info workflow, internal + public
    notes, activity timeline, JSON editor for geo/features/integrations
  * POST /status, /note, /request-info, /assign — every mutation writes
    to website_request_activity

Nav card:
  * "Get Your Own Vending Website" card on /dashboard for every authenticated account with Globe icon. Grants zero CRM permissions.

Notifications (Resend, reuses FROM_EMAIL):
  * On submit: customer confirmation ("We Received Your Website Request") + admin alert
  * On status change to needs_information / approved_for_build / in_development / client_review / ready_to_launch / launched: customer + admin
  * Idempotent per (request_id, event) via a "notified_*" activity marker row — status transitions don't double-fire

Security:
  * All API routes verify caller through getUserIdFromRequest / getAdminUserId — no client-side-only auth
  * Customer PATCH allowlist strips admin-only fields (status, assigned_to, submitted_at) so a rogue body can't self-promote
  * File uploads capped at 15 MB, image + video MIME whitelist, private bucket, signed URLs only
  * Domain step explicitly refuses password/API-secret fields with a visible warning; the schema has no columns for credentials
  * Lead delivery is email-only in v1 (schema allows 'crm' for later); the wizard never grants CRM access
  * Legal-pages step includes a "not legal advice" disclaimer
  * Internal notes never render on customer-facing routes (RLS gates website_request_activity SELECT to visibility='public')

Future-proof:
  * JSONB shape maps cleanly to future AI website generation, template selection, domain provisioning
  * `assigned_to` FK ready for the queue view / round-robin
  * Idempotency-marked notification rows ready for retry hooks