### PR TITLE
CRM — Export Report button on Leads, Agreements, Orders/Quotes

### DIFF
--- a/src/app/sales/agreements/page.tsx
+++ b/src/app/sales/agreements/page.tsx
@@ -16,7 +16,9 @@ import {
   Clock,
   Ban,
   AlertCircle,
+  FileSpreadsheet,
 } from "lucide-react";
+import { exportRowsToCsv } from "@/lib/csvExport";
 
 interface AgreementRow {
   id: string;
@@ -156,14 +158,49 @@ export default function AgreementsListPage() {
           <h1 className="text-2xl font-bold text-gray-900">Agreements</h1>
           <p className="text-sm text-gray-500 mt-1">{headerSubtitle}</p>
         </div>
-        <button
-          onClick={handleCreate}
-          disabled={creating}
-          className="rounded-xl bg-green-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-green-700 disabled:opacity-50 cursor-pointer inline-flex items-center gap-2"
-        >
-          {creating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
-          {newLabel}
-        </button>
+        <div className="flex gap-2">
+          <button
+            onClick={() => {
+              // Read-only CSV export of the filtered agreement rows so the
+              // team can email a report. Uses the same `filtered` list that
+              // drives the visible table — no server hop, no data mutation.
+              exportRowsToCsv({
+                filename: tab === "location_placement" ? "location_placement_agreements_report" : "agreements_report",
+                rows: filtered,
+                columns: [
+                  { header: "Type", value: (r) => r.agreement_type },
+                  { header: "Status", value: (r) => r.agreement_status },
+                  { header: "Operator Company", value: (r) => r.operator_company_name },
+                  { header: "Operator Contact", value: (r) => r.operator_legal_name },
+                  { header: "Operator Email", value: (r) => r.operator_email },
+                  { header: "Machine Model", value: (r) => r.machine_model },
+                  { header: "Machine Qty", value: (r) => r.machine_quantity },
+                  { header: "Due Prior to Procurement", value: (r) => r.total_due_prior_to_procurement },
+                  { header: "Location Business", value: (r) => r.location_business_name },
+                  { header: "Location Contact", value: (r) => r.location_contact_name },
+                  { header: "Location Email", value: (r) => r.location_contact_email },
+                  { header: "Placement Machine Count", value: (r) => r.placement_machine_count },
+                  { header: "Placement Term (months)", value: (r) => r.placement_term_months },
+                  { header: "Commission %", value: (r) => r.commission_pct },
+                  { header: "Created", value: (r) => r.created_at ? new Date(r.created_at) : null },
+                ],
+              });
+            }}
+            className="rounded-xl border border-gray-200 bg-white px-5 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50 cursor-pointer inline-flex items-center gap-2"
+            title="Download the currently-filtered agreements as a CSV file. Opens in Excel and Google Sheets."
+          >
+            <FileSpreadsheet className="h-4 w-4" />
+            Export Report
+          </button>
+          <button
+            onClick={handleCreate}
+            disabled={creating}
+            className="rounded-xl bg-green-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-green-700 disabled:opacity-50 cursor-pointer inline-flex items-center gap-2"
+          >
+            {creating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
+            {newLabel}
+          </button>
+        </div>
       </div>
 
       {/* Type tabs */}

--- a/src/app/sales/leads/page.tsx
+++ b/src/app/sales/leads/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { createBrowserClient } from "@/lib/supabase";
 import { Plus, Loader2, Search, X, UserPlus, ArrowRight, Trash2, PhoneOff, Phone, Upload, FileSpreadsheet, AlertCircle, CheckCircle2, AlertTriangle, CheckSquare, Pencil, Building2, Mail, Send, Clock, ShieldCheck, Paperclip, FileSignature, Globe } from "lucide-react";
 import { ENTITY_TYPES, IMMEDIATE_NEEDS, type SalesLead, type EntityType, type ImmediateNeed } from "@/lib/salesTypes";
+import { exportRowsToCsv } from "@/lib/csvExport";
 
 const LEAD_FIELDS: { key: LeadFieldKey; label: string; required?: boolean }[] = [
   { key: "business_name", label: "Business Name", required: true },
@@ -881,6 +882,37 @@ export default function LeadsPage() {
               Remove Duplicates
             </button>
           )}
+          <button
+            onClick={() => {
+              // Read-only export of the currently-filtered leads to CSV. No
+              // API round-trip, no data mutation — the CSV comes from what's
+              // already loaded on the page (so any filters/sort apply).
+              exportRowsToCsv({
+                filename: "leads_report",
+                rows: filtered,
+                columns: [
+                  { header: "Business", value: (r) => r.business_name },
+                  { header: "Contact", value: (r) => r.contact_name },
+                  { header: "Phone", value: (r) => r.phone },
+                  { header: "Email", value: (r) => r.email },
+                  { header: "Address", value: (r) => r.address },
+                  { header: "City", value: (r) => r.city },
+                  { header: "State", value: (r) => r.state },
+                  { header: "Entity Type", value: (r) => r.entity_type },
+                  { header: "Immediate Need", value: (r) => r.immediate_need },
+                  { header: "Status", value: (r) => r.status },
+                  { header: "Assigned To", value: (r) => salesUsers.find((u) => u.id === r.assigned_to)?.full_name || "" },
+                  { header: "Notes", value: (r) => r.notes },
+                  { header: "Created", value: (r) => r.created_at ? new Date(r.created_at) : null },
+                ],
+              });
+            }}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors cursor-pointer"
+            title="Download the currently-filtered leads as a CSV file. Opens in Excel and Google Sheets."
+          >
+            <FileSpreadsheet className="h-4 w-4" />
+            Export Report
+          </button>
           <button
             onClick={() => { setShowImport(!showImport); setShowAdd(false); }}
             className="inline-flex items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors cursor-pointer"

--- a/src/app/sales/orders/page.tsx
+++ b/src/app/sales/orders/page.tsx
@@ -6,7 +6,9 @@ import { createBrowserClient } from "@/lib/supabase";
 import {
   Loader2, ClipboardList, Plus, Search, AlertCircle,
   ChevronRight, Package, MapPin, Coffee, Monitor, Wrench, DollarSign, FileText,
+  FileSpreadsheet,
 } from "lucide-react";
+import { exportRowsToCsv } from "@/lib/csvExport";
 
 interface OrderItem {
   id: string;
@@ -144,13 +146,50 @@ export default function OrdersPage() {
           <h1 className="text-2xl font-bold text-gray-900">Orders / Quotes</h1>
           <p className="text-sm text-gray-500 mt-0.5">Manage orders, quotes, and fulfillment</p>
         </div>
-        <button
-          onClick={() => router.push(`/sales/orders/new?type=${docType}`)}
-          className="inline-flex items-center gap-1.5 rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 cursor-pointer"
-        >
-          <Plus className="h-4 w-4" />
-          New {docLabel}
-        </button>
+        <div className="flex gap-2">
+          <button
+            onClick={() => {
+              // Read-only CSV export — dumps the currently-loaded orders
+              // list (with active filters applied server-side) so team
+              // members can review offline or share in a report.
+              exportRowsToCsv({
+                filename: docType === "quote" ? "quotes_report" : "orders_report",
+                rows: orders,
+                columns: [
+                  { header: "Order #", value: (r) => r.order_number },
+                  { header: "Doc Type", value: (r) => r.document_type },
+                  { header: "Order Type", value: (r) => r.order_type },
+                  { header: "Status", value: (r) => r.order_status },
+                  { header: "Payment", value: (r) => r.payment_status },
+                  { header: "Invoice", value: (r) => r.invoice_status },
+                  { header: "Agreement", value: (r) => r.agreement_status },
+                  { header: "Fulfillment", value: (r) => r.fulfillment_status },
+                  { header: "Business", value: (r) => r.sales_accounts?.business_name },
+                  { header: "Contact", value: (r) => r.sales_accounts?.contact_name },
+                  { header: "Email", value: (r) => r.sales_accounts?.email },
+                  { header: "Phone", value: (r) => r.sales_accounts?.phone },
+                  { header: "Total", value: (r) => r.total_value },
+                  { header: "Assigned To", value: (r) => r.assigned_profile?.full_name },
+                  { header: "Next Action", value: (r) => r.next_required_action },
+                  { header: "Created", value: (r) => r.created_at ? new Date(r.created_at) : null },
+                  { header: "Updated", value: (r) => r.updated_at ? new Date(r.updated_at) : null },
+                ],
+              });
+            }}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 cursor-pointer"
+            title="Download the current list as a CSV file. Opens in Excel and Google Sheets."
+          >
+            <FileSpreadsheet className="h-4 w-4" />
+            Export Report
+          </button>
+          <button
+            onClick={() => router.push(`/sales/orders/new?type=${docType}`)}
+            className="inline-flex items-center gap-1.5 rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 cursor-pointer"
+          >
+            <Plus className="h-4 w-4" />
+            New {docLabel}
+          </button>
+        </div>
       </div>
 
       {/* Document Type Toggle */}

--- a/src/lib/csvExport.ts
+++ b/src/lib/csvExport.ts
@@ -1,0 +1,85 @@
+/**
+ * CSV export — client-side. Takes a list of rows + column definitions
+ * and downloads a CSV file. Zero external dependencies. Excel opens
+ * CSV directly, so the downloaded file works both as a Google Sheets
+ * import and as an email attachment for team members.
+ *
+ * Deliberately client-side and READ-ONLY — no server round-trip means
+ * no chance of accidental data mutation from a report action. The
+ * caller passes rows already loaded on the page (respecting any
+ * active filters), so the report matches what the user sees.
+ */
+
+export interface Column<T> {
+  header: string;
+  /** Extract the raw value from a row. Return primitive, Date, or null. */
+  value: (row: T) => string | number | boolean | Date | null | undefined;
+}
+
+/**
+ * Escape a single field per RFC 4180: wrap in double quotes if it
+ * contains a quote, comma, or newline; escape embedded quotes by
+ * doubling them.
+ */
+function escapeField(v: unknown): string {
+  if (v == null) return "";
+  let s: string;
+  if (v instanceof Date) {
+    s = isNaN(v.getTime()) ? "" : v.toISOString();
+  } else if (typeof v === "boolean") {
+    s = v ? "true" : "false";
+  } else {
+    s = String(v);
+  }
+  if (/[",\n\r]/.test(s)) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
+
+/**
+ * Build a CSV string from rows + column defs. Prepends a BOM so Excel
+ * opens UTF-8 with the correct encoding out of the box (otherwise
+ * accented characters + emoji show as mojibake on Windows Excel).
+ */
+export function buildCsv<T>(rows: T[], columns: Column<T>[]): string {
+  const header = columns.map((c) => escapeField(c.header)).join(",");
+  const body = rows.map((row) =>
+    columns.map((c) => escapeField(c.value(row))).join(","),
+  );
+  return "﻿" + [header, ...body].join("\r\n");
+}
+
+/**
+ * Trigger a browser download of the given CSV. Fires and returns
+ * immediately; the download prompt is native.
+ */
+export function downloadCsv(filename: string, csv: string): void {
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename.endsWith(".csv") ? filename : `${filename}.csv`;
+  document.body.appendChild(a);
+  a.click();
+  setTimeout(() => {
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }, 200);
+}
+
+/**
+ * Convenience: build + download in one call. Includes an ISO-date
+ * stamp in the filename so multiple exports don't overwrite each
+ * other in the downloads folder.
+ */
+export function exportRowsToCsv<T>(args: {
+  filename: string;
+  rows: T[];
+  columns: Column<T>[];
+}): void {
+  const csv = buildCsv(args.rows, args.columns);
+  const stamp = new Date().toISOString().slice(0, 10);
+  const name = args.filename.replace(/\.csv$/i, "");
+  downloadCsv(`${name}_${stamp}.csv`, csv);
+}


### PR DESCRIPTION
Sales team asked for a way to pull data out of each list surface and share with team members as a spreadsheet. Added a client-side CSV export driven by whatever is currently loaded + filtered on each page:

* /sales/leads — Export Report next to Import CSV, includes business, contact, phone/email, address, entity type, immediate need, status, assigned rep, notes, created date. Uses the same `filtered` list that drives the visible table.

* /sales/agreements — Export Report next to New Agreement, includes type, status, operator info, machine info, location info, placement terms, commission, created date. Respects the machine_purchase / location_placement tab + status filter + search.

* /sales/orders — Export Report next to New Order/Quote, includes order number, doc type, statuses, business/contact, total, assigned rep, next action, created + updated. Filename toggles between orders_report and quotes_report based on the doc-type toggle.

New shared helper: src/lib/csvExport.ts
* buildCsv / downloadCsv / exportRowsToCsv — RFC 4180 quoting, UTF-8 BOM so Windows Excel opens accented characters cleanly, ISO date stamp appended to filename so multiple exports don't overwrite.
* Zero external dependencies.

READ-ONLY guarantee — no server round-trip on any export path, no data mutation, no possibility of touching existing records. Exports match exactly what the user has visible on screen. CSV opens directly in Excel and Google Sheets — no Google auth setup required to share reports with team members.