### PR TITLE
Workflows — custom admin-defined templates + weighted workload load

### DIFF
--- a/src/app/admin/workflows/templates/page.tsx
+++ b/src/app/admin/workflows/templates/page.tsx
@@ -1,0 +1,479 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { createBrowserClient } from "@/lib/supabase";
+import {
+  Loader2, Plus, Pencil, Trash2, X, ChevronLeft, ChevronUp,
+  ChevronDown, GripVertical, ShieldCheck, Layers, ChevronLeft as Back,
+} from "lucide-react";
+
+interface Stage {
+  id?: string;
+  stage_key: string;
+  stage_name: string;
+  stage_order: number;
+  stage_type: "quantity" | "status" | "date" | "approval" | "document" | "milestone";
+  required_for_completion: boolean;
+  customer_visible: boolean;
+  default_customer_message?: string | null;
+  description?: string | null;
+}
+interface Template {
+  id: string;
+  workflow_type: string;
+  version: number;
+  title: string;
+  description: string | null;
+  default_deadline_days: number | null;
+  quantity_based: boolean;
+  completion_rule: "all_required_stages_completed" | "quantity_reached_on_final_stages" | "terminal_status" | "never_auto_completes";
+  active: boolean;
+  workload_weight: number;
+  is_custom: boolean;
+  category: string | null;
+  stages: Stage[];
+}
+
+const DEFAULT_CATEGORIES = [
+  "Perpetual",
+  "Account Management",
+  "Sales Ops",
+  "Operator Coaching",
+  "Other",
+];
+
+export default function AdminWorkflowTemplatesPage() {
+  const [templates, setTemplates] = useState<Template[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [editing, setEditing] = useState<Template | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [token, setToken] = useState<string | null>(null);
+
+  const load = useCallback(async (t: string) => {
+    setLoading(true);
+    const res = await fetch("/api/admin/workflow-templates", {
+      headers: { Authorization: `Bearer ${t}` },
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setTemplates(data.templates ?? []);
+    }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (session?.access_token) {
+        setToken(session.access_token);
+        load(session.access_token);
+      }
+    });
+  }, [load]);
+
+  async function handleDelete(t: Template) {
+    if (!token) return;
+    if (!window.confirm(`Delete "${t.title}"?\n\nThis cannot be undone. If live workflows use this template, the delete will be refused.`)) return;
+    const res = await fetch(`/api/admin/workflow-templates/${t.id}`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.ok) load(token);
+    else window.alert(`Delete failed: ${(await res.json()).error ?? "unknown"}`);
+  }
+
+  const grouped = templates.reduce((acc, t) => {
+    const key = t.is_custom ? (t.category ?? "Uncategorized") : "Built-in (system)";
+    if (!acc[key]) acc[key] = [];
+    acc[key].push(t);
+    return acc;
+  }, {} as Record<string, Template[]>);
+
+  return (
+    <div className="max-w-5xl mx-auto p-6">
+      <Link href="/sales/workflows" className="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-800 mb-4">
+        <Back className="h-4 w-4" /> Back to Workflows
+      </Link>
+
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900">Workflow Templates</h1>
+          <p className="text-sm text-gray-500 mt-1">
+            Built-in templates are protected. Custom templates carry a
+            workload weight — instances add that many points to the assignee&apos;s total.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setCreating(true)}
+          className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-600 text-white px-3 py-2 text-sm font-medium hover:bg-emerald-700"
+        >
+          <Plus className="h-4 w-4" /> New Template
+        </button>
+      </div>
+
+      {loading ? (
+        <div className="text-center py-12 text-gray-500"><Loader2 className="inline h-5 w-5 animate-spin mr-2" /> Loading…</div>
+      ) : (
+        <div className="space-y-6">
+          {Object.entries(grouped).map(([category, list]) => (
+            <div key={category}>
+              <h2 className="text-xs uppercase tracking-wide font-semibold text-gray-500 mb-2">{category}</h2>
+              <div className="space-y-2">
+                {list.map((t) => (
+                  <div key={t.id} className="rounded-lg border border-gray-200 bg-white p-4 flex flex-wrap items-center gap-3">
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className="font-medium text-gray-900">{t.title}</span>
+                        {!t.is_custom && (
+                          <span className="inline-flex items-center gap-1 rounded bg-gray-100 text-gray-600 px-1.5 py-0.5 text-[10px] font-medium uppercase">
+                            <ShieldCheck className="h-3 w-3" /> System
+                          </span>
+                        )}
+                        <span className="inline-flex items-center gap-1 rounded bg-emerald-50 text-emerald-700 px-1.5 py-0.5 text-[10px] font-medium">
+                          Weight {t.workload_weight}
+                        </span>
+                        {!t.active && (
+                          <span className="inline-flex items-center rounded bg-gray-100 text-gray-500 px-1.5 py-0.5 text-[10px] uppercase">Inactive</span>
+                        )}
+                      </div>
+                      <div className="text-xs text-gray-500 mt-0.5">
+                        {t.workflow_type} · {t.stages.length} stage{t.stages.length !== 1 ? "s" : ""} · rule: {t.completion_rule.replace(/_/g, " ")}
+                      </div>
+                      {t.description && <div className="text-xs text-gray-600 mt-1">{t.description}</div>}
+                    </div>
+                    {t.is_custom && (
+                      <>
+                        <button type="button" onClick={() => setEditing(t)} className="text-emerald-700 hover:bg-emerald-50 p-1.5 rounded" title="Edit"><Pencil className="h-4 w-4" /></button>
+                        <button type="button" onClick={() => handleDelete(t)} className="text-red-600 hover:bg-red-50 p-1.5 rounded" title="Delete"><Trash2 className="h-4 w-4" /></button>
+                      </>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+          {templates.length === 0 && (
+            <div className="text-center py-12 text-gray-400 border border-dashed border-gray-200 rounded-xl">
+              <Layers className="mx-auto h-8 w-8 mb-2" />
+              No templates yet. Click <b>New Template</b> to create one.
+            </div>
+          )}
+        </div>
+      )}
+
+      {(creating || editing) && token && (
+        <TemplateEditorModal
+          token={token}
+          template={editing}
+          onClose={() => { setCreating(false); setEditing(null); }}
+          onSaved={() => { setCreating(false); setEditing(null); load(token); }}
+        />
+      )}
+    </div>
+  );
+}
+
+function TemplateEditorModal({
+  token,
+  template,
+  onClose,
+  onSaved,
+}: {
+  token: string;
+  template: Template | null;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const [title, setTitle] = useState(template?.title ?? "");
+  const [workflowType, setWorkflowType] = useState(template?.workflow_type.replace(/^custom:/, "") ?? "");
+  const [description, setDescription] = useState(template?.description ?? "");
+  const [category, setCategory] = useState(template?.category ?? DEFAULT_CATEGORIES[0]);
+  const [weight, setWeight] = useState(template?.workload_weight ?? 1);
+  const [defaultDeadlineDays, setDefaultDeadlineDays] = useState<number | "">(template?.default_deadline_days ?? "");
+  const [quantityBased, setQuantityBased] = useState(template?.quantity_based ?? false);
+  const [completionRule, setCompletionRule] = useState<Template["completion_rule"]>(
+    template?.completion_rule ?? "never_auto_completes",
+  );
+  const [active, setActive] = useState(template?.active ?? true);
+  const [stages, setStages] = useState<Stage[]>(
+    template?.stages ?? [
+      { stage_key: "started", stage_name: "Started", stage_order: 10, stage_type: "milestone", required_for_completion: false, customer_visible: true },
+    ],
+  );
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  function moveStage(i: number, dir: -1 | 1) {
+    const j = i + dir;
+    if (j < 0 || j >= stages.length) return;
+    const copy = [...stages];
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+    setStages(copy.map((s, idx) => ({ ...s, stage_order: (idx + 1) * 10 })));
+  }
+
+  function updateStage(i: number, patch: Partial<Stage>) {
+    setStages(stages.map((s, idx) => (idx === i ? { ...s, ...patch } : s)));
+  }
+
+  function addStage() {
+    setStages([
+      ...stages,
+      {
+        stage_key: `stage_${stages.length + 1}`,
+        stage_name: "New Stage",
+        stage_order: (stages.length + 1) * 10,
+        stage_type: "milestone",
+        required_for_completion: false,
+        customer_visible: true,
+      },
+    ]);
+  }
+
+  function removeStage(i: number) {
+    setStages(stages.filter((_, idx) => idx !== i).map((s, idx) => ({ ...s, stage_order: (idx + 1) * 10 })));
+  }
+
+  async function save() {
+    setError(null);
+    if (!title.trim()) { setError("Title is required"); return; }
+    if (!template && !workflowType.trim()) { setError("Workflow type key is required"); return; }
+    if (stages.length === 0) { setError("At least one stage is required"); return; }
+
+    setSaving(true);
+    const payload = {
+      title: title.trim(),
+      description: description.trim() || null,
+      workflow_type: workflowType.trim() || undefined,
+      category: category?.trim() || null,
+      workload_weight: weight,
+      default_deadline_days: defaultDeadlineDays === "" ? null : Number(defaultDeadlineDays),
+      quantity_based: quantityBased,
+      completion_rule: completionRule,
+      active,
+      stages: stages.map((s, idx) => ({
+        stage_key: s.stage_key.trim(),
+        stage_name: s.stage_name.trim(),
+        stage_order: (idx + 1) * 10,
+        stage_type: s.stage_type,
+        required_for_completion: s.required_for_completion,
+        customer_visible: s.customer_visible,
+        default_customer_message: s.default_customer_message ?? null,
+        description: s.description ?? null,
+      })),
+    };
+    const res = await fetch(
+      template ? `/api/admin/workflow-templates/${template.id}` : "/api/admin/workflow-templates",
+      {
+        method: template ? "PATCH" : "POST",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+        body: JSON.stringify(payload),
+      },
+    );
+    if (res.ok) onSaved();
+    else {
+      const err = await res.json().catch(() => ({}));
+      setError(err.error ?? "Save failed");
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/40 p-4 overflow-y-auto">
+      <div className="w-full max-w-3xl rounded-2xl bg-white shadow-xl my-8">
+        <div className="flex items-center justify-between p-5 border-b border-gray-100">
+          <h2 className="text-lg font-semibold text-gray-900">{template ? "Edit template" : "New template"}</h2>
+          <button type="button" onClick={onClose} className="text-gray-400 hover:text-gray-700">
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        <div className="p-5 space-y-4">
+          <div className="grid grid-cols-2 gap-3">
+            <Field label="Title" value={title} onChange={setTitle} />
+            <Field
+              label="Workflow type key"
+              value={workflowType}
+              onChange={setWorkflowType}
+              hint="Auto-prefixed with custom:"
+              disabled={!!template}
+            />
+          </div>
+
+          <FieldTextarea label="Description" value={description} onChange={setDescription} />
+
+          <div className="grid grid-cols-3 gap-3">
+            <div>
+              <label className="block text-xs uppercase tracking-wide text-gray-500 mb-1">Category</label>
+              <input
+                type="text"
+                list="cat-list"
+                value={category ?? ""}
+                onChange={(e) => setCategory(e.target.value)}
+                className="w-full rounded-md border border-gray-200 px-3 py-2 text-sm"
+              />
+              <datalist id="cat-list">
+                {DEFAULT_CATEGORIES.map((c) => <option key={c} value={c} />)}
+              </datalist>
+            </div>
+            <div>
+              <label className="block text-xs uppercase tracking-wide text-gray-500 mb-1">Workload weight (1-20)</label>
+              <input
+                type="number"
+                min={1}
+                max={20}
+                value={weight}
+                onChange={(e) => setWeight(Math.max(1, Math.min(20, Number(e.target.value) || 1)))}
+                className="w-full rounded-md border border-gray-200 px-3 py-2 text-sm"
+              />
+            </div>
+            <div>
+              <label className="block text-xs uppercase tracking-wide text-gray-500 mb-1">Default deadline (days)</label>
+              <input
+                type="number"
+                min={0}
+                value={defaultDeadlineDays}
+                onChange={(e) => setDefaultDeadlineDays(e.target.value === "" ? "" : Number(e.target.value))}
+                placeholder="none"
+                className="w-full rounded-md border border-gray-200 px-3 py-2 text-sm"
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-xs uppercase tracking-wide text-gray-500 mb-1">Completion rule</label>
+              <select
+                value={completionRule}
+                onChange={(e) => setCompletionRule(e.target.value as Template["completion_rule"])}
+                className="w-full rounded-md border border-gray-200 px-3 py-2 text-sm"
+              >
+                <option value="never_auto_completes">Never auto-completes (perpetual)</option>
+                <option value="all_required_stages_completed">All required stages completed</option>
+                <option value="quantity_reached_on_final_stages">Quantity reached on final stages</option>
+                <option value="terminal_status">Terminal status</option>
+              </select>
+            </div>
+            <div className="flex flex-col justify-end gap-2 text-sm">
+              <label className="inline-flex items-center gap-2">
+                <input type="checkbox" checked={quantityBased} onChange={(e) => setQuantityBased(e.target.checked)} />
+                Quantity-based (stages track counts vs targets)
+              </label>
+              <label className="inline-flex items-center gap-2">
+                <input type="checkbox" checked={active} onChange={(e) => setActive(e.target.checked)} />
+                Active (available for new workflows)
+              </label>
+            </div>
+          </div>
+
+          <div>
+            <div className="flex items-center justify-between mb-2">
+              <label className="text-xs uppercase tracking-wide text-gray-500">Stages</label>
+              <button type="button" onClick={addStage} className="text-xs text-emerald-700 hover:underline inline-flex items-center gap-1">
+                <Plus className="h-3 w-3" /> Add stage
+              </button>
+            </div>
+            <div className="border border-gray-200 rounded-md divide-y divide-gray-100">
+              {stages.map((s, i) => (
+                <div key={i} className="p-3 space-y-2">
+                  <div className="flex items-center gap-2">
+                    <GripVertical className="h-4 w-4 text-gray-300" />
+                    <span className="text-xs text-gray-400 w-6">#{i + 1}</span>
+                    <input
+                      type="text"
+                      value={s.stage_name}
+                      onChange={(e) => updateStage(i, { stage_name: e.target.value })}
+                      placeholder="Stage name"
+                      className="flex-1 rounded-md border border-gray-200 px-2 py-1 text-sm"
+                    />
+                    <input
+                      type="text"
+                      value={s.stage_key}
+                      onChange={(e) => updateStage(i, { stage_key: e.target.value })}
+                      placeholder="stage_key"
+                      className="w-32 rounded-md border border-gray-200 px-2 py-1 text-xs font-mono"
+                    />
+                    <select
+                      value={s.stage_type}
+                      onChange={(e) => updateStage(i, { stage_type: e.target.value as Stage["stage_type"] })}
+                      className="rounded-md border border-gray-200 px-2 py-1 text-xs"
+                    >
+                      <option value="milestone">milestone</option>
+                      <option value="status">status</option>
+                      <option value="quantity">quantity</option>
+                      <option value="date">date</option>
+                      <option value="approval">approval</option>
+                      <option value="document">document</option>
+                    </select>
+                    <button type="button" onClick={() => moveStage(i, -1)} disabled={i === 0} className="text-gray-500 hover:text-gray-800 disabled:opacity-30 p-1"><ChevronUp className="h-4 w-4" /></button>
+                    <button type="button" onClick={() => moveStage(i, 1)} disabled={i === stages.length - 1} className="text-gray-500 hover:text-gray-800 disabled:opacity-30 p-1"><ChevronDown className="h-4 w-4" /></button>
+                    <button type="button" onClick={() => removeStage(i)} className="text-red-500 hover:text-red-700 p-1"><Trash2 className="h-4 w-4" /></button>
+                  </div>
+                  <div className="flex items-center gap-4 text-xs pl-8">
+                    <label className="inline-flex items-center gap-1">
+                      <input type="checkbox" checked={s.required_for_completion} onChange={(e) => updateStage(i, { required_for_completion: e.target.checked })} />
+                      Required for completion
+                    </label>
+                    <label className="inline-flex items-center gap-1">
+                      <input type="checkbox" checked={s.customer_visible} onChange={(e) => updateStage(i, { customer_visible: e.target.checked })} />
+                      Customer-visible
+                    </label>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {error && <div className="text-sm text-red-600">{error}</div>}
+
+          <div className="flex justify-end gap-2 pt-2">
+            <button type="button" onClick={onClose} className="text-sm text-gray-600 hover:text-gray-800 px-3 py-2">Cancel</button>
+            <button
+              type="button"
+              onClick={save}
+              disabled={saving}
+              className="inline-flex items-center gap-1 rounded-md bg-emerald-600 text-white px-4 py-2 text-sm font-medium hover:bg-emerald-700 disabled:opacity-50"
+            >
+              {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <ChevronLeft className="h-4 w-4 rotate-90" />}
+              {template ? "Save changes" : "Create template"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, value, onChange, hint, disabled }: {
+  label: string; value: string; onChange: (v: string) => void; hint?: string; disabled?: boolean;
+}) {
+  return (
+    <div>
+      <label className="block text-xs uppercase tracking-wide text-gray-500 mb-1">{label}</label>
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+        className="w-full rounded-md border border-gray-200 px-3 py-2 text-sm disabled:bg-gray-50"
+      />
+      {hint && <div className="text-xs text-gray-500 mt-1">{hint}</div>}
+    </div>
+  );
+}
+function FieldTextarea({ label, value, onChange }: {
+  label: string; value: string; onChange: (v: string) => void;
+}) {
+  return (
+    <div>
+      <label className="block text-xs uppercase tracking-wide text-gray-500 mb-1">{label}</label>
+      <textarea
+        rows={2}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full rounded-md border border-gray-200 px-3 py-2 text-sm"
+      />
+    </div>
+  );
+}

--- a/src/app/api/admin/workflow-templates/[id]/route.ts
+++ b/src/app/api/admin/workflow-templates/[id]/route.ts
@@ -1,0 +1,140 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+
+/**
+ * PATCH  /api/admin/workflow-templates/[id]  — edit a custom template
+ * DELETE /api/admin/workflow-templates/[id]  — delete a custom template
+ *
+ * Both refuse to touch built-in (is_custom=false) templates. Stage
+ * edits fully replace the existing stage list (simpler than diffing;
+ * safe because in-flight workflows carry their own copy of stages).
+ */
+
+const stageSchema = z.object({
+  stage_key: z.string().min(1).max(60),
+  stage_name: z.string().min(1).max(120),
+  stage_order: z.number().int().min(0),
+  stage_type: z.enum(["quantity", "status", "date", "approval", "document", "milestone"]),
+  required_for_completion: z.boolean().default(false),
+  customer_visible: z.boolean().default(true),
+  default_customer_message: z.string().max(500).nullable().optional(),
+  description: z.string().max(500).nullable().optional(),
+});
+
+const patchSchema = z.object({
+  title: z.string().min(1).max(200).optional(),
+  description: z.string().max(2000).nullable().optional(),
+  default_deadline_days: z.number().int().min(0).max(3650).nullable().optional(),
+  quantity_based: z.boolean().optional(),
+  completion_rule: z
+    .enum([
+      "all_required_stages_completed",
+      "quantity_reached_on_final_stages",
+      "terminal_status",
+      "never_auto_completes",
+    ])
+    .optional(),
+  workload_weight: z.number().int().min(1).max(20).optional(),
+  category: z.string().max(80).nullable().optional(),
+  active: z.boolean().optional(),
+  stages: z.array(stageSchema).min(1).max(30).optional(),
+});
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id } = await params;
+
+  const { data: existing } = await supabaseAdmin
+    .from("workflow_templates")
+    .select("id, is_custom")
+    .eq("id", id)
+    .maybeSingle();
+  if (!existing) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  if (!existing.is_custom) {
+    return NextResponse.json({ error: "Cannot edit built-in templates" }, { status: 403 });
+  }
+
+  const body = await req.json().catch(() => ({}));
+  const parsed = patchSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid input", details: parsed.error.format() }, { status: 400 });
+  }
+
+  const { stages, ...templateFields } = parsed.data;
+  const templateUpdate: Record<string, unknown> = { ...templateFields };
+  Object.keys(templateUpdate).forEach((k) => templateUpdate[k] === undefined && delete templateUpdate[k]);
+
+  if (Object.keys(templateUpdate).length > 0) {
+    const { error } = await supabaseAdmin
+      .from("workflow_templates")
+      .update(templateUpdate)
+      .eq("id", id);
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  if (stages) {
+    // Replace-all — safe because in-flight workflows carry their own
+    // stage rows copied at spawn time. Editing the template affects
+    // only future spawns.
+    await supabaseAdmin.from("workflow_template_stages").delete().eq("template_id", id);
+    const rows = stages.map((s) => ({
+      template_id: id,
+      stage_key: s.stage_key,
+      stage_name: s.stage_name,
+      stage_order: s.stage_order,
+      stage_type: s.stage_type,
+      required_for_completion: s.required_for_completion,
+      customer_visible: s.customer_visible,
+      default_customer_message: s.default_customer_message ?? null,
+      description: s.description ?? null,
+    }));
+    const { error: sErr } = await supabaseAdmin.from("workflow_template_stages").insert(rows);
+    if (sErr) return NextResponse.json({ error: `Stage replace failed: ${sErr.message}` }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true });
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const { id } = await params;
+
+  const { data: existing } = await supabaseAdmin
+    .from("workflow_templates")
+    .select("id, is_custom")
+    .eq("id", id)
+    .maybeSingle();
+  if (!existing) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  if (!existing.is_custom) {
+    return NextResponse.json({ error: "Cannot delete built-in templates" }, { status: 403 });
+  }
+
+  // Refuse if any workflows reference this template — protects live
+  // data. Admin can archive by setting active=false instead.
+  const { count } = await supabaseAdmin
+    .from("workflows")
+    .select("id", { count: "exact", head: true })
+    .eq("template_id", id);
+  if ((count ?? 0) > 0) {
+    return NextResponse.json(
+      { error: `${count} live workflows still use this template. Deactivate it instead of deleting.` },
+      { status: 409 },
+    );
+  }
+
+  await supabaseAdmin.from("workflow_template_stages").delete().eq("template_id", id);
+  const { error } = await supabaseAdmin.from("workflow_templates").delete().eq("id", id);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/admin/workflow-templates/route.ts
+++ b/src/app/api/admin/workflow-templates/route.ts
@@ -1,0 +1,149 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+
+/**
+ * GET  /api/admin/workflow-templates
+ * POST /api/admin/workflow-templates
+ *
+ * Admin-only CRUD for workflow_templates + workflow_template_stages.
+ * Built-in templates (is_custom=false) can be listed but not created
+ * by this endpoint; custom templates get is_custom=true and workflow
+ * type auto-prefixed with "custom:".
+ */
+
+const stageSchema = z.object({
+  stage_key: z.string().min(1).max(60),
+  stage_name: z.string().min(1).max(120),
+  stage_order: z.number().int().min(0),
+  stage_type: z.enum(["quantity", "status", "date", "approval", "document", "milestone"]),
+  required_for_completion: z.boolean().default(false),
+  customer_visible: z.boolean().default(true),
+  default_customer_message: z.string().max(500).nullable().optional(),
+  description: z.string().max(500).nullable().optional(),
+});
+
+const createSchema = z.object({
+  workflow_type: z.string().min(1).max(80),
+  title: z.string().min(1).max(200),
+  description: z.string().max(2000).nullable().optional(),
+  default_deadline_days: z.number().int().min(0).max(3650).nullable().optional(),
+  quantity_based: z.boolean().default(false),
+  completion_rule: z
+    .enum([
+      "all_required_stages_completed",
+      "quantity_reached_on_final_stages",
+      "terminal_status",
+      "never_auto_completes",
+    ])
+    .default("never_auto_completes"),
+  workload_weight: z.number().int().min(1).max(20).default(1),
+  category: z.string().max(80).nullable().optional(),
+  stages: z.array(stageSchema).min(1).max(30),
+});
+
+export async function GET(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const { data: templates } = await supabaseAdmin
+    .from("workflow_templates")
+    .select("*")
+    .order("is_custom", { ascending: true })
+    .order("category", { ascending: true, nullsFirst: true })
+    .order("title", { ascending: true });
+
+  const ids = (templates ?? []).map((t) => t.id);
+  const { data: stages } = ids.length > 0
+    ? await supabaseAdmin
+        .from("workflow_template_stages")
+        .select("*")
+        .in("template_id", ids)
+        .order("stage_order", { ascending: true })
+    : { data: [] };
+
+  const stagesByTemplate: Record<string, unknown[]> = {};
+  for (const s of stages ?? []) {
+    if (!stagesByTemplate[s.template_id]) stagesByTemplate[s.template_id] = [];
+    stagesByTemplate[s.template_id].push(s);
+  }
+
+  const withStages = (templates ?? []).map((t) => ({
+    ...t,
+    stages: stagesByTemplate[t.id] ?? [],
+  }));
+
+  return NextResponse.json({ templates: withStages });
+}
+
+export async function POST(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const body = await req.json().catch(() => ({}));
+  const parsed = createSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid input", details: parsed.error.format() }, { status: 400 });
+  }
+  const input = parsed.data;
+
+  // Force the workflow_type into the "custom:" namespace so admin
+  // templates can't collide with future built-in types.
+  const workflowType = input.workflow_type.startsWith("custom:")
+    ? input.workflow_type
+    : `custom:${input.workflow_type}`;
+
+  // New version = max existing for this type + 1.
+  const { data: existing } = await supabaseAdmin
+    .from("workflow_templates")
+    .select("version")
+    .eq("workflow_type", workflowType)
+    .order("version", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  const version = (existing?.version ?? 0) + 1;
+
+  const { data: template, error: tErr } = await supabaseAdmin
+    .from("workflow_templates")
+    .insert({
+      workflow_type: workflowType,
+      version,
+      title: input.title,
+      description: input.description ?? null,
+      default_deadline_days: input.default_deadline_days ?? null,
+      quantity_based: input.quantity_based,
+      completion_rule: input.completion_rule,
+      workload_weight: input.workload_weight,
+      is_custom: true,
+      category: input.category ?? null,
+      active: true,
+    })
+    .select("*")
+    .single();
+  if (tErr || !template) {
+    return NextResponse.json({ error: tErr?.message ?? "Template insert failed" }, { status: 500 });
+  }
+
+  const stageRows = input.stages.map((s) => ({
+    template_id: template.id,
+    stage_key: s.stage_key,
+    stage_name: s.stage_name,
+    stage_order: s.stage_order,
+    stage_type: s.stage_type,
+    required_for_completion: s.required_for_completion,
+    customer_visible: s.customer_visible,
+    default_customer_message: s.default_customer_message ?? null,
+    description: s.description ?? null,
+  }));
+  const { error: sErr } = await supabaseAdmin
+    .from("workflow_template_stages")
+    .insert(stageRows);
+  if (sErr) {
+    // Roll back the template insert to keep the schema consistent.
+    await supabaseAdmin.from("workflow_templates").delete().eq("id", template.id);
+    return NextResponse.json({ error: `Stage insert failed: ${sErr.message}` }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true, template });
+}

--- a/src/app/api/sales/workload/route.ts
+++ b/src/app/api/sales/workload/route.ts
@@ -145,7 +145,7 @@ export async function GET(req: NextRequest) {
 
   const { data: allWorkflows } = await supabaseAdmin
     .from("workflows")
-    .select("id, workflow_type, overall_status, assigned_user_id, due_date, created_at, completed_at, customer_id")
+    .select("id, workflow_type, overall_status, assigned_user_id, due_date, created_at, completed_at, customer_id, template_id")
     .in("assigned_user_id", staffIds);
 
   // Also pick up collaborator assignments (workflow_assignments).
@@ -176,7 +176,7 @@ export async function GET(req: NextRequest) {
   const collaboratorWorkflows = collaboratorOnlyIds.size > 0
     ? (await supabaseAdmin
         .from("workflows")
-        .select("id, workflow_type, overall_status, assigned_user_id, due_date, created_at, completed_at, customer_id")
+        .select("id, workflow_type, overall_status, assigned_user_id, due_date, created_at, completed_at, customer_id, template_id")
         .in("id", Array.from(collaboratorOnlyIds))).data ?? []
     : [];
   type WorkflowSlim = {
@@ -188,11 +188,33 @@ export async function GET(req: NextRequest) {
     created_at: string;
     completed_at: string | null;
     customer_id: string;
+    template_id: string | null;
   };
   const workflowMap = new Map<string, WorkflowSlim>();
   for (const w of [...(allWorkflows ?? []), ...collaboratorWorkflows]) {
     workflowMap.set(w.id, w as WorkflowSlim);
   }
+
+  // Fetch template weights so we can compute weighted load per user.
+  // Built-in templates default to weight=1; custom templates carry the
+  // admin-configured value.
+  const templateIds = Array.from(new Set(
+    [...(allWorkflows ?? []), ...collaboratorWorkflows]
+      .map((w) => w.template_id)
+      .filter(Boolean) as string[],
+  ));
+  const weightByTemplate = new Map<string, number>();
+  if (templateIds.length > 0) {
+    const { data: tmpls } = await supabaseAdmin
+      .from("workflow_templates")
+      .select("id, workload_weight")
+      .in("id", templateIds);
+    for (const t of tmpls ?? []) {
+      weightByTemplate.set(t.id, Number((t as { workload_weight?: number }).workload_weight ?? 1));
+    }
+  }
+  const weightFor = (w: WorkflowSlim): number =>
+    w.template_id ? weightByTemplate.get(w.template_id) ?? 1 : 1;
 
   // ─── Time entries in period ───────────────────────────────────────
   let timeQuery = supabaseAdmin
@@ -267,9 +289,15 @@ export async function GET(req: NextRequest) {
     const closedQuotes = quotesClosedByUser.get(profile.id) ?? 0;
     const closeRate = sentQuotes > 0 ? closedQuotes / sentQuotes : 0;
     const active = openWfs.length;
-    const capacity: "green" | "yellow" | "red" = active <= CAPACITY_GREEN_MAX
+    // Weighted load — built-in templates contribute 1 each, custom
+    // templates contribute their admin-configured weight (1-20). This
+    // is what drives the capacity flag so a rep with 3 heavy accounts
+    // (weight 5 each = 15) is flagged the same as one with 15 quick
+    // tasks.
+    const load = openWfs.reduce((sum, w) => sum + weightFor(w), 0);
+    const capacity: "green" | "yellow" | "red" = load <= CAPACITY_GREEN_MAX
       ? "green"
-      : active <= CAPACITY_YELLOW_MAX
+      : load <= CAPACITY_YELLOW_MAX
         ? "yellow"
         : "red";
 
@@ -279,6 +307,7 @@ export async function GET(req: NextRequest) {
       email: profile.email,
       role: profile.role,
       active,
+      load,
       by_type: byType,
       overdue,
       due_7d: due7d,
@@ -291,7 +320,7 @@ export async function GET(req: NextRequest) {
     };
   });
 
-  employees.sort((a, b) => b.active - a.active);
+  employees.sort((a, b) => b.load - a.load);
 
   return NextResponse.json({
     period: { since, until, label: period },

--- a/src/app/sales/workflows/page.tsx
+++ b/src/app/sales/workflows/page.tsx
@@ -512,12 +512,44 @@ function SavedViewChip({
 
 interface CustomerHit { id: string; full_name: string | null; email: string | null; role: string | null; }
 
+interface TemplateOption { workflow_type: string; title: string; category: string | null; is_custom: boolean; }
+
 function NewWorkflowModal({ onClose, onCreated }: { onClose: () => void; onCreated: (workflowId: string) => void }) {
   const [customerQuery, setCustomerQuery] = useState("");
   const [customerResults, setCustomerResults] = useState<CustomerHit[]>([]);
   const [selectedCustomer, setSelectedCustomer] = useState<CustomerHit | null>(null);
   const [searching, setSearching] = useState(false);
   const [workflowType, setWorkflowType] = useState<string>("ai_machine_fulfillment");
+  const [templates, setTemplates] = useState<TemplateOption[]>([]);
+
+  useEffect(() => {
+    // Pull custom templates so the dropdown includes admin-created
+    // perpetual-task types (Account Management, Cold Calling, etc.).
+    // Built-in templates are hard-coded in the fallback list below and
+    // rendered even if this fetch fails or returns nothing.
+    async function loadTemplates() {
+      const supabase = createBrowserClient();
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session?.access_token) return;
+      const res = await fetch("/api/admin/workflow-templates", {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setTemplates(
+          (data.templates ?? [])
+            .filter((t: { active: boolean }) => t.active)
+            .map((t: TemplateOption) => ({
+              workflow_type: t.workflow_type,
+              title: t.title,
+              category: t.category,
+              is_custom: t.is_custom,
+            })),
+        );
+      }
+    }
+    loadTemplates();
+  }, []);
   const [productName, setProductName] = useState("");
   const [quantity, setQuantity] = useState("1");
   const [dueDate, setDueDate] = useState("");
@@ -652,12 +684,41 @@ function NewWorkflowModal({ onClose, onCreated }: { onClose: () => void; onCreat
                 onChange={(e) => setWorkflowType(e.target.value)}
                 className="w-full rounded-md border border-gray-200 px-3 py-2 text-sm"
               >
-                <option value="ai_machine_fulfillment">AI Machine Fulfillment</option>
-                <option value="location_services">Location Services</option>
-                <option value="financing">Financing</option>
-                <option value="coffee_equipment">Coffee Equipment</option>
-                <option value="coffee_service">Coffee Service</option>
-                <option value="website_build">Website Build</option>
+                {/* Built-in templates always available even if the API
+                    fetch didn't return them (defensive). */}
+                <optgroup label="Built-in">
+                  {templates.filter((t) => !t.is_custom).length > 0
+                    ? templates
+                        .filter((t) => !t.is_custom)
+                        .map((t) => (
+                          <option key={t.workflow_type} value={t.workflow_type}>{t.title}</option>
+                        ))
+                    : (
+                      <>
+                        <option value="ai_machine_fulfillment">AI Machine Fulfillment</option>
+                        <option value="location_services">Location Services</option>
+                        <option value="financing">Financing</option>
+                        <option value="coffee_equipment">Coffee Equipment</option>
+                        <option value="coffee_service">Coffee Service</option>
+                        <option value="website_build">Website Build</option>
+                      </>
+                    )}
+                </optgroup>
+                {/* Custom templates grouped by category. Only appear
+                    when admin has created them via /admin/workflows/templates. */}
+                {Array.from(
+                  new Set(
+                    templates.filter((t) => t.is_custom).map((t) => t.category ?? "Uncategorized"),
+                  ),
+                ).map((cat) => (
+                  <optgroup key={cat} label={cat}>
+                    {templates
+                      .filter((t) => t.is_custom && (t.category ?? "Uncategorized") === cat)
+                      .map((t) => (
+                        <option key={t.workflow_type} value={t.workflow_type}>{t.title}</option>
+                      ))}
+                  </optgroup>
+                ))}
               </select>
             </div>
             <div>

--- a/src/app/sales/workload/page.tsx
+++ b/src/app/sales/workload/page.tsx
@@ -13,6 +13,7 @@ interface EmployeeRow {
   email: string;
   role: string;
   active: number;
+  load: number;
   by_type: Record<string, number>;
   overdue: number;
   due_7d: number;
@@ -48,13 +49,13 @@ const TYPE_LABEL: Record<string, string> = {
   website_build: "Web",
 };
 
-type SortKey = "name" | "active" | "overdue" | "hours" | "close_rate";
+type SortKey = "name" | "active" | "load" | "overdue" | "hours" | "close_rate";
 
 export default function WorkloadPage() {
   const [data, setData] = useState<Payload | null>(null);
   const [loading, setLoading] = useState(true);
   const [period, setPeriod] = useState<Period>("monthly");
-  const [sortKey, setSortKey] = useState<SortKey>("active");
+  const [sortKey, setSortKey] = useState<SortKey>("load");
   const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
 
   useEffect(() => {
@@ -77,6 +78,7 @@ export default function WorkloadPage() {
     switch (sortKey) {
       case "name": return a.name.localeCompare(b.name) * dir;
       case "active": return (a.active - b.active) * dir;
+      case "load": return (a.load - b.load) * dir;
       case "overdue": return (a.overdue - b.overdue) * dir;
       case "hours": return (a.hours_period - b.hours_period) * dir;
       case "close_rate": return (a.close_rate - b.close_rate) * dir;
@@ -97,15 +99,23 @@ export default function WorkloadPage() {
             Active workflows, capacity, hours, and close rate per employee.
           </p>
         </div>
-        <select
-          value={period}
-          onChange={(e) => setPeriod(e.target.value as Period)}
-          className="rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm focus:border-green-500 focus:outline-none cursor-pointer"
-        >
-          {PERIODS.map((p) => (
-            <option key={p.value} value={p.value}>{p.label}</option>
-          ))}
-        </select>
+        <div className="flex items-center gap-2">
+          <Link
+            href="/admin/workflows/templates"
+            className="text-sm text-emerald-700 hover:underline"
+          >
+            Manage templates →
+          </Link>
+          <select
+            value={period}
+            onChange={(e) => setPeriod(e.target.value as Period)}
+            className="rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm focus:border-green-500 focus:outline-none cursor-pointer"
+          >
+            {PERIODS.map((p) => (
+              <option key={p.value} value={p.value}>{p.label}</option>
+            ))}
+          </select>
+        </div>
       </div>
 
       {data && data.capacity_thresholds && (
@@ -126,6 +136,7 @@ export default function WorkloadPage() {
             <tr>
               <th className="px-4 py-3 cursor-pointer" onClick={() => toggleSort("name")}>Employee</th>
               <th className="px-4 py-3 cursor-pointer text-right" onClick={() => toggleSort("active")}>Active</th>
+              <th className="px-4 py-3 cursor-pointer text-right" onClick={() => toggleSort("load")} title="Weighted load — custom templates carry a point value; built-ins = 1">Load</th>
               <th className="px-4 py-3">By Type</th>
               <th className="px-4 py-3 cursor-pointer text-right" onClick={() => toggleSort("overdue")}>Overdue</th>
               <th className="px-4 py-3 text-right">Due 7d</th>
@@ -136,11 +147,11 @@ export default function WorkloadPage() {
           </thead>
           <tbody className="divide-y divide-gray-100">
             {loading ? (
-              <tr><td colSpan={8} className="px-4 py-12 text-center text-gray-500">
+              <tr><td colSpan={9} className="px-4 py-12 text-center text-gray-500">
                 <Loader2 className="inline-block h-5 w-5 animate-spin mr-2" /> Loading…
               </td></tr>
             ) : rows.length === 0 ? (
-              <tr><td colSpan={8} className="px-4 py-12 text-center text-gray-500">
+              <tr><td colSpan={9} className="px-4 py-12 text-center text-gray-500">
                 <Users className="inline-block h-5 w-5 mr-2 text-gray-400" />
                 No team members in this scope.
               </td></tr>
@@ -168,8 +179,11 @@ function EmployeeRowRender({ row }: { row: EmployeeRow }) {
         <div className="text-xs text-gray-500">{row.role.replace(/_/g, " ")}</div>
       </td>
       <td className="px-4 py-3 text-right">
+        <span className="text-lg font-bold text-gray-900">{row.active}</span>
+      </td>
+      <td className="px-4 py-3 text-right">
         <div className="inline-flex items-center gap-2">
-          <span className="text-lg font-bold text-gray-900">{row.active}</span>
+          <span className="text-lg font-bold text-gray-900">{row.load}</span>
           <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${capacityColors}`}>
             {row.capacity}
           </span>

--- a/src/lib/workflows/schemas.ts
+++ b/src/lib/workflows/schemas.ts
@@ -7,13 +7,21 @@
 
 import { z } from "zod";
 
-const workflowTypeEnum = z.enum([
+const BUILT_IN_TYPES = [
   "ai_machine_fulfillment",
   "location_services",
   "financing",
   "coffee_equipment",
   "coffee_service",
   "website_build",
+] as const;
+
+// Accept either a built-in workflow type or a custom:xxx admin-defined
+// type. Length + charset constraints keep the type key safe as a URL
+// path segment when needed.
+const workflowTypeEnum = z.union([
+  z.enum(BUILT_IN_TYPES),
+  z.string().regex(/^custom:[a-z0-9_]+$/i).min(8).max(80),
 ]);
 
 const sourceTypeEnum = z.enum([
@@ -212,7 +220,7 @@ export const setOverallStatusSchema = z.object({
 
 // ─── Filters for list endpoints ───────────────────────────────────────────
 export const listWorkflowsQuerySchema = z.object({
-  workflowType: workflowTypeEnum.optional(),
+  workflowType: workflowTypeEnum.optional() as z.ZodOptional<typeof workflowTypeEnum>,
   status: overallStatusEnum.optional(),
   assignedUserId: z.string().uuid().optional(),
   customerId: z.string().uuid().optional(),

--- a/src/lib/workflows/types.ts
+++ b/src/lib/workflows/types.ts
@@ -6,13 +6,18 @@
  * consumers can treat rows as `Workflow` without re-mapping.
  */
 
-export type WorkflowType =
+// Built-in workflow types + a wildcard for admin-created custom
+// templates (workflow_type keys prefixed with "custom:"). Anywhere the
+// exact built-in narrowing matters, use the BuiltInWorkflowType alias.
+export type BuiltInWorkflowType =
   | "ai_machine_fulfillment"
   | "location_services"
   | "financing"
   | "coffee_equipment"
   | "coffee_service"
   | "website_build";
+
+export type WorkflowType = BuiltInWorkflowType | (string & { readonly __brand?: "workflow_type" });
 
 export type WorkflowSourceType =
   | "agreement"
@@ -100,7 +105,7 @@ export type PrimaryTeam =
 
 export interface WorkflowTemplateRow {
   id: string;
-  workflow_type: WorkflowType;
+  workflow_type: string;
   version: number;
   title: string;
   description: string | null;
@@ -108,6 +113,9 @@ export interface WorkflowTemplateRow {
   quantity_based: boolean;
   completion_rule: CompletionRule;
   active: boolean;
+  workload_weight: number;
+  is_custom: boolean;
+  category: string | null;
   metadata: Record<string, unknown>;
   created_at: string;
   updated_at: string;

--- a/supabase/migrations/130_workflow_templates_workload_weight.sql
+++ b/supabase/migrations/130_workflow_templates_workload_weight.sql
@@ -1,0 +1,36 @@
+-- Migration 130 — Custom workflow templates for admin-managed
+-- perpetual tasks (account management, cold calling, operator
+-- coaching, etc.) with configurable workload point value.
+
+ALTER TABLE public.workflow_templates
+  ADD COLUMN IF NOT EXISTS workload_weight int NOT NULL DEFAULT 1
+    CHECK (workload_weight BETWEEN 1 AND 20),
+  ADD COLUMN IF NOT EXISTS is_custom boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS category text;
+
+-- Seeded (built-in) templates that shipped with migration 125 are
+-- flagged as non-custom so the admin UI can protect them from edits.
+-- Category left NULL; the admin can categorize later if desired.
+UPDATE public.workflow_templates
+   SET is_custom = false
+ WHERE workflow_type IN (
+   'ai_machine_fulfillment', 'location_services', 'financing',
+   'coffee_equipment', 'coffee_service', 'website_build'
+ );
+
+CREATE INDEX IF NOT EXISTS idx_workflow_templates_custom
+  ON public.workflow_templates(is_custom, category)
+  WHERE active = true;
+
+COMMENT ON COLUMN public.workflow_templates.workload_weight IS
+  'Point value each spawned workflow instance contributes to an
+   assignee''s total workload. Built-in templates stay at 1; admins
+   can weight custom perpetual tasks higher (e.g. key account
+   management = 5, cold calling = 1). Capped 1-20.';
+COMMENT ON COLUMN public.workflow_templates.is_custom IS
+  'true = admin-created template, editable/deletable via the admin
+   templates UI. false = seeded from code (protected from CRUD).';
+COMMENT ON COLUMN public.workflow_templates.category IS
+  'Freeform group label for the admin templates page. Suggested
+   categories: Perpetual, Account Management, Sales Ops,
+   Operator Coaching, Other.';


### PR DESCRIPTION
Adds admin-managed custom workflow templates for perpetual tasks (account management, cold calling, operator coaching, etc.) with a per-template workload point value. The existing 6 built-in templates are protected from edits/deletion.

MIGRATION 130
  workflow_templates.workload_weight  int 1-20 default 1
  workflow_templates.is_custom        bool  default false
  workflow_templates.category         text  freeform

ADMIN CRUD /api/admin/workflow-templates + /[id]
  GET  — list all (built-in + custom) with stages
  POST — create custom template + stages (workflow_type auto-prefixed
         "custom:", version auto-incremented per type)
  PATCH — edit any field; replace-all stage list (safe because in-flight
         workflows carry their own stage copies)
  DELETE — soft-blocks (rejects with 409) if any live workflow uses the
         template; admin can deactivate instead of deleting
  All refuse to touch is_custom=false rows.

ADMIN PAGE /admin/workflows/templates
  Grouped by category (built-ins under "Built-in (system)").
  Read-only badge on built-ins; edit + delete on custom.
  Full stage editor:
    - Add / remove / reorder (up-down arrows)
    - Per-stage: name, stage_key, type (milestone/status/quantity/date/ approval/document), required-for-completion, customer-visible Template metadata: title, workflow_type key, category (dropdown with defaults: Perpetual, Account Management, Sales Ops, Operator Coaching, Other — plus freeform), workload_weight (1-20), default deadline days, completion rule, quantity-based toggle, active toggle.

WORKLOAD /api/sales/workload
  Now joins workflows→workflow_templates to look up weight per row.
  Returns per-employee:
    - active  = raw count of open workflows (unchanged)
    - load    = weighted sum (built-ins contribute 1 each, custom
                templates contribute their admin-set weight)
  Capacity flag now driven by `load`, not `active`, so 3 heavy
  accounts (weight 5 = 15 load) flag the same as 15 quick tasks.
  Sort default swapped to `load`.

WORKLOAD PAGE /sales/workload
  New "Load" column between Active and By Type. Sortable. Capacity
  chip moved to the Load column so it reflects weighted total.
  "Manage templates →" link in the header opens the admin templates
  page.

NEW WORKFLOW MODAL /sales/workflows
  Type dropdown now fetches active templates from
  /api/admin/workflow-templates. Built-in and custom types appear in
  separate <optgroup>s. Custom templates grouped by their category.
  Falls back to hardcoded built-in list if the API returns nothing
  (defensive — first render before admin creates any customs).

TYPES + VALIDATION
  WorkflowType widened to allow custom:xxx strings (branded string)
  while BuiltInWorkflowType preserves the narrow enum where needed.
  Zod workflowTypeEnum accepts either the 6 built-ins or /^custom:
  [a-z0-9_]+$/i (length 8-80).