### PR TITLE
Close rate — align "closed" predicate with Won Revenue

### DIFF
--- a/src/app/api/sales/executive-snapshot/route.ts
+++ b/src/app/api/sales/executive-snapshot/route.ts
@@ -211,20 +211,19 @@ export async function GET(req: NextRequest) {
   const quoteTotalValue = quoteRows.reduce((s, q) => s + Number(q.total_value ?? 0), 0);
   const ordersCompleted = orderRows.filter((o) => o.status === "completed").length;
 
-  // Close rate = quotes-in-period that turned into a paid order,
-  // divided by quotes sent in period. "Paid" is strictly
-  // payment_status='paid'.
+  // Close rate = quotes-in-period that turned into a closed order,
+  // divided by quotes sent in period. "Closed" here is
+  // payment_status='paid' OR status='completed' — this matches the
+  // Won Revenue definition on the Results tile so the two numbers
+  // stay coherent (many teams mark orders completed without
+  // literally touching payment_status='paid').
   //
   // Matching is permissive because real-world quotes often skip
   // deal-flow: a quote counts as closed if ANY of these hold —
-  //   (a) its deal_id matches a paid order's deal_id, OR
-  //   (b) its account_id matches a paid order's account_id and that
-  //       paid order was created at/after the quote (i.e. plausibly
-  //       resulted from it).
-  //
-  // Without (b), close rate reads 0% whenever the rep quoted the
-  // customer directly and then created the order without a deal
-  // record — which is the common case for many pipelines.
+  //   (a) its deal_id matches a closed order's deal_id, OR
+  //   (b) its account_id matches a closed order's account_id and
+  //       that closed order was created at/after the quote (i.e.
+  //       plausibly resulted from it).
   let quotesClosed = 0;
   const quoteAccountIds = Array.from(
     new Set(
@@ -234,13 +233,15 @@ export async function GET(req: NextRequest) {
     ),
   );
   if (quoteRows.length > 0) {
-    // Pull every paid order whose deal_id OR account_id overlaps our
-    // quotes' set. Scope to the same reps so a different rep's paid
-    // order doesn't credit this one.
+    // Pull every closed (paid OR completed) order whose deal_id OR
+    // account_id overlaps our quotes' set.
     let paidQuery = supabaseAdmin
       .from("sales_orders")
       .select("id, deal_id, account_id, created_at")
-      .eq("payment_status", "paid")
+      // sales_orders has BOTH `status` and `order_status`; different
+      // parts of the app write to each. Accept either being 'completed'
+      // as evidence the order closed, plus payment_status='paid'.
+      .or("payment_status.eq.paid,status.eq.completed,order_status.eq.completed")
       .eq("document_type", "order");
     paidQuery = scopeByCreator(paidQuery);
     if (quoteDealIds.length > 0 || quoteAccountIds.length > 0) {

--- a/src/app/api/sales/results/route.ts
+++ b/src/app/api/sales/results/route.ts
@@ -305,7 +305,10 @@ export async function GET(req: NextRequest) {
       let paidQuery = supabaseAdmin
         .from("sales_orders")
         .select("deal_id, account_id, created_at, created_by")
-        .eq("payment_status", "paid");
+        // "Closed" here = payment_status='paid' OR either status column
+        // = 'completed', matching the Won Revenue definition on this
+        // same page so the two numbers stay coherent.
+        .or("payment_status.eq.paid,status.eq.completed,order_status.eq.completed");
       if (targetUserId) paidQuery = paidQuery.eq("created_by", targetUserId);
       else if (allowedUserIds) paidQuery = paidQuery.in("created_by", allowedUserIds);
       const clauses: string[] = [];

--- a/src/app/api/sales/workload/route.ts
+++ b/src/app/api/sales/workload/route.ts
@@ -263,7 +263,10 @@ export async function GET(req: NextRequest) {
       .from("sales_orders")
       .select("deal_id, account_id, created_at, created_by")
       .in("created_by", staffIds)
-      .eq("payment_status", "paid")
+      // Accept payment_status='paid' OR either of the two status
+      // columns being 'completed' — matches Won Revenue's definition
+      // and matches the executive snapshot.
+      .or("payment_status.eq.paid,status.eq.completed,order_status.eq.completed")
       .eq("document_type", "order");
     const clauses: string[] = [];
     if (quoteDealIds.length > 0) clauses.push(`deal_id.in.(${quoteDealIds.join(",")})`);


### PR DESCRIPTION
Won Revenue on the same page treats an order as won when status='completed' OR payment_status='paid'. Close rate had been tightened to strictly payment_status='paid' which then dropped to 0 whenever teams marked orders complete without literally touching payment_status.

sales_orders also carries BOTH `status` and `order_status`; different parts of the app write to each. Accept any of the three signals as evidence of a close:
  payment_status='paid' OR status='completed' OR order_status='completed'

Applied consistently across executive snapshot, workload per-rep close rate, and /api/sales/results. Numerator and denominator now agree with Won Revenue instead of contradicting it.

Account-based matching (added last commit) stays; the change is only what counts as a "closed" order on the paid side.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2