### PR TITLE
Workflows — inline stage rename on the detail page

### DIFF
--- a/src/app/api/workflows/[id]/stages/[stageKey]/route.ts
+++ b/src/app/api/workflows/[id]/stages/[stageKey]/route.ts
@@ -48,6 +48,10 @@ export async function PATCH(
   if (input.customerMessage !== undefined && !hasPermission(actor, "workflows.publish_customer_updates")) {
     return NextResponse.json({ error: "Forbidden — cannot publish customer updates" }, { status: 403 });
   }
+  // Renaming a stage is a status-class edit — sales_manager and above.
+  if (input.stageName !== undefined && !hasPermission(actor, "workflows.edit_status")) {
+    return NextResponse.json({ error: "Forbidden — cannot rename stage" }, { status: 403 });
+  }
   if (input.allowOverTarget && !hasPermission(actor, "workflows.override_validation")) {
     return NextResponse.json({ error: "Forbidden — cannot override validation" }, { status: 403 });
   }

--- a/src/app/sales/workflows/[id]/page.tsx
+++ b/src/app/sales/workflows/[id]/page.tsx
@@ -568,24 +568,29 @@ function StageRow({
     completed_quantity: stage.completed_quantity,
     internal_notes: stage.internal_notes ?? "",
     customer_message: stage.customer_message ?? "",
+    stage_name: stage.stage_name,
   });
   const [qtyDraft, setQtyDraft] = useState(String(stage.completed_quantity));
   const [notesDraft, setNotesDraft] = useState(stage.internal_notes ?? "");
   const [customerDraft, setCustomerDraft] = useState(stage.customer_message ?? "");
+  const [nameDraft, setNameDraft] = useState(stage.stage_name);
 
   if (
     lastSeen.completed_quantity !== stage.completed_quantity ||
     lastSeen.internal_notes !== (stage.internal_notes ?? "") ||
-    lastSeen.customer_message !== (stage.customer_message ?? "")
+    lastSeen.customer_message !== (stage.customer_message ?? "") ||
+    lastSeen.stage_name !== stage.stage_name
   ) {
     setLastSeen({
       completed_quantity: stage.completed_quantity,
       internal_notes: stage.internal_notes ?? "",
       customer_message: stage.customer_message ?? "",
+      stage_name: stage.stage_name,
     });
     setQtyDraft(String(stage.completed_quantity));
     setNotesDraft(stage.internal_notes ?? "");
     setCustomerDraft(stage.customer_message ?? "");
+    setNameDraft(stage.stage_name);
   }
 
   const isQuantity = stage.stage_type === "quantity";
@@ -598,7 +603,33 @@ function StageRow({
         <div className="flex-1">
           <div className="flex items-center gap-2">
             <StageStatusIcon status={stage.status} />
-            <span className="font-medium text-gray-900">{stage.stage_name}</span>
+            {staffView ? (
+              // Inline rename — template edits don't propagate to
+              // spawned workflows, so admins need to fix "New Stage"
+              // holdovers here. Auto-saves on blur; empty values are
+              // rejected server-side.
+              <input
+                type="text"
+                value={nameDraft}
+                onChange={(e) => setNameDraft(e.target.value)}
+                onBlur={() => {
+                  const trimmed = nameDraft.trim();
+                  if (trimmed.length === 0) {
+                    // Refuse empty — snap back to persisted name.
+                    setNameDraft(stage.stage_name);
+                    return;
+                  }
+                  if (trimmed !== stage.stage_name) {
+                    onUpdate({ stageName: trimmed });
+                  }
+                }}
+                className="font-medium text-gray-900 bg-transparent border-b border-transparent hover:border-gray-200 focus:border-emerald-500 focus:outline-none px-1 -mx-1 rounded-none min-w-[10rem]"
+                placeholder="Stage name"
+                title="Click to rename this stage"
+              />
+            ) : (
+              <span className="font-medium text-gray-900">{stage.stage_name}</span>
+            )}
             {stage.required_for_completion && (
               <span className="text-[10px] uppercase tracking-wide text-emerald-700 bg-emerald-50 px-1.5 py-0.5 rounded">
                 Required

--- a/src/lib/workflows/schemas.ts
+++ b/src/lib/workflows/schemas.ts
@@ -132,6 +132,11 @@ export const updateStageSchema = z.object({
   completedQuantity: z.number().nonnegative().optional(),
   internalNotes: z.string().max(4000).optional(),
   customerMessage: z.string().max(2000).optional(),
+  // Staff-only inline rename for in-flight workflow stages. Template
+  // edits don't propagate to workflows already spawned (they carry
+  // their own copy), so admin needs a way to fix "New Stage" holdovers
+  // on existing workflows.
+  stageName: z.string().min(1).max(200).optional(),
   updatedBy: z.string().uuid().nullable().optional(),
   changeKey: z.string().max(200).optional(),
   allowOverTarget: z.boolean().optional(),

--- a/src/lib/workflows/service.ts
+++ b/src/lib/workflows/service.ts
@@ -377,6 +377,7 @@ export async function updateStage(input: UpdateStageInput): Promise<UpdateStageR
     completed_quantity: stage.completed_quantity,
     internal_notes: stage.internal_notes,
     customer_message: stage.customer_message,
+    stage_name: stage.stage_name,
   };
 
   const patch: Record<string, unknown> = { updated_by: input.updatedBy ?? null };
@@ -438,6 +439,17 @@ export async function updateStage(input: UpdateStageInput): Promise<UpdateStageR
   if (input.customerMessage !== undefined && input.customerMessage !== stage.customer_message) {
     patch.customer_message = input.customerMessage;
     changedFields.push("customer_message");
+  }
+
+  if (input.stageName !== undefined) {
+    const trimmed = input.stageName.trim();
+    if (trimmed.length === 0) {
+      throw new Error("stage_name cannot be empty");
+    }
+    if (trimmed !== stage.stage_name) {
+      patch.stage_name = trimmed;
+      changedFields.push("stage_name");
+    }
   }
 
   if (changedFields.length === 0) {
@@ -503,6 +515,7 @@ export async function updateStage(input: UpdateStageInput): Promise<UpdateStageR
       completed_quantity: (updated as WorkflowStageRow).completed_quantity,
       internal_notes: (updated as WorkflowStageRow).internal_notes,
       customer_message: (updated as WorkflowStageRow).customer_message,
+      stage_name: (updated as WorkflowStageRow).stage_name,
     },
     changedFields,
     actorUserId: input.updatedBy ?? null,

--- a/src/lib/workflows/types.ts
+++ b/src/lib/workflows/types.ts
@@ -321,6 +321,7 @@ export interface UpdateStageInput {
   completedQuantity?: number;
   internalNotes?: string;
   customerMessage?: string;
+  stageName?: string;
   updatedBy?: string | null;
   changeKey?: string;
   allowOverTarget?: boolean;


### PR DESCRIPTION
Template edits only affect future spawns — workflow_stages rows carry their own copy of stage_name at seed time. Any workflow spawned from a template whose stages were mis-saved as the "New Stage" placeholder stayed stuck displaying "New Stage" with no path to fix it.

Adds staff-only inline rename on the workflow detail page: click the stage title, type a new name, blur to save. Empty values snap back to the persisted name (rejected server-side as well).

- updateStageSchema: new optional stageName field
- UpdateStageInput type + service: patch stage_name, include in event payload, refuse empty
- API route: gate stageName behind workflows.edit_status
- StageRow (workflow detail): swap the read-only span for an input in staff view; auto-save on blur, same pattern as internal_notes / customer_message drafts


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2