### PR TITLE
CRM — delete team members (admin) + fix Results metrics

### DIFF
--- a/src/app/api/sales/results/route.ts
+++ b/src/app/api/sales/results/route.ts
@@ -162,7 +162,7 @@ export async function GET(req: NextRequest) {
   // doesn't exist on very old schemas (all rows treated as orders then).
   let ordersQuery = supabaseAdmin
     .from("sales_orders")
-    .select("id, status, total_value, deal_id, created_at, document_type")
+    .select("id, status, payment_status, total_value, deal_id, created_at, document_type")
     .gte("created_at", since);
   if (until) ordersQuery = ordersQuery.lte("created_at", until);
 
@@ -178,7 +178,7 @@ export async function GET(req: NextRequest) {
   if (ordersError && String(ordersError.message).includes("document_type")) {
     let retry = supabaseAdmin
       .from("sales_orders")
-      .select("id, status, total_value, deal_id, created_at")
+      .select("id, status, payment_status, total_value, deal_id, created_at")
       .gte("created_at", since);
     if (until) retry = retry.lte("created_at", until);
     if (targetUserId) {
@@ -200,11 +200,15 @@ export async function GET(req: NextRequest) {
   const quotesInPeriod = rows.filter((r) => r.document_type === "quote");
 
   // --- Commissions ---
+  // commission_ledger is the current source (migration 109). The older
+  // sales_commissions table (migration 028) is deprecated and empty
+  // in production — querying it always returned $0. Read from ledger
+  // and convert amount_cents → dollars for the payload.
   let commissionsQuery = supabaseAdmin
-    .from("sales_commissions")
-    .select("id, commission_amount, status, created_at")
-    .gte("created_at", since);
-  if (until) commissionsQuery = commissionsQuery.lte("created_at", until);
+    .from("commission_ledger")
+    .select("id, amount_cents, status, earned_at")
+    .gte("earned_at", since);
+  if (until) commissionsQuery = commissionsQuery.lte("earned_at", until);
 
   if (targetUserId) {
     commissionsQuery = commissionsQuery.eq("user_id", targetUserId);
@@ -212,7 +216,27 @@ export async function GET(req: NextRequest) {
     commissionsQuery = commissionsQuery.in("user_id", allowedUserIds);
   }
 
-  const { data: commissions } = await commissionsQuery;
+  // eslint-disable-next-line prefer-const
+  let { data: commissions, error: commissionErr } = await commissionsQuery;
+  if (commissionErr) {
+    // Fallback for schemas that still only have sales_commissions.
+    let retry = supabaseAdmin
+      .from("sales_commissions")
+      .select("id, commission_amount, status, created_at")
+      .gte("created_at", since);
+    if (until) retry = retry.lte("created_at", until);
+    if (targetUserId) retry = retry.eq("user_id", targetUserId);
+    else if (allowedUserIds) retry = retry.in("user_id", allowedUserIds);
+    const fallback = await retry;
+    // Normalize old shape (commission_amount in dollars) to new shape
+    // (amount_cents) so the aggregator below stays uniform.
+    commissions = (fallback.data ?? []).map((r) => ({
+      id: (r as { id: string }).id,
+      amount_cents: Math.round(Number((r as { commission_amount: number }).commission_amount ?? 0) * 100),
+      status: (r as { status: string }).status,
+      earned_at: (r as { created_at: string }).created_at,
+    }));
+  }
 
   // --- Goal ---
   const goalPeriod = period === "ytd" ? "yearly" : period === "custom" ? "yearly" : period;
@@ -239,17 +263,16 @@ export async function GET(req: NextRequest) {
     pipelineValue += Number(d.value || 0);
   }
 
-  // Won metrics: orders linked to deals in the period
-  let wonValue = 0;
-  let wonCount = 0;
-  const wonDealIds = new Set<string>();
-  for (const o of orders || []) {
-    if (o.deal_id && !wonDealIds.has(o.deal_id)) {
-      wonDealIds.add(o.deal_id);
-      wonValue += Number(o.total_value || 0);
-      wonCount += 1;
-    }
-  }
+  // Won metrics — redefined to match Completed Orders / Order Revenue
+  // definition. Prior formula was "unique deal_ids on any order in the
+  // period", which returned 0 whenever orders had no deal_id (which is
+  // typical for direct-created and manual one-off orders). New formula:
+  // orders that are completed or paid.
+  const wonOrders = (orders || []).filter(
+    (o) => o.status === "completed" || (o as { payment_status?: string }).payment_status === "paid",
+  );
+  const wonCount = wonOrders.length;
+  const wonValue = wonOrders.reduce((sum, o) => sum + Number(o.total_value || 0), 0);
 
   const orderRevenue = (orders || []).reduce(
     (sum, o) => sum + Number(o.total_value || 0), 0
@@ -288,18 +311,27 @@ export async function GET(req: NextRequest) {
     closeRate = closedQuotes / quotesInPeriod.length;
   }
 
-  // Commission metrics
-  let commissionTotal = 0;
-  let commissionPending = 0;
-  let commissionApproved = 0;
-  let commissionPaid = 0;
+  // Commission metrics — commission_ledger stores amount_cents.
+  // status enum: 'pending' | 'held' | 'earned' | 'reversed' | 'paid' |
+  // 'cancelled'. Group them into the four buckets the dashboard shows:
+  // pending → pending; held+earned → approved; paid → paid; anything
+  // else drops out.
+  let commissionCentsTotal = 0;
+  let commissionCentsPending = 0;
+  let commissionCentsApproved = 0;
+  let commissionCentsPaid = 0;
   for (const c of commissions || []) {
-    const amt = Number(c.commission_amount || 0);
-    commissionTotal += amt;
-    if (c.status === "pending") commissionPending += amt;
-    else if (c.status === "approved") commissionApproved += amt;
-    else if (c.status === "paid") commissionPaid += amt;
+    const cents = Number((c as { amount_cents?: number }).amount_cents ?? 0);
+    commissionCentsTotal += cents;
+    const status = (c as { status: string }).status;
+    if (status === "pending") commissionCentsPending += cents;
+    else if (status === "earned" || status === "held" || status === "approved") commissionCentsApproved += cents;
+    else if (status === "paid") commissionCentsPaid += cents;
   }
+  const commissionTotal = commissionCentsTotal / 100;
+  const commissionPending = commissionCentsPending / 100;
+  const commissionApproved = commissionCentsApproved / 100;
+  const commissionPaid = commissionCentsPaid / 100;
 
   return NextResponse.json({
     period,

--- a/src/app/api/sales/users/[id]/route.ts
+++ b/src/app/api/sales/users/[id]/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser } from "@/lib/salesAuth";
+
+/**
+ * DELETE /api/sales/users/[id]
+ *
+ * Admin-only: remove a sales-team member. Deletes:
+ *   - The auth user (Supabase auth.users)
+ *   - Cascades to profiles via FK
+ *   - Sets assignment references (workflow_assignments, sales_leads.assigned_to,
+ *     sales_orders.created_by, etc.) to NULL via existing ON DELETE SET NULL
+ *     constraints — nothing else in the CRM breaks
+ *
+ * Refuses to delete:
+ *   - The requester themselves (prevents lockout)
+ *   - The last remaining admin (prevents system lockout)
+ */
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const user = await getSalesUser(req);
+  if (!user) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  if (user.role !== "admin") {
+    return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+  }
+
+  const { id } = await params;
+
+  if (id === user.id) {
+    return NextResponse.json({ error: "You cannot delete yourself" }, { status: 400 });
+  }
+
+  const { data: target } = await supabaseAdmin
+    .from("profiles")
+    .select("id, full_name, email, role")
+    .eq("id", id)
+    .maybeSingle();
+  if (!target) return NextResponse.json({ error: "User not found" }, { status: 404 });
+
+  // Last-admin guard
+  if (target.role === "admin") {
+    const { count } = await supabaseAdmin
+      .from("profiles")
+      .select("id", { count: "exact", head: true })
+      .eq("role", "admin");
+    if ((count ?? 0) <= 1) {
+      return NextResponse.json(
+        { error: "Cannot delete the last remaining admin" },
+        { status: 400 },
+      );
+    }
+  }
+
+  // Delete auth user — cascades to profiles.
+  const { error: authErr } = await supabaseAdmin.auth.admin.deleteUser(id);
+  if (authErr) {
+    return NextResponse.json({ error: `Auth delete failed: ${authErr.message}` }, { status: 500 });
+  }
+
+  // Belt-and-suspenders: ensure the profile row is also gone. Some
+  // schemas don't have the auth→profiles cascade wired.
+  await supabaseAdmin.from("profiles").delete().eq("id", id);
+
+  return NextResponse.json({
+    ok: true,
+    deleted: { id: target.id, email: target.email, role: target.role },
+  });
+}

--- a/src/app/sales/page.tsx
+++ b/src/app/sales/page.tsx
@@ -352,10 +352,6 @@ export default function SalesDashboard() {
                     <p className="text-xl font-bold text-green-600">{fmt(results.metrics.won_value)}</p>
                   </div>
                   <div className="rounded-lg bg-gray-50 p-4">
-                    <p className="text-xs text-gray-500">Pipeline</p>
-                    <p className="text-xl font-bold text-gray-900">{fmt(results.metrics.pipeline_value)}</p>
-                  </div>
-                  <div className="rounded-lg bg-gray-50 p-4">
                     <p className="text-xs text-gray-500">Orders Sent</p>
                     <p className="text-xl font-bold text-gray-900">{results.metrics.orders_total}</p>
                   </div>

--- a/src/app/sales/team/page.tsx
+++ b/src/app/sales/team/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { createBrowserClient } from "@/lib/supabase";
-import { Users, Loader2, Search, CheckCircle2, Clock, UserX, AlertTriangle, Plus, X, Eye, EyeOff, UserPlus } from "lucide-react";
+import { Users, Loader2, Search, CheckCircle2, Clock, UserX, AlertTriangle, Plus, X, Eye, EyeOff, UserPlus, Trash2 } from "lucide-react";
 
 interface TeamMember {
   id: string;
@@ -146,6 +146,31 @@ export default function TeamPage() {
     }
   }
 
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  async function handleDelete(userId: string, userName: string, userEmail: string) {
+    if (!window.confirm(
+      `Delete ${userName || userEmail}?\n\nThis removes their sales account, unassigns them from every workflow/lead/order (records stay), and cannot be undone.`,
+    )) return;
+    setDeletingId(userId);
+    try {
+      const res = await fetch(`/api/sales/users/${userId}`, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.ok) {
+        setTeamMembers((prev) => prev.filter((m) => m.id !== userId));
+      } else {
+        const err = await res.json().catch(() => ({}));
+        window.alert(`Delete failed: ${err.error ?? "Unknown error"}`);
+      }
+    } catch (e) {
+      window.alert(`Delete failed: ${e instanceof Error ? e.message : "Network error"}`);
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
   async function handleRoleChange(userId: string, newRole: string) {
     setRoleUpdating(userId);
     setRoleError(null);
@@ -271,6 +296,9 @@ export default function TeamPage() {
                 <th className="text-left px-4 py-3 font-medium text-gray-500">Name</th>
                 <th className="text-left px-4 py-3 font-medium text-gray-500">Email</th>
                 <th className="text-left px-4 py-3 font-medium text-gray-500">Role</th>
+                {currentUserRole === "admin" && (
+                  <th className="text-right px-4 py-3 font-medium text-gray-500 w-20">Actions</th>
+                )}
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-50">
@@ -300,10 +328,30 @@ export default function TeamPage() {
                       </span>
                     )}
                   </td>
+                  {currentUserRole === "admin" && (
+                    <td className="px-4 py-3 text-right">
+                      {m.id !== currentUserId && (
+                        <button
+                          type="button"
+                          onClick={() => handleDelete(m.id, m.full_name, m.email)}
+                          disabled={deletingId === m.id}
+                          className="inline-flex items-center gap-1 rounded-md p-1.5 text-gray-300 hover:bg-red-50 hover:text-red-600 disabled:opacity-50 transition-colors"
+                          title={`Delete ${m.full_name || m.email}`}
+                          aria-label={`Delete ${m.full_name || m.email}`}
+                        >
+                          {deletingId === m.id ? (
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                          ) : (
+                            <Trash2 className="h-4 w-4" />
+                          )}
+                        </button>
+                      )}
+                    </td>
+                  )}
                 </tr>
               ))}
               {filteredTeam.length === 0 && (
-                <tr><td colSpan={3} className="px-4 py-8 text-center text-gray-400">No team members found.</td></tr>
+                <tr><td colSpan={currentUserRole === "admin" ? 4 : 3} className="px-4 py-8 text-center text-gray-400">No team members found.</td></tr>
               )}
             </tbody>
           </table>


### PR DESCRIPTION
TEAM MEMBER DELETE
  - New DELETE /api/sales/users/[id] — admin-only
  - Refuses to delete self (prevents lockout) and refuses to delete the last remaining admin (prevents system lockout)
  - Uses supabase.auth.admin.deleteUser which cascades to profiles; workflow/lead/order assignments become NULL via existing FK ON DELETE SET NULL rules — records stay, ownership just clears
  - Trash icon on each row of /sales/team (admin view only) with confirmation dialog

RESULTS METRICS FIXES
  - Deals Won + Won Revenue redefined: were "unique deal_ids on any order in period" which returned 0 whenever orders had no deal_id (typical for direct/manual orders). Now: count + sum of orders where order_status='completed' OR payment_status='paid' — same definition as close_rate numerator. So if Completed Orders shows 5 with $48K revenue, Won and Won Revenue will now match.
  - Commissions switched from sales_commissions (deprecated per migration 109) to commission_ledger. amount_cents converted to dollars for the payload. Status enum mapped: pending → Manual Adj — Pending earned + held → Manual Adj — Approved paid → Manual Adj — Paid Fallback to sales_commissions for schemas that don't have commission_ledger. Explains why Manual Adj — Paid was $0 on real data with paid commissions.

UI CLEANUP
  - Removed the Pipeline tile from Results (was showing $0 constantly and duplicated info already in Executive Snapshot's Deals section)
  - sales_orders query now selects payment_status so the Won metric computation actually has the field