### PR TITLE
Workload — count workflows in every non-terminal state, not just 7

### DIFF
--- a/src/app/api/sales/executive-snapshot/route.ts
+++ b/src/app/api/sales/executive-snapshot/route.ts
@@ -277,16 +277,12 @@ export async function GET(req: NextRequest) {
   }
 
   // ─── Workflows ──────────────────────────────────────────────────────
-  // Company-wide only when the caller isn't scoped to one user.
-  const OPEN_STATUSES = [
-    "not_started",
-    "in_progress",
-    "waiting_on_customer",
-    "waiting_on_vendor",
-    "ready_to_begin",
-    "at_risk",
-    "overdue",
-  ];
+  // Company-wide only when the caller isn't scoped to one user. A
+  // workflow counts as "open" until it reaches a terminal state — this
+  // matches the workload endpoint definition so counts on the Exec
+  // Snapshot and Team Workload views agree with each other.
+  const TERMINAL = new Set(["completed", "cancelled", "refunded", "expired"]);
+  const isOpen = (status: string) => !TERMINAL.has(status);
   const nowIso = new Date().toISOString();
   const in7 = new Date(Date.now() + 7 * 86400_000).toISOString();
 
@@ -296,17 +292,17 @@ export async function GET(req: NextRequest) {
 
   const { data: wfRowsRaw } = await wfBase;
   const wfRows = wfRowsRaw ?? [];
-  const wfActive = wfRows.filter((w) => OPEN_STATUSES.includes(w.overall_status)).length;
-  const wfUnassigned = wfRows.filter((w) => !w.assigned_user_id && OPEN_STATUSES.includes(w.overall_status)).length;
+  const wfActive = wfRows.filter((w) => isOpen(w.overall_status)).length;
+  const wfUnassigned = wfRows.filter((w) => !w.assigned_user_id && isOpen(w.overall_status)).length;
   const wfDue7d = wfRows.filter(
-    (w) => OPEN_STATUSES.includes(w.overall_status) && w.due_date && w.due_date <= in7 && w.due_date >= nowIso,
+    (w) => isOpen(w.overall_status) && w.due_date && w.due_date <= in7 && w.due_date >= nowIso,
   ).length;
   const wfOverdue = wfRows.filter(
-    (w) => OPEN_STATUSES.includes(w.overall_status) && w.due_date && w.due_date < nowIso,
+    (w) => isOpen(w.overall_status) && w.due_date && w.due_date < nowIso,
   ).length;
   const wfByType: Record<string, number> = {};
   for (const w of wfRows) {
-    if (OPEN_STATUSES.includes(w.overall_status)) {
+    if (isOpen(w.overall_status)) {
       wfByType[w.workflow_type] = (wfByType[w.workflow_type] ?? 0) + 1;
     }
   }

--- a/src/app/api/sales/workload/route.ts
+++ b/src/app/api/sales/workload/route.ts
@@ -134,7 +134,14 @@ export async function GET(req: NextRequest) {
   for (const p of profiles ?? []) profileMap.set(p.id, p);
 
   // ─── Workflows: pull only what we need for aggregation ────────────
-  const OPEN = ["not_started", "in_progress", "waiting_on_customer", "waiting_on_vendor", "ready_to_begin", "at_risk", "overdue"];
+  // A workflow counts as "active workload" until it reaches a terminal
+  // state (completed / cancelled / refunded / expired). Prior list only
+  // included the seven "in flight" statuses, which excluded newly-
+  // assigned workflows whose overall_status was still pending_payment,
+  // draft, or on_hold — those got dropped from workload counts even
+  // though the assignee still owned them.
+  const TERMINAL = ["completed", "cancelled", "refunded", "expired"];
+  const isOpen = (s: string) => !TERMINAL.includes(s);
 
   const { data: allWorkflows } = await supabaseAdmin
     .from("workflows")
@@ -238,7 +245,7 @@ export async function GET(req: NextRequest) {
   const employees = Array.from(profileMap.values()).map((profile) => {
     const wfIds = Array.from(userWorkflows.get(profile.id) ?? []);
     const wfs = wfIds.map((id) => workflowMap.get(id)!).filter(Boolean);
-    const openWfs = wfs.filter((w) => OPEN.includes(w.overall_status));
+    const openWfs = wfs.filter((w) => isOpen(w.overall_status));
     const byType: Record<string, number> = {};
     for (const w of openWfs) byType[w.workflow_type] = (byType[w.workflow_type] ?? 0) + 1;
     const overdue = openWfs.filter((w) => w.due_date && w.due_date < nowIso).length;


### PR DESCRIPTION
Team Workload showed no change after assigning workflows because the "open" filter was an allow-list of 7 statuses that omitted pending_payment, draft, on_hold, and any future non-terminal status. Newly-assigned workflows almost always sit in pending_payment right after spawn (the payment_confirmed stage hasn't been marked yet), so they got silently dropped from the assignee's active count.

Switched both /api/sales/workload and /api/sales/executive-snapshot to a deny-list check: a workflow is open unless overall_status IS IN (completed, cancelled, refunded, expired). Any newly-introduced non-terminal status (draft, pending_payment, waiting_on_customer, on_hold, at_risk, etc.) now correctly rolls into workload counts.

Both endpoints share the same definition so per-employee workload, executive snapshot workflow tile, and Team Workload summary now agree on which workflows are "active".