### PR TITLE
Signup — capture optional 'Name of Sales Rep' at signup

### DIFF
--- a/src/app/api/auth/signup-email/route.ts
+++ b/src/app/api/auth/signup-email/route.ts
@@ -8,6 +8,7 @@ export async function POST(req: NextRequest) {
     const firstName = String(body.first_name || "").trim();
     const lastName = String(body.last_name || "").trim();
     const companyName = String(body.company_name || "").trim();
+    const salesRepName = String(body.sales_rep_name || "").trim();
     const email = String(body.email || "").trim().toLowerCase();
     const phone = String(body.phone || "").trim();
     const address = String(body.address || "").trim();
@@ -99,6 +100,7 @@ export async function POST(req: NextRequest) {
           zip,
           role,
           company_name: companyName || null,
+          referring_sales_rep_name: salesRepName || null,
           email_verified: false,
         },
         { onConflict: "id" },

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -55,6 +55,7 @@ function SignupContent() {
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
   const [companyName, setCompanyName] = useState("");
+  const [salesRepName, setSalesRepName] = useState("");
   const [email, setEmail] = useState("");
   const [phone, setPhone] = useState("");
   const [address, setAddress] = useState("");
@@ -151,6 +152,7 @@ function SignupContent() {
           first_name: firstName.trim(),
           last_name: lastName.trim(),
           company_name: companyName.trim(),
+          sales_rep_name: salesRepName.trim(),
           email: email.trim().toLowerCase(),
           phone: phone.trim(),
           address: address.trim(),
@@ -337,6 +339,19 @@ function SignupContent() {
             <div>
               <label className="block text-xs font-medium text-gray-600 mb-1">Company <span className="text-gray-400 text-[10px]">(optional)</span></label>
               <input value={companyName} onChange={(e) => setCompanyName(e.target.value)} disabled={!!loading} placeholder="Your company name" className={inputClass} autoComplete="organization" />
+            </div>
+
+            <div>
+              <label className="block text-xs font-medium text-gray-600 mb-1">
+                Name of Sales Rep <span className="text-gray-400 text-[10px]">(optional)</span>
+              </label>
+              <input
+                value={salesRepName}
+                onChange={(e) => setSalesRepName(e.target.value)}
+                disabled={!!loading}
+                placeholder="Who told you about us?"
+                className={inputClass}
+              />
             </div>
 
             <div>

--- a/supabase/migrations/124_profile_referring_sales_rep.sql
+++ b/supabase/migrations/124_profile_referring_sales_rep.sql
@@ -1,0 +1,11 @@
+-- Optional referring-sales-rep field captured at signup.
+--
+-- Free-text name of the sales rep that told the client about us. Not a
+-- FK to profiles — customers rarely know a rep's system id or exact
+-- spelling, and mismatching against a lookup would drop useful data.
+-- Reporting can join by fuzzy match against sales role profiles later.
+--
+-- Additive column, nullable, safe on live data.
+
+ALTER TABLE profiles
+  ADD COLUMN IF NOT EXISTS referring_sales_rep_name text;


### PR DESCRIPTION
Sales team asked for a way to see who referred a new client. Added an optional free-text field on the email signup form and stored it on profiles for later reporting.

Migration 124 — profiles.referring_sales_rep_name text (nullable). Free-text intentionally rather than an FK to profiles — customers rarely know the rep's exact system id or spelling; a bad match would drop useful data. Reporting can join fuzzy against sales-role profiles later.

Signup form — new optional input right after Company: "Name of Sales Rep — Who told you about us?"

Signup API — reads sales_rep_name from body and writes referring_sales_rep_name on the profile upsert.

Not required, blank-safe on both ends. Zero effect on existing signup paths (Google OAuth, complete-profile flow) — those users can be tagged manually by admin later.