### PR TITLE
Exec dashboard — Assignments tile (assigned vs accepted)

### DIFF
--- a/src/app/api/sales/executive-snapshot/route.ts
+++ b/src/app/api/sales/executive-snapshot/route.ts
@@ -307,6 +307,31 @@ export async function GET(req: NextRequest) {
     }
   }
 
+  // ─── Assignment acceptance rollup ───────────────────────────────────
+  // Count active workflow_assignments in scope and split by whether
+  // the assignee has clicked Accept. Limited to open workflows so a
+  // completed workflow's stale pending assignment doesn't distort the
+  // "waiting to acknowledge" number.
+  const openWfIds = wfRows.filter((w) => isOpen(w.overall_status)).map((w) => w.id);
+  let assignmentsTotal = 0;
+  let assignmentsAccepted = 0;
+  if (openWfIds.length > 0) {
+    let assignQuery = supabaseAdmin
+      .from("workflow_assignments")
+      .select("id, user_id, accepted_at")
+      .eq("active", true)
+      .in("workflow_id", openWfIds);
+    if (targetUserId) assignQuery = assignQuery.eq("user_id", targetUserId);
+    else if (allowedUserIds) assignQuery = assignQuery.in("user_id", allowedUserIds);
+    const { data: assignRows } = await assignQuery;
+    for (const a of assignRows ?? []) {
+      assignmentsTotal += 1;
+      if (a.accepted_at) assignmentsAccepted += 1;
+    }
+  }
+  const assignmentsPending = assignmentsTotal - assignmentsAccepted;
+  const acceptRate = assignmentsTotal > 0 ? assignmentsAccepted / assignmentsTotal : 0;
+
   // ─── Leads ──────────────────────────────────────────────────────────
   let leadsQuery = supabaseAdmin
     .from("sales_leads")
@@ -395,6 +420,12 @@ export async function GET(req: NextRequest) {
       due_7d: wfDue7d,
       overdue: wfOverdue,
       by_type: wfByType,
+    },
+    assignments: {
+      total: assignmentsTotal,
+      accepted: assignmentsAccepted,
+      pending: assignmentsPending,
+      accept_rate: acceptRate,
     },
     leads: { total: (leads ?? []).length, by_status: leadsByStatus },
     deals: { total: dealsInPeriod.length, pipeline_value: pipelineValue, in_stage: dealsByStage },

--- a/src/app/sales/page.tsx
+++ b/src/app/sales/page.tsx
@@ -22,6 +22,7 @@ import {
   MapPin,
   Coffee,
   Globe,
+  UserCheck,
 } from "lucide-react";
 import Link from "next/link";
 
@@ -66,6 +67,7 @@ interface SnapshotResponse {
     provider_included: boolean;
   };
   workflows: { active: number; unassigned: number; due_7d: number; overdue: number; by_type: Record<string, number> };
+  assignments: { total: number; accepted: number; pending: number; accept_rate: number };
   leads: { total: number; by_status: Record<string, number> };
   deals: { total: number; pipeline_value: number; in_stage: Record<string, number> };
   commissions: { total: number; pending: number; approved: number; paid: number };
@@ -498,7 +500,7 @@ function ExecutiveSnapshot({ data }: { data: SnapshotResponse }) {
         </h2>
       </div>
 
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
         <SnapshotCard
           href="/sales/orders?doc=quote"
           icon={<FileText className="h-4 w-4" />}
@@ -562,6 +564,26 @@ function ExecutiveSnapshot({ data }: { data: SnapshotResponse }) {
             [`Due within 7d`, `${w.due_7d}`],
           ]}
           tone="purple"
+        />
+        <SnapshotCard
+          href="/sales/workflows"
+          icon={<UserCheck className="h-4 w-4" />}
+          label="Assignments"
+          primary={`${data.assignments.total} assigned`}
+          numerator={data.assignments.accepted}
+          denominator={data.assignments.total}
+          progressLabel={
+            data.assignments.total === 0
+              ? "—"
+              : `${data.assignments.accepted} accepted (${Math.round(data.assignments.accept_rate * 100)}%)`
+          }
+          rows={[
+            // Pending flips red the moment anyone hasn't clicked
+            // Accept — accountability signal for the exec.
+            [`Pending acceptance`, `${data.assignments.pending}`, data.assignments.pending > 0 ? "danger" : undefined],
+            [`Accepted`, `${data.assignments.accepted}`],
+          ]}
+          tone="emerald"
         />
       </div>
 


### PR DESCRIPTION
New 5th tile on Executive Snapshot showing acknowledgement health at a glance: how many workflow assignments currently exist in scope, how many the assignees have clicked Accept on, and the share still pending.

Endpoint:
- /api/sales/executive-snapshot returns a new `assignments` block: total, accepted, pending, accept_rate. Counted from active workflow_assignments where workflow_id is one of the open, in-scope workflows and user_id is one of the scoped reps. Closed workflows are excluded so stale pending rows don't distort the "waiting to acknowledge" number.

UI:
- Grid changes from md:2 / lg:4 to md:2 / lg:3 / xl:5 so the fifth tile has room on wide screens and wraps cleanly on smaller ones.
- New emerald Assignments card. Progress bar reads "N accepted (X%)". Pending row flips red when >0, same accountability signal pattern as Overdue on the Workflows card.
- Card links to /sales/workflows so an exec drills straight into the queue to see which assignments are stuck pending.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2