### PR TITLE
Workflows — multi-assignee panel on the detail page

### DIFF
--- a/src/app/api/workflows/[id]/assign/route.ts
+++ b/src/app/api/workflows/[id]/assign/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getWorkflowActor, hasPermission } from "@/lib/workflows/permissions";
 import { assignmentSchema } from "@/lib/workflows/schemas";
-import { assignWorkflow } from "@/lib/workflows/service";
+import { assignWorkflow, unassignWorkflow } from "@/lib/workflows/service";
 
 /**
  * POST /api/workflows/[id]/assign
@@ -31,6 +31,42 @@ export async function POST(
     return NextResponse.json({ ok: true });
   } catch (err) {
     const message = err instanceof Error ? err.message : "Assignment failed";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}
+
+/**
+ * DELETE /api/workflows/[id]/assign?assignmentId=<uuid>
+ *
+ * Remove a single assignment (soft-delete). Query-param rather than
+ * nested route because the assignment id doesn't need its own URL
+ * hierarchy — the collection lives inside the workflow.
+ */
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const actor = await getWorkflowActor(req);
+  if (!actor) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (!hasPermission(actor, "workflows.assign")) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { id } = await params;
+  const assignmentId = new URL(req.url).searchParams.get("assignmentId");
+  if (!assignmentId) {
+    return NextResponse.json({ error: "assignmentId query param is required" }, { status: 400 });
+  }
+
+  try {
+    const result = await unassignWorkflow({
+      workflowId: id,
+      assignmentId,
+      removedBy: actor.id,
+    });
+    return NextResponse.json(result);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unassign failed";
     return NextResponse.json({ error: message }, { status: 400 });
   }
 }

--- a/src/app/api/workflows/[id]/route.ts
+++ b/src/app/api/workflows/[id]/route.ts
@@ -60,13 +60,36 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
 
   // Assignments (staff only — customers see only assignee name when
   // show_assignee_to_customer is true on the workflow, joined below).
-  const { data: assignments } = staffView
-    ? await supabaseAdmin
-        .from("workflow_assignments")
-        .select("*")
-        .eq("workflow_id", id)
-        .eq("active", true)
-    : { data: null };
+  // Hydrated with each user's display name so the detail-page
+  // Assignees panel can render "Vic Reynolds — primary_owner" without
+  // an N+1 lookup on the client.
+  const rawAssignments = staffView
+    ? (
+        await supabaseAdmin
+          .from("workflow_assignments")
+          .select("*")
+          .eq("workflow_id", id)
+          .eq("active", true)
+          .order("assigned_at", { ascending: true })
+      ).data ?? []
+    : [];
+  let assignments: Array<Record<string, unknown>> = rawAssignments;
+  if (rawAssignments.length > 0) {
+    const assigneeIds = Array.from(
+      new Set(rawAssignments.map((a) => a.user_id).filter(Boolean) as string[]),
+    );
+    const { data: assigneeProfiles } = await supabaseAdmin
+      .from("profiles")
+      .select("id, full_name, email")
+      .in("id", assigneeIds);
+    const byId = new Map(
+      (assigneeProfiles ?? []).map((p) => [p.id, { full_name: p.full_name, email: p.email }]),
+    );
+    assignments = rawAssignments.map((a) => ({
+      ...a,
+      user_profile: a.user_id ? byId.get(a.user_id) ?? null : null,
+    }));
+  }
 
   // Shipments always visible.
   const { data: shipments } = await supabaseAdmin

--- a/src/app/sales/workflows/[id]/page.tsx
+++ b/src/app/sales/workflows/[id]/page.tsx
@@ -24,6 +24,8 @@ import {
   Mail,
   Phone,
   Trash2,
+  Plus,
+  X,
 } from "lucide-react";
 import { useRouter } from "next/navigation";
 
@@ -56,6 +58,7 @@ interface Assignment {
   team: string | null;
   active: boolean;
   assigned_at: string;
+  user_profile: { full_name: string | null; email: string | null } | null;
 }
 interface Shipment {
   id: string;
@@ -344,14 +347,14 @@ export default function WorkflowDetailPage({ params }: { params: Promise<{ id: s
                 : undefined
             }
           />
-          <AssigneeTile
+          <AssigneesTile
+            assignments={data.assignments}
             assigneeDisplay={data.assigneeDisplay}
             currentUserId={w.assigned_user_id}
             team={w.primary_team}
             staffView={data.isStaffView}
-            onAssign={(userId) =>
-              postAction("/assign", { userId, role: "primary_owner", makePrimary: true })
-            }
+            workflowId={id}
+            onChanged={load}
           />
           <PaymentTile
             paymentStatus={w.payment_status}
@@ -775,28 +778,42 @@ function PriorityBadge({ priority }: { priority: string }) {
 
 interface StaffPicker { id: string; full_name: string | null; email: string; role: string }
 
-function AssigneeTile({
+/**
+ * Multi-assignee tile — shows the primary owner + every collaborator,
+ * each with a remove button. Also exposes an inline picker to add
+ * another team member as a collaborator, or to set a new primary
+ * owner (when Reassign is clicked).
+ *
+ * Every add/remove hits the shared /assign endpoint and its
+ * DELETE?assignmentId variant, then calls onChanged() so the parent
+ * re-fetches and re-renders with the fresh list.
+ */
+function AssigneesTile({
+  assignments,
   assigneeDisplay,
   currentUserId,
   team,
   staffView,
-  onAssign,
+  workflowId,
+  onChanged,
 }: {
+  assignments: Assignment[];
   assigneeDisplay: string | null;
   currentUserId: string | null;
   team: string | null;
   staffView: boolean;
-  onAssign: (userId: string) => Promise<boolean>;
+  workflowId: string;
+  onChanged: () => Promise<void> | void;
 }) {
-  const [picking, setPicking] = useState(false);
+  const [mode, setMode] = useState<null | "primary" | "collaborator">(null);
   const [staff, setStaff] = useState<StaffPicker[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [saving, setSaving] = useState<string | null>(null);
+  const [loadingStaff, setLoadingStaff] = useState(false);
+  const [busy, setBusy] = useState<string | null>(null);
 
-  async function openPicker() {
-    setPicking(true);
+  async function openPicker(next: "primary" | "collaborator") {
+    setMode(next);
     if (staff.length > 0) return;
-    setLoading(true);
+    setLoadingStaff(true);
     const supabase = createBrowserClient();
     const { data: { session } } = await supabase.auth.getSession();
     if (session?.access_token) {
@@ -805,60 +822,163 @@ function AssigneeTile({
       });
       if (res.ok) setStaff(await res.json());
     }
-    setLoading(false);
+    setLoadingStaff(false);
   }
 
-  async function assign(userId: string) {
-    setSaving(userId);
-    const ok = await onAssign(userId);
-    setSaving(null);
-    if (ok) setPicking(false);
+  async function withAuth<T>(fn: (token: string) => Promise<T>): Promise<T | null> {
+    const supabase = createBrowserClient();
+    const { data: { session } } = await supabase.auth.getSession();
+    if (!session?.access_token) return null;
+    return fn(session.access_token);
   }
+
+  async function pickUser(userId: string) {
+    if (!mode) return;
+    setBusy(userId);
+    const body = mode === "primary"
+      ? { userId, role: "primary_owner", makePrimary: true }
+      : { userId, role: "observer" };
+    const res = await withAuth((token) =>
+      fetch(`/api/workflows/${workflowId}/assign`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+        body: JSON.stringify(body),
+      }),
+    );
+    setBusy(null);
+    if (res && res.ok) {
+      setMode(null);
+      await onChanged();
+    } else if (res) {
+      const err = await res.json().catch(() => ({}));
+      alert(`Failed: ${err.error ?? "Unknown"}`);
+    }
+  }
+
+  async function removeAssignment(assignmentId: string) {
+    if (!window.confirm("Remove this assignment?")) return;
+    setBusy(assignmentId);
+    const res = await withAuth((token) =>
+      fetch(`/api/workflows/${workflowId}/assign?assignmentId=${assignmentId}`, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+    );
+    setBusy(null);
+    if (res && res.ok) {
+      await onChanged();
+    } else if (res) {
+      const err = await res.json().catch(() => ({}));
+      alert(`Failed: ${err.error ?? "Unknown"}`);
+    }
+  }
+
+  // Show only active rows. Sort primary_owner first so the tile has a
+  // clear header person.
+  const active = [...assignments]
+    .filter((a) => a.active)
+    .sort((a, b) => {
+      if (a.role === "primary_owner" && b.role !== "primary_owner") return -1;
+      if (b.role === "primary_owner" && a.role !== "primary_owner") return 1;
+      return a.assigned_at.localeCompare(b.assigned_at);
+    });
+
+  // Prevent the picker from suggesting people already on the list.
+  const assignedUserIds = new Set(active.map((a) => a.user_id));
+  const pickable = staff.filter((s) => !assignedUserIds.has(s.id));
 
   return (
     <div className="rounded-lg border border-gray-100 bg-gray-50 p-3">
       <div className="text-xs uppercase tracking-wide text-gray-500 flex items-center gap-1">
-        <UserCircle2 className="h-4 w-4" /> Assigned
+        <UserCircle2 className="h-4 w-4" /> Assigned{active.length > 1 ? ` (${active.length})` : ""}
       </div>
-      <div className="text-sm font-medium text-gray-900 mt-1 capitalize">
-        {assigneeDisplay ?? "Unassigned"}
-      </div>
-      {team && <div className="text-xs text-gray-500 mt-0.5">Team: {team}</div>}
-      {staffView && !picking && (
-        <button
-          type="button"
-          onClick={openPicker}
-          className="mt-2 text-xs text-emerald-700 hover:underline"
-        >
-          {currentUserId ? "Reassign" : "Assign"}
-        </button>
+
+      {active.length === 0 ? (
+        <div className="text-sm font-medium text-gray-900 mt-1">
+          {assigneeDisplay ?? "Unassigned"}
+        </div>
+      ) : (
+        <div className="mt-1 space-y-1">
+          {active.map((a) => (
+            <div key={a.id} className="flex items-center justify-between gap-2 text-sm">
+              <div className="min-w-0">
+                <div className="font-medium text-gray-900 truncate">
+                  {a.user_profile?.full_name ?? a.user_profile?.email ?? a.user_id.slice(0, 8)}
+                </div>
+                <div className="text-[10px] uppercase tracking-wide text-gray-500">
+                  {a.role.replace(/_/g, " ")}
+                </div>
+              </div>
+              {staffView && (
+                <button
+                  type="button"
+                  onClick={() => removeAssignment(a.id)}
+                  disabled={busy === a.id}
+                  className="text-gray-400 hover:text-red-600 disabled:opacity-40"
+                  title="Remove this assignment"
+                >
+                  {busy === a.id ? <Loader2 className="h-3 w-3 animate-spin" /> : <X className="h-3.5 w-3.5" />}
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
       )}
-      {staffView && picking && (
+
+      {team && <div className="text-xs text-gray-500 mt-1.5">Team: {team}</div>}
+
+      {staffView && !mode && (
+        <div className="mt-2 flex flex-wrap gap-3 text-xs">
+          <button
+            type="button"
+            onClick={() => openPicker("primary")}
+            className="text-emerald-700 hover:underline"
+          >
+            {currentUserId ? "Reassign primary" : "Set primary"}
+          </button>
+          <button
+            type="button"
+            onClick={() => openPicker("collaborator")}
+            className="text-emerald-700 hover:underline inline-flex items-center gap-1"
+          >
+            <Plus className="h-3 w-3" /> Add collaborator
+          </button>
+        </div>
+      )}
+
+      {staffView && mode && (
         <div className="mt-2">
-          {loading ? (
+          <div className="text-[10px] uppercase tracking-wide text-gray-500 mb-1">
+            {mode === "primary" ? "Set primary owner" : "Add collaborator"}
+          </div>
+          {loadingStaff ? (
             <div className="text-xs text-gray-500 inline-flex items-center gap-1">
               <Loader2 className="h-3 w-3 animate-spin" /> Loading team…
             </div>
           ) : (
             <>
               <select
-                onChange={(e) => e.target.value && assign(e.target.value)}
+                onChange={(e) => e.target.value && pickUser(e.target.value)}
                 defaultValue=""
-                disabled={saving !== null}
+                disabled={busy !== null}
                 className="w-full rounded-md border border-gray-200 text-xs px-2 py-1"
               >
-                <option value="" disabled>Select assignee…</option>
-                {staff.map((s) => (
-                  <option key={s.id} value={s.id}>
-                    {s.full_name ?? s.email} ({s.role})
-                  </option>
-                ))}
+                <option value="" disabled>Select team member…</option>
+                {pickable.length === 0 ? (
+                  <option value="" disabled>Everyone is already on this workflow</option>
+                ) : (
+                  pickable.map((s) => (
+                    <option key={s.id} value={s.id}>
+                      {s.full_name ?? s.email} ({s.role})
+                    </option>
+                  ))
+                )}
               </select>
               <button
                 type="button"
-                onClick={() => setPicking(false)}
+                onClick={() => setMode(null)}
                 className="mt-1 text-xs text-gray-500 hover:text-gray-800"
-                disabled={saving !== null}
+                disabled={busy !== null}
               >
                 Cancel
               </button>

--- a/src/lib/workflows/service.ts
+++ b/src/lib/workflows/service.ts
@@ -830,6 +830,60 @@ export async function assignWorkflow(input: AssignmentInput) {
   }
 }
 
+/**
+ * Remove an assignment (soft-delete via active=false + removed_at).
+ *
+ * If the assignment being removed is the primary_owner, we blank
+ * workflows.assigned_user_id too so the CRM list stops showing them as
+ * owner. The caller is expected to re-assign a new primary right
+ * after; otherwise the workflow shows "Unassigned".
+ */
+export async function unassignWorkflow(input: {
+  workflowId: string;
+  assignmentId: string;
+  removedBy?: string | null;
+}) {
+  const { data: assignment } = await supabaseAdmin
+    .from("workflow_assignments")
+    .select("*")
+    .eq("id", input.assignmentId)
+    .eq("workflow_id", input.workflowId)
+    .maybeSingle();
+  if (!assignment) throw new Error("Assignment not found");
+  if (!assignment.active) return { ok: true, already: true };
+
+  await supabaseAdmin
+    .from("workflow_assignments")
+    .update({ active: false, removed_at: new Date().toISOString() })
+    .eq("id", assignment.id);
+
+  if (assignment.role === "primary_owner") {
+    const workflow = await getWorkflow(input.workflowId);
+    if (workflow && workflow.assigned_user_id === assignment.user_id) {
+      await supabaseAdmin
+        .from("workflows")
+        .update({
+          assigned_user_id: null,
+          updated_by: input.removedBy ?? null,
+          version: workflow.version + 1,
+        })
+        .eq("id", input.workflowId)
+        .eq("version", workflow.version);
+    }
+  }
+
+  await recordEvent({
+    workflowId: input.workflowId,
+    eventType: "assignment_removed",
+    previousValue: { user_id: assignment.user_id, role: assignment.role },
+    newValue: null,
+    actorUserId: input.removedBy ?? null,
+    actorType: "staff",
+  });
+
+  return { ok: true, already: false };
+}
+
 // ─── Notes ────────────────────────────────────────────────────────────────
 
 export async function addNote(input: AddNoteInput) {


### PR DESCRIPTION
The DB has always supported multiple people per workflow via the workflow_assignments many-to-many (primary_owner + N collaborators), and the workload endpoint already counts collaborations toward each person's load — but the detail-page UI only rendered the single primary and hid every other assignee.

- GET /api/workflows/[id] now hydrates each assignment's user_profile (full_name, email) into the assignments array so the panel renders without an N+1
- New unassignWorkflow() service — soft-deletes an assignment (active = false + removed_at), blanks workflows.assigned_user_id when the removed row was the primary owner, records an audit event
- New DELETE /api/workflows/[id]/assign?assignmentId=<uuid> — gated behind workflows.assign, calls unassignWorkflow
- AssigneeTile replaced with AssigneesTile: shows every active assignment (primary first, then collaborators by assigned_at), X-button per row to remove, "Reassign primary" and "Add collaborator" pickers, deduped so already-assigned users don't appear in the picker


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2