### PR TITLE
Dashboard — Executive Snapshot + fix quotes-counted-as-revenue bug

### DIFF
--- a/src/app/api/sales/executive-snapshot/route.ts
+++ b/src/app/api/sales/executive-snapshot/route.ts
@@ -1,0 +1,390 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser, isElevatedRole } from "@/lib/salesAuth";
+
+/**
+ * GET /api/sales/executive-snapshot
+ *
+ * The unified operating snapshot for the /sales dashboard header. Groups
+ * every commercial artifact (quotes, orders, agreements, workflows,
+ * leads, deals, commissions) into one payload with definitions locked
+ * against what the business actually asked for:
+ *
+ *   quotes.sent           — quotes created in period (document_type='quote')
+ *   quotes.converted      — quotes with a matching order (same deal_id)
+ *   quotes.outstanding    — quotes currently open (status='sent') regardless of period
+ *   orders.placed         — orders created in period (document_type='order')
+ *   orders.completed      — orders in period with status='completed'
+ *   orders.outstanding    — orders currently open regardless of period
+ *   orders.revenue        — sum of total_value for orders in period (quotes never counted)
+ *   agreements.crm_signed — purchase_agreements where agreement_status='signed'
+ *                           (= both operator + Apex signed) in period
+ *   agreements.provider_signed — user_agreements where status='fully_executed'
+ *   workflows.*           — proxied from /api/workflows/metrics semantics
+ *
+ * Scope:
+ *   - admin / director_of_sales    → company-wide (or filter to a market_id/user_id)
+ *   - market_leader                → their market's reps + themselves
+ *   - sales / sales_manager        → their own numbers only
+ *
+ * Period options match /api/sales/results: daily, weekly, monthly,
+ * quarterly, yearly, ytd, custom (with start_date + end_date).
+ */
+
+type Period = "daily" | "weekly" | "monthly" | "quarterly" | "yearly" | "ytd" | "custom";
+
+function periodStart(period: Period): Date {
+  const now = new Date();
+  const d = new Date(now);
+  switch (period) {
+    case "daily":
+      d.setHours(0, 0, 0, 0);
+      return d;
+    case "weekly": {
+      const day = d.getDay();
+      d.setDate(d.getDate() - day);
+      d.setHours(0, 0, 0, 0);
+      return d;
+    }
+    case "monthly":
+      return new Date(d.getFullYear(), d.getMonth(), 1);
+    case "quarterly": {
+      const q = Math.floor(d.getMonth() / 3) * 3;
+      return new Date(d.getFullYear(), q, 1);
+    }
+    case "yearly":
+    case "ytd":
+      return new Date(d.getFullYear(), 0, 1);
+    case "custom":
+      return new Date(d.getFullYear(), 0, 1);
+  }
+}
+
+function periodLabel(period: Period): string {
+  return {
+    daily: "Today",
+    weekly: "This Week",
+    monthly: "This Month",
+    quarterly: "This Quarter",
+    yearly: "This Year",
+    ytd: "Year to Date",
+    custom: "Custom Range",
+  }[period];
+}
+
+export async function GET(req: NextRequest) {
+  const user = await getSalesUser(req);
+  if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const url = new URL(req.url);
+  const period = (url.searchParams.get("period") || "monthly") as Period;
+  const filterUserId = url.searchParams.get("user_id") || null;
+  const marketId = url.searchParams.get("market_id") || null;
+  const elevated = isElevatedRole(user.role);
+
+  // ─── Resolve scope (reuses the exact same logic as /api/sales/results) ─
+  let allowedUserIds: string[] | null = null;
+  let companyWide = false;
+
+  if (elevated) {
+    if (marketId) {
+      const { data: members } = await supabaseAdmin
+        .from("market_members")
+        .select("user_id")
+        .eq("market_id", marketId);
+      allowedUserIds = (members || []).map((m) => m.user_id);
+    } else if (!filterUserId) {
+      companyWide = true;
+    }
+  } else if (user.role === "market_leader") {
+    const { data: leaderOf } = await supabaseAdmin
+      .from("market_leaders")
+      .select("market_id")
+      .eq("user_id", user.id);
+    const leaderMarketIds = (leaderOf || []).map((m) => m.market_id);
+    if (leaderMarketIds.length === 0) {
+      allowedUserIds = [user.id];
+    } else {
+      let membersQuery = supabaseAdmin.from("market_members").select("user_id");
+      if (marketId && leaderMarketIds.includes(marketId)) {
+        membersQuery = membersQuery.eq("market_id", marketId);
+      } else {
+        membersQuery = membersQuery.in("market_id", leaderMarketIds);
+      }
+      const { data: members } = await membersQuery;
+      allowedUserIds = (members || []).map((m) => m.user_id);
+      if (!allowedUserIds.includes(user.id)) allowedUserIds.push(user.id);
+    }
+    if (filterUserId && !allowedUserIds.includes(filterUserId)) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+  } else {
+    if (filterUserId && filterUserId !== user.id) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    allowedUserIds = [user.id];
+  }
+
+  const targetUserId = filterUserId || null;
+
+  // ─── Resolve period ─────────────────────────────────────────────────
+  let since: string;
+  let until: string | null = null;
+  if (period === "custom") {
+    const startDate = url.searchParams.get("start_date");
+    const endDate = url.searchParams.get("end_date");
+    if (!startDate) return NextResponse.json({ error: "start_date required" }, { status: 400 });
+    since = new Date(startDate).toISOString();
+    if (endDate) {
+      const end = new Date(endDate);
+      end.setHours(23, 59, 59, 999);
+      until = end.toISOString();
+    }
+  } else {
+    since = periodStart(period).toISOString();
+  }
+
+  // Helper: apply the scope filter to a query on a table with `created_by`.
+  function scopeByCreator<T>(q: T, column = "created_by"): T {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let query: any = q;
+    if (targetUserId) query = query.eq(column, targetUserId);
+    else if (allowedUserIds) query = query.in(column, allowedUserIds);
+    return query;
+  }
+
+  // ─── Sales orders + quotes (split by document_type) ─────────────────
+  let ordersQuery = supabaseAdmin
+    .from("sales_orders")
+    .select("id, status, total_value, deal_id, created_at, document_type")
+    .gte("created_at", since);
+  if (until) ordersQuery = ordersQuery.lte("created_at", until);
+  ordersQuery = scopeByCreator(ordersQuery);
+
+  // eslint-disable-next-line prefer-const
+  let { data: periodRows, error: soErr } = await ordersQuery;
+  if (soErr && String(soErr.message).includes("document_type")) {
+    let retry = supabaseAdmin
+      .from("sales_orders")
+      .select("id, status, total_value, deal_id, created_at")
+      .gte("created_at", since);
+    if (until) retry = retry.lte("created_at", until);
+    retry = scopeByCreator(retry);
+    const fallback = await retry;
+    periodRows = (fallback.data ?? []).map((r) => ({ ...r, document_type: null }));
+  }
+  const orderRows = (periodRows ?? []).filter((r) => (r.document_type ?? "order") === "order");
+  const quoteRows = (periodRows ?? []).filter((r) => r.document_type === "quote");
+
+  // For "outstanding" (unbounded by period), separately query open rows.
+  const outstandingQuery = scopeByCreator(
+    supabaseAdmin.from("sales_orders").select("id, deal_id, status, document_type").in("status", ["draft", "sent"]),
+  );
+  const { data: openRowsRaw } = await outstandingQuery;
+  const openRows = (openRowsRaw ?? []) as { id: string; deal_id: string | null; status: string; document_type: string | null }[];
+  const outstandingOrders = openRows.filter((r) => (r.document_type ?? "order") === "order" && r.status !== "draft").length;
+  const outstandingQuotes = openRows.filter((r) => r.document_type === "quote" && r.status === "sent").length;
+
+  // Quotes converted: quotes in period whose deal_id has any matching order row
+  // in sales_orders (any period). Requires a lookup of orders by those deal_ids.
+  const quoteDealIds = Array.from(new Set(quoteRows.map((q) => q.deal_id).filter(Boolean))) as string[];
+  let convertedDealIdSet = new Set<string>();
+  if (quoteDealIds.length > 0) {
+    const { data: matchingOrders } = await supabaseAdmin
+      .from("sales_orders")
+      .select("deal_id, document_type")
+      .in("deal_id", quoteDealIds);
+    convertedDealIdSet = new Set(
+      (matchingOrders ?? [])
+        .filter((r) => (r.document_type ?? "order") === "order")
+        .map((r) => r.deal_id)
+        .filter(Boolean) as string[],
+    );
+  }
+  const quotesConverted = quoteRows.filter((q) => q.deal_id && convertedDealIdSet.has(q.deal_id)).length;
+
+  const orderRevenue = orderRows.reduce((s, o) => s + Number(o.total_value ?? 0), 0);
+  const quoteTotalValue = quoteRows.reduce((s, q) => s + Number(q.total_value ?? 0), 0);
+  const ordersCompleted = orderRows.filter((o) => o.status === "completed").length;
+
+  // ─── Purchase agreements (CRM: machine + location placement) ────────
+  let agrQuery = supabaseAdmin
+    .from("purchase_agreements")
+    .select("id, agreement_status, created_at, created_by")
+    .gte("created_at", since);
+  if (until) agrQuery = agrQuery.lte("created_at", until);
+  agrQuery = scopeByCreator(agrQuery);
+  const { data: crmAgreementsPeriod } = await agrQuery;
+  const crmAgrRows = crmAgreementsPeriod ?? [];
+
+  const SENT_STATUSES = ["sent", "viewed", "partially_signed", "signed"];
+  const AWAITING_STATUSES = ["sent", "viewed", "partially_signed"];
+  const crmSent = crmAgrRows.filter((a) => SENT_STATUSES.includes(a.agreement_status)).length;
+  const crmSigned = crmAgrRows.filter((a) => a.agreement_status === "signed").length;
+  // Awaiting is CURRENT open (unbounded by period).
+  const crmAwaitingQuery = scopeByCreator(
+    supabaseAdmin
+      .from("purchase_agreements")
+      .select("id, agreement_status")
+      .in("agreement_status", AWAITING_STATUSES),
+  );
+  const { data: crmAwaitingRows } = await crmAwaitingQuery;
+  const crmAwaiting = (crmAwaitingRows ?? []).length;
+
+  // ─── User agreements (Placement Provider + coffee_supply) ────────────
+  // These aren't attributed to a sales rep, so they're only included in
+  // company-wide / market-scoped views. For per-rep views they return 0.
+  let providerSent = 0, providerSigned = 0, providerAwaiting = 0;
+  const includeProviderAgreements = companyWide || (allowedUserIds && allowedUserIds.length > 1 && !targetUserId);
+  if (includeProviderAgreements) {
+    let uaQuery = supabaseAdmin
+      .from("user_agreements")
+      .select("id, status, agreement_type, created_at")
+      .in("agreement_type", ["placement_provider", "coffee_supply"])
+      .gte("created_at", since);
+    if (until) uaQuery = uaQuery.lte("created_at", until);
+    const { data: uaPeriod } = await uaQuery;
+    const uaRows = uaPeriod ?? [];
+    providerSent = uaRows.length;
+    providerSigned = uaRows.filter((r) => r.status === "fully_executed").length;
+
+    const { data: uaOpen } = await supabaseAdmin
+      .from("user_agreements")
+      .select("id, status")
+      .in("agreement_type", ["placement_provider", "coffee_supply"])
+      .eq("status", "provider_signed_pending_company_countersign");
+    providerAwaiting = (uaOpen ?? []).length;
+  }
+
+  // ─── Workflows ──────────────────────────────────────────────────────
+  // Company-wide only when the caller isn't scoped to one user.
+  const OPEN_STATUSES = [
+    "not_started",
+    "in_progress",
+    "waiting_on_customer",
+    "waiting_on_vendor",
+    "ready_to_begin",
+    "at_risk",
+    "overdue",
+  ];
+  const nowIso = new Date().toISOString();
+  const in7 = new Date(Date.now() + 7 * 86400_000).toISOString();
+
+  let wfBase = supabaseAdmin.from("workflows").select("id, workflow_type, overall_status, assigned_user_id, due_date", { count: "exact" });
+  if (targetUserId) wfBase = wfBase.eq("assigned_user_id", targetUserId);
+  else if (allowedUserIds) wfBase = wfBase.in("assigned_user_id", allowedUserIds);
+
+  const { data: wfRowsRaw } = await wfBase;
+  const wfRows = wfRowsRaw ?? [];
+  const wfActive = wfRows.filter((w) => OPEN_STATUSES.includes(w.overall_status)).length;
+  const wfUnassigned = wfRows.filter((w) => !w.assigned_user_id && OPEN_STATUSES.includes(w.overall_status)).length;
+  const wfDue7d = wfRows.filter(
+    (w) => OPEN_STATUSES.includes(w.overall_status) && w.due_date && w.due_date <= in7 && w.due_date >= nowIso,
+  ).length;
+  const wfOverdue = wfRows.filter(
+    (w) => OPEN_STATUSES.includes(w.overall_status) && w.due_date && w.due_date < nowIso,
+  ).length;
+  const wfByType: Record<string, number> = {};
+  for (const w of wfRows) {
+    if (OPEN_STATUSES.includes(w.overall_status)) {
+      wfByType[w.workflow_type] = (wfByType[w.workflow_type] ?? 0) + 1;
+    }
+  }
+
+  // ─── Leads ──────────────────────────────────────────────────────────
+  let leadsQuery = supabaseAdmin
+    .from("sales_leads")
+    .select("id, status, created_at")
+    .gte("created_at", since);
+  if (until) leadsQuery = leadsQuery.lte("created_at", until);
+  if (targetUserId) {
+    leadsQuery = leadsQuery.or(`assigned_to.eq.${targetUserId},created_by.eq.${targetUserId}`);
+  } else if (allowedUserIds) {
+    const clauses = allowedUserIds.map((u) => `assigned_to.eq.${u},created_by.eq.${u}`).join(",");
+    leadsQuery = leadsQuery.or(clauses);
+  }
+  const { data: leads } = await leadsQuery;
+  const leadsByStatus: Record<string, number> = {};
+  for (const l of leads ?? []) leadsByStatus[l.status] = (leadsByStatus[l.status] ?? 0) + 1;
+
+  // ─── Deals ──────────────────────────────────────────────────────────
+  let dealsQuery = supabaseAdmin.from("sales_deals").select("id, stage, value, created_at");
+  if (targetUserId) dealsQuery = dealsQuery.eq("assigned_to", targetUserId);
+  else if (allowedUserIds) dealsQuery = dealsQuery.in("assigned_to", allowedUserIds);
+  const { data: allDeals } = await dealsQuery;
+  const dealsInPeriod = (allDeals ?? []).filter((d) => {
+    if (d.created_at < since) return false;
+    if (until && d.created_at > until) return false;
+    return true;
+  });
+  const dealsByStage: Record<string, number> = {};
+  let pipelineValue = 0;
+  for (const d of dealsInPeriod) {
+    dealsByStage[d.stage] = (dealsByStage[d.stage] ?? 0) + 1;
+    pipelineValue += Number(d.value ?? 0);
+  }
+
+  // ─── Commissions ────────────────────────────────────────────────────
+  let commissionsQuery = supabaseAdmin
+    .from("sales_commissions")
+    .select("id, commission_amount, status, created_at")
+    .gte("created_at", since);
+  if (until) commissionsQuery = commissionsQuery.lte("created_at", until);
+  if (targetUserId) commissionsQuery = commissionsQuery.eq("user_id", targetUserId);
+  else if (allowedUserIds) commissionsQuery = commissionsQuery.in("user_id", allowedUserIds);
+  const { data: commissions } = await commissionsQuery;
+  let commissionTotal = 0, commissionPending = 0, commissionApproved = 0, commissionPaid = 0;
+  for (const c of commissions ?? []) {
+    const amt = Number(c.commission_amount ?? 0);
+    commissionTotal += amt;
+    if (c.status === "pending") commissionPending += amt;
+    else if (c.status === "approved") commissionApproved += amt;
+    else if (c.status === "paid") commissionPaid += amt;
+  }
+
+  return NextResponse.json({
+    period: { since, until, label: periodLabel(period) },
+    scope: {
+      user_id: filterUserId,
+      market_id: marketId,
+      is_company_wide: companyWide,
+      viewer_role: user.role,
+    },
+    quotes: {
+      sent: quoteRows.length,
+      outstanding: outstandingQuotes,
+      converted: quotesConverted,
+      total_value: quoteTotalValue,
+    },
+    orders: {
+      placed: orderRows.length,
+      completed: ordersCompleted,
+      outstanding: outstandingOrders,
+      revenue: orderRevenue,
+    },
+    agreements: {
+      crm_sent: crmSent,
+      crm_awaiting: crmAwaiting,
+      crm_signed: crmSigned,
+      provider_sent: providerSent,
+      provider_awaiting: providerAwaiting,
+      provider_signed: providerSigned,
+      provider_included: includeProviderAgreements,
+    },
+    workflows: {
+      active: wfActive,
+      unassigned: wfUnassigned,
+      due_7d: wfDue7d,
+      overdue: wfOverdue,
+      by_type: wfByType,
+    },
+    leads: { total: (leads ?? []).length, by_status: leadsByStatus },
+    deals: { total: dealsInPeriod.length, pipeline_value: pipelineValue, in_stage: dealsByStage },
+    commissions: {
+      total: commissionTotal,
+      pending: commissionPending,
+      approved: commissionApproved,
+      paid: commissionPaid,
+    },
+  });
+}

--- a/src/app/api/sales/results/route.ts
+++ b/src/app/api/sales/results/route.ts
@@ -155,10 +155,14 @@ export async function GET(req: NextRequest) {
     return true;
   });
 
-  // --- Orders ---
+  // --- Orders + Quotes (sales_orders holds both, distinguished by document_type) ---
+  // Prior code summed ALL sales_orders rows into revenue, which counted
+  // quotes as revenue and inflated every downstream metric. We now select
+  // document_type and split them; falls back gracefully if the column
+  // doesn't exist on very old schemas (all rows treated as orders then).
   let ordersQuery = supabaseAdmin
     .from("sales_orders")
-    .select("id, status, total_value, deal_id, created_at")
+    .select("id, status, total_value, deal_id, created_at, document_type")
     .gte("created_at", since);
   if (until) ordersQuery = ordersQuery.lte("created_at", until);
 
@@ -168,7 +172,31 @@ export async function GET(req: NextRequest) {
     ordersQuery = ordersQuery.in("created_by", allowedUserIds);
   }
 
-  const { data: orders } = await ordersQuery;
+  // eslint-disable-next-line prefer-const
+  let { data: allSalesOrderRows, error: ordersError } = await ordersQuery;
+
+  if (ordersError && String(ordersError.message).includes("document_type")) {
+    let retry = supabaseAdmin
+      .from("sales_orders")
+      .select("id, status, total_value, deal_id, created_at")
+      .gte("created_at", since);
+    if (until) retry = retry.lte("created_at", until);
+    if (targetUserId) {
+      retry = retry.eq("created_by", targetUserId);
+    } else if (allowedUserIds) {
+      retry = retry.in("created_by", allowedUserIds);
+    }
+    const fallback = await retry;
+    // Legacy rows have no document_type — cast to the wider shape and
+    // let the null-coalesce below default them to 'order'.
+    allSalesOrderRows = (fallback.data ?? []).map((r) => ({ ...r, document_type: null }));
+  }
+
+  const rows = allSalesOrderRows || [];
+  // Treat NULL document_type as 'order' (legacy rows created before the
+  // column existed were all orders). Quotes are filtered out so they
+  // never contribute to orders_total / order_revenue / deals_won.
+  const orders = rows.filter((r) => (r.document_type ?? "order") === "order");
 
   // --- Commissions ---
   let commissionsQuery = supabaseAdmin

--- a/src/app/sales/page.tsx
+++ b/src/app/sales/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect } from "react";
 import { createBrowserClient } from "@/lib/supabase";
 import {
   Users,
@@ -15,6 +15,13 @@ import {
   Copy,
   Check,
   Calendar,
+  FileText,
+  ScrollText,
+  Workflow,
+  Package,
+  MapPin,
+  Coffee,
+  Globe,
 } from "lucide-react";
 import Link from "next/link";
 
@@ -46,6 +53,22 @@ interface ResultsResponse {
     target_leads: number;
     target_commission: number;
   } | null;
+}
+
+interface SnapshotResponse {
+  period: { since: string; until: string | null; label: string };
+  scope: { user_id: string | null; market_id: string | null; is_company_wide: boolean; viewer_role: string };
+  quotes: { sent: number; outstanding: number; converted: number; total_value: number };
+  orders: { placed: number; completed: number; outstanding: number; revenue: number };
+  agreements: {
+    crm_sent: number; crm_awaiting: number; crm_signed: number;
+    provider_sent: number; provider_awaiting: number; provider_signed: number;
+    provider_included: boolean;
+  };
+  workflows: { active: number; unassigned: number; due_7d: number; overdue: number; by_type: Record<string, number> };
+  leads: { total: number; by_status: Record<string, number> };
+  deals: { total: number; pipeline_value: number; in_stage: Record<string, number> };
+  commissions: { total: number; pending: number; approved: number; paid: number };
 }
 
 interface SalesUserOption {
@@ -98,6 +121,7 @@ export default function SalesDashboard() {
   const [filterUserId, setFilterUserId] = useState<string>("");
   const [salesUsers, setSalesUsers] = useState<SalesUserOption[]>([]);
   const [results, setResults] = useState<ResultsResponse | null>(null);
+  const [snapshot, setSnapshot] = useState<SnapshotResponse | null>(null);
   const [counts, setCounts] = useState({ leads: 0, deals: 0, accounts: 0, orders: 0 });
   const [loading, setLoading] = useState(true);
 
@@ -125,43 +149,51 @@ export default function SalesDashboard() {
       });
   }, [token, userId]);
 
-  const load = useCallback(async () => {
-    if (!token) return;
-    if (period === "custom" && !startDate) return;
-    setLoading(true);
-    const headers = { Authorization: `Bearer ${token}` };
+  useEffect(() => {
+    async function load() {
+      if (!token) return;
+      if (period === "custom" && !startDate) return;
+      setLoading(true);
+      const headers = { Authorization: `Bearer ${token}` };
 
-    let resultsUrl = `/api/sales/results?period=${period}`;
-    if (period === "custom" && startDate) {
-      resultsUrl += `&start_date=${startDate}`;
-      if (endDate) resultsUrl += `&end_date=${endDate}`;
+      let resultsUrl = `/api/sales/results?period=${period}`;
+      let snapshotUrl = `/api/sales/executive-snapshot?period=${period}`;
+      if (period === "custom" && startDate) {
+        const qs = `&start_date=${startDate}${endDate ? `&end_date=${endDate}` : ""}`;
+        resultsUrl += qs;
+        snapshotUrl += qs;
+      }
+      if (filterUserId) {
+        resultsUrl += `&user_id=${filterUserId}`;
+        snapshotUrl += `&user_id=${filterUserId}`;
+      }
+
+      const [resultsRes, snapshotRes, leadsRes, dealsRes, accountsRes, ordersRes] = await Promise.all([
+        fetch(resultsUrl, { headers }),
+        fetch(snapshotUrl, { headers }),
+        fetch("/api/sales/leads", { headers }),
+        fetch("/api/sales/deals", { headers }),
+        fetch("/api/sales/accounts", { headers }),
+        fetch("/api/sales/orders", { headers }),
+      ]);
+      if (resultsRes.ok) setResults(await resultsRes.json());
+      if (snapshotRes.ok) setSnapshot(await snapshotRes.json());
+      const [leads, deals, accounts, orders] = await Promise.all([
+        leadsRes.ok ? leadsRes.json() : [],
+        dealsRes.ok ? dealsRes.json() : [],
+        accountsRes.ok ? accountsRes.json() : [],
+        ordersRes.ok ? ordersRes.json() : [],
+      ]);
+      setCounts({
+        leads: leads.length,
+        deals: deals.length,
+        accounts: accounts.length,
+        orders: orders.length,
+      });
+      setLoading(false);
     }
-    if (filterUserId) resultsUrl += `&user_id=${filterUserId}`;
-
-    const [resultsRes, leadsRes, dealsRes, accountsRes, ordersRes] = await Promise.all([
-      fetch(resultsUrl, { headers }),
-      fetch("/api/sales/leads", { headers }),
-      fetch("/api/sales/deals", { headers }),
-      fetch("/api/sales/accounts", { headers }),
-      fetch("/api/sales/orders", { headers }),
-    ]);
-    if (resultsRes.ok) setResults(await resultsRes.json());
-    const [leads, deals, accounts, orders] = await Promise.all([
-      leadsRes.ok ? leadsRes.json() : [],
-      dealsRes.ok ? dealsRes.json() : [],
-      accountsRes.ok ? accountsRes.json() : [],
-      ordersRes.ok ? ordersRes.json() : [],
-    ]);
-    setCounts({
-      leads: leads.length,
-      deals: deals.length,
-      accounts: accounts.length,
-      orders: orders.length,
-    });
-    setLoading(false);
+    load();
   }, [token, period, startDate, endDate, filterUserId]);
-
-  useEffect(() => { load(); }, [load]);
 
   const cards = [
     { label: "Leads", value: counts.leads, icon: Users, href: "/sales/leads", color: "text-blue-600 bg-blue-50" },
@@ -266,6 +298,9 @@ export default function SalesDashboard() {
               </div>
             </div>
           )}
+
+          {/* Executive Snapshot — quotes / orders / agreements / workflows */}
+          {snapshot && <ExecutiveSnapshot data={snapshot} />}
 
           {/* Totals */}
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
@@ -420,6 +455,184 @@ export default function SalesDashboard() {
           )}
         </div>
       )}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Executive Snapshot                                                */
+/*  A compact operating view: quotes/orders/agreements/workflows.     */
+/*  Numerator/denominator + progress bar for each so leadership sees  */
+/*  the gap at a glance. Individual reps see their own numbers;       */
+/*  admin + DOS see company-wide (or filtered).                       */
+/* ------------------------------------------------------------------ */
+function ExecutiveSnapshot({ data }: { data: SnapshotResponse }) {
+  const q = data.quotes;
+  const o = data.orders;
+  const a = data.agreements;
+  const w = data.workflows;
+
+  const wfTypeIcons: Record<string, React.ComponentType<{ className?: string }>> = {
+    ai_machine_fulfillment: Package,
+    location_services: MapPin,
+    financing: DollarSign,
+    coffee_equipment: Coffee,
+    coffee_service: Coffee,
+    website_build: Globe,
+  };
+
+  const wfTypeLabels: Record<string, string> = {
+    ai_machine_fulfillment: "AI Machines",
+    location_services: "Location Services",
+    financing: "Financing",
+    coffee_equipment: "Coffee Equipment",
+    coffee_service: "Coffee Service",
+    website_build: "Website Builds",
+  };
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-6">
+      <div className="flex items-center gap-2 mb-4">
+        <Target className="h-5 w-5 text-green-600" />
+        <h2 className="text-base font-semibold text-gray-900">
+          Executive Snapshot — {data.period.label}
+          <span className="ml-2 text-sm font-normal text-gray-500">
+            {data.scope.is_company_wide ? "Company-wide" : data.scope.user_id ? "This rep" : "My activity"}
+          </span>
+        </h2>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <SnapshotCard
+          icon={<FileText className="h-4 w-4" />}
+          label="Quotes"
+          primary={`${q.sent} sent`}
+          numerator={q.converted}
+          denominator={Math.max(q.sent, q.converted)}
+          progressLabel={`${q.converted} converted`}
+          rows={[
+            [`Outstanding`, `${q.outstanding}`],
+            [`Total quoted value`, `$${q.total_value.toLocaleString("en-US", { maximumFractionDigits: 0 })}`],
+          ]}
+          tone="blue"
+        />
+        <SnapshotCard
+          icon={<ClipboardList className="h-4 w-4" />}
+          label="Orders"
+          primary={`${o.placed} placed`}
+          numerator={o.completed}
+          denominator={Math.max(o.placed, o.completed)}
+          progressLabel={`${o.completed} completed`}
+          rows={[
+            [`Outstanding`, `${o.outstanding}`],
+            [`Revenue`, `$${o.revenue.toLocaleString("en-US", { maximumFractionDigits: 0 })}`],
+          ]}
+          tone="orange"
+        />
+        <SnapshotCard
+          icon={<ScrollText className="h-4 w-4" />}
+          label="Agreements"
+          primary={`${a.crm_sent} sent`}
+          numerator={a.crm_signed}
+          denominator={Math.max(a.crm_sent, a.crm_signed)}
+          progressLabel={`${a.crm_signed} fully signed`}
+          rows={[
+            [`Awaiting signature`, `${a.crm_awaiting}`],
+            ...(a.provider_included
+              ? [[`Provider (PPA + coffee)`, `${a.provider_signed}/${a.provider_sent}`] as [string, string]]
+              : []),
+          ]}
+          tone="emerald"
+        />
+        <SnapshotCard
+          icon={<Workflow className="h-4 w-4" />}
+          label="Workflows"
+          primary={`${w.active} active`}
+          numerator={w.active - w.overdue - w.unassigned}
+          denominator={w.active}
+          progressLabel={w.active === 0 ? "—" : `${w.active - w.overdue - w.unassigned} on track`}
+          rows={[
+            [`Overdue`, `${w.overdue}`],
+            [`Unassigned`, `${w.unassigned}`],
+            [`Due within 7d`, `${w.due_7d}`],
+          ]}
+          tone="purple"
+        />
+      </div>
+
+      {/* By-type workflow breakdown (only shown when there are any) */}
+      {Object.keys(w.by_type).length > 0 && (
+        <div className="mt-4 flex flex-wrap items-center gap-2 text-xs text-gray-600">
+          <span className="font-medium uppercase tracking-wide text-gray-500">Active by service:</span>
+          {Object.entries(w.by_type).map(([type, count]) => {
+            const Icon = wfTypeIcons[type] ?? Workflow;
+            return (
+              <span
+                key={type}
+                className="inline-flex items-center gap-1.5 rounded-full bg-gray-100 px-2.5 py-1"
+              >
+                <Icon className="h-3 w-3" />
+                {wfTypeLabels[type] ?? type} · <span className="font-semibold">{count}</span>
+              </span>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SnapshotCard({
+  icon,
+  label,
+  primary,
+  numerator,
+  denominator,
+  progressLabel,
+  rows,
+  tone,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  primary: string;
+  numerator: number;
+  denominator: number;
+  progressLabel: string;
+  rows: [string, string][];
+  tone: "blue" | "orange" | "emerald" | "purple";
+}) {
+  const pct = denominator > 0 ? Math.min(100, Math.round((numerator / denominator) * 100)) : 0;
+  const toneClasses = {
+    blue: { text: "text-blue-700", bg: "bg-blue-50", bar: "bg-blue-500" },
+    orange: { text: "text-orange-700", bg: "bg-orange-50", bar: "bg-orange-500" },
+    emerald: { text: "text-emerald-700", bg: "bg-emerald-50", bar: "bg-emerald-500" },
+    purple: { text: "text-purple-700", bg: "bg-purple-50", bar: "bg-purple-500" },
+  }[tone];
+
+  return (
+    <div className="rounded-lg border border-gray-100 bg-gray-50 p-4">
+      <div className="flex items-center gap-1.5 text-xs uppercase tracking-wide text-gray-500">
+        <span className={toneClasses.text}>{icon}</span>
+        {label}
+      </div>
+      <div className="mt-1 text-xl font-bold text-gray-900">{primary}</div>
+      <div className="mt-2">
+        <div className="flex items-center justify-between text-xs text-gray-600 mb-1">
+          <span>{progressLabel}</span>
+          <span>{denominator > 0 ? `${pct}%` : "—"}</span>
+        </div>
+        <div className="h-2 w-full rounded-full bg-gray-100">
+          <div className={`h-2 rounded-full ${toneClasses.bar}`} style={{ width: `${pct}%` }} />
+        </div>
+      </div>
+      <div className="mt-3 space-y-1 text-xs">
+        {rows.map(([k, v]) => (
+          <div key={k} className="flex justify-between text-gray-600">
+            <span>{k}</span>
+            <span className="font-medium text-gray-900">{v}</span>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
FIX: /api/sales/results was summing every sales_orders row into order_revenue / orders_total / deals_won regardless of document_type, which meant quotes were counted as revenue and every downstream metric was inflated. Filter document_type='order' (nulls treated as 'order' for legacy rows) before computing. Payload shape unchanged, just accurate numbers now.

NEW: /api/sales/executive-snapshot — single operating view of every commercial artifact with locked definitions:
  quotes.sent           quotes created in period
  quotes.converted      quotes whose deal_id has a matching order
  quotes.outstanding    quotes currently open (status='sent') regardless of period
  orders.placed         orders created in period
  orders.completed      orders in period with status='completed'
  orders.outstanding    orders currently open regardless of period
  orders.revenue        sum of order total_value in period (never quotes)
  agreements.crm_*      purchase_agreements sent/awaiting/signed;
                        signed = agreement_status='signed' = both parties signed
  agreements.provider_* user_agreements sent/awaiting/signed for
                        placement_provider + coffee_supply;
                        signed = status='fully_executed';
                        only included when scope is company/market-wide
                        (per-rep views set provider_included=false)
  workflows.*           active/unassigned/due_7d/overdue + by_type breakdown
  leads/deals/commissions  same shape as /api/sales/results

Scope logic matches /api/sales/results exactly:
  admin/DOS       → company-wide (or filter by market_id/user_id)
  market_leader   → their market's reps + themselves
  sales/manager   → their own numbers only

NEW: Executive Snapshot section on /sales dashboard, rendered above the totals grid. Four SnapshotCards (Quotes/Orders/Agreements/ Workflows) each with numerator+denominator+progress bar. Below the cards, a chip row shows active workflows broken down by service type (AI Machines, Location Services, Financing, Coffee, Website Builds).

Everything else on the dashboard (referral link, existing totals grid, Results section, Goal section) stays exactly as it was.

Also refactored /sales/page.tsx load helper from useCallback+useEffect pattern to a single inlined async function (fixes react-hooks/set-state-in-effect lint that was already on this file before these changes but was pre-existing).