### PR TITLE
CRM reports — set dateFormat so xlsx path stops throwing on Date cells

### DIFF
--- a/src/lib/spreadsheetExport.ts
+++ b/src/lib/spreadsheetExport.ts
@@ -145,8 +145,14 @@ export async function exportRowsToCsv<T>(args: {
       };
     });
 
+    // `dateFormat` is required by write-excel-file whenever any cell is
+    // a Date — otherwise it throws mid-generation. "yyyy-mm-dd" matches
+    // Excel's default date display and sorts naturally.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const result = writeXlsxFile(args.rows as any, { columns: columns as any });
+    const result = writeXlsxFile(args.rows as any, {
+      columns: columns as any,
+      dateFormat: "yyyy-mm-dd",
+    } as any);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await (result as any).toFile(`${base}.xlsx`);
     console.log("[export] xlsx download triggered");


### PR DESCRIPTION
write-excel-file throws mid-generation whenever a cell is a Date and no format is set. Pass "yyyy-mm-dd" as the sheet-level dateFormat so Created/Joined/etc. columns render as real Excel dates.