### PR TITLE
Workflows — surface customer identity + contact in CRM list and detail

### DIFF
--- a/src/app/api/workflows/[id]/route.ts
+++ b/src/app/api/workflows/[id]/route.ts
@@ -129,6 +129,37 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
     }
   }
 
+  // Customer profile — always fetched so both the CRM header and the
+  // customer's own view have a name to render. Contact info (email,
+  // phone) is included only for staff; customers already know their own.
+  const { data: customerProfile } = await supabaseAdmin
+    .from("profiles")
+    .select("id, full_name, email, phone, role")
+    .eq("id", workflow.customer_id)
+    .maybeSingle();
+
+  const customerInfo = customerProfile
+    ? {
+        id: customerProfile.id,
+        full_name: customerProfile.full_name,
+        role: customerProfile.role,
+        email: staffView ? customerProfile.email : null,
+        phone: staffView ? customerProfile.phone : null,
+      }
+    : null;
+
+  // Optional company (sales_accounts) — only when workflow.company_id
+  // is set. Staff-only, since it's an internal account record.
+  let companyInfo: { id: string; business_name: string; phone: string | null; email: string | null } | null = null;
+  if (staffView && workflow.company_id) {
+    const { data: acc } = await supabaseAdmin
+      .from("sales_accounts")
+      .select("id, business_name, phone, email")
+      .eq("id", workflow.company_id)
+      .maybeSingle();
+    if (acc) companyInfo = acc;
+  }
+
   // Customer approvals (pending + recent decisions). Customers must see
   // pending items so they can accept/decline; staff need visibility for
   // support.
@@ -183,6 +214,8 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
     approvals: approvals ?? [],
     remainingDeclines,
     balanceSummary,
+    customerInfo,
+    companyInfo,
     assigneeDisplay,
     isStaffView: staffView,
     isOwner,

--- a/src/app/api/workflows/route.ts
+++ b/src/app/api/workflows/route.ts
@@ -76,8 +76,29 @@ export async function GET(req: NextRequest) {
   const { data, error, count } = await query;
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
+  // Batch-fetch customer names for the returned page so the CRM table
+  // can show "who this workflow is for" without an N+1.
+  const rows = data ?? [];
+  const customerIds = Array.from(new Set(rows.map((r) => r.customer_id).filter(Boolean)));
+  const customerMap: Record<string, { full_name: string | null; email: string | null }> = {};
+  if (customerIds.length > 0) {
+    const { data: profiles } = await supabaseAdmin
+      .from("profiles")
+      .select("id, full_name, email")
+      .in("id", customerIds);
+    for (const p of profiles ?? []) {
+      customerMap[p.id] = { full_name: p.full_name, email: p.email };
+    }
+  }
+
+  const workflowsWithCustomer = rows.map((r) => ({
+    ...r,
+    customer_name: customerMap[r.customer_id]?.full_name ?? null,
+    customer_email: customerMap[r.customer_id]?.email ?? null,
+  }));
+
   return NextResponse.json({
-    workflows: data ?? [],
+    workflows: workflowsWithCustomer,
     total: count ?? 0,
     limit,
     offset,

--- a/src/app/sales/workflows/[id]/page.tsx
+++ b/src/app/sales/workflows/[id]/page.tsx
@@ -20,6 +20,8 @@ import {
   Package,
   Eye,
   EyeOff,
+  Mail,
+  Phone,
 } from "lucide-react";
 
 interface Stage {
@@ -89,6 +91,19 @@ interface PlacementSummary {
   submissions_accepted: number;
   submissions_pending_admin: number;
 }
+interface CustomerInfo {
+  id: string;
+  full_name: string | null;
+  role: string | null;
+  email: string | null;
+  phone: string | null;
+}
+interface CompanyInfo {
+  id: string;
+  business_name: string;
+  phone: string | null;
+  email: string | null;
+}
 interface DetailPayload {
   workflow: {
     id: string;
@@ -118,6 +133,8 @@ interface DetailPayload {
   orderItems: OrderItem[];
   events: EventRow[];
   placementSummary: PlacementSummary | null;
+  customerInfo: CustomerInfo | null;
+  companyInfo: CompanyInfo | null;
   assigneeDisplay: string | null;
   isStaffView: boolean;
 }
@@ -232,13 +249,53 @@ export default function WorkflowDetailPage({ params }: { params: Promise<{ id: s
       {/* Header */}
       <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
         <div className="flex flex-wrap items-start justify-between gap-4">
-          <div>
-            <div className="flex items-center gap-3">
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-3 flex-wrap">
               <div className="font-mono text-xs text-gray-500">{w.workflow_number}</div>
               <StatusBadge status={w.overall_status} />
               <PriorityBadge priority={w.priority} />
             </div>
-            <h1 className="text-2xl font-semibold text-gray-900 mt-2">{w.title}</h1>
+            {/* Customer identity — always shown above title so staff see
+                who this workflow is for at a glance. */}
+            {data.customerInfo && (
+              <div className="mt-3 flex items-center gap-2 text-lg font-semibold text-gray-900">
+                <UserCircle2 className="h-5 w-5 text-gray-500" />
+                <span>{data.customerInfo.full_name ?? data.customerInfo.email ?? "Customer"}</span>
+                {data.companyInfo && (
+                  <span className="text-sm font-normal text-gray-500">
+                    · {data.companyInfo.business_name}
+                  </span>
+                )}
+              </div>
+            )}
+            {data.customerInfo && (data.customerInfo.email || data.customerInfo.phone) && (
+              <div className="mt-1 flex flex-wrap items-center gap-3 text-sm text-gray-600">
+                {data.customerInfo.email && (
+                  <a
+                    href={`mailto:${data.customerInfo.email}`}
+                    className="inline-flex items-center gap-1 hover:text-emerald-700"
+                  >
+                    <Mail className="h-3.5 w-3.5" />
+                    {data.customerInfo.email}
+                  </a>
+                )}
+                {data.customerInfo.phone && (
+                  <a
+                    href={`tel:${data.customerInfo.phone}`}
+                    className="inline-flex items-center gap-1 hover:text-emerald-700"
+                  >
+                    <Phone className="h-3.5 w-3.5" />
+                    {data.customerInfo.phone}
+                  </a>
+                )}
+                {data.customerInfo.role && (
+                  <span className="text-xs uppercase tracking-wide text-gray-400">
+                    {data.customerInfo.role.replace(/_/g, " ")}
+                  </span>
+                )}
+              </div>
+            )}
+            <h1 className="text-2xl font-semibold text-gray-900 mt-3">{w.title}</h1>
             {w.description && <p className="text-sm text-gray-600 mt-1">{w.description}</p>}
             {w.product_name && <p className="text-xs text-gray-500 mt-2">{w.product_name}</p>}
           </div>

--- a/src/app/sales/workflows/page.tsx
+++ b/src/app/sales/workflows/page.tsx
@@ -39,6 +39,8 @@ interface WorkflowRow {
   assigned_user_id: string | null;
   customer_id: string;
   company_id: string | null;
+  customer_name: string | null;
+  customer_email: string | null;
   updated_at: string;
 }
 
@@ -254,6 +256,7 @@ export default function WorkflowsPage() {
           <thead className="bg-gray-50 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
             <tr>
               <th className="px-4 py-3">Workflow</th>
+              <th className="px-4 py-3">Customer</th>
               <th className="px-4 py-3">Type</th>
               <th className="px-4 py-3">Progress</th>
               <th className="px-4 py-3">Status</th>
@@ -264,14 +267,14 @@ export default function WorkflowsPage() {
           <tbody className="divide-y divide-gray-100">
             {loading ? (
               <tr>
-                <td colSpan={6} className="px-4 py-12 text-center text-gray-500">
+                <td colSpan={7} className="px-4 py-12 text-center text-gray-500">
                   <Loader2 className="inline-block h-5 w-5 animate-spin mr-2" />
                   Loading workflows…
                 </td>
               </tr>
             ) : workflows.length === 0 ? (
               <tr>
-                <td colSpan={6} className="px-4 py-12 text-center text-gray-500">
+                <td colSpan={7} className="px-4 py-12 text-center text-gray-500">
                   <Filter className="inline-block h-5 w-5 mr-2 text-gray-400" />
                   No workflows match the current filters.
                 </td>
@@ -322,6 +325,14 @@ function WorkflowRowRender({ workflow, nowMs }: { workflow: WorkflowRow; nowMs: 
           <div className="font-medium text-gray-900 hover:text-emerald-700">{workflow.title}</div>
           {workflow.product_name && <div className="text-xs text-gray-500 mt-0.5">{workflow.product_name}</div>}
         </Link>
+      </td>
+      <td className="px-4 py-3">
+        <div className="text-sm font-medium text-gray-900">
+          {workflow.customer_name ?? workflow.customer_email ?? <span className="text-gray-400">—</span>}
+        </div>
+        {workflow.customer_email && workflow.customer_name && (
+          <div className="text-xs text-gray-500 truncate max-w-[200px]">{workflow.customer_email}</div>
+        )}
       </td>
       <td className="px-4 py-3">
         <div className="inline-flex items-center gap-1.5 rounded-md bg-gray-100 px-2 py-1 text-xs font-medium text-gray-700">


### PR DESCRIPTION
Detail endpoint (GET /api/workflows/[id]) now returns:
  - customerInfo: { id, full_name, role, email, phone } (email + phone included only for staff view)
  - companyInfo: { id, business_name, phone, email } (staff-only; when workflow.company_id is set → joins sales_accounts)

List endpoint (GET /api/workflows) now batch-fetches profiles by customer_id to include customer_name + customer_email on each row (no N+1 — single IN query per page).

CRM UI:
  - /sales/workflows/[id] header now shows the customer name and business (when company linked) with clickable mailto: + tel: contact links directly under the workflow number/status badges
  - /sales/workflows list adds a Customer column showing name + email so staff know who each workflow is for without opening it

Customer detail page ignores customerInfo since customers already know their own name — nothing changed there.