### PR TITLE
Executive Snapshot — make every card + chip clickable

### DIFF
--- a/src/app/sales/orders/page.tsx
+++ b/src/app/sales/orders/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { createBrowserClient } from "@/lib/supabase";
 import {
   Loader2, ClipboardList, Plus, Search, AlertCircle,
@@ -101,7 +101,12 @@ export default function OrdersPage() {
   const [token, setToken] = useState("");
   const [statusFilter, setStatusFilter] = useState("all");
   const [search, setSearch] = useState("");
-  const [docType, setDocType] = useState<"order" | "quote">("order");
+  // Read ?doc=quote on first render so the Executive Snapshot's Quotes
+  // card can deep-link straight into the quotes toggle without an extra
+  // click. Undefined/other values keep the default (orders).
+  const searchParams = useSearchParams();
+  const initialDocType = searchParams.get("doc") === "quote" ? "quote" : "order";
+  const [docType, setDocType] = useState<"order" | "quote">(initialDocType);
   const [userRole, setUserRole] = useState<string>("");
   const [deletingId, setDeletingId] = useState<string | null>(null);
 

--- a/src/app/sales/page.tsx
+++ b/src/app/sales/page.tsx
@@ -500,6 +500,7 @@ function ExecutiveSnapshot({ data }: { data: SnapshotResponse }) {
 
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
         <SnapshotCard
+          href="/sales/orders?doc=quote"
           icon={<FileText className="h-4 w-4" />}
           label="Quotes"
           primary={`${q.sent} sent`}
@@ -514,6 +515,7 @@ function ExecutiveSnapshot({ data }: { data: SnapshotResponse }) {
           tone="blue"
         />
         <SnapshotCard
+          href="/sales/orders"
           icon={<ClipboardList className="h-4 w-4" />}
           label="Orders"
           primary={`${o.placed} placed`}
@@ -527,6 +529,7 @@ function ExecutiveSnapshot({ data }: { data: SnapshotResponse }) {
           tone="orange"
         />
         <SnapshotCard
+          href="/sales/agreements"
           icon={<ScrollText className="h-4 w-4" />}
           label="Agreements"
           primary={`${a.crm_sent} sent`}
@@ -542,6 +545,7 @@ function ExecutiveSnapshot({ data }: { data: SnapshotResponse }) {
           tone="emerald"
         />
         <SnapshotCard
+          href="/sales/workflows"
           icon={<Workflow className="h-4 w-4" />}
           label="Workflows"
           primary={`${w.active} active`}
@@ -564,13 +568,14 @@ function ExecutiveSnapshot({ data }: { data: SnapshotResponse }) {
           {Object.entries(w.by_type).map(([type, count]) => {
             const Icon = wfTypeIcons[type] ?? Workflow;
             return (
-              <span
+              <Link
                 key={type}
-                className="inline-flex items-center gap-1.5 rounded-full bg-gray-100 px-2.5 py-1"
+                href={`/sales/workflows?workflowType=${encodeURIComponent(type)}`}
+                className="inline-flex items-center gap-1.5 rounded-full bg-gray-100 px-2.5 py-1 hover:bg-emerald-50 hover:text-emerald-700 transition-colors"
               >
                 <Icon className="h-3 w-3" />
                 {wfTypeLabels[type] ?? type} · <span className="font-semibold">{count}</span>
-              </span>
+              </Link>
             );
           })}
         </div>
@@ -644,6 +649,7 @@ function TeamWorkloadRow({ periodLabel }: { periodLabel: string }) {
 }
 
 function SnapshotCard({
+  href,
   icon,
   label,
   primary,
@@ -653,6 +659,7 @@ function SnapshotCard({
   rows,
   tone,
 }: {
+  href?: string;
   icon: React.ReactNode;
   label: string;
   primary: string;
@@ -670,8 +677,15 @@ function SnapshotCard({
     purple: { text: "text-purple-700", bg: "bg-purple-50", bar: "bg-purple-500" },
   }[tone];
 
-  return (
-    <div className="rounded-lg border border-gray-100 bg-gray-50 p-4">
+  // Whole-card click target — cleaner than nesting per-row links which
+  // would require breaking out of the outer anchor. Hover state hints
+  // that the card is interactive.
+  const containerCls = href
+    ? "block rounded-lg border border-gray-100 bg-gray-50 p-4 hover:border-gray-200 hover:bg-white transition-colors cursor-pointer"
+    : "rounded-lg border border-gray-100 bg-gray-50 p-4";
+
+  const body = (
+    <>
       <div className="flex items-center gap-1.5 text-xs uppercase tracking-wide text-gray-500">
         <span className={toneClasses.text}>{icon}</span>
         {label}
@@ -694,6 +708,12 @@ function SnapshotCard({
           </div>
         ))}
       </div>
-    </div>
+    </>
+  );
+
+  return href ? (
+    <Link href={href} className={containerCls}>{body}</Link>
+  ) : (
+    <div className={containerCls}>{body}</div>
   );
 }

--- a/src/app/sales/workflows/page.tsx
+++ b/src/app/sales/workflows/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import { createBrowserClient } from "@/lib/supabase";
 import {
   Search,
@@ -108,7 +109,21 @@ export default function WorkflowsPage() {
   const [workflows, setWorkflows] = useState<WorkflowRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");
-  const [savedView, setSavedView] = useState<string>("all");
+  // Deep-link support for the Executive Snapshot chips (?workflowType=…)
+  // and for the Team Workload page's "overdue" link (?overdue=true).
+  // filtersForView already keys off savedView, so we translate URL
+  // params → the matching savedView on first render.
+  const urlParams = useSearchParams();
+  const initialSavedView = (() => {
+    const overdue = urlParams.get("overdue");
+    if (overdue === "true") return "overdue";
+    const unassigned = urlParams.get("unassigned");
+    if (unassigned === "true") return "unassigned";
+    const type = urlParams.get("workflowType");
+    if (type && Object.hasOwn(TYPE_META, type)) return type;
+    return "all";
+  })();
+  const [savedView, setSavedView] = useState<string>(initialSavedView);
   const [orderBy, setOrderBy] = useState<"due_date" | "created_at" | "updated_at" | "priority">("due_date");
   const [orderDir, setOrderDir] = useState<"asc" | "desc">("asc");
   const [showNewModal, setShowNewModal] = useState(false);


### PR DESCRIPTION
The tiles listed activity counts but never linked anywhere; every number required knowing which sidebar page it corresponded to.

- SnapshotCard gains an optional href; when present, the whole card becomes a Link with a hover state hinting interactivity
- Wired the four cards to their pages:
    Quotes     → /sales/orders?doc=quote
    Orders     → /sales/orders
    Agreements → /sales/agreements
    Workflows  → /sales/workflows
- Workflow-type breakdown chips deep-link into
  /sales/workflows?workflowType=<type>
- Orders page reads ?doc=quote on first render so the Quotes card
  lands directly on the quotes toggle
- Workflows list page reads ?workflowType, ?overdue, ?unassigned on
  first render and translates them into the matching savedView chip,
  so both the snapshot chips and the existing workload page's
  "overdue" link now filter on arrival


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2