### PR TITLE
Sales — surface creating rep as "Sales Person" in export reports

### DIFF
--- a/src/app/api/sales/orders/route.ts
+++ b/src/app/api/sales/orders/route.ts
@@ -55,6 +55,33 @@ export async function GET(req: NextRequest) {
 
   let results = data || [];
 
+  // Hydrate the creator's display name from profiles. Manual join
+  // rather than a PostgREST embed because sales_orders.created_by
+  // references auth.users, and the embed hop to profiles is flaky in
+  // that direction. Adds `created_by_profile: { full_name } | null`
+  // to every row — this is what the Export Report "Sales Person"
+  // column reads for creator-based accountability.
+  const creatorIds = Array.from(
+    new Set(
+      (results as Record<string, unknown>[])
+        .map((r) => r.created_by as string | null | undefined)
+        .filter((v): v is string => typeof v === "string" && v.length > 0),
+    ),
+  );
+  if (creatorIds.length > 0) {
+    const { data: creators } = await supabaseAdmin
+      .from("profiles")
+      .select("id, full_name, email")
+      .in("id", creatorIds);
+    const byId = new Map(
+      (creators ?? []).map((c) => [c.id, { full_name: c.full_name, email: c.email }]),
+    );
+    results = (results as Record<string, unknown>[]).map((r) => ({
+      ...r,
+      created_by_profile: r.created_by ? byId.get(r.created_by as string) ?? null : null,
+    }));
+  }
+
   if (search) {
     const s = search.toLowerCase();
     results = results.filter((o: Record<string, unknown>) => {

--- a/src/app/sales/agreements/page.tsx
+++ b/src/app/sales/agreements/page.tsx
@@ -38,6 +38,11 @@ interface AgreementRow {
   placement_term_months: number | null;
   commission_pct: number | null;
   created_at: string;
+  // Stamped at POST time from the creating rep's profile (see
+  // /api/sales/agreements POST). Used by the Export Report
+  // "Sales Person" column for accountability tracking.
+  rep_name: string | null;
+  rep_email: string | null;
 }
 
 const STATUS_COLORS: Record<string, string> = {
@@ -170,6 +175,11 @@ export default function AgreementsListPage() {
                 columns: [
                   { header: "Type", value: (r) => r.agreement_type },
                   { header: "Status", value: (r) => r.agreement_status },
+                  // Rep name is stamped at agreement creation time
+                  // (POST /api/sales/agreements pulls it from profiles).
+                  // Falls back to email so pre-migration rows still
+                  // surface something rather than a blank cell.
+                  { header: "Sales Person", value: (r) => r.rep_name ?? r.rep_email },
                   { header: "Operator Company", value: (r) => r.operator_company_name },
                   { header: "Operator Contact", value: (r) => r.operator_legal_name },
                   { header: "Operator Email", value: (r) => r.operator_email },

--- a/src/app/sales/orders/page.tsx
+++ b/src/app/sales/orders/page.tsx
@@ -35,6 +35,7 @@ interface Order {
   sales_accounts: { id: string; business_name: string; contact_name: string; email: string; phone: string } | null;
   order_items: OrderItem[];
   assigned_profile: { full_name: string } | null;
+  created_by_profile: { full_name: string | null; email: string | null } | null;
 }
 
 const STATUS_FILTERS = [
@@ -207,6 +208,11 @@ export default function OrdersPage() {
                   { header: "Email", value: (r) => r.sales_accounts?.email },
                   { header: "Phone", value: (r) => r.sales_accounts?.phone },
                   { header: "Total", value: (r) => r.total_value },
+                  // "Sales Person" = the rep who created the record.
+                  // Distinct from "Assigned To" because ownership can be
+                  // reassigned later; accountability for the initial
+                  // creation stays with the creator.
+                  { header: "Sales Person", value: (r) => r.created_by_profile?.full_name ?? r.created_by_profile?.email },
                   { header: "Assigned To", value: (r) => r.assigned_profile?.full_name },
                   { header: "Next Action", value: (r) => r.next_required_action },
                   { header: "Created", value: (r) => r.created_at ? new Date(r.created_at) : null },


### PR DESCRIPTION
Every quote, order, and agreement already stamps its creator at insert (sales_orders.created_by, purchase_agreements.created_by + rep_name/rep_email snapshots) — the accountability data was in the DB but never made it into the exports.

- /api/sales/orders GET now hydrates created_by → profiles (manual join, not PostgREST embed, because sales_orders.created_by → auth.users). Each row gains created_by_profile: { full_name, email }.
- Orders/Quotes export gains a "Sales Person" column reading that hydrated field. Placed before "Assigned To" so ownership vs. authorship are both visible — ownership can be reassigned, creator is the accountability anchor.
- Agreements export gains a "Sales Person" column reading the already-denormalized purchase_agreements.rep_name snapshot; no server change needed since GET already selects("*"). Falls back to rep_email so old rows still render something.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2