### PR TITLE
Dashboard — fix close rate; enable order delete from the list

### DIFF
--- a/src/app/api/sales/executive-snapshot/route.ts
+++ b/src/app/api/sales/executive-snapshot/route.ts
@@ -361,6 +361,7 @@ export async function GET(req: NextRequest) {
       completed: ordersCompleted,
       outstanding: outstandingOrders,
       revenue: orderRevenue,
+      close_rate: orderRows.length > 0 ? ordersCompleted / orderRows.length : 0,
     },
     agreements: {
       crm_sent: crmSent,

--- a/src/app/api/sales/results/route.ts
+++ b/src/app/api/sales/results/route.ts
@@ -255,8 +255,13 @@ export async function GET(req: NextRequest) {
   );
   const completedOrders = (orders || []).filter((o) => o.status === "completed").length;
 
-  const totalDeals = (allDeals || []).length;
-  const closeRate = totalDeals > 0 ? wonCount / totalDeals : 0;
+  // Close rate = % of orders placed in the period that were completed.
+  // Prior formula was `unique-deal-ids-on-orders / total-deals`, which
+  // returned 0% whenever orders were created without a linked deal
+  // (which happens routinely for direct-created orders and any manual
+  // one-off). New formula matches what the numbers on the same tile
+  // visibly imply: completed_orders / orders_placed.
+  const closeRate = orders.length > 0 ? completedOrders / orders.length : 0;
 
   // Commission metrics
   let commissionTotal = 0;

--- a/src/app/sales/orders/page.tsx
+++ b/src/app/sales/orders/page.tsx
@@ -6,7 +6,7 @@ import { createBrowserClient } from "@/lib/supabase";
 import {
   Loader2, ClipboardList, Plus, Search, AlertCircle,
   ChevronRight, Package, MapPin, Coffee, Monitor, Wrench, DollarSign, FileText,
-  FileSpreadsheet,
+  FileSpreadsheet, Trash2,
 } from "lucide-react";
 import { exportRowsToCsv } from "@/lib/spreadsheetExport";
 
@@ -101,11 +101,25 @@ export default function OrdersPage() {
   const [statusFilter, setStatusFilter] = useState("all");
   const [search, setSearch] = useState("");
   const [docType, setDocType] = useState<"order" | "quote">("order");
+  const [userRole, setUserRole] = useState<string>("");
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const canDelete = ["admin", "director_of_sales", "market_leader"].includes(userRole);
 
   useEffect(() => {
     const supabase = createBrowserClient();
-    supabase.auth.getSession().then(({ data: { session } }) => {
-      if (session?.access_token) setToken(session.access_token);
+    supabase.auth.getSession().then(async ({ data: { session } }) => {
+      if (!session?.access_token) return;
+      setToken(session.access_token);
+      // Fetch role so we know whether to render the delete control.
+      const res = await fetch("/api/sales/users", {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      });
+      if (res.ok) {
+        const users: { id: string; role: string }[] = await res.json();
+        const me = users.find((u) => u.id === session.user.id);
+        if (me) setUserRole(me.role);
+      }
     });
   }, []);
 
@@ -137,6 +151,30 @@ export default function OrdersPage() {
 
   const isQuote = docType === "quote";
   const docLabel = isQuote ? "Quote" : "Order";
+
+  async function deleteOrder(orderId: string, orderNumber: number | string) {
+    const label = `${docLabel} #${orderNumber || orderId.slice(0, 6).toUpperCase()}`;
+    if (!window.confirm(
+      `Delete ${label}?\n\nThis permanently removes the ${docLabel.toLowerCase()} and its line items. Attached PDFs and any linked workflow's order reference will be cleared. This cannot be undone.`,
+    )) return;
+    setDeletingId(orderId);
+    try {
+      const res = await fetch(`/api/sales/orders/${orderId}`, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.ok) {
+        setOrders((prev) => prev.filter((o) => o.id !== orderId));
+      } else {
+        const err = await res.json().catch(() => ({}));
+        window.alert(`Delete failed: ${err.error ?? "Unknown error"}`);
+      }
+    } catch (e) {
+      window.alert(`Delete failed: ${e instanceof Error ? e.message : "Network error"}`);
+    } finally {
+      setDeletingId(null);
+    }
+  }
 
   return (
     <div className="p-6">
@@ -314,6 +352,26 @@ export default function OrdersPage() {
                 <span className={`shrink-0 rounded-full px-2.5 py-1 text-xs font-medium ring-1 ring-inset ${STATUS_COLORS[order.order_status] || STATUS_COLORS.draft}`}>
                   {formatStatus(order.order_status || "draft")}
                 </span>
+
+                {canDelete && (
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      deleteOrder(order.id, order.order_number);
+                    }}
+                    disabled={deletingId === order.id}
+                    className="shrink-0 rounded-lg p-1.5 text-gray-300 hover:bg-red-50 hover:text-red-600 disabled:opacity-50 transition-colors"
+                    title={`Delete ${docLabel.toLowerCase()}`}
+                    aria-label={`Delete ${docLabel.toLowerCase()}`}
+                  >
+                    {deletingId === order.id ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <Trash2 className="h-4 w-4" />
+                    )}
+                  </button>
+                )}
 
                 <ChevronRight className="h-4 w-4 text-gray-300 group-hover:text-green-500 shrink-0" />
               </div>


### PR DESCRIPTION
Close rate was 0.0% even with real revenue because the formula was "unique-deal-ids-on-orders / total-deals" — direct-created and manual one-off orders often have no deal_id, so the numerator collapsed to 0 regardless of how many orders completed. Redefine as:

  close_rate = orders_completed / orders_placed  (in period)

Matches what the same tile visibly implies (5 completed of 11 placed should read 45%, not 0%). Applied to both /api/sales/results (Results section) and /api/sales/executive-snapshot (new Executive Snapshot).

Enable order delete from /sales/orders:
  - Fetch userRole on mount via /api/sales/users
  - canDelete gates a trash button on each row (admin, DOS, market_leader only — mirrors the existing DELETE endpoint's isElevatedRole check)
  - Confirmation dialog quotes the specific order number and warns about attached PDFs and workflow order_id references being cleared
  - Optimistic remove from local list on success; inline error alert surfaces the API's error string on failure

The DELETE endpoint already existed (returned 403 for non-elevated, cascaded sales_documents cleanup); this just wires the missing UI so test/dud orders can be cleaned out of the data.