### PR TITLE
Workflows — intake flow-through + payment sync + workload + UX cleanups

### DIFF
--- a/src/app/account/workflows/[id]/page.tsx
+++ b/src/app/account/workflows/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { use, useEffect, useState } from "react";
 import Link from "next/link";
 import { createBrowserClient } from "@/lib/supabase";
+import { SourceIntakePanel } from "@/app/components/SourceIntakePanel";
 import {
   ChevronLeft,
   CheckCircle2,
@@ -91,6 +92,7 @@ interface DetailPayload {
     completed_at: string | null;
     primary_team: string | null;
     payment_status: string;
+    metadata: Record<string, unknown> | null;
   };
   stages: Stage[];
   notes: Note[];
@@ -284,6 +286,12 @@ export default function MyWorkflowDetail({ params }: { params: Promise<{ id: str
           </div>
         </div>
       )}
+
+      {/* Source Intake (customer-safe view — hides staff-only fields) */}
+      <SourceIntakePanel
+        intake={(data.workflow.metadata as { source_intake?: unknown } | null)?.source_intake}
+        customerSafe
+      />
 
       {/* Stages timeline */}
       <div className="rounded-2xl border border-gray-100 bg-white p-6 shadow-sm">

--- a/src/app/api/request-location/route.ts
+++ b/src/app/api/request-location/route.ts
@@ -223,12 +223,20 @@ export async function POST(req: Request) {
             deposit_amount_cents: DEPOSIT_CENTS,
             deposit_paid_cents: DEPOSIT_CENTS,
             total_due_cents: totalDueCents,
-            state,
-            zip_codes,
-            business_name,
-            contact_name,
-            phone,
-            email,
+            // source_intake = exactly what the customer submitted, so
+            // whoever picks up the workflow sees the full request.
+            source_intake: {
+              business_name,
+              contact_name,
+              phone,
+              email,
+              address, // was previously dropped — bug fix
+              state,
+              zip_codes,
+              zip_code,
+              machine_count,
+              referring_sales_rep_name: referringRepName,
+            },
           },
           actorType: "system",
         });

--- a/src/app/api/sales/orders/[id]/status/route.ts
+++ b/src/app/api/sales/orders/[id]/status/route.ts
@@ -147,5 +147,19 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
     }
   }
 
+  // Mirror the payment onto any workflow linked to this order.
+  if (action === "mark_paid") {
+    try {
+      const { syncWorkflowFromSalesOrderPaid } = await import("@/lib/workflows/paymentSync");
+      await syncWorkflowFromSalesOrderPaid({
+        orderId: id,
+        source: "sales_orders.status",
+        changeKey: `manual:sales_order:${id}:mark_paid`,
+      });
+    } catch (e) {
+      console.error("[orders.status] workflow payment sync failed:", e);
+    }
+  }
+
   return NextResponse.json(data);
 }

--- a/src/app/api/sales/workload/route.ts
+++ b/src/app/api/sales/workload/route.ts
@@ -1,0 +1,294 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser, isElevatedRole } from "@/lib/salesAuth";
+
+/**
+ * GET /api/sales/workload?period=<period>&start_date=<iso>&end_date=<iso>&market_id=<id>
+ *
+ * Per-employee workload aggregation for the /sales/workload page.
+ *
+ * For each staff user in scope, returns:
+ *   - active workflows count (assigned as primary OR active collaborator)
+ *   - by_type breakdown (ai_machine, location_services, etc.)
+ *   - overdue count
+ *   - due within 7d count
+ *   - hours clocked in period (from time_entries)
+ *   - avg time to close (days between created_at and completed_at for
+ *     their closed workflows in the last 90 days)
+ *   - close rate (quotes-they-sent that ended up with a completed/paid
+ *     order by deal_id) in period
+ *   - capacity flag (green <10 / yellow 10-20 / red >20 active)
+ *
+ * Scope:
+ *   admin / DOS  → every sales user
+ *   market_leader → their market's users
+ *   sales / sales_manager → just themselves
+ */
+
+type Period = "daily" | "weekly" | "monthly" | "quarterly" | "yearly" | "ytd" | "custom";
+
+function periodStart(period: Period): Date {
+  const now = new Date();
+  const d = new Date(now);
+  switch (period) {
+    case "daily":
+      d.setHours(0, 0, 0, 0);
+      return d;
+    case "weekly": {
+      const day = d.getDay();
+      d.setDate(d.getDate() - day);
+      d.setHours(0, 0, 0, 0);
+      return d;
+    }
+    case "monthly":
+      return new Date(d.getFullYear(), d.getMonth(), 1);
+    case "quarterly": {
+      const q = Math.floor(d.getMonth() / 3) * 3;
+      return new Date(d.getFullYear(), q, 1);
+    }
+    case "yearly":
+    case "ytd":
+      return new Date(d.getFullYear(), 0, 1);
+    case "custom":
+      return new Date(d.getFullYear(), 0, 1);
+  }
+}
+
+const CAPACITY_GREEN_MAX = Number(process.env.WORKLOAD_CAPACITY_GREEN_MAX ?? 10);
+const CAPACITY_YELLOW_MAX = Number(process.env.WORKLOAD_CAPACITY_YELLOW_MAX ?? 20);
+
+export async function GET(req: NextRequest) {
+  const user = await getSalesUser(req);
+  if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const url = new URL(req.url);
+  const period = (url.searchParams.get("period") || "monthly") as Period;
+  const marketId = url.searchParams.get("market_id") || null;
+  const elevated = isElevatedRole(user.role);
+
+  // ─── Resolve who this viewer can see ──────────────────────────────
+  let staffIds: string[];
+  if (elevated) {
+    if (marketId) {
+      const { data: members } = await supabaseAdmin
+        .from("market_members")
+        .select("user_id")
+        .eq("market_id", marketId);
+      staffIds = (members ?? []).map((m) => m.user_id);
+    } else {
+      const { data: allStaff } = await supabaseAdmin
+        .from("profiles")
+        .select("id")
+        .in("role", ["admin", "director_of_sales", "market_leader", "sales_manager", "sales"]);
+      staffIds = (allStaff ?? []).map((s) => s.id);
+    }
+  } else if (user.role === "market_leader") {
+    const { data: leaderOf } = await supabaseAdmin
+      .from("market_leaders")
+      .select("market_id")
+      .eq("user_id", user.id);
+    const leaderMarketIds = (leaderOf ?? []).map((r) => r.market_id);
+    if (leaderMarketIds.length === 0) {
+      staffIds = [user.id];
+    } else {
+      const { data: members } = await supabaseAdmin
+        .from("market_members")
+        .select("user_id")
+        .in("market_id", leaderMarketIds);
+      staffIds = Array.from(new Set([user.id, ...((members ?? []).map((m) => m.user_id))]));
+    }
+  } else {
+    staffIds = [user.id];
+  }
+
+  if (staffIds.length === 0) {
+    return NextResponse.json({ period: { label: period }, employees: [] });
+  }
+
+  // ─── Period bounds ────────────────────────────────────────────────
+  let since: string;
+  let until: string | null = null;
+  if (period === "custom") {
+    const startDate = url.searchParams.get("start_date");
+    const endDate = url.searchParams.get("end_date");
+    if (!startDate) return NextResponse.json({ error: "start_date required" }, { status: 400 });
+    since = new Date(startDate).toISOString();
+    if (endDate) {
+      const end = new Date(endDate);
+      end.setHours(23, 59, 59, 999);
+      until = end.toISOString();
+    }
+  } else {
+    since = periodStart(period).toISOString();
+  }
+  const nowIso = new Date().toISOString();
+  const in7 = new Date(Date.now() + 7 * 86400_000).toISOString();
+  const ninetyDaysAgo = new Date(Date.now() - 90 * 86400_000).toISOString();
+
+  // ─── Profiles for name/role/email ─────────────────────────────────
+  const { data: profiles } = await supabaseAdmin
+    .from("profiles")
+    .select("id, full_name, email, role")
+    .in("id", staffIds);
+  const profileMap = new Map<string, { id: string; full_name: string | null; email: string; role: string }>();
+  for (const p of profiles ?? []) profileMap.set(p.id, p);
+
+  // ─── Workflows: pull only what we need for aggregation ────────────
+  const OPEN = ["not_started", "in_progress", "waiting_on_customer", "waiting_on_vendor", "ready_to_begin", "at_risk", "overdue"];
+
+  const { data: allWorkflows } = await supabaseAdmin
+    .from("workflows")
+    .select("id, workflow_type, overall_status, assigned_user_id, due_date, created_at, completed_at, customer_id")
+    .in("assigned_user_id", staffIds);
+
+  // Also pick up collaborator assignments (workflow_assignments).
+  const { data: collaborations } = await supabaseAdmin
+    .from("workflow_assignments")
+    .select("workflow_id, user_id, active")
+    .in("user_id", staffIds)
+    .eq("active", true);
+
+  // Build a set of (user_id, workflow_id) — includes primary + collaborator.
+  const userWorkflows = new Map<string, Set<string>>();
+  for (const w of allWorkflows ?? []) {
+    if (!w.assigned_user_id) continue;
+    if (!userWorkflows.has(w.assigned_user_id)) userWorkflows.set(w.assigned_user_id, new Set());
+    userWorkflows.get(w.assigned_user_id)!.add(w.id);
+  }
+  for (const c of collaborations ?? []) {
+    if (!userWorkflows.has(c.user_id)) userWorkflows.set(c.user_id, new Set());
+    userWorkflows.get(c.user_id)!.add(c.workflow_id);
+  }
+
+  // Also need workflows for collaborator IDs — fetch missing ones.
+  const knownWorkflowIds = new Set((allWorkflows ?? []).map((w) => w.id));
+  const collaboratorOnlyIds = new Set<string>();
+  for (const c of collaborations ?? []) {
+    if (!knownWorkflowIds.has(c.workflow_id)) collaboratorOnlyIds.add(c.workflow_id);
+  }
+  const collaboratorWorkflows = collaboratorOnlyIds.size > 0
+    ? (await supabaseAdmin
+        .from("workflows")
+        .select("id, workflow_type, overall_status, assigned_user_id, due_date, created_at, completed_at, customer_id")
+        .in("id", Array.from(collaboratorOnlyIds))).data ?? []
+    : [];
+  type WorkflowSlim = {
+    id: string;
+    workflow_type: string;
+    overall_status: string;
+    assigned_user_id: string | null;
+    due_date: string | null;
+    created_at: string;
+    completed_at: string | null;
+    customer_id: string;
+  };
+  const workflowMap = new Map<string, WorkflowSlim>();
+  for (const w of [...(allWorkflows ?? []), ...collaboratorWorkflows]) {
+    workflowMap.set(w.id, w as WorkflowSlim);
+  }
+
+  // ─── Time entries in period ───────────────────────────────────────
+  let timeQuery = supabaseAdmin
+    .from("time_entries")
+    .select("user_id, duration_minutes")
+    .in("user_id", staffIds)
+    .gte("clock_in", since);
+  if (until) timeQuery = timeQuery.lte("clock_in", until);
+  const { data: timeEntries } = await timeQuery;
+  const hoursByUser = new Map<string, number>();
+  for (const t of timeEntries ?? []) {
+    const mins = Number((t as { duration_minutes?: number | null }).duration_minutes ?? 0);
+    hoursByUser.set(t.user_id, (hoursByUser.get(t.user_id) ?? 0) + mins);
+  }
+
+  // ─── Sales orders/quotes for close-rate ───────────────────────────
+  // Pull quotes created in period for these users, then look for matching
+  // closed orders (any date) via deal_id.
+  const { data: quoteRows } = await supabaseAdmin
+    .from("sales_orders")
+    .select("id, deal_id, created_by, document_type, created_at")
+    .in("created_by", staffIds)
+    .eq("document_type", "quote")
+    .gte("created_at", since);
+  const quoteRowsList = (quoteRows ?? []) as { id: string; deal_id: string | null; created_by: string; created_at: string }[];
+  const quoteDealIds = Array.from(
+    new Set(quoteRowsList.map((q) => q.deal_id).filter(Boolean) as string[]),
+  );
+  const closedDealIds = new Set<string>();
+  if (quoteDealIds.length > 0) {
+    const { data: closedOrders } = await supabaseAdmin
+      .from("sales_orders")
+      .select("deal_id")
+      .in("deal_id", quoteDealIds)
+      .or("payment_status.eq.paid,order_status.eq.completed");
+    for (const r of (closedOrders ?? []) as { deal_id: string | null }[]) {
+      if (r.deal_id) closedDealIds.add(r.deal_id);
+    }
+  }
+  const quotesSentByUser = new Map<string, number>();
+  const quotesClosedByUser = new Map<string, number>();
+  for (const q of quoteRowsList) {
+    quotesSentByUser.set(q.created_by, (quotesSentByUser.get(q.created_by) ?? 0) + 1);
+    if (q.deal_id && closedDealIds.has(q.deal_id)) {
+      quotesClosedByUser.set(q.created_by, (quotesClosedByUser.get(q.created_by) ?? 0) + 1);
+    }
+  }
+
+  // ─── Assemble per-employee rows ───────────────────────────────────
+  const employees = Array.from(profileMap.values()).map((profile) => {
+    const wfIds = Array.from(userWorkflows.get(profile.id) ?? []);
+    const wfs = wfIds.map((id) => workflowMap.get(id)!).filter(Boolean);
+    const openWfs = wfs.filter((w) => OPEN.includes(w.overall_status));
+    const byType: Record<string, number> = {};
+    for (const w of openWfs) byType[w.workflow_type] = (byType[w.workflow_type] ?? 0) + 1;
+    const overdue = openWfs.filter((w) => w.due_date && w.due_date < nowIso).length;
+    const due7d = openWfs.filter((w) => w.due_date && w.due_date >= nowIso && w.due_date <= in7).length;
+    const closedRecently = wfs.filter(
+      (w) => w.overall_status === "completed" && w.completed_at && w.completed_at >= ninetyDaysAgo,
+    );
+    const avgDaysToClose = closedRecently.length > 0
+      ? Math.round(
+          closedRecently.reduce((sum, w) => {
+            const created = new Date(w.created_at).getTime();
+            const done = new Date(w.completed_at!).getTime();
+            return sum + Math.max(0, (done - created) / 86400_000);
+          }, 0) / closedRecently.length,
+        )
+      : null;
+    const hoursMins = hoursByUser.get(profile.id) ?? 0;
+    const sentQuotes = quotesSentByUser.get(profile.id) ?? 0;
+    const closedQuotes = quotesClosedByUser.get(profile.id) ?? 0;
+    const closeRate = sentQuotes > 0 ? closedQuotes / sentQuotes : 0;
+    const active = openWfs.length;
+    const capacity: "green" | "yellow" | "red" = active <= CAPACITY_GREEN_MAX
+      ? "green"
+      : active <= CAPACITY_YELLOW_MAX
+        ? "yellow"
+        : "red";
+
+    return {
+      user_id: profile.id,
+      name: profile.full_name ?? profile.email,
+      email: profile.email,
+      role: profile.role,
+      active,
+      by_type: byType,
+      overdue,
+      due_7d: due7d,
+      hours_period: Math.round((hoursMins / 60) * 10) / 10,
+      avg_days_to_close: avgDaysToClose,
+      close_rate: closeRate,
+      quotes_sent: sentQuotes,
+      quotes_closed: closedQuotes,
+      capacity,
+    };
+  });
+
+  employees.sort((a, b) => b.active - a.active);
+
+  return NextResponse.json({
+    period: { since, until, label: period },
+    capacity_thresholds: { green_max: CAPACITY_GREEN_MAX, yellow_max: CAPACITY_YELLOW_MAX },
+    employees,
+  });
+}

--- a/src/app/api/time-entries/route.ts
+++ b/src/app/api/time-entries/route.ts
@@ -122,6 +122,12 @@ export async function POST(req: NextRequest) {
     notes: body.notes || null,
   };
   if (role) insertData.role = role;
+  // Optional workflow link — feeds the /sales/workload hours-per-workflow
+  // rollup. Only set when the client passed one; NULL means "generic /
+  // admin overhead time".
+  if (typeof body.workflow_id === "string" && body.workflow_id.length === 36) {
+    insertData.workflow_id = body.workflow_id;
+  }
 
   const { data, error } = await supabaseAdmin
     .from("time_entries")

--- a/src/app/api/webhooks/quickbooks/route.ts
+++ b/src/app/api/webhooks/quickbooks/route.ts
@@ -199,6 +199,17 @@ async function handleQBPayment(paymentId: string, realmId: string) {
         description: `QuickBooks payment received on invoice ${invoiceId}${isRemaining ? " (remaining balance)" : ""}`,
       });
       await stampOrderAndEarnCommissions(paymentId, salesOrder.id, null);
+      // Mirror the payment onto any workflow linked to this order.
+      try {
+        const { syncWorkflowFromSalesOrderPaid } = await import("@/lib/workflows/paymentSync");
+        await syncWorkflowFromSalesOrderPaid({
+          orderId: salesOrder.id,
+          source: "qb_webhook",
+          changeKey: `qb_payment:${paymentId}:${invoiceId}`,
+        });
+      } catch (e) {
+        console.error("[qb-webhook] workflow payment sync failed:", e);
+      }
       continue;
     }
 
@@ -297,6 +308,17 @@ async function handleQBPayment(paymentId: string, realmId: string) {
         .from("machine_listing_purchases")
         .update({ qb_payment_id: paymentId })
         .eq("id", machinePurchase.id);
+      // Mirror to workflow.
+      try {
+        const { syncWorkflowFromMachinePurchasePaid } = await import("@/lib/workflows/paymentSync");
+        await syncWorkflowFromMachinePurchasePaid({
+          purchaseId: machinePurchase.id,
+          source: "qb_webhook",
+          changeKey: `qb_payment:${paymentId}:${invoiceId}`,
+        });
+      } catch (e) {
+        console.error("[qb-webhook] machine workflow sync failed:", e);
+      }
       continue;
     }
 
@@ -319,7 +341,34 @@ async function handleQBPayment(paymentId: string, realmId: string) {
         .from("coffee_orders")
         .update({ qb_payment_id: paymentId })
         .eq("id", coffeeOrder.id);
+      // Mark the corresponding workflow_order_items sub-item fulfilled.
+      try {
+        const { syncCoffeeOrderPaid } = await import("@/lib/workflows/paymentSync");
+        await syncCoffeeOrderPaid({
+          coffeeOrderId: coffeeOrder.id,
+          source: "qb_webhook",
+          changeKey: `qb_payment:${paymentId}:${invoiceId}`,
+        });
+      } catch (e) {
+        console.error("[qb-webhook] coffee order workflow sync failed:", e);
+      }
       continue;
+    }
+
+    // Check workflow balance invoices (created via /api/account/workflows/[id]/pay-balance).
+    try {
+      const { syncWorkflowFromBalanceInvoicePaid } = await import("@/lib/workflows/paymentSync");
+      const balanceUpdated = await syncWorkflowFromBalanceInvoicePaid({
+        qbInvoiceId: invoiceId,
+        source: "qb_webhook",
+        changeKey: `qb_payment:${paymentId}:${invoiceId}`,
+      });
+      if (balanceUpdated > 0) {
+        console.log(`[qb-webhook] Marked ${balanceUpdated} workflow(s) as paid via balance invoice ${invoiceId}`);
+        continue;
+      }
+    } catch (e) {
+      console.error("[qb-webhook] balance invoice sync check failed:", e);
     }
 
     // Check lead_generator_subscriptions — QB invoice acts as the

--- a/src/app/components/SourceIntakePanel.tsx
+++ b/src/app/components/SourceIntakePanel.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown, ChevronRight, FileInput } from "lucide-react";
+
+/**
+ * Renders workflow.metadata.source_intake as a labeled key-value list
+ * so anyone opening a workflow sees exactly what the customer submitted
+ * on the origin form — without clicking back to the source table.
+ *
+ * Handles nested groups (e.g. coffee's { agreement, application }) by
+ * rendering each subsection as its own group inside the panel. Skips
+ * empty values entirely.
+ *
+ * Used by both /sales/workflows/[id] and /account/workflows/[id]. On
+ * the customer view: pass `customerSafe` to hide financing background
+ * flags and other staff-only fields.
+ */
+export function SourceIntakePanel({
+  intake,
+  customerSafe = false,
+}: {
+  intake: unknown;
+  customerSafe?: boolean;
+}) {
+  const [open, setOpen] = useState(true);
+
+  if (!isNonEmptyObject(intake)) return null;
+
+  const groups = normalizeIntake(intake, customerSafe);
+  if (groups.length === 0) return null;
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white shadow-sm">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="w-full p-5 border-b border-gray-100 flex items-center gap-2 text-left hover:bg-gray-50 transition-colors"
+      >
+        {open ? (
+          <ChevronDown className="h-4 w-4 text-gray-500" />
+        ) : (
+          <ChevronRight className="h-4 w-4 text-gray-500" />
+        )}
+        <FileInput className="h-4 w-4 text-gray-500" />
+        <h2 className="text-base font-semibold text-gray-900">Source Intake</h2>
+        <span className="text-xs text-gray-500 ml-2">— as submitted by customer</span>
+      </button>
+      {open && (
+        <div className="p-5 space-y-5">
+          {groups.map((group) => (
+            <div key={group.title}>
+              {group.title !== "_root" && (
+                <h3 className="text-xs uppercase tracking-wide font-semibold text-gray-500 mb-2">
+                  {humanize(group.title)}
+                </h3>
+              )}
+              <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2 text-sm">
+                {group.entries.map(({ key, value }) => (
+                  <div key={key} className="flex gap-2">
+                    <dt className="text-gray-500 shrink-0">{humanize(key)}:</dt>
+                    <dd className="text-gray-900 font-medium break-words">{formatValue(value)}</dd>
+                  </div>
+                ))}
+              </dl>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────
+
+// Fields that should never render on the customer view — background
+// flags on financing applications, internal source ids, etc.
+const CUSTOMER_HIDE = new Set([
+  "has_verifiable_income", "has_tax_liens", "has_bankruptcy",
+  "has_judgments", "has_felony", "has_legal_actions", "has_federal_debt",
+  "agreed_provide_docs", "agreed_accurate_info",
+  "credit_score_range", "net_worth_range", "annual_income",
+  "citizenship_status", "date_of_birth",
+  "operator_id", "user_id", "account_id", "created_by",
+  "source_agreement", "marketplace_contract_id",
+]);
+
+interface Group {
+  title: string;
+  entries: { key: string; value: unknown }[];
+}
+
+function normalizeIntake(intake: unknown, customerSafe: boolean): Group[] {
+  if (!isNonEmptyObject(intake)) return [];
+
+  // Split top-level keys into "primitive/simple" (become _root group)
+  // and "nested object" (become their own group).
+  const rootEntries: { key: string; value: unknown }[] = [];
+  const subGroups: Group[] = [];
+
+  for (const [k, v] of Object.entries(intake)) {
+    if (customerSafe && CUSTOMER_HIDE.has(k)) continue;
+    if (isNonEmptyObject(v) && !Array.isArray(v)) {
+      const subEntries = Object.entries(v as Record<string, unknown>)
+        .filter(([sk]) => !(customerSafe && CUSTOMER_HIDE.has(sk)))
+        .filter(([, sv]) => !isEmpty(sv))
+        .map(([sk, sv]) => ({ key: sk, value: sv }));
+      if (subEntries.length > 0) subGroups.push({ title: k, entries: subEntries });
+    } else if (!isEmpty(v)) {
+      rootEntries.push({ key: k, value: v });
+    }
+  }
+
+  const groups: Group[] = [];
+  if (rootEntries.length > 0) groups.push({ title: "_root", entries: rootEntries });
+  groups.push(...subGroups);
+  return groups;
+}
+
+function isNonEmptyObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && Object.keys(v).length > 0;
+}
+
+function isEmpty(v: unknown): boolean {
+  if (v === null || v === undefined) return true;
+  if (v === "") return true;
+  if (Array.isArray(v) && v.length === 0) return true;
+  return false;
+}
+
+function humanize(key: string): string {
+  return key
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+    .replace(/\bZip\b/, "ZIP")
+    .replace(/\bLlc\b/, "LLC")
+    .replace(/\bId\b/, "ID")
+    .replace(/\bUrl\b/, "URL");
+}
+
+function formatValue(v: unknown): string {
+  if (v === null || v === undefined) return "—";
+  if (Array.isArray(v)) return v.map((x) => String(x)).join(", ");
+  if (typeof v === "boolean") return v ? "Yes" : "No";
+  if (typeof v === "object") return JSON.stringify(v);
+  if (typeof v === "string" && /^\d{4}-\d{2}-\d{2}T/.test(v)) {
+    // ISO timestamp — show date + short time
+    try {
+      return new Date(v).toLocaleString("en-US", {
+        year: "numeric", month: "short", day: "numeric",
+        hour: "numeric", minute: "2-digit",
+      });
+    } catch {
+      return v;
+    }
+  }
+  return String(v);
+}

--- a/src/app/sales/layout.tsx
+++ b/src/app/sales/layout.tsx
@@ -43,6 +43,7 @@ const NAV_ITEMS = [
   { href: "/sales/orders", label: "Orders / Quotes", icon: ClipboardList, minLevel: 4 as const },
   { href: "/sales/agreements", label: "Agreements", icon: ScrollText, minLevel: 4 as const },
   { href: "/sales/workflows", label: "Workflows", icon: Workflow, minLevel: 4 as const },
+  { href: "/sales/workload", label: "Team Workload", icon: BarChart3, minLevel: 3 as const },
   { href: "/sales/catalog", label: "Item Catalog", icon: BookOpen, minLevel: 1 as const },
   { href: "/sales/team", label: "Team", icon: UserCog, minLevel: 3 as const },
   { href: "/sales/commissions", label: "Commissions", icon: DollarSign, minLevel: 4 as const },

--- a/src/app/sales/page.tsx
+++ b/src/app/sales/page.tsx
@@ -579,7 +579,71 @@ function ExecutiveSnapshot({ data }: { data: SnapshotResponse }) {
           })}
         </div>
       )}
+
+      {/* Team Workload row — only company/market scope; per-rep hides it */}
+      {(data.scope.is_company_wide || data.scope.viewer_role === "market_leader") && (
+        <TeamWorkloadRow periodLabel={data.period.label} />
+      )}
     </div>
+  );
+}
+
+interface WorkloadPayload {
+  employees: {
+    user_id: string; active: number; overdue: number; hours_period: number; capacity: "green" | "yellow" | "red";
+  }[];
+}
+
+function TeamWorkloadRow({ periodLabel }: { periodLabel: string }) {
+  const [data, setData] = useState<WorkloadPayload | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      const supabase = createBrowserClient();
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session?.access_token) return;
+      const res = await fetch(`/api/sales/workload?period=${periodLabel.toLowerCase().replace(/\s/g, "")}`, {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      });
+      if (res.ok) setData(await res.json());
+    }
+    load();
+  }, [periodLabel]);
+
+  if (!data || data.employees.length === 0) return null;
+
+  const totalActive = data.employees.reduce((s, e) => s + e.active, 0);
+  const totalOverdue = data.employees.reduce((s, e) => s + e.overdue, 0);
+  const totalHours = data.employees.reduce((s, e) => s + e.hours_period, 0);
+  const overCapacity = data.employees.filter((e) => e.capacity === "red").length;
+  const avgPerPerson = data.employees.length > 0
+    ? Math.round(totalActive / data.employees.length)
+    : 0;
+
+  return (
+    <Link
+      href="/sales/workload"
+      className="mt-4 block rounded-lg border border-gray-200 bg-gray-50 p-3 hover:bg-gray-100 transition-colors"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2 text-sm font-medium text-gray-900">
+          <Users className="h-4 w-4 text-purple-600" />
+          Team Workload
+        </div>
+        <div className="flex flex-wrap items-center gap-4 text-xs text-gray-600">
+          <span><span className="font-semibold text-gray-900">{totalActive}</span> active</span>
+          <span>~<span className="font-semibold text-gray-900">{avgPerPerson}</span>/person</span>
+          {totalOverdue > 0 && (
+            <span className="text-red-700"><span className="font-semibold">{totalOverdue}</span> overdue</span>
+          )}
+          {overCapacity > 0 && (
+            <span className="text-red-700 font-semibold">{overCapacity} over capacity</span>
+          )}
+          <span><span className="font-semibold text-gray-900">{Math.round(totalHours)}h</span> logged</span>
+          <span className="text-emerald-700">Open →</span>
+        </div>
+      </div>
+    </Link>
   );
 }
 

--- a/src/app/sales/time-clock/page.tsx
+++ b/src/app/sales/time-clock/page.tsx
@@ -50,6 +50,11 @@ export default function TimeClockPage() {
   const [error, setError] = useState<string | null>(null);
   const [view, setView] = useState<"today" | "week">("today");
   const [noSession, setNoSession] = useState(false);
+  // Optional workflow the user is punching in on. Blank = generic /
+  // admin overhead; picking one feeds the /sales/workload hours-per-
+  // workflow rollup so leadership sees where time actually goes.
+  const [workflowPicks, setWorkflowPicks] = useState<{ id: string; label: string }[]>([]);
+  const [selectedWorkflowId, setSelectedWorkflowId] = useState("");
 
   useEffect(() => {
     const supabase = createBrowserClient();
@@ -122,6 +127,25 @@ export default function TimeClockPage() {
     return () => clearInterval(interval);
   }, [activeEntry]);
 
+  // Fetch workflows this user is currently assigned to so they can
+  // punch in on a specific one. Fires when the token first loads.
+  useEffect(() => {
+    if (!token || !userId) return;
+    fetch(`/api/workflows?assignedUserId=${userId}&status=in_progress&limit=25`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((r) => (r.ok ? r.json() : { workflows: [] }))
+      .then((data: { workflows?: { id: string; workflow_number: string; title: string }[] }) => {
+        setWorkflowPicks(
+          (data.workflows ?? []).map((w) => ({
+            id: w.id,
+            label: `${w.workflow_number} — ${w.title}`,
+          })),
+        );
+      })
+      .catch(() => setWorkflowPicks([]));
+  }, [token, userId]);
+
   async function clockIn() {
     setActing(true);
     setError(null);
@@ -129,7 +153,7 @@ export default function TimeClockPage() {
       const res = await fetch("/api/time-entries", {
         method: "POST",
         headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
-        body: JSON.stringify({}),
+        body: JSON.stringify({ workflow_id: selectedWorkflowId || undefined }),
       });
       if (res.ok) {
         const data = await res.json();
@@ -264,15 +288,32 @@ export default function TimeClockPage() {
                     Punch Out
                   </button>
                 ) : (
-                  <button
-                    type="button"
-                    onClick={clockIn}
-                    disabled={acting}
-                    className="inline-flex items-center gap-2 rounded-lg bg-green-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-green-700 disabled:opacity-50 cursor-pointer transition-colors"
-                  >
-                    {acting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Play className="h-4 w-4" />}
-                    Punch In
-                  </button>
+                  <div className="flex flex-wrap items-center gap-2">
+                    {workflowPicks.length > 0 && (
+                      <select
+                        value={selectedWorkflowId}
+                        onChange={(e) => setSelectedWorkflowId(e.target.value)}
+                        className="rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-700 focus:border-green-500 focus:outline-none max-w-[240px]"
+                        title="Optional — punch in on a specific workflow so it counts toward that workflow's hours"
+                      >
+                        <option value="">General work (no workflow)</option>
+                        {workflowPicks.map((w) => (
+                          <option key={w.id} value={w.id}>
+                            {w.label.length > 40 ? `${w.label.slice(0, 40)}…` : w.label}
+                          </option>
+                        ))}
+                      </select>
+                    )}
+                    <button
+                      type="button"
+                      onClick={clockIn}
+                      disabled={acting}
+                      className="inline-flex items-center gap-2 rounded-lg bg-green-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-green-700 disabled:opacity-50 cursor-pointer transition-colors"
+                    >
+                      {acting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Play className="h-4 w-4" />}
+                      Punch In
+                    </button>
+                  </div>
                 )}
               </td>
             </tr>

--- a/src/app/sales/workflows/[id]/page.tsx
+++ b/src/app/sales/workflows/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { use, useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { createBrowserClient } from "@/lib/supabase";
+import { SourceIntakePanel } from "@/app/components/SourceIntakePanel";
 import {
   Loader2,
   ChevronLeft,
@@ -387,6 +388,12 @@ export default function WorkflowDetailPage({ params }: { params: Promise<{ id: s
         </div>
       </div>
 
+      {/* Source Intake — as-submitted customer data from the origin form.
+          Snapshots into workflow.metadata.source_intake at spawn time so
+          the person picking up this workflow sees the full context
+          without clicking back to the source table. */}
+      <SourceIntakePanel intake={(w.metadata as { source_intake?: unknown } | null)?.source_intake} />
+
       {/* Order items (coffee_service etc.) */}
       {data.orderItems.length > 0 && (
         <div className="rounded-xl border border-gray-200 bg-white shadow-sm">
@@ -636,42 +643,38 @@ function StageRow({
       {staffView && (
         <div className="mt-3 grid md:grid-cols-2 gap-3">
           <div>
-            <label className="block text-xs uppercase tracking-wide text-gray-500 mb-1">Internal note</label>
-            <div className="flex gap-2">
-              <textarea
-                value={notesDraft}
-                onChange={(e) => setNotesDraft(e.target.value)}
-                rows={2}
-                className="flex-1 rounded-md border border-gray-200 px-2 py-1 text-sm resize-none"
-              />
-              <button
-                type="button"
-                disabled={notesDraft === (stage.internal_notes ?? "")}
-                onClick={() => onUpdate({ internalNotes: notesDraft })}
-                className="text-xs text-emerald-700 hover:underline disabled:opacity-40"
-              >
-                Save
-              </button>
-            </div>
+            <label className="block text-xs uppercase tracking-wide text-gray-500 mb-1">
+              Internal note
+              <span className="text-gray-400 normal-case font-normal ml-2">auto-saves on blur</span>
+            </label>
+            <textarea
+              value={notesDraft}
+              onChange={(e) => setNotesDraft(e.target.value)}
+              onBlur={() => {
+                if (notesDraft !== (stage.internal_notes ?? "")) {
+                  onUpdate({ internalNotes: notesDraft });
+                }
+              }}
+              rows={2}
+              className="w-full rounded-md border border-gray-200 px-2 py-1 text-sm resize-none"
+            />
           </div>
           <div>
-            <label className="block text-xs uppercase tracking-wide text-emerald-700 mb-1">Customer message</label>
-            <div className="flex gap-2">
-              <textarea
-                value={customerDraft}
-                onChange={(e) => setCustomerDraft(e.target.value)}
-                rows={2}
-                className="flex-1 rounded-md border border-emerald-200 bg-emerald-50/50 px-2 py-1 text-sm resize-none"
-              />
-              <button
-                type="button"
-                disabled={customerDraft === (stage.customer_message ?? "")}
-                onClick={() => onUpdate({ customerMessage: customerDraft })}
-                className="text-xs text-emerald-700 hover:underline disabled:opacity-40"
-              >
-                Publish
-              </button>
-            </div>
+            <label className="block text-xs uppercase tracking-wide text-emerald-700 mb-1">
+              Customer message
+              <span className="text-emerald-600/60 normal-case font-normal ml-2">auto-saves on blur</span>
+            </label>
+            <textarea
+              value={customerDraft}
+              onChange={(e) => setCustomerDraft(e.target.value)}
+              onBlur={() => {
+                if (customerDraft !== (stage.customer_message ?? "")) {
+                  onUpdate({ customerMessage: customerDraft });
+                }
+              }}
+              rows={2}
+              className="w-full rounded-md border border-emerald-200 bg-emerald-50/50 px-2 py-1 text-sm resize-none"
+            />
           </div>
         </div>
       )}

--- a/src/app/sales/workload/page.tsx
+++ b/src/app/sales/workload/page.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { createBrowserClient } from "@/lib/supabase";
+import { Loader2, Users, Clock, AlertTriangle, TrendingUp } from "lucide-react";
+
+type Period = "daily" | "weekly" | "monthly" | "quarterly" | "yearly" | "ytd";
+
+interface EmployeeRow {
+  user_id: string;
+  name: string;
+  email: string;
+  role: string;
+  active: number;
+  by_type: Record<string, number>;
+  overdue: number;
+  due_7d: number;
+  hours_period: number;
+  avg_days_to_close: number | null;
+  close_rate: number;
+  quotes_sent: number;
+  quotes_closed: number;
+  capacity: "green" | "yellow" | "red";
+}
+
+interface Payload {
+  period: { label: string };
+  capacity_thresholds: { green_max: number; yellow_max: number };
+  employees: EmployeeRow[];
+}
+
+const PERIODS: { value: Period; label: string }[] = [
+  { value: "daily", label: "Today" },
+  { value: "weekly", label: "This Week" },
+  { value: "monthly", label: "This Month" },
+  { value: "quarterly", label: "This Quarter" },
+  { value: "ytd", label: "Year to Date" },
+  { value: "yearly", label: "This Year" },
+];
+
+const TYPE_LABEL: Record<string, string> = {
+  ai_machine_fulfillment: "AI",
+  location_services: "Loc",
+  financing: "Fin",
+  coffee_equipment: "Coffee Eq",
+  coffee_service: "Coffee Sv",
+  website_build: "Web",
+};
+
+type SortKey = "name" | "active" | "overdue" | "hours" | "close_rate";
+
+export default function WorkloadPage() {
+  const [data, setData] = useState<Payload | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [period, setPeriod] = useState<Period>("monthly");
+  const [sortKey, setSortKey] = useState<SortKey>("active");
+  const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
+
+  useEffect(() => {
+    async function load() {
+      setLoading(true);
+      const supabase = createBrowserClient();
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session?.access_token) { setLoading(false); return; }
+      const res = await fetch(`/api/sales/workload?period=${period}`, {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      });
+      if (res.ok) setData(await res.json());
+      setLoading(false);
+    }
+    load();
+  }, [period]);
+
+  const rows = [...(data?.employees ?? [])].sort((a, b) => {
+    const dir = sortDir === "asc" ? 1 : -1;
+    switch (sortKey) {
+      case "name": return a.name.localeCompare(b.name) * dir;
+      case "active": return (a.active - b.active) * dir;
+      case "overdue": return (a.overdue - b.overdue) * dir;
+      case "hours": return (a.hours_period - b.hours_period) * dir;
+      case "close_rate": return (a.close_rate - b.close_rate) * dir;
+    }
+  });
+
+  function toggleSort(key: SortKey) {
+    if (sortKey === key) setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    else { setSortKey(key); setSortDir(key === "name" ? "asc" : "desc"); }
+  }
+
+  return (
+    <div className="p-6">
+      <div className="flex flex-wrap items-center justify-between gap-3 mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Team Workload</h1>
+          <p className="text-sm text-gray-500 mt-1">
+            Active workflows, capacity, hours, and close rate per employee.
+          </p>
+        </div>
+        <select
+          value={period}
+          onChange={(e) => setPeriod(e.target.value as Period)}
+          className="rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm focus:border-green-500 focus:outline-none cursor-pointer"
+        >
+          {PERIODS.map((p) => (
+            <option key={p.value} value={p.value}>{p.label}</option>
+          ))}
+        </select>
+      </div>
+
+      {data && data.capacity_thresholds && (
+        <div className="mb-4 text-xs text-gray-500">
+          Capacity: <span className="text-green-700">green ≤{data.capacity_thresholds.green_max}</span>
+          {" · "}
+          <span className="text-amber-700">yellow ≤{data.capacity_thresholds.yellow_max}</span>
+          {" · "}
+          <span className="text-red-700">red &gt;{data.capacity_thresholds.yellow_max}</span>
+          {" · "}
+          set via WORKLOAD_CAPACITY_GREEN_MAX / WORKLOAD_CAPACITY_YELLOW_MAX env vars
+        </div>
+      )}
+
+      <div className="overflow-x-auto rounded-lg border border-gray-200 bg-white">
+        <table className="min-w-full text-sm">
+          <thead className="bg-gray-50 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+            <tr>
+              <th className="px-4 py-3 cursor-pointer" onClick={() => toggleSort("name")}>Employee</th>
+              <th className="px-4 py-3 cursor-pointer text-right" onClick={() => toggleSort("active")}>Active</th>
+              <th className="px-4 py-3">By Type</th>
+              <th className="px-4 py-3 cursor-pointer text-right" onClick={() => toggleSort("overdue")}>Overdue</th>
+              <th className="px-4 py-3 text-right">Due 7d</th>
+              <th className="px-4 py-3 cursor-pointer text-right" onClick={() => toggleSort("hours")}>Hours</th>
+              <th className="px-4 py-3 text-right">Avg Close</th>
+              <th className="px-4 py-3 cursor-pointer text-right" onClick={() => toggleSort("close_rate")}>Close Rate</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100">
+            {loading ? (
+              <tr><td colSpan={8} className="px-4 py-12 text-center text-gray-500">
+                <Loader2 className="inline-block h-5 w-5 animate-spin mr-2" /> Loading…
+              </td></tr>
+            ) : rows.length === 0 ? (
+              <tr><td colSpan={8} className="px-4 py-12 text-center text-gray-500">
+                <Users className="inline-block h-5 w-5 mr-2 text-gray-400" />
+                No team members in this scope.
+              </td></tr>
+            ) : rows.map((r) => (
+              <EmployeeRowRender key={r.user_id} row={r} />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function EmployeeRowRender({ row }: { row: EmployeeRow }) {
+  const capacityColors = {
+    green: "bg-green-100 text-green-800",
+    yellow: "bg-amber-100 text-amber-800",
+    red: "bg-red-100 text-red-800",
+  }[row.capacity];
+
+  return (
+    <tr className="hover:bg-gray-50">
+      <td className="px-4 py-3">
+        <div className="font-medium text-gray-900">{row.name}</div>
+        <div className="text-xs text-gray-500">{row.role.replace(/_/g, " ")}</div>
+      </td>
+      <td className="px-4 py-3 text-right">
+        <div className="inline-flex items-center gap-2">
+          <span className="text-lg font-bold text-gray-900">{row.active}</span>
+          <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${capacityColors}`}>
+            {row.capacity}
+          </span>
+        </div>
+      </td>
+      <td className="px-4 py-3">
+        <div className="flex flex-wrap gap-1">
+          {Object.entries(row.by_type).map(([type, count]) => (
+            <span key={type} className="inline-flex items-center rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-700">
+              {TYPE_LABEL[type] ?? type} <span className="font-semibold ml-1">{count}</span>
+            </span>
+          ))}
+        </div>
+      </td>
+      <td className="px-4 py-3 text-right">
+        {row.overdue > 0 ? (
+          <Link
+            href={`/sales/workflows?assignedUserId=${row.user_id}&overdue=true`}
+            className="inline-flex items-center gap-1 text-red-700 font-semibold hover:underline"
+          >
+            <AlertTriangle className="h-3.5 w-3.5" />
+            {row.overdue}
+          </Link>
+        ) : (
+          <span className="text-gray-400">0</span>
+        )}
+      </td>
+      <td className="px-4 py-3 text-right text-amber-700">{row.due_7d > 0 ? row.due_7d : "—"}</td>
+      <td className="px-4 py-3 text-right text-gray-900">
+        <span className="inline-flex items-center gap-1">
+          <Clock className="h-3.5 w-3.5 text-gray-400" />
+          {row.hours_period}h
+        </span>
+      </td>
+      <td className="px-4 py-3 text-right text-gray-700">
+        {row.avg_days_to_close != null ? `${row.avg_days_to_close}d` : "—"}
+      </td>
+      <td className="px-4 py-3 text-right">
+        <span className="inline-flex items-center gap-1 text-gray-900">
+          <TrendingUp className="h-3.5 w-3.5 text-emerald-500" />
+          {row.quotes_sent > 0 ? `${Math.round(row.close_rate * 100)}%` : "—"}
+        </span>
+        {row.quotes_sent > 0 && (
+          <div className="text-xs text-gray-400">{row.quotes_closed}/{row.quotes_sent}</div>
+        )}
+      </td>
+    </tr>
+  );
+}

--- a/src/lib/paymentIngest.ts
+++ b/src/lib/paymentIngest.ts
@@ -83,6 +83,21 @@ export async function ingestStripeEvent(event: Stripe.Event, eventRowId: string)
       status: "paid",
       paidAt: new Date().toISOString(),
     });
+
+    // Mirror the payment to any workflow linked to this order.
+    if (orderId) {
+      try {
+        const { syncWorkflowFromSalesOrderPaid } = await import("./workflows/paymentSync");
+        await syncWorkflowFromSalesOrderPaid({
+          orderId,
+          amountCents: amount,
+          source: "stripe_webhook",
+          changeKey: `stripe:${paymentIntentId || session.id}`,
+        });
+      } catch (e) {
+        console.error("[paymentIngest] workflow payment sync failed:", e);
+      }
+    }
     return;
   }
 

--- a/src/lib/workflows/hooks.ts
+++ b/src/lib/workflows/hooks.ts
@@ -16,6 +16,33 @@ import { supabaseAdmin } from "../supabaseAdmin";
 import { getOrCreateWorkflow, updateStage } from "./service";
 import type { CreateWorkflowInput, WorkflowRow } from "./types";
 
+/**
+ * Project a source row into a shape safe to snapshot into
+ * workflow.metadata.source_intake. Strips columns that are noise for
+ * "what did the customer submit" (system timestamps, internal-only IDs,
+ * anything containing a secret). Everything else — including the
+ * business context, contact info, and per-form fields — is copied
+ * verbatim so whoever picks up the workflow has full context without
+ * clicking back to the source table.
+ */
+function snapshotSourceIntake<T extends Record<string, unknown>>(row: T): Record<string, unknown> {
+  const DROP = new Set([
+    "id", "created_at", "updated_at", "created_by", "updated_by",
+    "deleted_at", "sign_token", "qb_invoice_id",
+    "location_remaining_qb_invoice_id", "apex_placement_qb_invoice_id",
+    "stripe_customer_id", "stripe_subscription_id", "stripe_account_id",
+    "stripe_checkout_session_id", "stripe_payment_intent_id",
+    "raw_stripe_event", "raw_webhook",
+  ]);
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(row)) {
+    if (DROP.has(k)) continue;
+    if (v === null || v === undefined) continue;
+    out[k] = v;
+  }
+  return out;
+}
+
 // ─── Purchase agreement (machine + location placement) ──────────────────
 //
 // Called from generateAgreementPdf.handleFullySignedAgreement when both
@@ -65,6 +92,7 @@ export async function spawnFromPurchaseAgreement(
         unit_price: ag.machine_unit_price,
         total: ag.total_due_prior_to_procurement,
         operator_company: ag.operator_company_name,
+        source_intake: snapshotSourceIntake(ag),
       },
       actorType: "system",
     });
@@ -110,6 +138,7 @@ export async function spawnFromPurchaseAgreement(
         location_state: ag.location_state,
         send_to_marketplace: ag.send_to_marketplace,
         marketplace_contract_id: placementContractId,
+        source_intake: snapshotSourceIntake(ag),
       },
       actorType: "system",
     });
@@ -140,6 +169,22 @@ export async function spawnFromCoffeeAgreement(
   const committedQty =
     Number((ua.metadata as Record<string, unknown> | null)?.equipment_quantity) || 1;
 
+  // Pull the original coffee_application intake so the fulfillment
+  // team sees the customer's shipping address, contact, volume estimate,
+  // notes, etc. — not just the agreement.
+  const { data: application } = await supabaseAdmin
+    .from("coffee_applications")
+    .select("*")
+    .eq("operator_id", customerId)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  const coffeeIntake = {
+    agreement: snapshotSourceIntake(ua),
+    application: application ? snapshotSourceIntake(application) : null,
+  };
+
   const equipmentResult = await safeCreate({
     customerId,
     workflowType: "coffee_equipment",
@@ -151,7 +196,10 @@ export async function spawnFromCoffeeAgreement(
     paymentStatus: "na",
     primaryTeam: "coffee",
     assignedUserId: teamEmailAssignee("coffee"),
-    metadata: { source_agreement: userAgreementId },
+    metadata: {
+      source_agreement: userAgreementId,
+      source_intake: coffeeIntake,
+    },
     actorType: "system",
   });
   if (equipmentResult) spawned.push(equipmentResult);
@@ -169,7 +217,10 @@ export async function spawnFromCoffeeAgreement(
     paymentStatus: "na",
     primaryTeam: "coffee",
     assignedUserId: teamEmailAssignee("coffee"),
-    metadata: { source_agreement: userAgreementId },
+    metadata: {
+      source_agreement: userAgreementId,
+      source_intake: coffeeIntake,
+    },
     actorType: "system",
   });
   if (serviceResult) spawned.push(serviceResult);
@@ -218,6 +269,15 @@ export async function spawnFromMachineListingPurchase(
     machineTitle?: string;
   },
 ): Promise<WorkflowRow | null> {
+  // Grab the full buyer intake so the fulfillment team sees buyer type,
+  // business address, LLC status, location plan, timeline, power/space
+  // flags, connectivity, shipping intent, etc.
+  const { data: purchase } = await supabaseAdmin
+    .from("machine_listing_purchases")
+    .select("*")
+    .eq("id", purchaseId)
+    .maybeSingle();
+
   return safeCreate({
     customerId: args.customerId,
     workflowType: "ai_machine_fulfillment",
@@ -230,6 +290,7 @@ export async function spawnFromMachineListingPurchase(
     paymentStatus: "paid",
     primaryTeam: "fulfillment",
     assignedUserId: teamEmailAssignee("fulfillment"),
+    metadata: purchase ? { source_intake: snapshotSourceIntake(purchase) } : undefined,
     actorType: "system",
   });
 }
@@ -239,6 +300,15 @@ export async function spawnFromFinancingApplication(
   applicationId: string,
   args: { customerId: string; companyId?: string },
 ): Promise<WorkflowRow | null> {
+  // Load the full application row so the financing team sees the
+  // 17-field intake (income, credit range, background flags, etc.)
+  // without needing to click into the source table.
+  const { data: application } = await supabaseAdmin
+    .from("financing_applications")
+    .select("*")
+    .eq("id", applicationId)
+    .maybeSingle();
+
   return safeCreate({
     customerId: args.customerId,
     companyId: args.companyId ?? null,
@@ -252,6 +322,7 @@ export async function spawnFromFinancingApplication(
     paymentStatus: "na",
     primaryTeam: "financing",
     assignedUserId: teamEmailAssignee("financing"),
+    metadata: application ? { source_intake: snapshotSourceIntake(application) } : undefined,
     actorType: "system",
   });
 }
@@ -261,6 +332,15 @@ export async function spawnFromWebsiteRequest(
   requestId: string,
   args: { customerId: string; companyId?: string; siteName?: string },
 ): Promise<WorkflowRow | null> {
+  // Pull the full wizard payload so the build team sees every step —
+  // business, brand, domain, content, products, media, features,
+  // contact, launch prefs — without opening a separate admin view.
+  const { data: request } = await supabaseAdmin
+    .from("website_requests")
+    .select("*")
+    .eq("id", requestId)
+    .maybeSingle();
+
   return safeCreate({
     customerId: args.customerId,
     companyId: args.companyId ?? null,
@@ -274,6 +354,7 @@ export async function spawnFromWebsiteRequest(
     paymentStatus: "na",
     primaryTeam: "fulfillment",
     assignedUserId: teamEmailAssignee("fulfillment"),
+    metadata: request ? { source_intake: snapshotSourceIntake(request) } : undefined,
     actorType: "system",
   });
 }

--- a/src/lib/workflows/paymentSync.ts
+++ b/src/lib/workflows/paymentSync.ts
@@ -1,0 +1,188 @@
+/**
+ * Workflows — payment sync helpers.
+ *
+ * When a payment lands on any source object that a workflow tracks
+ * (sales_orders, coffee_orders, machine_listing_purchases, or the
+ * workflow's own balance invoice), we mirror the payment state onto
+ * workflows.payment_status + workflows.deposit_paid_cents.
+ *
+ * Every helper is idempotent — safe to call repeatedly on the same
+ * source. Uses the workflow_events audit log to record the sync so
+ * duplicate webhook fires stay traceable.
+ */
+
+import { supabaseAdmin } from "../supabaseAdmin";
+import { recordEvent } from "./service";
+
+/**
+ * Mark any workflow(s) linked to this sales_order as paid.
+ */
+export async function syncWorkflowFromSalesOrderPaid(args: {
+  orderId: string;
+  amountCents?: number;
+  source: string;
+  changeKey?: string;
+}): Promise<number> {
+  const { data: workflows } = await supabaseAdmin
+    .from("workflows")
+    .select("id, payment_status, deposit_paid_cents, total_due_cents, version")
+    .eq("order_id", args.orderId);
+
+  let updated = 0;
+  for (const w of workflows ?? []) {
+    if (w.payment_status === "paid") continue;
+    const patch: Record<string, unknown> = {
+      payment_status: "paid",
+      version: (w.version ?? 1) + 1,
+    };
+    if (args.amountCents != null) {
+      patch.deposit_paid_cents = Math.max(Number(w.deposit_paid_cents ?? 0), args.amountCents);
+    } else if (w.total_due_cents != null && Number(w.total_due_cents) > 0) {
+      patch.deposit_paid_cents = Number(w.total_due_cents);
+    }
+    const { error } = await supabaseAdmin
+      .from("workflows")
+      .update(patch)
+      .eq("id", w.id)
+      .eq("version", w.version);
+    if (!error) {
+      updated += 1;
+      await recordEvent({
+        workflowId: w.id,
+        eventType: "payment_synced",
+        previousValue: { payment_status: w.payment_status },
+        newValue: { payment_status: "paid", source_order_id: args.orderId },
+        actorType: "webhook",
+        source: args.source,
+        changeKey: args.changeKey,
+      });
+    }
+  }
+  return updated;
+}
+
+/**
+ * Mark a coffee_order's workflow_order_items sub-item as fulfilled
+ * (used when the QB webhook confirms the coffee order paid).
+ */
+export async function syncCoffeeOrderPaid(args: {
+  coffeeOrderId: string;
+  source: string;
+  changeKey?: string;
+}): Promise<number> {
+  const { data: items } = await supabaseAdmin
+    .from("workflow_order_items")
+    .select("id, workflow_id, fulfillment_status")
+    .eq("external_order_id", args.coffeeOrderId)
+    .eq("external_order_type", "coffee_order");
+
+  let updated = 0;
+  for (const item of items ?? []) {
+    if (item.fulfillment_status === "fulfilled" || item.fulfillment_status === "cancelled") continue;
+    const { error } = await supabaseAdmin
+      .from("workflow_order_items")
+      .update({
+        fulfillment_status: "fulfilled",
+        fulfilled_at: new Date().toISOString(),
+      })
+      .eq("id", item.id);
+    if (!error) {
+      updated += 1;
+      await recordEvent({
+        workflowId: item.workflow_id,
+        eventType: "order_item_paid",
+        newValue: { coffee_order_id: args.coffeeOrderId, item_id: item.id },
+        actorType: "webhook",
+        source: args.source,
+        changeKey: args.changeKey,
+      });
+    }
+  }
+  return updated;
+}
+
+/**
+ * When a QB invoice ID that was created via
+ * /api/account/workflows/[id]/pay-balance gets paid, find the workflow
+ * that stashed that invoice ID and mark it paid.
+ */
+export async function syncWorkflowFromBalanceInvoicePaid(args: {
+  qbInvoiceId: string;
+  amountCents?: number;
+  source: string;
+  changeKey?: string;
+}): Promise<number> {
+  // Postgres JSON containment: find any workflow whose metadata contains
+  // { balance_qb_invoice_id: <id> }.
+  const { data: workflows } = await supabaseAdmin
+    .from("workflows")
+    .select("id, payment_status, deposit_paid_cents, total_due_cents, version, metadata")
+    .contains("metadata", { balance_qb_invoice_id: args.qbInvoiceId });
+
+  let updated = 0;
+  for (const w of workflows ?? []) {
+    if (w.payment_status === "paid") continue;
+    const patch: Record<string, unknown> = {
+      payment_status: "paid",
+      version: (w.version ?? 1) + 1,
+      deposit_paid_cents: w.total_due_cents != null && Number(w.total_due_cents) > 0
+        ? Number(w.total_due_cents)
+        : Math.max(Number(w.deposit_paid_cents ?? 0), args.amountCents ?? 0),
+    };
+    const { error } = await supabaseAdmin
+      .from("workflows")
+      .update(patch)
+      .eq("id", w.id)
+      .eq("version", w.version);
+    if (!error) {
+      updated += 1;
+      await recordEvent({
+        workflowId: w.id,
+        eventType: "balance_paid",
+        previousValue: { payment_status: w.payment_status },
+        newValue: { payment_status: "paid", qb_invoice_id: args.qbInvoiceId },
+        actorType: "webhook",
+        source: args.source,
+        changeKey: args.changeKey,
+      });
+    }
+  }
+  return updated;
+}
+
+/**
+ * Mark a machine_listing_purchase's workflow as paid.
+ */
+export async function syncWorkflowFromMachinePurchasePaid(args: {
+  purchaseId: string;
+  source: string;
+  changeKey?: string;
+}): Promise<number> {
+  const { data: workflows } = await supabaseAdmin
+    .from("workflows")
+    .select("id, payment_status, version")
+    .eq("purchase_id", args.purchaseId);
+
+  let updated = 0;
+  for (const w of workflows ?? []) {
+    if (w.payment_status === "paid") continue;
+    const { error } = await supabaseAdmin
+      .from("workflows")
+      .update({ payment_status: "paid", version: (w.version ?? 1) + 1 })
+      .eq("id", w.id)
+      .eq("version", w.version);
+    if (!error) {
+      updated += 1;
+      await recordEvent({
+        workflowId: w.id,
+        eventType: "payment_synced",
+        previousValue: { payment_status: w.payment_status },
+        newValue: { payment_status: "paid", source_purchase_id: args.purchaseId },
+        actorType: "webhook",
+        source: args.source,
+        changeKey: args.changeKey,
+      });
+    }
+  }
+  return updated;
+}

--- a/supabase/migrations/129_time_entries_workflow_link.sql
+++ b/supabase/migrations/129_time_entries_workflow_link.sql
@@ -1,0 +1,18 @@
+-- Migration 129 — link time_entries to workflows (optional)
+--
+-- Adds a nullable workflow_id column so the Time Clock can capture
+-- "who's working on what" per clock-in. Left blank for admin overhead
+-- and non-workflow work. Executive workload reporting reads this to
+-- roll up hours-per-workflow and hours-per-employee-per-workflow.
+
+ALTER TABLE public.time_entries
+  ADD COLUMN IF NOT EXISTS workflow_id uuid REFERENCES public.workflows(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_time_entries_workflow
+  ON public.time_entries(workflow_id)
+  WHERE workflow_id IS NOT NULL;
+
+COMMENT ON COLUMN public.time_entries.workflow_id IS
+  'Optional link to a workflow the user was working on during this
+   clock-in. NULL for admin overhead, breaks, non-workflow work.
+   ON DELETE SET NULL so deleting a workflow doesn''t lose the time entry.';


### PR DESCRIPTION
Six concerns in one build:

1. SOURCE INTAKE FLOW-THROUGH Every workflow-spawn hook now snapshots the source row into workflow.metadata.source_intake so anyone opening the workflow sees the customer's original submission without clicking back to the source table. New SourceIntakePanel component renders the metadata as a labeled key-value list on both the CRM and customer detail pages. Customer view hides staff-only fields (financing background flags, internal IDs).

   Fixed /request-location dropping the `address` field — was omitted from the workflow metadata block; now included in source_intake.

   Coffee equipment + coffee service workflows also snapshot the original coffee_applications row so fulfillment sees shipping address, volume estimate, num_locations, notes.

2. PAYMENT SYNC New src/lib/workflows/paymentSync.ts helpers mirror payment events from source tables onto workflows.payment_status + deposit_paid_cents:
     - syncWorkflowFromSalesOrderPaid — called from QB webhook, Stripe paymentIngest, and manual mark_paid - syncCoffeeOrderPaid — marks workflow_order_items fulfilled - syncWorkflowFromBalanceInvoicePaid — QB payment on invoice created via /api/account/workflows/[id]/pay-balance - syncWorkflowFromMachinePurchasePaid — QB payment on P2P machine purchase All idempotent, all audit-logged via workflow_events with change_key dedup.

3. STAGE UI — REMOVED Publish + Save BUTTONS The two redundant buttons on each stage row are gone. Internal notes and customer messages now auto-save on blur when the value changed. Status dropdown already updates the workflow inline — nothing was lost.

4. MIGRATION 129 — time_entries.workflow_id Nullable FK linking a Time Clock entry to a workflow. ON DELETE SET NULL so deleting a workflow doesn't lose the time entry. Index for lookup-by-workflow.

5. WORKLOAD ENDPOINT + PAGE New GET /api/sales/workload aggregates per-user: - Active workflows count + by-type breakdown - Overdue + due-within-7d - Hours clocked in period (from time_entries) - Avg days-to-close (from completed workflows in last 90d) - Close rate (same defn as executive-snapshot: quotes → completed or paid order via deal_id) - Capacity flag (green ≤10 / yellow ≤20 / red >20 by default; tuned via WORKLOAD_CAPACITY_GREEN_MAX + _YELLOW_MAX env vars) New /sales/workload page renders sortable table + Team Workload sidebar item (level 3+ — market_leader and above). Scope: admin/DOS see everyone, market_leader sees their market, sales sees only self.

6. TIME CLOCK — OPTIONAL WORKFLOW PICKER Adds a "General work / [workflow]" dropdown next to Punch In. Populated from workflows currently assigned to the user + in progress. Stamps the clock-in with workflow_id when selected; blank = admin overhead. Feeds the workload page's hours-per-workflow rollup.

7. EXECUTIVE SNAPSHOT — Team Workload row New one-line summary below the by-type chip row (company/market scope only): total active workflows across team, avg per person, overdue count, over-capacity count, hours logged. Click through opens /sales/workload.