### PR TITLE
Workflows — surface which field failed validation on create

### DIFF
--- a/src/app/api/workflows/route.ts
+++ b/src/app/api/workflows/route.ts
@@ -144,7 +144,17 @@ export async function POST(req: NextRequest) {
     actorType: "staff",
   });
   if (!parsed.success) {
-    return NextResponse.json({ error: "Invalid input", details: parsed.error.format() }, { status: 400 });
+    // Bubble the first failed field into `error` so the client shows
+    // something actionable instead of the generic "Invalid input".
+    const first = parsed.error.issues[0];
+    const path = first?.path?.join(".") || "unknown_field";
+    return NextResponse.json(
+      {
+        error: `Invalid input on ${path}: ${first?.message ?? "validation failed"}`,
+        details: parsed.error.format(),
+      },
+      { status: 400 },
+    );
   }
 
   try {

--- a/src/lib/workflows/schemas.ts
+++ b/src/lib/workflows/schemas.ts
@@ -17,11 +17,13 @@ const BUILT_IN_TYPES = [
 ] as const;
 
 // Accept either a built-in workflow type or a custom:xxx admin-defined
-// type. Length + charset constraints keep the type key safe as a URL
-// path segment when needed.
+// type. Length keeps rows bounded; charset is intentionally permissive
+// because the admin CRUD lets admins type free-form keys ("Ongoing
+// Coaching", "Ops-Support", "AM/Coach", etc.) and we'd rather accept
+// what's already stored than reject spawns after the fact.
 const workflowTypeEnum = z.union([
   z.enum(BUILT_IN_TYPES),
-  z.string().regex(/^custom:[a-z0-9_]+$/i).min(8).max(80),
+  z.string().regex(/^custom:.+$/).min(8).max(80),
 ]);
 
 const sourceTypeEnum = z.enum([


### PR DESCRIPTION
The admin CRUD lets templates be created with workflow_type keys the create-workflow schema then rejects — a template titled "Ongoing Coaching/Ops Support" ends up stored as e.g. "custom:Ongoing Coaching" (space, slash) which failed the old strict `^custom:[a-z0-9_]+$` regex on spawn.

- Relaxed workflowTypeEnum's custom fallback to `/^custom:.+$/` so we accept whatever the admin CRUD already stored. Length bounds stay in place.
- POST /api/workflows now embeds the first failed field name in the error string (e.g. "Invalid input on workflowType: ...") instead of a generic "Invalid input". Details object still returned for full context.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2