### PR TITLE
Dashboard — bold black borders on nav cards + Get Your Free Coffee Br…

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -28,6 +28,7 @@ import {
   Zap,
   Globe,
   Workflow,
+  Coffee,
 } from "lucide-react";
 import type {
   Profile,
@@ -537,7 +538,7 @@ export default function DashboardPage() {
             <>
               <Link
                 href="/browse-requests"
-                className="group flex items-center gap-4 rounded-2xl border border-gray-100 bg-white p-5 shadow-sm transition-all hover:-translate-y-0.5 hover:border-green-100 hover:shadow-md"
+                className="group flex items-center gap-4 rounded-2xl border-2 border-black bg-white p-5 shadow-sm transition-all hover:-translate-y-0.5 hover:border-green-primary hover:shadow-md"
                 title={TOOLTIP_COPY["Locations for Sale"]}
                 aria-label={TOOLTIP_COPY["Locations for Sale"]}
               >
@@ -559,7 +560,7 @@ export default function DashboardPage() {
             <>
               <Link
                 href="/post-request"
-                className="group flex items-center gap-4 rounded-2xl border border-gray-100 bg-white p-5 shadow-sm transition-all hover:-translate-y-0.5 hover:border-green-100 hover:shadow-md"
+                className="group flex items-center gap-4 rounded-2xl border-2 border-black bg-white p-5 shadow-sm transition-all hover:-translate-y-0.5 hover:border-green-primary hover:shadow-md"
                 title={TOOLTIP_COPY["Post a Request"]}
                 aria-label={TOOLTIP_COPY["Post a Request"]}
               >
@@ -578,7 +579,7 @@ export default function DashboardPage() {
               </Link>
               <Link
                 href="/browse-operators"
-                className="group flex items-center gap-4 rounded-2xl border border-gray-100 bg-white p-5 shadow-sm transition-all hover:-translate-y-0.5 hover:border-green-100 hover:shadow-md"
+                className="group flex items-center gap-4 rounded-2xl border-2 border-black bg-white p-5 shadow-sm transition-all hover:-translate-y-0.5 hover:border-green-primary hover:shadow-md"
                 title={TOOLTIP_COPY["Browse Operators"]}
                 aria-label={TOOLTIP_COPY["Browse Operators"]}
               >
@@ -599,7 +600,7 @@ export default function DashboardPage() {
           )}
           <Link
             href="/post-route"
-            className="group flex items-center gap-4 rounded-2xl border border-gray-100 bg-white p-5 shadow-sm transition-all hover:-translate-y-0.5 hover:border-green-100 hover:shadow-md"
+            className="group flex items-center gap-4 rounded-2xl border-2 border-black bg-white p-5 shadow-sm transition-all hover:-translate-y-0.5 hover:border-green-primary hover:shadow-md"
             title={TOOLTIP_COPY["Sell a Route"]}
             aria-label={TOOLTIP_COPY["Sell a Route"]}
           >
@@ -618,7 +619,7 @@ export default function DashboardPage() {
           </Link>
           <Link
             href="/your-leads"
-            className="group flex items-center gap-4 rounded-2xl border border-gray-100 bg-white p-5 shadow-sm transition-all hover:-translate-y-0.5 hover:border-green-100 hover:shadow-md"
+            className="group flex items-center gap-4 rounded-2xl border-2 border-black bg-white p-5 shadow-sm transition-all hover:-translate-y-0.5 hover:border-green-primary hover:shadow-md"
             title={TOOLTIP_COPY["Your Leads"]}
             aria-label={TOOLTIP_COPY["Your Leads"]}
           >
@@ -643,7 +644,7 @@ export default function DashboardPage() {
           */}
           <Link
             href="/account/workflows"
-            className="group flex items-center gap-4 rounded-2xl border border-gray-100 bg-white p-5 shadow-sm transition-all hover:-translate-y-0.5 hover:border-green-100 hover:shadow-md"
+            className="group flex items-center gap-4 rounded-2xl border-2 border-black bg-white p-5 shadow-sm transition-all hover:-translate-y-0.5 hover:border-green-primary hover:shadow-md"
           >
             <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-blue-50 text-blue-600 transition-colors group-hover:bg-blue-600 group-hover:text-white">
               <Workflow className="h-6 w-6" />
@@ -661,7 +662,7 @@ export default function DashboardPage() {
           {(profile.role === "operator" || profile.role === "locator" || profile.role === "location_manager") && (
             <Link
               href="/my-listings"
-              className="group flex items-center gap-4 rounded-2xl border border-gray-100 bg-white p-5 shadow-sm transition-all hover:-translate-y-0.5 hover:border-green-100 hover:shadow-md"
+              className="group flex items-center gap-4 rounded-2xl border-2 border-black bg-white p-5 shadow-sm transition-all hover:-translate-y-0.5 hover:border-green-primary hover:shadow-md"
             >
               <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-emerald-50 text-emerald-600 transition-colors group-hover:bg-emerald-600 group-hover:text-white">
                 <HandCoins className="h-6 w-6" />
@@ -680,7 +681,7 @@ export default function DashboardPage() {
           {profile.role === "operator" && (
             <Link
               href="/operator/contracts"
-              className="group flex items-center gap-4 rounded-2xl border border-gray-100 bg-white p-5 shadow-sm transition-all hover:-translate-y-0.5 hover:border-green-100 hover:shadow-md"
+              className="group flex items-center gap-4 rounded-2xl border-2 border-black bg-white p-5 shadow-sm transition-all hover:-translate-y-0.5 hover:border-green-primary hover:shadow-md"
             >
               <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-green-50 text-green-primary transition-colors group-hover:bg-green-primary group-hover:text-white">
                 <Briefcase className="h-6 w-6" />
@@ -707,7 +708,7 @@ export default function DashboardPage() {
           */}
           <Link
             href="/tools/lead-generator"
-            className="group flex items-center gap-4 rounded-2xl border border-gray-100 bg-white p-5 shadow-sm transition-all hover:-translate-y-0.5 hover:border-green-100 hover:shadow-md"
+            className="group flex items-center gap-4 rounded-2xl border-2 border-black bg-white p-5 shadow-sm transition-all hover:-translate-y-0.5 hover:border-green-primary hover:shadow-md"
           >
             <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-green-50 text-green-primary transition-colors group-hover:bg-green-primary group-hover:text-white">
               <Zap className="h-6 w-6" />
@@ -733,7 +734,7 @@ export default function DashboardPage() {
           */}
           <Link
             href="/website-builder"
-            className="group flex items-center gap-4 rounded-2xl border border-gray-100 bg-white p-5 shadow-sm transition-all hover:-translate-y-0.5 hover:border-green-100 hover:shadow-md"
+            className="group flex items-center gap-4 rounded-2xl border-2 border-black bg-white p-5 shadow-sm transition-all hover:-translate-y-0.5 hover:border-green-primary hover:shadow-md"
           >
             <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-green-50 text-green-primary transition-colors group-hover:bg-green-primary group-hover:text-white">
               <Globe className="h-6 w-6" />
@@ -747,6 +748,30 @@ export default function DashboardPage() {
               </p>
             </div>
             <ChevronRight className="ml-auto h-5 w-5 text-black-primary/20 transition-colors group-hover:text-green-primary" />
+          </Link>
+
+          {/*
+            Get Your Free Coffee Brewer — routes to the coffee supply
+            application. Admin approves, then the customer signs the
+            Equipment Loan & Beverage Supply Agreement; brewer is
+            provided at no charge in exchange for the supply agreement.
+          */}
+          <Link
+            href="/coffee/apply"
+            className="group flex items-center gap-4 rounded-2xl border-2 border-black bg-white p-5 shadow-sm transition-all hover:-translate-y-0.5 hover:border-green-primary hover:shadow-md"
+          >
+            <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-amber-50 text-amber-700 transition-colors group-hover:bg-amber-700 group-hover:text-white">
+              <Coffee className="h-6 w-6" />
+            </div>
+            <div>
+              <p className="font-semibold text-black-primary">
+                Get Your Free Coffee Brewer
+              </p>
+              <p className="text-sm text-black-primary/50">
+                Apply for our coffee program — free brewer with the supply agreement
+              </p>
+            </div>
+            <ChevronRight className="ml-auto h-5 w-5 text-black-primary/20 transition-colors group-hover:text-amber-700" />
           </Link>
         </div>
 


### PR DESCRIPTION
…ewer

All 10 quick-nav "bubble" cards on the customer dashboard (Post a Request, Browse Requests, Browse Operators, Featured Operator, Your Leads, My Order Status, My Listings, Placement Contracts, Lead Generator, Get Your Own Vending Website) now render with border-2 border-black instead of the near-invisible border-gray-100. Hover state upgraded from border-green-100 to border-green-primary so the interaction remains visible against the bolder base.

Added new "Get Your Free Coffee Brewer" card next to "Get Your Own Vending Website" — amber Coffee icon, routes to /coffee/apply, copy explains the free-brewer-with-supply-agreement offer.