### PR TITLE
Dashboard — close rate = quotes-that-became-paid-orders / quotes-sent

### DIFF
--- a/src/app/api/sales/executive-snapshot/route.ts
+++ b/src/app/api/sales/executive-snapshot/route.ts
@@ -207,6 +207,26 @@ export async function GET(req: NextRequest) {
   const quoteTotalValue = quoteRows.reduce((s, q) => s + Number(q.total_value ?? 0), 0);
   const ordersCompleted = orderRows.filter((o) => o.status === "completed").length;
 
+  // Close rate = (quotes sent in period that turned into a PAID order)
+  // / (quotes sent in period). Matches the metric definition on
+  // /api/sales/results — not every paid order comes from a quote, so
+  // we scope strictly to quote-to-paid-order conversion.
+  let quotesPaid = 0;
+  if (quoteDealIds.length > 0) {
+    const { data: paidFromQuotes } = await supabaseAdmin
+      .from("sales_orders")
+      .select("deal_id")
+      .in("deal_id", quoteDealIds)
+      .eq("payment_status", "paid");
+    const paidSet = new Set(
+      ((paidFromQuotes ?? []) as { deal_id: string | null }[])
+        .map((r) => r.deal_id)
+        .filter(Boolean) as string[],
+    );
+    quotesPaid = quoteRows.filter((q) => q.deal_id && paidSet.has(q.deal_id)).length;
+  }
+  const closeRate = quoteRows.length > 0 ? quotesPaid / quoteRows.length : 0;
+
   // ─── Purchase agreements (CRM: machine + location placement) ────────
   let agrQuery = supabaseAdmin
     .from("purchase_agreements")
@@ -353,15 +373,16 @@ export async function GET(req: NextRequest) {
     quotes: {
       sent: quoteRows.length,
       outstanding: outstandingQuotes,
-      converted: quotesConverted,
+      converted: quotesConverted,           // quote → any order (attribution)
+      paid: quotesPaid,                     // quote → paid order (close rate numerator)
       total_value: quoteTotalValue,
+      close_rate: closeRate,                // paid-from-quote / quotes_sent
     },
     orders: {
       placed: orderRows.length,
       completed: ordersCompleted,
       outstanding: outstandingOrders,
       revenue: orderRevenue,
-      close_rate: orderRows.length > 0 ? ordersCompleted / orderRows.length : 0,
     },
     agreements: {
       crm_sent: crmSent,

--- a/src/app/api/sales/results/route.ts
+++ b/src/app/api/sales/results/route.ts
@@ -197,6 +197,7 @@ export async function GET(req: NextRequest) {
   // column existed were all orders). Quotes are filtered out so they
   // never contribute to orders_total / order_revenue / deals_won.
   const orders = rows.filter((r) => (r.document_type ?? "order") === "order");
+  const quotesInPeriod = rows.filter((r) => r.document_type === "quote");
 
   // --- Commissions ---
   let commissionsQuery = supabaseAdmin
@@ -255,13 +256,39 @@ export async function GET(req: NextRequest) {
   );
   const completedOrders = (orders || []).filter((o) => o.status === "completed").length;
 
-  // Close rate = % of orders placed in the period that were completed.
-  // Prior formula was `unique-deal-ids-on-orders / total-deals`, which
-  // returned 0% whenever orders were created without a linked deal
-  // (which happens routinely for direct-created orders and any manual
-  // one-off). New formula matches what the numbers on the same tile
-  // visibly imply: completed_orders / orders_placed.
-  const closeRate = orders.length > 0 ? completedOrders / orders.length : 0;
+  // Close rate = (quotes sent in period that turned into a PAID order) /
+  // (quotes sent in period). Per business rule: not every paid order
+  // comes from a quote, so we can't use paid-orders/orders-placed; we
+  // scope strictly to quotes and check whether their deal_id ended up
+  // on a paid order (any date — a quote sent in Q1 that gets paid in
+  // Q2 still counts as converted for the Q1 rate).
+  //
+  // Quotes with no deal_id can't be tied back to an order, so they're
+  // counted in the denominator but never in the numerator (surfaces
+  // the real drop-off from quote-without-attribution).
+  let closeRate = 0;
+  if (quotesInPeriod.length > 0) {
+    const quoteDealIds = Array.from(
+      new Set(quotesInPeriod.map((q) => q.deal_id).filter(Boolean) as string[]),
+    );
+    let paidDealIdSet = new Set<string>();
+    if (quoteDealIds.length > 0) {
+      const { data: paidOrdersFromQuotes } = await supabaseAdmin
+        .from("sales_orders")
+        .select("deal_id")
+        .in("deal_id", quoteDealIds)
+        .eq("payment_status", "paid");
+      paidDealIdSet = new Set(
+        ((paidOrdersFromQuotes ?? []) as { deal_id: string | null }[])
+          .map((r) => r.deal_id)
+          .filter(Boolean) as string[],
+      );
+    }
+    const convertedQuotes = quotesInPeriod.filter(
+      (q) => q.deal_id && paidDealIdSet.has(q.deal_id),
+    ).length;
+    closeRate = convertedQuotes / quotesInPeriod.length;
+  }
 
   // Commission metrics
   let commissionTotal = 0;

--- a/src/app/sales/page.tsx
+++ b/src/app/sales/page.tsx
@@ -58,7 +58,7 @@ interface ResultsResponse {
 interface SnapshotResponse {
   period: { since: string; until: string | null; label: string };
   scope: { user_id: string | null; market_id: string | null; is_company_wide: boolean; viewer_role: string };
-  quotes: { sent: number; outstanding: number; converted: number; total_value: number };
+  quotes: { sent: number; outstanding: number; converted: number; paid: number; total_value: number; close_rate: number };
   orders: { placed: number; completed: number; outstanding: number; revenue: number };
   agreements: {
     crm_sent: number; crm_awaiting: number; crm_signed: number;
@@ -507,10 +507,11 @@ function ExecutiveSnapshot({ data }: { data: SnapshotResponse }) {
           icon={<FileText className="h-4 w-4" />}
           label="Quotes"
           primary={`${q.sent} sent`}
-          numerator={q.converted}
-          denominator={Math.max(q.sent, q.converted)}
-          progressLabel={`${q.converted} converted`}
+          numerator={q.paid}
+          denominator={q.sent}
+          progressLabel={`${q.paid} paid (${Math.round(q.close_rate * 100)}% close rate)`}
           rows={[
+            [`Converted to order`, `${q.converted}`],
             [`Outstanding`, `${q.outstanding}`],
             [`Total quoted value`, `$${q.total_value.toLocaleString("en-US", { maximumFractionDigits: 0 })}`],
           ]}


### PR DESCRIPTION
Business rule: not every paid order comes from a quote (direct orders, customer self-service, etc.), so the earlier "completed_orders / orders_placed" definition still overstated conversion. Rewritten to strictly measure quote→paid-order conversion:

  close_rate = (quotes sent in period whose deal_id ended up on a
                paid order — any date) / (quotes sent in period)

Applied to both /api/sales/results (Results section — existing `conversion_rate` field) and /api/sales/executive-snapshot (Quotes card — new `close_rate` field on quotes block).

Quotes without a deal_id count in the denominator but never in the numerator — surfaces the real drop-off from quote-without-attribution.

Snapshot Quotes card on /sales now shows:
  primary:   "N sent"
  progress:  "M paid (X% close rate)"
  rows:      "Converted to order: K" · "Outstanding: O" · "Total quoted value: $V"

Conversion (any order) and paid-order (close rate) are both surfaced so you can see the gap between "customer accepted a quote" and "customer paid the invoice".