### PR TITLE
Workflows — admin hard-delete with cascade + audit trail

### DIFF
--- a/src/app/api/workflows/[id]/route.ts
+++ b/src/app/api/workflows/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
-import { canViewWorkflow, getWorkflowActor, isStaff } from "@/lib/workflows/permissions";
+import { canViewWorkflow, getWorkflowActor, hasPermission, isStaff } from "@/lib/workflows/permissions";
 
 /**
  * GET /api/workflows/[id]
@@ -219,7 +219,66 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
     assigneeDisplay,
     isStaffView: staffView,
     isOwner,
+    canDelete: hasPermission(actor, "workflows.delete"),
   });
+}
+
+/**
+ * DELETE /api/workflows/[id]
+ *
+ * Admin-only hard delete. The workflow row and every child
+ * (workflow_stages, workflow_events, workflow_notes,
+ * workflow_assignments, workflow_shipments, workflow_order_items,
+ * workflow_notification_dispatches, workflow_customer_approvals) drop
+ * via ON DELETE CASCADE. time_entries.workflow_id is SET NULL so time
+ * clock history stays intact.
+ *
+ * An audit_logs row is written BEFORE the delete so the paper trail
+ * survives the cascade — reason is required.
+ */
+export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const actor = await getWorkflowActor(req);
+  if (!actor) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (!hasPermission(actor, "workflows.delete")) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  const { id } = await params;
+
+  const body = await req.json().catch(() => ({}));
+  const reason = typeof body?.reason === "string" ? body.reason.trim() : "";
+  if (!reason) {
+    return NextResponse.json({ error: "Reason is required" }, { status: 400 });
+  }
+  if (reason.length > 500) {
+    return NextResponse.json({ error: "Reason too long" }, { status: 400 });
+  }
+
+  const { data: workflow } = await supabaseAdmin
+    .from("workflows")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+  if (!workflow) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  // Write the audit trail first — after the delete the workflow_events
+  // rows are gone with the cascade, so audit_logs is the last surviving
+  // record of who did what and why.
+  await supabaseAdmin.from("audit_logs").insert({
+    actor_id: actor.id,
+    action: "workflow_deleted",
+    entity_type: "workflow",
+    entity_id: id,
+    reason,
+    before: workflow,
+    after: null,
+  });
+
+  const { error } = await supabaseAdmin.from("workflows").delete().eq("id", id);
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true });
 }
 
 function friendlyTeamName(team: string | null): string {

--- a/src/app/sales/workflows/[id]/page.tsx
+++ b/src/app/sales/workflows/[id]/page.tsx
@@ -23,7 +23,9 @@ import {
   EyeOff,
   Mail,
   Phone,
+  Trash2,
 } from "lucide-react";
+import { useRouter } from "next/navigation";
 
 interface Stage {
   id: string;
@@ -138,10 +140,12 @@ interface DetailPayload {
   companyInfo: CompanyInfo | null;
   assigneeDisplay: string | null;
   isStaffView: boolean;
+  canDelete: boolean;
 }
 
 export default function WorkflowDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
+  const router = useRouter();
   const [data, setData] = useState<DetailPayload | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState<string | null>(null);
@@ -531,7 +535,14 @@ export default function WorkflowDetailPage({ params }: { params: Promise<{ id: s
       {/* Admin actions */}
       {data.isStaffView && (
         <div className="rounded-xl border border-gray-200 bg-white shadow-sm p-5 flex flex-wrap gap-3">
-          <AdminActions workflowId={id} status={w.overall_status} onDone={load} />
+          <AdminActions
+            workflowId={id}
+            workflowNumber={w.workflow_number}
+            status={w.overall_status}
+            canDelete={data.canDelete}
+            onDone={load}
+            onDeleted={() => router.push("/sales/workflows")}
+          />
         </div>
       )}
     </div>
@@ -1053,7 +1064,23 @@ function AddShipmentButton({ workflowId, onSaved }: { workflowId: string; onSave
   );
 }
 
-function AdminActions({ workflowId, status, onDone }: { workflowId: string; status: string; onDone: () => void }) {
+function AdminActions({
+  workflowId,
+  workflowNumber,
+  status,
+  canDelete,
+  onDone,
+  onDeleted,
+}: {
+  workflowId: string;
+  workflowNumber: string;
+  status: string;
+  canDelete: boolean;
+  onDone: () => void;
+  onDeleted: () => void;
+}) {
+  const [deleting, setDeleting] = useState(false);
+
   async function submit(path: string, method: string, body: Record<string, unknown>) {
     const reason = window.prompt("Reason (audit-logged):");
     if (!reason) return;
@@ -1067,6 +1094,42 @@ function AdminActions({ workflowId, status, onDone }: { workflowId: string; stat
     });
     if (res.ok) onDone();
     else alert(`Failed: ${(await res.json()).error}`);
+  }
+
+  async function handleDelete() {
+    // Two-step confirm because the delete cascades every stage, note,
+    // shipment, order-item, event, and pending approval — irreversible.
+    const confirmed = window.confirm(
+      `Permanently delete workflow ${workflowNumber}?\n\n` +
+      `This removes every stage, note, shipment, order item, event, and pending approval. ` +
+      `Time entries stay but lose their workflow link. Prefer Cancel over Delete for real customer work.`,
+    );
+    if (!confirmed) return;
+    const reason = window.prompt(
+      `Reason (audit-logged, required):`,
+      "Test/duplicate workflow cleanup",
+    );
+    if (!reason || !reason.trim()) return;
+
+    setDeleting(true);
+    try {
+      const supabase = createBrowserClient();
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session?.access_token) return;
+      const res = await fetch(`/api/workflows/${workflowId}`, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${session.access_token}` },
+        body: JSON.stringify({ reason: reason.trim() }),
+      });
+      if (res.ok) {
+        onDeleted();
+      } else {
+        const err = await res.json().catch(() => ({}));
+        alert(`Delete failed: ${err.error ?? "Unknown"}`);
+      }
+    } finally {
+      setDeleting(false);
+    }
   }
 
   return (
@@ -1107,6 +1170,18 @@ function AdminActions({ workflowId, status, onDone }: { workflowId: string; stat
           className="inline-flex items-center gap-1.5 rounded-md border border-gray-200 bg-white text-gray-700 px-3 py-1.5 text-sm hover:bg-gray-50"
         >
           <RotateCw className="h-3.5 w-3.5" /> Reopen
+        </button>
+      )}
+      {canDelete && (
+        <button
+          type="button"
+          onClick={handleDelete}
+          disabled={deleting}
+          className="ml-auto inline-flex items-center gap-1.5 rounded-md border border-red-300 bg-red-600 text-white px-3 py-1.5 text-sm hover:bg-red-700 disabled:opacity-50"
+          title="Permanently delete this workflow and all its children (admin only)"
+        >
+          {deleting ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Trash2 className="h-3.5 w-3.5" />}
+          Delete
         </button>
       )}
     </>

--- a/src/lib/workflows/permissions.ts
+++ b/src/lib/workflows/permissions.ts
@@ -90,7 +90,11 @@ export function hasPermission(actor: WorkflowActor, permission: WorkflowPermissi
     case "workflows.reopen":
       return ROLES_ADMIN_ONLY.has(actor.role);
     case "workflows.delete":
-      return false; // never — cancellation only
+      // Admin-only hard delete. Cancellation remains the default path;
+      // delete exists for cleaning up test/duplicate workflows the CRM
+      // shouldn't carry forever. Every deletion writes an audit_logs
+      // row before the cascade fires.
+      return ROLES_ADMIN_ONLY.has(actor.role);
     case "workflows.manage_templates":
     case "workflows.override_validation":
       return ROLES_ADMIN_ONLY.has(actor.role);


### PR DESCRIPTION
Adds a Delete button next to the other admin actions on the workflow detail page (right-aligned so it doesn't sit next to safer actions). Two-step confirm plus a required reason before firing.

- permissions.workflows.delete flipped from false → admin-only
- DELETE /api/workflows/[id] handler:
  * requires actor with workflows.delete
  * requires a reason string
  * writes an audit_logs row BEFORE the delete so the paper trail survives the cascade
  * lets ON DELETE CASCADE clean up stages/events/notes/assignments/ shipments/order_items/approvals/notification_dispatches; time_entries are SET NULL so time-clock history stays intact
- GET response gains canDelete so UI can gate the button per actor
- Detail page routes back to /sales/workflows on successful delete


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2