### PR TITLE
Workflows — red overdue on exec dashboard + email admins on overdue

### DIFF
--- a/src/app/sales/page.tsx
+++ b/src/app/sales/page.tsx
@@ -553,7 +553,11 @@ function ExecutiveSnapshot({ data }: { data: SnapshotResponse }) {
           denominator={w.active}
           progressLabel={w.active === 0 ? "—" : `${w.active - w.overdue - w.unassigned} on track`}
           rows={[
-            [`Overdue`, `${w.overdue}`],
+            // Overdue row flips red when > 0 so the exec eye can catch
+            // it at a glance. The `deadline.overdue` cron simultaneously
+            // fires an email to every admin the first time each
+            // workflow crosses its deadline (send_once per admin).
+            [`Overdue`, `${w.overdue}`, w.overdue > 0 ? "danger" : undefined],
             [`Unassigned`, `${w.unassigned}`],
             [`Due within 7d`, `${w.due_7d}`],
           ]}
@@ -666,7 +670,9 @@ function SnapshotCard({
   numerator: number;
   denominator: number;
   progressLabel: string;
-  rows: [string, string][];
+  // Optional 3rd tuple slot = per-row emphasis. "danger" turns the row
+  // red so the exec eye catches an overdue/blocked count immediately.
+  rows: Array<[string, string] | [string, string, "danger" | undefined]>;
   tone: "blue" | "orange" | "emerald" | "purple";
 }) {
   const pct = denominator > 0 ? Math.min(100, Math.round((numerator / denominator) * 100)) : 0;
@@ -701,12 +707,19 @@ function SnapshotCard({
         </div>
       </div>
       <div className="mt-3 space-y-1 text-xs">
-        {rows.map(([k, v]) => (
-          <div key={k} className="flex justify-between text-gray-600">
-            <span>{k}</span>
-            <span className="font-medium text-gray-900">{v}</span>
-          </div>
-        ))}
+        {rows.map((row) => {
+          const [k, v, emphasis] = row;
+          const danger = emphasis === "danger";
+          return (
+            <div
+              key={k}
+              className={`flex justify-between ${danger ? "text-red-700 font-semibold" : "text-gray-600"}`}
+            >
+              <span>{k}</span>
+              <span className={danger ? "text-red-700" : "font-medium text-gray-900"}>{v}</span>
+            </div>
+          );
+        })}
       </div>
     </>
   );

--- a/src/lib/workflows/notifications.ts
+++ b/src/lib/workflows/notifications.ts
@@ -139,6 +139,7 @@ async function resolveRecipients(
     send_to_customer: boolean;
     send_to_assignee: boolean;
     send_to_team_email: string | null;
+    send_to_admins?: boolean;
   },
   workflow: WorkflowRow,
 ): Promise<Recipient[]> {
@@ -168,6 +169,19 @@ async function resolveRecipients(
 
   if (rule.send_to_team_email) {
     recipients.push({ email: rule.send_to_team_email, audience: "team" });
+  }
+
+  if (rule.send_to_admins) {
+    // Every profiles.role='admin' gets a copy. The notification log's
+    // send-once index keys on recipient, so if the rule is send_once
+    // each admin gets exactly one email per workflow.
+    const { data: admins } = await supabaseAdmin
+      .from("profiles")
+      .select("email")
+      .eq("role", "admin");
+    for (const a of admins ?? []) {
+      if (a?.email) recipients.push({ email: a.email, audience: "team" });
+    }
   }
 
   return recipients;
@@ -328,6 +342,17 @@ const TEMPLATES: Record<string, TemplateFn> = {
   overdue_employee: (w) => ({
     title: `Overdue: ${w.workflow_number} — ${w.title}`,
     body: `<p>This workflow has passed its deadline${w.due_date ? ` (${new Date(w.due_date).toLocaleDateString()})` : ""} and remains open. Escalation recommended.</p>`,
+    ctaLabel: "Open workflow",
+  }),
+  overdue_admin: (w) => ({
+    title: `[Overdue] ${w.workflow_number} — ${w.title}`,
+    body: `<p>A workflow has just gone overdue and needs admin attention.</p>
+      <table style="margin-top:12px;border-collapse:collapse;font-size:13px">
+        <tr><td style="padding:2px 12px 2px 0;color:#6b7280">Type</td><td style="padding:2px 0"><strong>${escape(w.workflow_type)}</strong></td></tr>
+        <tr><td style="padding:2px 12px 2px 0;color:#6b7280">Due date</td><td style="padding:2px 0"><strong>${w.due_date ? new Date(w.due_date).toLocaleDateString() : "unset"}</strong></td></tr>
+        <tr><td style="padding:2px 12px 2px 0;color:#6b7280">Status</td><td style="padding:2px 0"><strong>${escape(w.overall_status)}</strong></td></tr>
+        <tr><td style="padding:2px 12px 2px 0;color:#6b7280">Assigned</td><td style="padding:2px 0"><strong>${w.assigned_user_id ? "yes" : "unassigned"}</strong></td></tr>
+      </table>`,
     ctaLabel: "Open workflow",
   }),
 };

--- a/supabase/migrations/133_notification_rules_send_to_admins.sql
+++ b/supabase/migrations/133_notification_rules_send_to_admins.sql
@@ -1,0 +1,31 @@
+-- Migration 133: notify all admins on deadline.overdue
+--
+-- The existing overdue rule notifies the assignee daily (send_once=false).
+-- Admins had no visibility unless they were the assignee. This migration
+-- adds a send_to_admins flag on workflow_notification_rules and seeds a
+-- new admin rule for deadline.overdue that fires once per (workflow,
+-- admin) — so admins get exactly one email the first time a workflow
+-- crosses its deadline, not a daily replay.
+--
+-- resolveRecipients() in src/lib/workflows/notifications.ts resolves
+-- profiles.role='admin' → email when this flag is on.
+
+ALTER TABLE public.workflow_notification_rules
+  ADD COLUMN IF NOT EXISTS send_to_admins boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN public.workflow_notification_rules.send_to_admins IS
+  'When true, resolveRecipients loads every profiles.role=admin email and adds it to the recipient list.';
+
+INSERT INTO workflow_notification_rules
+  (trigger_event, workflow_type, stage_key, template_key,
+   send_to_customer, send_to_assignee, send_to_team_email,
+   enabled, send_once, send_to_admins, description)
+VALUES
+  ('deadline.overdue', NULL, NULL, 'overdue_admin',
+   false, false, NULL,
+   true, true, true,
+   'Notify every admin the first time a workflow crosses its deadline')
+ON CONFLICT (trigger_event, workflow_type, stage_key, template_key) DO UPDATE
+  SET send_to_admins = EXCLUDED.send_to_admins,
+      send_once      = EXCLUDED.send_once,
+      enabled        = EXCLUDED.enabled;


### PR DESCRIPTION
Two connected changes.

UI:
- SnapshotCard rows accept an optional 3rd tuple slot for row emphasis. Workflows card marks the "Overdue" row as "danger" when the count is >0, flipping it red so the exec eye catches it at a glance. Other rows keep the normal gray.

Notifications:
- Migration 133 adds workflow_notification_rules.send_to_admins (default false) and seeds a new deadline.overdue rule targeting every admin, send_once=true so each admin gets exactly one email per workflow the first time it crosses its deadline (not a daily replay).
- resolveRecipients() in notifications.ts loads every profiles.role='admin' email when the flag is on and adds them to the recipient list.
- New TEMPLATES.overdue_admin renders a compact fact-table (type, due, status, assignment) — admin-focused wording distinct from the assignee reminder.

The existing /api/cron/workflows/due-soon endpoint already fires deadline.overdue for every open workflow past its deadline; that now fans out to all admins automatically via the new rule.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2