### PR TITLE
Workflow templates — graceful degrade before mig 132 + tighten close …

### DIFF
--- a/src/app/api/admin/workflow-templates/[id]/route.ts
+++ b/src/app/api/admin/workflow-templates/[id]/route.ts
@@ -76,7 +76,18 @@ export async function PATCH(
       .from("workflow_templates")
       .update(templateUpdate)
       .eq("id", id);
-    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    if (error && /requires_payment/i.test(error.message)) {
+      // Retry without the field when the DB predates migration 132.
+      const { requires_payment: _rp, ...rest } = templateUpdate as Record<string, unknown>;
+      void _rp;
+      const retry = await supabaseAdmin
+        .from("workflow_templates")
+        .update(rest)
+        .eq("id", id);
+      if (retry.error) return NextResponse.json({ error: retry.error.message }, { status: 500 });
+    } else if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
   }
 
   if (stages) {

--- a/src/app/api/admin/workflow-templates/route.ts
+++ b/src/app/api/admin/workflow-templates/route.ts
@@ -105,24 +105,42 @@ export async function POST(req: NextRequest) {
     .maybeSingle();
   const version = (existing?.version ?? 0) + 1;
 
-  const { data: template, error: tErr } = await supabaseAdmin
+  // Insert payload. `requires_payment` only exists once migration 132
+  // has run. When the DB predates it PostgREST returns a schema-cache
+  // miss on that column name — we detect that and retry without the
+  // field so template creation still works before the migration is
+  // applied.
+  const insertBase = {
+    workflow_type: workflowType,
+    version,
+    title: input.title,
+    description: input.description ?? null,
+    default_deadline_days: input.default_deadline_days ?? null,
+    quantity_based: input.quantity_based,
+    completion_rule: input.completion_rule,
+    workload_weight: input.workload_weight,
+    is_custom: true,
+    category: input.category ?? null,
+    active: true,
+  };
+  let template: Record<string, unknown> | null = null;
+  let tErr: { message: string } | null = null;
+  const first = await supabaseAdmin
     .from("workflow_templates")
-    .insert({
-      workflow_type: workflowType,
-      version,
-      title: input.title,
-      description: input.description ?? null,
-      default_deadline_days: input.default_deadline_days ?? null,
-      quantity_based: input.quantity_based,
-      completion_rule: input.completion_rule,
-      workload_weight: input.workload_weight,
-      is_custom: true,
-      category: input.category ?? null,
-      requires_payment: input.requires_payment,
-      active: true,
-    })
+    .insert({ ...insertBase, requires_payment: input.requires_payment })
     .select("*")
     .single();
+  template = first.data as Record<string, unknown> | null;
+  tErr = first.error;
+  if (tErr && /requires_payment/i.test(tErr.message)) {
+    const retry = await supabaseAdmin
+      .from("workflow_templates")
+      .insert(insertBase)
+      .select("*")
+      .single();
+    template = retry.data as Record<string, unknown> | null;
+    tErr = retry.error;
+  }
   if (tErr || !template) {
     return NextResponse.json({ error: tErr?.message ?? "Template insert failed" }, { status: 500 });
   }

--- a/src/app/api/sales/executive-snapshot/route.ts
+++ b/src/app/api/sales/executive-snapshot/route.ts
@@ -207,17 +207,17 @@ export async function GET(req: NextRequest) {
   const quoteTotalValue = quoteRows.reduce((s, q) => s + Number(q.total_value ?? 0), 0);
   const ordersCompleted = orderRows.filter((o) => o.status === "completed").length;
 
-  // Close rate = (quotes whose deal_id ended up on a CLOSED order) /
-  // (quotes sent in period). A "closed" order is payment_status='paid'
-  // OR order_status='completed' — an order being completed = paid in
-  // this workflow.
+  // Close rate = (quotes whose deal_id ended up on a PAID order) /
+  // (quotes sent in period). "Paid" is strictly payment_status='paid'
+  // — an order marked completed without payment does not count as
+  // closed here, so the rate reflects actual revenue conversion.
   let quotesClosed = 0;
   if (quoteDealIds.length > 0) {
     const { data: closedFromQuotes } = await supabaseAdmin
       .from("sales_orders")
       .select("deal_id")
       .in("deal_id", quoteDealIds)
-      .or("payment_status.eq.paid,order_status.eq.completed");
+      .eq("payment_status", "paid");
     const closedSet = new Set(
       ((closedFromQuotes ?? []) as { deal_id: string | null }[])
         .map((r) => r.deal_id)

--- a/src/app/api/sales/workload/route.ts
+++ b/src/app/api/sales/workload/route.ts
@@ -245,11 +245,13 @@ export async function GET(req: NextRequest) {
   );
   const closedDealIds = new Set<string>();
   if (quoteDealIds.length > 0) {
+    // "Closed" = strictly payment_status='paid' (matches executive
+    // snapshot). Completed-but-unpaid orders do not count as closed.
     const { data: closedOrders } = await supabaseAdmin
       .from("sales_orders")
       .select("deal_id")
       .in("deal_id", quoteDealIds)
-      .or("payment_status.eq.paid,order_status.eq.completed");
+      .eq("payment_status", "paid");
     for (const r of (closedOrders ?? []) as { deal_id: string | null }[]) {
       if (r.deal_id) closedDealIds.add(r.deal_id);
     }


### PR DESCRIPTION
…rate

Two fixes.

1) requires_payment field tolerates a pre-mig-132 DB.
   PostgREST caches the schema and rejects writes to columns it
   doesn't know about, so template create/edit was failing with
   'Could not find the requires_payment column' on any DB where
   migration 132 hasn't been applied yet.
   POST /api/admin/workflow-templates now attempts the insert with
   requires_payment; on that specific error it retries without the
   field so template creation still works. PATCH follows the same
   pattern.
   Templates saved on a pre-mig DB simply default to
   requires_payment=true implicitly (matching the mig's DEFAULT).

2) Close rate = paid orders / respective quotes.
   Previous rule counted a quote as closed if its deal_id ended up on
   ANY order where payment_status='paid' OR order_status='completed'.
   The completed-but-not-paid branch was inflating the rate.
   Tightened to strictly payment_status='paid' in both the executive
   snapshot and the workload endpoint so both dashboards agree on
   revenue-realized conversion.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2