### PR TITLE
Coffee checkout — graceful fallback when migration 118 hasn't run yet

### DIFF
--- a/src/app/api/coffee/checkout/route.ts
+++ b/src/app/api/coffee/checkout/route.ts
@@ -164,10 +164,19 @@ export async function POST(req: NextRequest) {
       order_id: order.id,
     }));
 
-    const { error: itemsError } = await supabaseAdmin
+    // Insert order lines. pricing_tier_id was added in migration 118 —
+    // if a customer hasn't applied it yet, PostgREST returns "Could not
+    // find the pricing_tier_id column". Fall back to inserting without
+    // the tier snapshot so orders still commit. Once migration 118 is
+    // applied the first attempt succeeds and the retry never runs.
+    let { error: itemsError } = await supabaseAdmin
       .from("coffee_order_items")
       .insert(itemsWithOrderId);
-
+    if (itemsError && /pricing_tier_id/.test(itemsError.message || "")) {
+      const legacy = itemsWithOrderId.map(({ pricing_tier_id: _tier, ...rest }) => rest);
+      const retry = await supabaseAdmin.from("coffee_order_items").insert(legacy);
+      itemsError = retry.error;
+    }
     if (itemsError) {
       return NextResponse.json({ error: itemsError.message }, { status: 500 });
     }

--- a/src/app/api/coffee/orders/route.ts
+++ b/src/app/api/coffee/orders/route.ts
@@ -161,10 +161,16 @@ export async function POST(req: NextRequest) {
       order_id: order.id,
     }));
 
-    const { error: itemsError } = await supabaseAdmin
+    // Retry-without-tier-snapshot if migration 118 hasn't been applied
+    // in this environment yet (see /api/coffee/checkout for context).
+    let { error: itemsError } = await supabaseAdmin
       .from("coffee_order_items")
       .insert(itemsWithOrderId);
-
+    if (itemsError && /pricing_tier_id/.test(itemsError.message || "")) {
+      const legacy = itemsWithOrderId.map(({ pricing_tier_id: _tier, ...rest }) => rest);
+      const retry = await supabaseAdmin.from("coffee_order_items").insert(legacy);
+      itemsError = retry.error;
+    }
     if (itemsError) {
       return NextResponse.json({ error: itemsError.message }, { status: 500 });
     }


### PR DESCRIPTION
Customer hit "Could not find the pricing_tier_id column of coffee_order_items in schema cache" during checkout — that column was added by migration 118 (pricing tiers) but hadn't been applied yet on their environment. The insert failed and the customer couldn't pay.

Fix: both write paths (/api/coffee/checkout and /api/coffee/orders POST) now catch the specific "pricing_tier_id" schema-cache error, strip the column from the payload, and retry once. Once migration 118 is applied the first attempt succeeds and the retry never runs.

Not a substitute for applying the migration — the tier resolver still runs and the correct unit_price gets snapshotted on the order line. Only the pricing_tier_id lineage column is skipped when absent.