### PR TITLE
Workflow templates — "Requires Payment" toggle hides Payment tile

### DIFF
--- a/src/app/admin/workflows/templates/page.tsx
+++ b/src/app/admin/workflows/templates/page.tsx
@@ -32,6 +32,7 @@ interface Template {
   workload_weight: number;
   is_custom: boolean;
   category: string | null;
+  requires_payment: boolean;
   stages: Stage[];
 }
 
@@ -197,6 +198,7 @@ function TemplateEditorModal({
     template?.completion_rule ?? "never_auto_completes",
   );
   const [active, setActive] = useState(template?.active ?? true);
+  const [requiresPayment, setRequiresPayment] = useState(template?.requires_payment ?? true);
   const [stages, setStages] = useState<Stage[]>(
     template?.stages ?? [
       { stage_key: "started", stage_name: "Started", stage_order: 10, stage_type: "milestone", required_for_completion: false, customer_visible: true },
@@ -262,6 +264,7 @@ function TemplateEditorModal({
       quantity_based: quantityBased,
       completion_rule: completionRule,
       active,
+      requires_payment: requiresPayment,
       stages: stages.map((s, idx) => ({
         stage_key: s.stage_key.trim(),
         stage_name: s.stage_name.trim(),
@@ -373,6 +376,10 @@ function TemplateEditorModal({
               <label className="inline-flex items-center gap-2">
                 <input type="checkbox" checked={active} onChange={(e) => setActive(e.target.checked)} />
                 Active (available for new workflows)
+              </label>
+              <label className="inline-flex items-center gap-2" title="Turn off for perpetual/coaching work with no invoice — the Payment tile is hidden on the workflow page.">
+                <input type="checkbox" checked={requiresPayment} onChange={(e) => setRequiresPayment(e.target.checked)} />
+                Requires payment (shows the Payment tile on workflows)
               </label>
             </div>
           </div>

--- a/src/app/api/admin/workflow-templates/[id]/route.ts
+++ b/src/app/api/admin/workflow-templates/[id]/route.ts
@@ -38,6 +38,7 @@ const patchSchema = z.object({
     .optional(),
   workload_weight: z.number().int().min(1).max(20).optional(),
   category: z.string().max(80).nullable().optional(),
+  requires_payment: z.boolean().optional(),
   active: z.boolean().optional(),
   stages: z.array(stageSchema).min(1).max(30).optional(),
 });

--- a/src/app/api/admin/workflow-templates/route.ts
+++ b/src/app/api/admin/workflow-templates/route.ts
@@ -40,6 +40,7 @@ const createSchema = z.object({
     .default("never_auto_completes"),
   workload_weight: z.number().int().min(1).max(20).default(1),
   category: z.string().max(80).nullable().optional(),
+  requires_payment: z.boolean().default(true),
   stages: z.array(stageSchema).min(1).max(30),
 });
 
@@ -117,6 +118,7 @@ export async function POST(req: NextRequest) {
       workload_weight: input.workload_weight,
       is_custom: true,
       category: input.category ?? null,
+      requires_payment: input.requires_payment,
       active: true,
     })
     .select("*")

--- a/src/app/sales/workflows/[id]/page.tsx
+++ b/src/app/sales/workflows/[id]/page.tsx
@@ -356,13 +356,18 @@ export default function WorkflowDetailPage({ params }: { params: Promise<{ id: s
             workflowId={id}
             onChanged={load}
           />
-          <PaymentTile
-            paymentStatus={w.payment_status}
-            staffView={data.isStaffView}
-            onOverride={(next, reason) =>
-              postAction("/payment-status", { payment_status: next, reason })
-            }
-          />
+          {/* Payment tile is hidden when the template opted out of
+              payment tracking (requires_payment=false → status='na').
+              The row collapses to three tiles naturally. */}
+          {w.payment_status !== "na" && (
+            <PaymentTile
+              paymentStatus={w.payment_status}
+              staffView={data.isStaffView}
+              onOverride={(next, reason) =>
+                postAction("/payment-status", { payment_status: next, reason })
+              }
+            />
+          )}
           <InfoTile
             icon={<Clock className="h-4 w-4" />}
             label="Started"

--- a/src/lib/workflows/service.ts
+++ b/src/lib/workflows/service.ts
@@ -163,7 +163,14 @@ export async function getOrCreateWorkflow(
     service_id: input.serviceId ?? null,
     quantity_purchased: input.quantityPurchased ?? 1,
     quantity_completed: 0,
-    payment_status: input.paymentStatus ?? "unpaid",
+    // Templates flagged requires_payment=false (perpetual/coaching work
+    // with no invoice) start as 'na' so the Payment tile hides itself.
+    // An explicit caller-supplied paymentStatus still wins.
+    payment_status:
+      input.paymentStatus ??
+      ((template as { requires_payment?: boolean } | null)?.requires_payment === false
+        ? "na"
+        : "unpaid"),
     overall_status: "not_started",
     priority: input.priority ?? "normal",
     start_date: input.startDate ?? new Date().toISOString(),

--- a/supabase/migrations/132_workflow_templates_requires_payment.sql
+++ b/supabase/migrations/132_workflow_templates_requires_payment.sql
@@ -1,0 +1,15 @@
+-- Migration 132: workflow_templates.requires_payment
+--
+-- Perpetual/coaching-style workflows have no invoice attached — showing
+-- a "Payment" tile on their detail page is noise. This flag lets the
+-- admin CRUD say "this template doesn't involve payment"; the workflow
+-- service reads it at spawn time and marks the resulting workflow's
+-- payment_status = 'na' so the detail UI can hide the tile.
+--
+-- Default TRUE preserves existing behaviour for every current template.
+
+ALTER TABLE public.workflow_templates
+  ADD COLUMN IF NOT EXISTS requires_payment boolean NOT NULL DEFAULT true;
+
+COMMENT ON COLUMN public.workflow_templates.requires_payment IS
+  'When false, spawned workflows start with payment_status=na and the Payment tile is hidden. Toggled per-template in the admin CRUD.';


### PR DESCRIPTION
Perpetual/coaching-style templates (Cold Calling, Ongoing Coaching, Account Management, etc.) don't have an invoice attached — the Payment tile on the workflow detail page is noise for those.

Migration 132: workflow_templates.requires_payment boolean NOT NULL DEFAULT true. Default preserves current behaviour for every existing template; admin can toggle off per template.

- Admin template editor gains a "Requires payment" checkbox next to Quantity-based / Active. Persisted through both POST + PATCH.
- Service reads template.requires_payment at spawn: when false, the new workflow starts with payment_status='na' (existing enum value). Caller-supplied paymentStatus still wins.
- Workflow detail page hides PaymentTile whenever payment_status === 'na'. The 4-tile info row collapses to 3 naturally in that case.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2