### PR TITLE
Accounts — profile photo + business logo uploads

### DIFF
--- a/src/app/api/account/media/route.ts
+++ b/src/app/api/account/media/route.ts
@@ -1,0 +1,177 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+
+/**
+ * Account media — upload / remove an avatar or business logo on the
+ * authenticated user's profile.
+ *
+ *   POST   /api/account/media   multipart body: { file, type }
+ *   DELETE /api/account/media?type=avatar|logo
+ *
+ * The bucket is public-read so URLs can drop straight into <img>. All
+ * writes flow through here so the server (running as service_role)
+ * owns per-user auth and cleanup of the previous file.
+ */
+
+const MAX_BYTES = 5 * 1024 * 1024; // 5 MB
+const ALLOWED_MIME = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/jpg",
+  "image/webp",
+  "image/gif",
+  "image/svg+xml",
+]);
+const BUCKET = "profile-media";
+const COL_BY_TYPE = { avatar: "avatar_url", logo: "logo_url" } as const;
+type MediaType = keyof typeof COL_BY_TYPE;
+
+async function getUserId(req: NextRequest): Promise<string | null> {
+  const authHeader = req.headers.get("authorization");
+  if (!authHeader?.startsWith("Bearer ")) return null;
+  const token = authHeader.replace("Bearer ", "");
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+  );
+  const { data: { user } } = await supabase.auth.getUser(token);
+  return user?.id ?? null;
+}
+
+function extForMime(mime: string): string {
+  switch (mime) {
+    case "image/png": return "png";
+    case "image/jpeg":
+    case "image/jpg": return "jpg";
+    case "image/webp": return "webp";
+    case "image/gif": return "gif";
+    case "image/svg+xml": return "svg";
+    default: return "bin";
+  }
+}
+
+// Extract the object path from a public storage URL so we can delete
+// the previous file when a new one lands. Best-effort — a broken URL
+// just skips cleanup rather than failing the whole upload.
+function pathFromPublicUrl(url: string | null): string | null {
+  if (!url) return null;
+  const marker = `/object/public/${BUCKET}/`;
+  const i = url.indexOf(marker);
+  if (i < 0) return null;
+  return url.slice(i + marker.length);
+}
+
+export async function POST(req: NextRequest) {
+  const userId = await getUserId(req);
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const form = await req.formData().catch(() => null);
+  if (!form) return NextResponse.json({ error: "Invalid form data" }, { status: 400 });
+
+  const file = form.get("file");
+  const typeRaw = form.get("type");
+  const type = typeof typeRaw === "string" ? (typeRaw as MediaType) : null;
+
+  if (!type || !(type in COL_BY_TYPE)) {
+    return NextResponse.json({ error: "type must be 'avatar' or 'logo'" }, { status: 400 });
+  }
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: "file is required" }, { status: 400 });
+  }
+  if (file.size === 0) {
+    return NextResponse.json({ error: "File is empty" }, { status: 400 });
+  }
+  if (file.size > MAX_BYTES) {
+    return NextResponse.json({ error: `File exceeds ${MAX_BYTES / 1024 / 1024}MB limit` }, { status: 413 });
+  }
+  if (!ALLOWED_MIME.has(file.type)) {
+    return NextResponse.json(
+      { error: `Unsupported type ${file.type}. Use PNG, JPG, WebP, GIF, or SVG.` },
+      { status: 415 },
+    );
+  }
+
+  const ext = extForMime(file.type);
+  // Timestamp keeps CDN caches from serving the old image after an
+  // upload; the previous file is deleted below.
+  const path = `${userId}/${type}-${Date.now()}.${ext}`;
+
+  const bytes = new Uint8Array(await file.arrayBuffer());
+  const { error: uploadError } = await supabaseAdmin.storage
+    .from(BUCKET)
+    .upload(path, bytes, {
+      contentType: file.type,
+      cacheControl: "3600",
+      upsert: false,
+    });
+  if (uploadError) {
+    return NextResponse.json({ error: uploadError.message }, { status: 500 });
+  }
+
+  const { data: publicData } = supabaseAdmin.storage.from(BUCKET).getPublicUrl(path);
+  const publicUrl = publicData.publicUrl;
+
+  // Grab the previous URL BEFORE writing so we can delete the old
+  // object after the profile update succeeds.
+  const column = COL_BY_TYPE[type];
+  const { data: prev } = await supabaseAdmin
+    .from("profiles")
+    .select(column)
+    .eq("id", userId)
+    .maybeSingle();
+  const previousUrl = (prev as Record<string, string | null> | null)?.[column] ?? null;
+
+  const { error: updateError } = await supabaseAdmin
+    .from("profiles")
+    .update({ [column]: publicUrl })
+    .eq("id", userId);
+  if (updateError) {
+    // Roll back the upload so we don't leave orphaned objects.
+    await supabaseAdmin.storage.from(BUCKET).remove([path]).catch(() => {});
+    return NextResponse.json({ error: updateError.message }, { status: 500 });
+  }
+
+  // Delete the previous file (fire-and-forget — the profile is
+  // already pointing at the new one, so leftover storage is cosmetic).
+  const previousPath = pathFromPublicUrl(previousUrl);
+  if (previousPath && previousPath !== path) {
+    supabaseAdmin.storage.from(BUCKET).remove([previousPath]).catch(() => {});
+  }
+
+  return NextResponse.json({ ok: true, type, url: publicUrl });
+}
+
+export async function DELETE(req: NextRequest) {
+  const userId = await getUserId(req);
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const typeRaw = new URL(req.url).searchParams.get("type");
+  const type = typeRaw as MediaType | null;
+  if (!type || !(type in COL_BY_TYPE)) {
+    return NextResponse.json({ error: "type must be 'avatar' or 'logo'" }, { status: 400 });
+  }
+
+  const column = COL_BY_TYPE[type];
+  const { data: prev } = await supabaseAdmin
+    .from("profiles")
+    .select(column)
+    .eq("id", userId)
+    .maybeSingle();
+  const previousUrl = (prev as Record<string, string | null> | null)?.[column] ?? null;
+
+  const { error: updateError } = await supabaseAdmin
+    .from("profiles")
+    .update({ [column]: null })
+    .eq("id", userId);
+  if (updateError) {
+    return NextResponse.json({ error: updateError.message }, { status: 500 });
+  }
+
+  const previousPath = pathFromPublicUrl(previousUrl);
+  if (previousPath) {
+    supabaseAdmin.storage.from(BUCKET).remove([previousPath]).catch(() => {});
+  }
+
+  return NextResponse.json({ ok: true, type });
+}

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -13,6 +13,9 @@ import {
   MapPin,
   Phone,
   Mail,
+  Camera,
+  Image as ImageIcon,
+  Trash2,
 } from "lucide-react";
 import { createBrowserClient } from "@/lib/supabase";
 import { US_STATES } from "@/lib/types";
@@ -215,6 +218,14 @@ function ProfilePageInner() {
 
       <div className="mx-auto max-w-2xl px-4 py-8 sm:px-6 lg:px-8">
         <form onSubmit={handleSave} className="space-y-6">
+          {/* Photos + Logo — outside the save-on-submit path because
+              uploads are POST/DELETE-per-file and independently
+              persisted. The rest of the form still saves as a batch. */}
+          <MediaSection
+            profile={profile}
+            onUpdated={(next) => setProfile(next)}
+          />
+
           {/* Personal Info */}
           <div className="rounded-2xl border border-gray-100 bg-white p-6 shadow-sm">
             <h2 className="mb-4 text-lg font-semibold text-black-primary">
@@ -551,6 +562,194 @@ function ProfilePageInner() {
           )}
           {toast.message}
         </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Avatar + business logo uploader. Independent of the main form's
+ * save-on-submit because each upload/removal is its own POST/DELETE
+ * against /api/account/media — the server owns per-user auth and
+ * cleans up the previous file on replacement.
+ *
+ * Renders two identical widgets side-by-side: a round preview for the
+ * avatar, a rectangular one for the logo. Both accept the same image
+ * types; the API validates size and MIME.
+ */
+function MediaSection({
+  profile,
+  onUpdated,
+}: {
+  profile: Profile;
+  onUpdated: (next: Profile) => void;
+}) {
+  return (
+    <div className="rounded-2xl border border-gray-100 bg-white p-6 shadow-sm">
+      <h2 className="mb-1 text-lg font-semibold text-black-primary">
+        Photo &amp; Logo
+      </h2>
+      <p className="mb-4 text-xs text-black-primary/50">
+        Up to 5&nbsp;MB each. PNG, JPG, WebP, GIF, or SVG.
+      </p>
+      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
+        <MediaUploader
+          type="avatar"
+          label="Profile Photo"
+          currentUrl={profile.avatar_url ?? null}
+          shape="circle"
+          icon={<Camera className="h-6 w-6 text-black-primary/30" />}
+          onUpdated={onUpdated}
+        />
+        <MediaUploader
+          type="logo"
+          label="Business Logo"
+          currentUrl={profile.logo_url ?? null}
+          shape="rect"
+          icon={<ImageIcon className="h-6 w-6 text-black-primary/30" />}
+          onUpdated={onUpdated}
+        />
+      </div>
+    </div>
+  );
+}
+
+function MediaUploader({
+  type,
+  label,
+  currentUrl,
+  shape,
+  icon,
+  onUpdated,
+}: {
+  type: "avatar" | "logo";
+  label: string;
+  currentUrl: string | null;
+  shape: "circle" | "rect";
+  icon: React.ReactNode;
+  onUpdated: (next: Profile) => void;
+}) {
+  const [busy, setBusy] = useState<"upload" | "delete" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function refreshProfile(token: string) {
+    const meRes = await fetch("/api/auth/me", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (meRes.ok) onUpdated(await meRes.json());
+  }
+
+  async function onFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setError(null);
+    setBusy("upload");
+
+    const supabase = createBrowserClient();
+    const { data: { session } } = await supabase.auth.getSession();
+    if (!session?.access_token) {
+      setBusy(null);
+      setError("Please sign in again.");
+      return;
+    }
+
+    const form = new FormData();
+    form.append("file", file);
+    form.append("type", type);
+
+    const res = await fetch("/api/account/media", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${session.access_token}` },
+      body: form,
+    });
+
+    if (res.ok) {
+      await refreshProfile(session.access_token);
+    } else {
+      const err = await res.json().catch(() => ({}));
+      setError(err.error ?? "Upload failed");
+    }
+    setBusy(null);
+    // Clear the file input so re-uploading the same file re-triggers change.
+    e.target.value = "";
+  }
+
+  async function onRemove() {
+    if (!window.confirm(`Remove your ${label.toLowerCase()}?`)) return;
+    setError(null);
+    setBusy("delete");
+    const supabase = createBrowserClient();
+    const { data: { session } } = await supabase.auth.getSession();
+    if (!session?.access_token) {
+      setBusy(null);
+      return;
+    }
+    const res = await fetch(`/api/account/media?type=${type}`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${session.access_token}` },
+    });
+    if (res.ok) {
+      await refreshProfile(session.access_token);
+    } else {
+      const err = await res.json().catch(() => ({}));
+      setError(err.error ?? "Remove failed");
+    }
+    setBusy(null);
+  }
+
+  const previewShape = shape === "circle"
+    ? "h-24 w-24 rounded-full"
+    : "h-24 w-32 rounded-xl";
+
+  return (
+    <div>
+      <label className="mb-2 block text-sm font-medium text-black-primary">
+        {label}
+      </label>
+      <div className="flex items-center gap-4">
+        <div className={`${previewShape} flex items-center justify-center overflow-hidden border border-gray-200 bg-gray-50`}>
+          {currentUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={currentUrl} alt={label} className="h-full w-full object-cover" />
+          ) : (
+            icon
+          )}
+        </div>
+        <div className="flex flex-col gap-2">
+          <label className="inline-flex cursor-pointer items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-black-primary hover:bg-gray-50">
+            {busy === "upload" ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Camera className="h-3.5 w-3.5" />
+            )}
+            {currentUrl ? "Replace" : "Upload"}
+            <input
+              type="file"
+              accept="image/png,image/jpeg,image/webp,image/gif,image/svg+xml"
+              className="hidden"
+              onChange={onFileChange}
+              disabled={busy !== null}
+            />
+          </label>
+          {currentUrl && (
+            <button
+              type="button"
+              onClick={onRemove}
+              disabled={busy !== null}
+              className="inline-flex items-center gap-1.5 text-xs text-red-600 hover:underline disabled:opacity-50"
+            >
+              {busy === "delete" ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Trash2 className="h-3.5 w-3.5" />
+              )}
+              Remove
+            </button>
+          )}
+        </div>
+      </div>
+      {error && (
+        <div className="mt-2 text-xs text-red-600">{error}</div>
       )}
     </div>
   );

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -65,6 +65,8 @@ export interface Profile {
   payout_account_number?: string | null;
   payout_notes?: string | null;
   locator_status?: string | null;
+  avatar_url?: string | null;
+  logo_url?: string | null;
   created_at: string;
 }
 

--- a/supabase/migrations/131_profile_avatar_logo.sql
+++ b/supabase/migrations/131_profile_avatar_logo.sql
@@ -1,0 +1,67 @@
+-- Migration 131: profile avatar + business logo
+--
+-- Two columns on `profiles`:
+--   avatar_url — personal photo shown next to the user's name
+--   logo_url   — business logo (for operators / companies)
+--
+-- Both are optional text URLs pointing into the new `profile-media`
+-- storage bucket. Anywhere the account has "an image" (avatar or
+-- logo), it's rendered from these columns.
+--
+-- Storage bucket is PUBLIC read so the URLs work in any <img> tag
+-- without signed-URL round-trips. Writes go through the API which
+-- runs as service_role, so we don't need per-object owner RLS —
+-- the client can't upload directly.
+
+-- ── Columns ───────────────────────────────────────────────────────
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS avatar_url text,
+  ADD COLUMN IF NOT EXISTS logo_url   text;
+
+COMMENT ON COLUMN public.profiles.avatar_url IS
+  'Public URL of the user''s personal photo. Managed via /api/account/media.';
+COMMENT ON COLUMN public.profiles.logo_url IS
+  'Public URL of the account''s business logo. Managed via /api/account/media.';
+
+-- ── Storage bucket ────────────────────────────────────────────────
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('profile-media', 'profile-media', true)
+ON CONFLICT (id) DO UPDATE SET public = true;
+
+-- ── Storage RLS ───────────────────────────────────────────────────
+-- Writes are gated to service_role only (the /api/account/media
+-- route enforces per-user ownership before proxying to storage).
+-- Reads are open to both authenticated and anonymous clients so an
+-- <img src={profile.avatar_url}> works everywhere with no auth.
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'storage' AND tablename = 'objects'
+      AND policyname = 'profile_media_service_role_all'
+  ) THEN
+    CREATE POLICY profile_media_service_role_all
+      ON storage.objects FOR ALL TO service_role
+      USING (bucket_id = 'profile-media')
+      WITH CHECK (bucket_id = 'profile-media');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'storage' AND tablename = 'objects'
+      AND policyname = 'profile_media_public_select'
+  ) THEN
+    CREATE POLICY profile_media_public_select
+      ON storage.objects FOR SELECT TO anon
+      USING (bucket_id = 'profile-media');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'storage' AND tablename = 'objects'
+      AND policyname = 'profile_media_authenticated_select'
+  ) THEN
+    CREATE POLICY profile_media_authenticated_select
+      ON storage.objects FOR SELECT TO authenticated
+      USING (bucket_id = 'profile-media');
+  END IF;
+END $$;


### PR DESCRIPTION
Adds two optional image slots to every account, editable from /dashboard/profile:

- avatar_url — personal photo shown next to the user's name
- logo_url   — business logo (operators / companies)

Schema (migration 131):
- profiles.avatar_url + logo_url text columns
- profile-media storage bucket (public read) with service_role-only writes; auth/ownership is enforced in the API layer, not in storage RLS, matching the codebase's existing server-proxy upload pattern

API (/api/account/media):
- POST multipart { file, type } — validates MIME (PNG/JPG/WebP/GIF/ SVG) and size (<=5 MB), uploads to `{userId}/{type}-{ts}.{ext}`, updates the corresponding profile column, deletes the previous file, rolls back the upload on DB failure
- DELETE ?type=avatar|logo — clears the column and removes the storage object

UI:
- New "Photo & Logo" card at the top of the profile edit form with two side-by-side uploaders (round preview for avatar, rectangular for logo). Each has an Upload/Replace label-button, Remove button, and inline error surface. Independent of the main form's save-on-submit because each upload is its own request.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2