### PR TITLE
Coffee agreement — legacy_approved users can now actually sign

### DIFF
--- a/src/app/coffee/agreement/page.tsx
+++ b/src/app/coffee/agreement/page.tsx
@@ -122,7 +122,11 @@ export default function CoffeeAgreementPage() {
   }
 
   const status = agreement?.status;
-  const alreadyExecuted = status === "fully_executed" || status === "legacy_approved";
+  // Only fully_executed hides the form — legacy_approved users are
+  // grandfathered so they can order, but they landed here on purpose to
+  // sign the real current version. Show them the form.
+  const alreadyExecuted = status === "fully_executed";
+  const isLegacy = status === "legacy_approved";
   const pendingCountersign = status === "provider_signed_pending_company_countersign";
 
   return (

--- a/src/lib/placementAgreements.ts
+++ b/src/lib/placementAgreements.ts
@@ -152,7 +152,11 @@ export async function signAsProvider(args: SignAsProviderArgs): Promise<UserAgre
   if (current.user_id !== args.actingUserId) {
     throw new Error("You may only sign your own agreement");
   }
-  const allowedFrom: AgreementStatus[] = ["not_started", "draft", "correction_requested"];
+  // legacy_approved rows are backfilled grandfather grants; allow the
+  // user to upgrade to a real signature so their record reflects the
+  // current template. Sign flips them into pending-countersign like
+  // anyone else.
+  const allowedFrom: AgreementStatus[] = ["not_started", "draft", "correction_requested", "legacy_approved"];
   if (!allowedFrom.includes(current.status)) {
     throw new Error(`Cannot sign from status "${current.status}"`);
   }


### PR DESCRIPTION
Bug: the grandfather banner sent legacy users to /coffee/agreement to sign the real current version, but the sign page hid the form because it treated legacy_approved as "already executed." Nothing to click on.

Fix, two parts:

1. /coffee/agreement — alreadyExecuted only matches fully_executed now. legacy_approved renders the form with the existing "Grandfathered — please sign the current version below" banner, which now matches reality.

2. signAsProvider (placementAgreements.ts) — added legacy_approved to the allowedFrom list so the state machine accepts the upgrade transition (legacy_approved → provider_signed_pending_company_countersign). Admin then countersigns to move the row to fully_executed, replacing the grandfather grant with a real signed record.

Applies to both agreement types that share this state machine (placement_provider + coffee_supply).