### PR TITLE
CRM accounts — assign equipment to accounts

### DIFF
--- a/src/app/api/sales/accounts/[id]/equipment/[equipmentId]/route.ts
+++ b/src/app/api/sales/accounts/[id]/equipment/[equipmentId]/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser } from "@/lib/salesAuth";
+
+/**
+ * PATCH  /api/sales/accounts/[id]/equipment/[equipmentId]
+ *   Update editable fields OR flip status to 'removed' with reason.
+ * DELETE /api/sales/accounts/[id]/equipment/[equipmentId]
+ *   Hard delete — use sparingly; PATCH → status='removed' preserves history.
+ */
+
+const EDITABLE = new Set([
+  "name",
+  "serial_number",
+  "model",
+  "notes",
+  "assigned_at",
+  "status",
+  "removed_reason",
+]);
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string; equipmentId: string }> },
+) {
+  const user = await getSalesUser(req);
+  if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id, equipmentId } = await params;
+
+  const body = await req.json().catch(() => ({}));
+  const patch: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(body)) {
+    if (EDITABLE.has(k)) patch[k] = v;
+  }
+  if (Object.keys(patch).length === 0) {
+    return NextResponse.json({ error: "No editable fields in body" }, { status: 400 });
+  }
+
+  // status transition side-effects: when marking removed, stamp
+  // removed_at automatically. Reverting to active clears removal
+  // fields so the row looks fresh again.
+  if (patch.status === "removed") {
+    patch.removed_at = new Date().toISOString();
+  } else if (patch.status === "active") {
+    patch.removed_at = null;
+    patch.removed_reason = null;
+  }
+  patch.updated_at = new Date().toISOString();
+
+  const { data, error } = await supabaseAdmin
+    .from("account_equipment")
+    .update(patch)
+    .eq("id", equipmentId)
+    .eq("account_id", id)
+    .select("*")
+    .single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (!data) return NextResponse.json({ error: "Equipment not found" }, { status: 404 });
+  return NextResponse.json({ equipment: data });
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string; equipmentId: string }> },
+) {
+  const user = await getSalesUser(req);
+  if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id, equipmentId } = await params;
+
+  const { error } = await supabaseAdmin
+    .from("account_equipment")
+    .delete()
+    .eq("id", equipmentId)
+    .eq("account_id", id);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/sales/accounts/[id]/equipment/route.ts
+++ b/src/app/api/sales/accounts/[id]/equipment/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser } from "@/lib/salesAuth";
+
+/**
+ * GET  /api/sales/accounts/[id]/equipment
+ * POST /api/sales/accounts/[id]/equipment
+ *
+ * Equipment assigned to a CRM account. Distinct from machine_listings
+ * (machines for sale) — these rows represent hardware deployed at the
+ * customer's location.
+ */
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const user = await getSalesUser(req);
+  if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id } = await params;
+
+  const { data, error } = await supabaseAdmin
+    .from("account_equipment")
+    .select("*")
+    .eq("account_id", id)
+    .order("assigned_at", { ascending: false });
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ equipment: data || [] });
+}
+
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const user = await getSalesUser(req);
+  if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id } = await params;
+
+  // Confirm the account exists — protects against orphan rows if the
+  // caller passes a garbage account id.
+  const { data: account } = await supabaseAdmin
+    .from("sales_accounts")
+    .select("id")
+    .eq("id", id)
+    .maybeSingle();
+  if (!account) return NextResponse.json({ error: "Account not found" }, { status: 404 });
+
+  const body = await req.json().catch(() => ({}));
+  const name = typeof body.name === "string" ? body.name.trim() : "";
+  if (!name) return NextResponse.json({ error: "Equipment name is required" }, { status: 400 });
+
+  const assignedAt = typeof body.assigned_at === "string" && body.assigned_at
+    ? new Date(body.assigned_at).toISOString()
+    : new Date().toISOString();
+
+  const { data, error } = await supabaseAdmin
+    .from("account_equipment")
+    .insert({
+      account_id: id,
+      name,
+      serial_number: typeof body.serial_number === "string" ? body.serial_number.trim() || null : null,
+      model: typeof body.model === "string" ? body.model.trim() || null : null,
+      notes: typeof body.notes === "string" ? body.notes.trim() || null : null,
+      assigned_at: assignedAt,
+      assigned_by: user.id,
+    })
+    .select("*")
+    .single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ equipment: data }, { status: 201 });
+}

--- a/src/app/api/sales/accounts/[id]/route.ts
+++ b/src/app/api/sales/accounts/[id]/route.ts
@@ -7,13 +7,23 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
   if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   const { id } = await params;
 
-  // Fetch account with related leads, deals, orders, documents
-  const [accountRes, leadsRes, dealsRes, ordersRes, docsRes] = await Promise.all([
+  // Fetch account with related leads, deals, orders, documents, equipment.
+  // Equipment fetch is wrapped so a missing account_equipment table on an
+  // environment without migration 123 doesn't break the whole account page.
+  const equipmentQuery = supabaseAdmin
+    .from("account_equipment")
+    .select("*")
+    .eq("account_id", id)
+    .order("assigned_at", { ascending: false })
+    .then((r) => r, () => ({ data: [] as unknown[], error: null as unknown }));
+
+  const [accountRes, leadsRes, dealsRes, ordersRes, docsRes, equipmentRes] = await Promise.all([
     supabaseAdmin.from("sales_accounts").select("*").eq("id", id).single(),
     supabaseAdmin.from("sales_leads").select("*").eq("account_id", id).order("created_at", { ascending: false }),
     supabaseAdmin.from("sales_deals").select("*, deal_services(*)").eq("account_id", id).order("created_at", { ascending: false }),
     supabaseAdmin.from("sales_orders").select("*, order_items(*)").eq("account_id", id).order("created_at", { ascending: false }),
     supabaseAdmin.from("sales_documents").select("*").eq("account_id", id).order("created_at", { ascending: false }),
+    equipmentQuery,
   ]);
 
   if (accountRes.error) return NextResponse.json({ error: accountRes.error.message }, { status: 404 });
@@ -24,6 +34,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
     deals: dealsRes.data || [],
     orders: ordersRes.data || [],
     documents: docsRes.data || [],
+    equipment: equipmentRes.data || [],
   });
 }
 

--- a/src/app/sales/accounts/[id]/page.tsx
+++ b/src/app/sales/accounts/[id]/page.tsx
@@ -3,14 +3,29 @@
 import { useState, useEffect, useCallback } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { createBrowserClient } from "@/lib/supabase";
-import { ArrowLeft, Loader2, FileText, Upload, Trash2, X } from "lucide-react";
+import { ArrowLeft, Loader2, FileText, Upload, Trash2, X, Package, Plus, PencilLine } from "lucide-react";
 import type { SalesAccount, SalesDeal, SalesOrder, SalesDocument, SalesLead } from "@/lib/salesTypes";
+
+interface Equipment {
+  id: string;
+  account_id: string;
+  name: string;
+  serial_number: string | null;
+  model: string | null;
+  notes: string | null;
+  status: "active" | "removed";
+  assigned_at: string;
+  removed_at: string | null;
+  removed_reason: string | null;
+  created_at: string;
+}
 
 interface AccountDetail extends SalesAccount {
   leads: SalesLead[];
   deals: SalesDeal[];
   orders: SalesOrder[];
   documents: SalesDocument[];
+  equipment: Equipment[];
 }
 
 export default function AccountDetailPage() {
@@ -21,6 +36,12 @@ export default function AccountDetailPage() {
   const [token, setToken] = useState("");
   const [uploading, setUploading] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
+
+  // Equipment add form state
+  const [showAddEquipment, setShowAddEquipment] = useState(false);
+  const [equipmentForm, setEquipmentForm] = useState({ name: "", serial_number: "", model: "", assigned_at: "", notes: "" });
+  const [equipmentSaving, setEquipmentSaving] = useState(false);
+  const [equipmentError, setEquipmentError] = useState<string | null>(null);
 
   useEffect(() => {
     const supabase = createBrowserClient();
@@ -40,6 +61,60 @@ export default function AccountDetailPage() {
   }, [token, id]);
 
   useEffect(() => { fetchAccount(); }, [fetchAccount]);
+
+  async function saveEquipment() {
+    if (!token || !id) return;
+    setEquipmentError(null);
+    if (!equipmentForm.name.trim()) { setEquipmentError("Equipment name is required."); return; }
+    setEquipmentSaving(true);
+    const res = await fetch(`/api/sales/accounts/${id}/equipment`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({
+        name: equipmentForm.name.trim(),
+        serial_number: equipmentForm.serial_number.trim() || null,
+        model: equipmentForm.model.trim() || null,
+        notes: equipmentForm.notes.trim() || null,
+        assigned_at: equipmentForm.assigned_at || undefined,
+      }),
+    });
+    setEquipmentSaving(false);
+    if (!res.ok) {
+      setEquipmentError((await res.json().catch(() => ({}))).error || "Failed to add equipment");
+      return;
+    }
+    setEquipmentForm({ name: "", serial_number: "", model: "", assigned_at: "", notes: "" });
+    setShowAddEquipment(false);
+    fetchAccount();
+  }
+
+  async function markEquipmentRemoved(equipmentId: string) {
+    const reason = prompt("Reason for removal? (optional)") ?? "";
+    const res = await fetch(`/api/sales/accounts/${id}/equipment/${equipmentId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ status: "removed", removed_reason: reason.trim() || null }),
+    });
+    if (res.ok) fetchAccount();
+  }
+
+  async function reactivateEquipment(equipmentId: string) {
+    const res = await fetch(`/api/sales/accounts/${id}/equipment/${equipmentId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ status: "active" }),
+    });
+    if (res.ok) fetchAccount();
+  }
+
+  async function deleteEquipment(equipmentId: string) {
+    if (!confirm("Permanently delete this equipment record? Use Remove instead to preserve history.")) return;
+    const res = await fetch(`/api/sales/accounts/${id}/equipment/${equipmentId}`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.ok) fetchAccount();
+  }
 
   async function handleFileUpload(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
@@ -212,6 +287,144 @@ export default function AccountDetailPage() {
                 )}
                 <span className="text-xs text-gray-400">{new Date(doc.created_at).toLocaleDateString()}</span>
               </a>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Equipment */}
+      <div className="rounded-xl border border-gray-200 bg-white p-6 mb-6">
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-sm font-semibold text-gray-900 flex items-center gap-2">
+            <Package className="h-4 w-4 text-gray-400" /> Equipment ({(account.equipment || []).filter((e) => e.status === "active").length} active)
+          </h2>
+          {!showAddEquipment && (
+            <button
+              type="button"
+              onClick={() => setShowAddEquipment(true)}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-green-primary hover:bg-green-hover px-3 py-1.5 text-xs font-semibold text-white cursor-pointer"
+            >
+              <Plus className="h-3.5 w-3.5" /> Assign Equipment
+            </button>
+          )}
+        </div>
+
+        {showAddEquipment && (
+          <div className="mb-4 rounded-lg border border-emerald-200 bg-emerald-50/40 p-3 space-y-2">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+              <input
+                type="text"
+                value={equipmentForm.name}
+                onChange={(e) => setEquipmentForm((f) => ({ ...f, name: e.target.value }))}
+                placeholder="Equipment name *"
+                className="rounded-lg border border-gray-200 px-3 py-2 text-sm bg-white"
+              />
+              <input
+                type="text"
+                value={equipmentForm.serial_number}
+                onChange={(e) => setEquipmentForm((f) => ({ ...f, serial_number: e.target.value }))}
+                placeholder="Serial number"
+                className="rounded-lg border border-gray-200 px-3 py-2 text-sm bg-white"
+              />
+              <input
+                type="text"
+                value={equipmentForm.model}
+                onChange={(e) => setEquipmentForm((f) => ({ ...f, model: e.target.value }))}
+                placeholder="Model (optional)"
+                className="rounded-lg border border-gray-200 px-3 py-2 text-sm bg-white"
+              />
+              <input
+                type="date"
+                value={equipmentForm.assigned_at}
+                onChange={(e) => setEquipmentForm((f) => ({ ...f, assigned_at: e.target.value }))}
+                placeholder="Date assigned"
+                className="rounded-lg border border-gray-200 px-3 py-2 text-sm bg-white"
+              />
+            </div>
+            <textarea
+              value={equipmentForm.notes}
+              onChange={(e) => setEquipmentForm((f) => ({ ...f, notes: e.target.value }))}
+              placeholder="Notes (optional)"
+              rows={2}
+              className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm bg-white"
+            />
+            {equipmentError && <p className="text-xs text-red-600">{equipmentError}</p>}
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={saveEquipment}
+                disabled={equipmentSaving}
+                className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-600 hover:bg-emerald-700 px-3 py-1.5 text-xs font-semibold text-white cursor-pointer disabled:opacity-50"
+              >
+                {equipmentSaving ? <Loader2 className="h-3 w-3 animate-spin" /> : <Plus className="h-3 w-3" />} Save
+              </button>
+              <button
+                type="button"
+                onClick={() => { setShowAddEquipment(false); setEquipmentError(null); }}
+                className="rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-semibold text-gray-700 hover:bg-gray-50 cursor-pointer"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+
+        {(account.equipment || []).length === 0 ? (
+          <p className="text-sm text-gray-400">No equipment assigned yet.</p>
+        ) : (
+          <div className="space-y-2">
+            {(account.equipment || []).map((e) => (
+              <div key={e.id} className={`rounded-lg border ${e.status === "removed" ? "border-gray-100 bg-gray-50 opacity-70" : "border-gray-100 bg-white"} p-3`}>
+                <div className="flex items-start justify-between gap-2">
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-medium text-gray-900 truncate">
+                      {e.name}
+                      {e.model && <span className="text-xs text-gray-500 font-normal ml-1">· {e.model}</span>}
+                    </p>
+                    <div className="mt-0.5 text-[11px] text-gray-500 flex flex-wrap items-center gap-x-3 gap-y-0.5">
+                      {e.serial_number && <span>SN: {e.serial_number}</span>}
+                      <span>Assigned: {new Date(e.assigned_at).toLocaleDateString()}</span>
+                      {e.status === "removed" && e.removed_at && (
+                        <span className="text-red-600">Removed: {new Date(e.removed_at).toLocaleDateString()}</span>
+                      )}
+                    </div>
+                    {e.notes && <p className="mt-1 text-[11px] text-gray-500 whitespace-pre-wrap">{e.notes}</p>}
+                    {e.removed_reason && <p className="mt-1 text-[11px] italic text-gray-500">Reason: {e.removed_reason}</p>}
+                  </div>
+                  <div className="flex items-center gap-1 shrink-0">
+                    <span className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${e.status === "active" ? "bg-emerald-100 text-emerald-800" : "bg-gray-200 text-gray-600"}`}>
+                      {e.status}
+                    </span>
+                    {e.status === "active" ? (
+                      <button
+                        type="button"
+                        onClick={() => markEquipmentRemoved(e.id)}
+                        title="Mark as removed"
+                        className="rounded-lg p-1.5 text-gray-400 hover:text-orange-600 hover:bg-orange-50 cursor-pointer"
+                      >
+                        <X className="h-3.5 w-3.5" />
+                      </button>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={() => reactivateEquipment(e.id)}
+                        title="Re-activate"
+                        className="rounded-lg p-1.5 text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 cursor-pointer"
+                      >
+                        <PencilLine className="h-3.5 w-3.5" />
+                      </button>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => deleteEquipment(e.id)}
+                      title="Delete permanently"
+                      className="rounded-lg p-1.5 text-gray-400 hover:text-red-600 hover:bg-red-50 cursor-pointer"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+                </div>
+              </div>
             ))}
           </div>
         )}

--- a/supabase/migrations/123_account_equipment.sql
+++ b/supabase/migrations/123_account_equipment.sql
@@ -1,0 +1,41 @@
+-- Account-linked equipment.
+--
+-- Every sales_accounts row can have zero or more pieces of equipment
+-- assigned to it — a physical machine at the customer's location, a
+-- coffee brewer, a POS unit, etc. Distinct from machine_listings /
+-- machine_orders which model machines FOR SALE. This models machines
+-- DEPLOYED at a customer account, with lightweight lifecycle: assigned
+-- → active → removed.
+--
+-- Additive migration. No changes to existing tables.
+
+CREATE TABLE IF NOT EXISTS account_equipment (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id uuid NOT NULL REFERENCES sales_accounts(id) ON DELETE CASCADE,
+
+  name text NOT NULL,                  -- e.g. "AI Vending Machine", "Bunn Coffee Brewer"
+  serial_number text,
+  model text,
+  notes text,
+
+  status text NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'removed')),
+  assigned_at timestamptz NOT NULL DEFAULT now(),
+  assigned_by uuid REFERENCES profiles(id) ON DELETE SET NULL,
+  removed_at timestamptz,
+  removed_reason text,
+
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_account_equipment_account_status
+  ON account_equipment(account_id, status);
+CREATE INDEX IF NOT EXISTS idx_account_equipment_serial
+  ON account_equipment(serial_number)
+  WHERE serial_number IS NOT NULL;
+
+ALTER TABLE account_equipment ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Service role only" ON account_equipment;
+CREATE POLICY "Service role only" ON account_equipment
+  FOR ALL TO service_role USING (true) WITH CHECK (true);


### PR DESCRIPTION
Sales reps needed a place to record hardware deployed at a customer's location (vending machine at Site X, coffee brewer, etc.). Distinct from machine_listings (machines for sale) — this models what's physically installed and belongs to the account today.

Migration 123 — account_equipment:
  * id, account_id FK to sales_accounts (cascade delete with account)
  * name (required), serial_number, model, notes
  * status ('active' | 'removed') with default 'active'
  * assigned_at (defaults to now), assigned_by FK to profiles
  * removed_at, removed_reason — populated when marked removed
  * Indexes on (account_id, status) and serial_number
  * Service-role RLS; API-mediated writes

APIs:
  * GET /api/sales/accounts/[id]/equipment — list
  * POST /api/sales/accounts/[id]/equipment — assign (name required, everything else optional); validates account exists before insert to prevent orphan rows
  * PATCH /api/sales/accounts/[id]/equipment/[equipmentId] — edit or flip status. Status → 'removed' auto-stamps removed_at; flipping back to 'active' clears removal fields
  * DELETE — hard delete for cleanup (rare); UX steers users toward Remove instead so history stays

Account detail wiring:
  * /api/sales/accounts/[id] GET now returns equipment[] alongside leads/deals/orders/documents. The equipment fetch is wrapped so an env without migration 123 falls back to [] instead of breaking the whole account page
  * /sales/accounts/[id] page renders a new Equipment card between Documents and Orders — inline add form (name / serial / model / date / notes), per-row Remove and Delete buttons, active/removed status badge, reactivate action, notes + removal-reason display

Zero regression risk on unrelated flows — additive schema, additive routes, additive UI card that only shows equipment for that account.