### PR TITLE
Dashboard — close rate counts completed OR paid orders

### DIFF
--- a/src/app/api/sales/executive-snapshot/route.ts
+++ b/src/app/api/sales/executive-snapshot/route.ts
@@ -207,25 +207,25 @@ export async function GET(req: NextRequest) {
   const quoteTotalValue = quoteRows.reduce((s, q) => s + Number(q.total_value ?? 0), 0);
   const ordersCompleted = orderRows.filter((o) => o.status === "completed").length;
 
-  // Close rate = (quotes sent in period that turned into a PAID order)
-  // / (quotes sent in period). Matches the metric definition on
-  // /api/sales/results — not every paid order comes from a quote, so
-  // we scope strictly to quote-to-paid-order conversion.
-  let quotesPaid = 0;
+  // Close rate = (quotes whose deal_id ended up on a CLOSED order) /
+  // (quotes sent in period). A "closed" order is payment_status='paid'
+  // OR order_status='completed' — an order being completed = paid in
+  // this workflow.
+  let quotesClosed = 0;
   if (quoteDealIds.length > 0) {
-    const { data: paidFromQuotes } = await supabaseAdmin
+    const { data: closedFromQuotes } = await supabaseAdmin
       .from("sales_orders")
       .select("deal_id")
       .in("deal_id", quoteDealIds)
-      .eq("payment_status", "paid");
-    const paidSet = new Set(
-      ((paidFromQuotes ?? []) as { deal_id: string | null }[])
+      .or("payment_status.eq.paid,order_status.eq.completed");
+    const closedSet = new Set(
+      ((closedFromQuotes ?? []) as { deal_id: string | null }[])
         .map((r) => r.deal_id)
         .filter(Boolean) as string[],
     );
-    quotesPaid = quoteRows.filter((q) => q.deal_id && paidSet.has(q.deal_id)).length;
+    quotesClosed = quoteRows.filter((q) => q.deal_id && closedSet.has(q.deal_id)).length;
   }
-  const closeRate = quoteRows.length > 0 ? quotesPaid / quoteRows.length : 0;
+  const closeRate = quoteRows.length > 0 ? quotesClosed / quoteRows.length : 0;
 
   // ─── Purchase agreements (CRM: machine + location placement) ────────
   let agrQuery = supabaseAdmin
@@ -374,9 +374,9 @@ export async function GET(req: NextRequest) {
       sent: quoteRows.length,
       outstanding: outstandingQuotes,
       converted: quotesConverted,           // quote → any order (attribution)
-      paid: quotesPaid,                     // quote → paid order (close rate numerator)
+      closed: quotesClosed,                 // quote → completed OR paid order (close rate numerator)
       total_value: quoteTotalValue,
-      close_rate: closeRate,                // paid-from-quote / quotes_sent
+      close_rate: closeRate,                // closed-from-quote / quotes_sent
     },
     orders: {
       placed: orderRows.length,

--- a/src/app/api/sales/results/route.ts
+++ b/src/app/api/sales/results/route.ts
@@ -256,12 +256,10 @@ export async function GET(req: NextRequest) {
   );
   const completedOrders = (orders || []).filter((o) => o.status === "completed").length;
 
-  // Close rate = (quotes sent in period that turned into a PAID order) /
-  // (quotes sent in period). Per business rule: not every paid order
-  // comes from a quote, so we can't use paid-orders/orders-placed; we
-  // scope strictly to quotes and check whether their deal_id ended up
-  // on a paid order (any date — a quote sent in Q1 that gets paid in
-  // Q2 still counts as converted for the Q1 rate).
+  // Close rate = (quotes sent in period that turned into a CLOSED
+  // order) / (quotes sent in period). A "closed" order is one that
+  // reached payment_status='paid' OR order_status='completed' — per
+  // business rule an order being completed = paid in this workflow.
   //
   // Quotes with no deal_id can't be tied back to an order, so they're
   // counted in the denominator but never in the numerator (surfaces
@@ -271,23 +269,23 @@ export async function GET(req: NextRequest) {
     const quoteDealIds = Array.from(
       new Set(quotesInPeriod.map((q) => q.deal_id).filter(Boolean) as string[]),
     );
-    let paidDealIdSet = new Set<string>();
+    let closedDealIdSet = new Set<string>();
     if (quoteDealIds.length > 0) {
-      const { data: paidOrdersFromQuotes } = await supabaseAdmin
+      const { data: closedOrdersFromQuotes } = await supabaseAdmin
         .from("sales_orders")
         .select("deal_id")
         .in("deal_id", quoteDealIds)
-        .eq("payment_status", "paid");
-      paidDealIdSet = new Set(
-        ((paidOrdersFromQuotes ?? []) as { deal_id: string | null }[])
+        .or("payment_status.eq.paid,order_status.eq.completed");
+      closedDealIdSet = new Set(
+        ((closedOrdersFromQuotes ?? []) as { deal_id: string | null }[])
           .map((r) => r.deal_id)
           .filter(Boolean) as string[],
       );
     }
-    const convertedQuotes = quotesInPeriod.filter(
-      (q) => q.deal_id && paidDealIdSet.has(q.deal_id),
+    const closedQuotes = quotesInPeriod.filter(
+      (q) => q.deal_id && closedDealIdSet.has(q.deal_id),
     ).length;
-    closeRate = convertedQuotes / quotesInPeriod.length;
+    closeRate = closedQuotes / quotesInPeriod.length;
   }
 
   // Commission metrics

--- a/src/app/sales/page.tsx
+++ b/src/app/sales/page.tsx
@@ -58,7 +58,7 @@ interface ResultsResponse {
 interface SnapshotResponse {
   period: { since: string; until: string | null; label: string };
   scope: { user_id: string | null; market_id: string | null; is_company_wide: boolean; viewer_role: string };
-  quotes: { sent: number; outstanding: number; converted: number; paid: number; total_value: number; close_rate: number };
+  quotes: { sent: number; outstanding: number; converted: number; closed: number; total_value: number; close_rate: number };
   orders: { placed: number; completed: number; outstanding: number; revenue: number };
   agreements: {
     crm_sent: number; crm_awaiting: number; crm_signed: number;
@@ -507,9 +507,9 @@ function ExecutiveSnapshot({ data }: { data: SnapshotResponse }) {
           icon={<FileText className="h-4 w-4" />}
           label="Quotes"
           primary={`${q.sent} sent`}
-          numerator={q.paid}
+          numerator={q.closed}
           denominator={q.sent}
-          progressLabel={`${q.paid} paid (${Math.round(q.close_rate * 100)}% close rate)`}
+          progressLabel={`${q.closed} closed (${Math.round(q.close_rate * 100)}% close rate)`}
           rows={[
             [`Converted to order`, `${q.converted}`],
             [`Outstanding`, `${q.outstanding}`],


### PR DESCRIPTION
Per business rule: an order being marked completed = paid in this workflow. Relax the close-rate numerator from strict payment_status='paid' to:

  payment_status='paid' OR order_status='completed'

Snapshot Quotes card now shows "M closed" instead of "M paid", and the payload field is quotes.closed (was quotes.paid). Otherwise unchanged — denominator still quotes-sent-in-period; quotes without deal_id still count in denominator but not numerator.