### PR TITLE
Workflows — auto-sync + manual override for payment status

### DIFF
--- a/src/app/api/workflows/[id]/payment-status/route.ts
+++ b/src/app/api/workflows/[id]/payment-status/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getWorkflowActor, hasPermission } from "@/lib/workflows/permissions";
+import { recordEvent, recomputeWorkflowRollup } from "@/lib/workflows/service";
+
+/**
+ * PATCH /api/workflows/[id]/payment-status
+ *
+ * Manual payment-status override. Automatic sync from
+ * webhooks/stage-completion continues to run; this is a fallback for
+ * when a payment was received off-platform (cash, wire, external Stripe
+ * account, etc.) and staff need to flip the workflow without a matching
+ * source event.
+ *
+ * Requires workflows.edit_status (admin, DOS, market_leader).
+ */
+const bodySchema = z.object({
+  payment_status: z.enum(["unpaid", "partial", "paid", "refunded", "na"]),
+  reason: z.string().min(1).max(500),
+});
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const actor = await getWorkflowActor(req);
+  if (!actor) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (!hasPermission(actor, "workflows.edit_status")) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { id } = await params;
+  const parsed = bodySchema.safeParse(await req.json().catch(() => ({})));
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid input", details: parsed.error.format() }, { status: 400 });
+  }
+
+  const { data: workflow } = await supabaseAdmin
+    .from("workflows")
+    .select("id, payment_status, version, total_due_cents, deposit_paid_cents")
+    .eq("id", id)
+    .maybeSingle();
+  if (!workflow) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  if (workflow.payment_status === parsed.data.payment_status) {
+    return NextResponse.json({ ok: true, workflow, unchanged: true });
+  }
+
+  const patch: Record<string, unknown> = {
+    payment_status: parsed.data.payment_status,
+    version: (workflow.version ?? 1) + 1,
+    updated_by: actor.id,
+  };
+  // Bumping to 'paid' also zeroes the balance for the UI's Pay Balance
+  // section (matches what happens when the QB webhook lands).
+  if (
+    parsed.data.payment_status === "paid" &&
+    workflow.total_due_cents != null &&
+    Number(workflow.total_due_cents) > 0
+  ) {
+    patch.deposit_paid_cents = Number(workflow.total_due_cents);
+  }
+
+  const { data: updated, error } = await supabaseAdmin
+    .from("workflows")
+    .update(patch)
+    .eq("id", workflow.id)
+    .eq("version", workflow.version)
+    .select("*")
+    .single();
+  if (error || !updated) {
+    return NextResponse.json({ error: error?.message ?? "Update failed" }, { status: 409 });
+  }
+
+  await recordEvent({
+    workflowId: workflow.id,
+    eventType: "payment_status_overridden",
+    previousValue: { payment_status: workflow.payment_status },
+    newValue: { payment_status: parsed.data.payment_status, reason: parsed.data.reason },
+    changedFields: ["payment_status"],
+    actorUserId: actor.id,
+    actorType: "staff",
+    source: "manual_override",
+    notes: parsed.data.reason,
+  });
+
+  // Recompute overall_status so the list view reflects the change
+  // immediately (e.g. drops out of 'pending_payment').
+  await recomputeWorkflowRollup(workflow.id, actor.id);
+
+  return NextResponse.json({ ok: true, workflow: updated });
+}

--- a/src/app/sales/workflows/[id]/page.tsx
+++ b/src/app/sales/workflows/[id]/page.tsx
@@ -200,7 +200,13 @@ export default function WorkflowDetailPage({ params }: { params: Promise<{ id: s
   async function postAction(path: string, body: Record<string, unknown>) {
     const res = await withAuth((token) =>
       fetch(`/api/workflows/${id}${path}`, {
-        method: path.includes("/deadline") || path.includes("/status") || path.includes("/order-items") ? "PATCH" : "POST",
+        method:
+          path.includes("/deadline") ||
+          path.includes("/status") ||
+          path.includes("/order-items") ||
+          path.includes("/payment-status")
+            ? "PATCH"
+            : "POST",
         headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
         body: JSON.stringify(body),
       }),
@@ -343,10 +349,12 @@ export default function WorkflowDetailPage({ params }: { params: Promise<{ id: s
               postAction("/assign", { userId, role: "primary_owner", makePrimary: true })
             }
           />
-          <InfoTile
-            icon={<Package className="h-4 w-4" />}
-            label="Payment"
-            value={w.payment_status.replace(/_/g, " ")}
+          <PaymentTile
+            paymentStatus={w.payment_status}
+            staffView={data.isStaffView}
+            onOverride={(next, reason) =>
+              postAction("/payment-status", { payment_status: next, reason })
+            }
           />
           <InfoTile
             icon={<Clock className="h-4 w-4" />}
@@ -814,6 +822,92 @@ function AssigneeTile({
               </button>
             </>
           )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PaymentTile({
+  paymentStatus,
+  staffView,
+  onOverride,
+}: {
+  paymentStatus: string;
+  staffView: boolean;
+  onOverride: (next: string, reason: string) => Promise<boolean>;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [next, setNext] = useState(paymentStatus);
+  const [reason, setReason] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  async function submit() {
+    if (!reason.trim()) return;
+    setSaving(true);
+    const ok = await onOverride(next, reason.trim());
+    setSaving(false);
+    if (ok) { setEditing(false); setReason(""); }
+  }
+
+  return (
+    <div className="rounded-lg border border-gray-100 bg-gray-50 p-3">
+      <div className="text-xs uppercase tracking-wide text-gray-500 flex items-center gap-1">
+        <Package className="h-4 w-4" /> Payment
+      </div>
+      <div className="text-sm font-medium text-gray-900 mt-1 capitalize">
+        {paymentStatus.replace(/_/g, " ")}
+      </div>
+      {staffView && !editing && (
+        <button
+          type="button"
+          onClick={() => { setNext(paymentStatus); setEditing(true); }}
+          className="mt-2 text-xs text-emerald-700 hover:underline"
+        >
+          Override
+        </button>
+      )}
+      {staffView && editing && (
+        <div className="mt-2 space-y-2">
+          <select
+            value={next}
+            onChange={(e) => setNext(e.target.value)}
+            disabled={saving}
+            className="w-full rounded-md border border-gray-200 text-xs px-2 py-1"
+          >
+            <option value="unpaid">Unpaid</option>
+            <option value="partial">Partial</option>
+            <option value="paid">Paid</option>
+            <option value="refunded">Refunded</option>
+            <option value="na">N/A</option>
+          </select>
+          <input
+            type="text"
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            placeholder="Reason (audit-logged)"
+            disabled={saving}
+            className="w-full rounded-md border border-gray-200 text-xs px-2 py-1"
+          />
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => { setEditing(false); setReason(""); }}
+              disabled={saving}
+              className="text-xs text-gray-500 hover:text-gray-800"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={submit}
+              disabled={saving || !reason.trim() || next === paymentStatus}
+              className="inline-flex items-center gap-1 rounded-md bg-emerald-600 text-white px-2 py-1 text-xs disabled:opacity-50"
+            >
+              {saving ? <Loader2 className="h-3 w-3 animate-spin" /> : null}
+              Save
+            </button>
+          </div>
         </div>
       )}
     </div>

--- a/src/lib/workflows/service.ts
+++ b/src/lib/workflows/service.ts
@@ -459,6 +459,40 @@ export async function updateStage(input: UpdateStageInput): Promise<UpdateStageR
     throw new Error("Stage update failed — another user may have edited it. Please refresh.");
   }
 
+  // Auto-sync workflow.payment_status when the payment_confirmed stage
+  // is marked completed. Fixes the "workflow list still says 'pending
+  // payment' after clicking the stage complete" bug — the two fields
+  // were tracking the same concept without staying in sync.
+  const updatedStage = updated as WorkflowStageRow;
+  if (
+    stage.stage_key === "payment_confirmed" &&
+    updatedStage.status === "completed" &&
+    workflow.payment_status !== "paid"
+  ) {
+    await supabaseAdmin
+      .from("workflows")
+      .update({
+        payment_status: "paid",
+        version: workflow.version + 1,
+        updated_by: input.updatedBy ?? null,
+      })
+      .eq("id", workflow.id)
+      .eq("version", workflow.version);
+    await recordEvent({
+      workflowId: workflow.id,
+      eventType: "payment_status_auto_synced",
+      previousValue: { payment_status: workflow.payment_status },
+      newValue: { payment_status: "paid" },
+      changedFields: ["payment_status"],
+      actorUserId: input.updatedBy ?? null,
+      actorType: input.actorType ?? "staff",
+      source: "payment_confirmed_stage",
+    });
+    // Bump the local copy so the rollup below sees the new value.
+    workflow.payment_status = "paid";
+    workflow.version = workflow.version + 1;
+  }
+
   await recordEvent({
     workflowId: input.workflowId,
     stageId: stage.id,


### PR DESCRIPTION
Two fixes for the "workflow list still says pending payment after the payment_confirmed stage is completed" bug:

AUTO-SYNC (trigger points continue)
  When the payment_confirmed stage transitions to completed via
  updateStage(), workflow.payment_status is automatically flipped to
  'paid'. Recomputes overall_status right after, so the list view
  drops out of 'pending_payment' on the next fetch. Audit event
  logged as payment_status_auto_synced.

MANUAL OVERRIDE (fallback)
  New PATCH /api/workflows/[id]/payment-status accepts:
    { payment_status: 'unpaid'|'partial'|'paid'|'refunded'|'na',
      reason: string }
  Requires workflows.edit_status (admin, DOS, market_leader).
  Records payment_status_overridden event with reason for audit.
  Zeroes the customer's Pay Balance CTA when set to 'paid'.

  UI: Payment InfoTile now has an "Override" link (staff only) that
  expands into a status dropdown + reason input + Save. Confirmation
  bypass — just pick + reason + Save. Rebuilds recompute overall
  status so the list view updates immediately.

Together: webhook sync + stage completion sync + admin manual override — three ways to keep the two fields aligned.