### PR TITLE
Close rate — normalized-identity match through sales_accounts

### DIFF
--- a/src/app/api/sales/executive-snapshot/route.ts
+++ b/src/app/api/sales/executive-snapshot/route.ts
@@ -224,20 +224,33 @@ export async function GET(req: NextRequest) {
   //   (b) its account_id matches a closed order's account_id and
   //       that closed order was created at/after the quote (i.e.
   //       plausibly resulted from it).
-  // Match quotes to closed orders on FOUR axes (any hit counts):
-  //   1. deal_id
-  //   2. lead_id
-  //   3. account_id — closed order exists for that account (ANY date)
-  //   4. recipient_email (lowercased) — closed order exists for that
-  //      recipient (ANY date). Reps very often type the same customer
-  //      email on both quote and follow-up order, so this catches the
-  //      case where none of the FKs are populated.
+  // Match quotes to closed orders.
   //
-  // No timestamp guard on axes 3 and 4: real pipelines have repeat
-  // customers whose paid orders often predate the newest quote, and
-  // requiring paid_at ≥ quote_at was zeroing the rate out. We
-  // interpret "this quote's customer has a closed relationship" as
-  // "closed" for the purpose of this metric.
+  // === Root cause + real fix (TODO) ===================================
+  // sales_accounts has no unique constraint on email/business_name, and
+  // every insert site is a naked INSERT — see the flows in
+  // src/lib/coffeeCrmMirror.ts, src/app/api/sales/accounts/route.ts,
+  // src/app/api/sales/leads/route.ts, src/lib/paymentHandlers.ts, etc.
+  // Rep-created quote accounts and coffee-mirror-created paid-order
+  // accounts are DIFFERENT sales_accounts rows for the same real
+  // customer, so direct account_id comparison never lands.
+  //
+  // The RIGHT fix is a dedup guard on sales_accounts inserts (find-or-
+  // create by normalized email+name), plus a one-shot backfill that
+  // merges duplicate accounts and updates all FKs. Until that ships,
+  // this metric normalizes both sides to a customer identity
+  // (email lowercased, or business_name lower+whitespace-collapsed) and
+  // matches through THAT. Direct FK matches still short-circuit first,
+  // so existing data-clean rows don't regress.
+  // ====================================================================
+  //
+  // Axes, any hit counts (highest to lowest confidence):
+  //   1. deal_id (exact)
+  //   2. lead_id (exact)
+  //   3. account_id (exact)
+  //   4. normalized email — quote.account.email OR quote.recipient_email
+  //      vs paid.account.email OR paid.recipient_email
+  //   5. normalized business_name (fallback for accounts with no email)
   //
   // "Closed" = payment_status='paid' OR status='completed' OR
   // order_status='completed'. No document_type filter — legacy orders
@@ -254,6 +267,7 @@ export async function GET(req: NextRequest) {
 
   let debugPaidAccountIds: string[] = [];
   let debugPaidCount = 0;
+  let debugMatchDetail: Record<string, unknown> = {};
 
   if (q2.length > 0) {
     let paidQuery = supabaseAdmin
@@ -277,22 +291,71 @@ export async function GET(req: NextRequest) {
       new Set(paid.map((p) => p.account_id).filter((v): v is string => !!v)),
     );
 
+    // Resolve every account_id referenced by either side to its
+    // sales_accounts row so we can match on normalized email/name.
+    const allAccountIds = Array.from(
+      new Set(
+        [
+          ...q2.map((q) => q.account_id),
+          ...paid.map((p) => p.account_id),
+        ].filter((v): v is string => !!v),
+      ),
+    );
+    const accountById = new Map<string, { email: string | null; business_name: string | null }>();
+    if (allAccountIds.length > 0) {
+      const { data: accts } = await supabaseAdmin
+        .from("sales_accounts")
+        .select("id, email, business_name")
+        .in("id", allAccountIds);
+      for (const a of accts ?? []) {
+        accountById.set(a.id, { email: a.email, business_name: a.business_name });
+      }
+    }
+
+    const normEmail = (s: string | null | undefined) =>
+      s ? s.trim().toLowerCase() || null : null;
+    const normName = (s: string | null | undefined) =>
+      s ? s.trim().toLowerCase().replace(/\s+/g, " ") || null : null;
+
+    // Build paid-side identity sets from account.email, account.business_name,
+    // and recipient_email.
+    const paidEmails = new Set<string>();
+    const paidNames = new Set<string>();
+    for (const p of paid) {
+      const acct = p.account_id ? accountById.get(p.account_id) : null;
+      const email = normEmail(acct?.email) ?? normEmail(p.recipient_email);
+      if (email) paidEmails.add(email);
+      const name = normName(acct?.business_name);
+      if (name) paidNames.add(name);
+    }
     const paidByDeal = new Set(paid.map((p) => p.deal_id).filter(Boolean) as string[]);
     const paidByLead = new Set(paid.map((p) => p.lead_id).filter(Boolean) as string[]);
-    const paidByAccount = new Set(paid.map((p) => p.account_id).filter((v): v is string => !!v));
-    const paidByEmail = new Set(
-      paid
-        .map((p) => p.recipient_email?.trim().toLowerCase())
-        .filter((v): v is string => !!v),
-    );
+    const paidByAccountId = new Set(paid.map((p) => p.account_id).filter((v): v is string => !!v));
 
+    let matchedByDeal = 0, matchedByLead = 0, matchedByAccount = 0, matchedByEmail = 0, matchedByName = 0;
     quotesClosed = q2.filter((q) => {
-      if (q.deal_id && paidByDeal.has(q.deal_id)) return true;
-      if (q.lead_id && paidByLead.has(q.lead_id)) return true;
-      if (q.account_id && paidByAccount.has(q.account_id)) return true;
-      if (q.recipient_email && paidByEmail.has(q.recipient_email.trim().toLowerCase())) return true;
+      if (q.deal_id && paidByDeal.has(q.deal_id)) { matchedByDeal++; return true; }
+      if (q.lead_id && paidByLead.has(q.lead_id)) { matchedByLead++; return true; }
+      if (q.account_id && paidByAccountId.has(q.account_id)) { matchedByAccount++; return true; }
+      const acct = q.account_id ? accountById.get(q.account_id) : null;
+      const qEmail = normEmail(acct?.email) ?? normEmail(q.recipient_email);
+      if (qEmail && paidEmails.has(qEmail)) { matchedByEmail++; return true; }
+      const qName = normName(acct?.business_name);
+      if (qName && paidNames.has(qName)) { matchedByName++; return true; }
       return false;
     }).length;
+
+    debugMatchDetail = {
+      matched_by_deal: matchedByDeal,
+      matched_by_lead: matchedByLead,
+      matched_by_account: matchedByAccount,
+      matched_by_email: matchedByEmail,
+      matched_by_business_name: matchedByName,
+      paid_side_distinct_emails: paidEmails.size,
+      paid_side_distinct_names: paidNames.size,
+      sample_paid_emails: Array.from(paidEmails).slice(0, 3),
+      sample_paid_names: Array.from(paidNames).slice(0, 3),
+    };
   }
   const closeRate = q2.length > 0 ? quotesClosed / q2.length : 0;
 
@@ -479,12 +542,10 @@ export async function GET(req: NextRequest) {
               quotes_have_recipient_email: q2.filter((q) => q.recipient_email).length,
               paid_orders_in_scope: debugPaidCount,
               paid_orders_distinct_account_ids: debugPaidAccountIds.length,
-              // Overlap between quote-side account_ids and paid-side
-              // account_ids — this number should equal quotesClosed when
-              // account_id is the only match axis populated.
               quote_account_ids_matching_paid: q2.filter(
                 (q) => q.account_id && debugPaidAccountIds.includes(q.account_id),
               ).length,
+              ...debugMatchDetail,
               sample_quotes: q2.slice(0, 3).map((q) => ({
                 id: q.id,
                 deal_id: q.deal_id,

--- a/src/app/api/sales/results/route.ts
+++ b/src/app/api/sales/results/route.ts
@@ -279,67 +279,91 @@ export async function GET(req: NextRequest) {
   );
   const completedOrders = (orders || []).filter((o) => o.status === "completed").length;
 
-  // Close rate = quotes-in-period that turned into a paid order /
-  // quotes-in-period. "Paid" is strictly payment_status='paid'.
+  // Close rate = quotes-in-period that turned into a closed order.
+  // Full logic docs live in /api/sales/executive-snapshot; the tl;dr
+  // is: sales_accounts has no dedup, quotes and paid orders come from
+  // different flows creating different account rows for the same
+  // customer, so we match through normalized identity (email,
+  // business_name) resolved via sales_accounts. Direct FK matches
+  // (deal_id, lead_id, account_id) short-circuit first so any cleanly
+  // linked pipeline still hits them.
   //
-  // Match permissively — a quote counts as closed if EITHER its
-  // deal_id matches a paid order's deal_id OR its account_id
-  // matches a paid order's account_id created at/after the quote.
-  // Deal-flow-less pipelines were previously reading 0% because
-  // deal_id is rarely populated on real quotes or orders.
+  // TODO(dedup): the real fix is a find-or-create dedup guard on all
+  // sales_accounts insert sites + a one-shot backfill merging existing
+  // duplicates. Until that ships this normalized-identity match
+  // approximates close rate for messy data.
   let closeRate = 0;
   if (quotesInPeriod.length > 0) {
-    const quoteDealIds = Array.from(
-      new Set(quotesInPeriod.map((q) => q.deal_id).filter(Boolean) as string[]),
-    );
-    const quoteAccountIds = Array.from(
+    const closedRowsQuery = supabaseAdmin
+      .from("sales_orders")
+      .select("deal_id, account_id, lead_id, recipient_email, created_at, created_by, document_type")
+      .or("payment_status.eq.paid,status.eq.completed,order_status.eq.completed");
+    let closedRowsScoped = closedRowsQuery;
+    if (targetUserId) closedRowsScoped = closedRowsScoped.eq("created_by", targetUserId);
+    else if (allowedUserIds) closedRowsScoped = closedRowsScoped.in("created_by", allowedUserIds);
+    const { data: closedRowsAll } = await closedRowsScoped;
+    const closed = ((closedRowsAll ?? []) as Array<{
+      deal_id: string | null;
+      account_id: string | null;
+      lead_id: string | null;
+      recipient_email: string | null;
+      created_at: string;
+      created_by: string;
+      document_type: string | null;
+    }>).filter((p) => p.document_type !== "quote");
+
+    const allAccountIds = Array.from(
       new Set(
-        quotesInPeriod
-          .map((q) => (q as { account_id?: string | null }).account_id)
-          .filter((v): v is string => !!v),
+        [
+          ...quotesInPeriod.map((q) => (q as { account_id?: string | null }).account_id),
+          ...closed.map((p) => p.account_id),
+        ].filter((v): v is string => !!v),
       ),
     );
-    const paidByDeal = new Set<string>();
-    const paidByAccount = new Map<string, string[]>();
-    if (quoteDealIds.length > 0 || quoteAccountIds.length > 0) {
-      let paidQuery = supabaseAdmin
-        .from("sales_orders")
-        .select("deal_id, account_id, created_at, created_by")
-        // "Closed" here = payment_status='paid' OR either status column
-        // = 'completed', matching the Won Revenue definition on this
-        // same page so the two numbers stay coherent.
-        .or("payment_status.eq.paid,status.eq.completed,order_status.eq.completed");
-      if (targetUserId) paidQuery = paidQuery.eq("created_by", targetUserId);
-      else if (allowedUserIds) paidQuery = paidQuery.in("created_by", allowedUserIds);
-      const clauses: string[] = [];
-      if (quoteDealIds.length > 0) clauses.push(`deal_id.in.(${quoteDealIds.join(",")})`);
-      if (quoteAccountIds.length > 0) clauses.push(`account_id.in.(${quoteAccountIds.join(",")})`);
-      paidQuery = paidQuery.or(clauses.join(","));
-      const { data: paidRows } = await paidQuery;
-      for (const p of (paidRows ?? []) as {
-        deal_id: string | null;
-        account_id: string | null;
-        created_at: string;
-      }[]) {
-        if (p.deal_id) paidByDeal.add(p.deal_id);
-        if (p.account_id) {
-          const list = paidByAccount.get(p.account_id) ?? [];
-          list.push(p.created_at);
-          paidByAccount.set(p.account_id, list);
-        }
-      }
-      for (const [k, v] of paidByAccount) {
-        v.sort();
-        paidByAccount.set(k, v);
+    const accountById = new Map<string, { email: string | null; business_name: string | null }>();
+    if (allAccountIds.length > 0) {
+      const { data: accts } = await supabaseAdmin
+        .from("sales_accounts")
+        .select("id, email, business_name")
+        .in("id", allAccountIds);
+      for (const a of accts ?? []) {
+        accountById.set(a.id, { email: a.email, business_name: a.business_name });
       }
     }
-    // No timestamp guard: repeat customers whose paid orders predate a
-    // new quote were being dropped, zeroing the rate out.
-    const paidAccountSet = new Set(paidByAccount.keys());
+
+    const normEmail = (s: string | null | undefined) =>
+      s ? s.trim().toLowerCase() || null : null;
+    const normName = (s: string | null | undefined) =>
+      s ? s.trim().toLowerCase().replace(/\s+/g, " ") || null : null;
+
+    const paidByDeal = new Set(closed.map((p) => p.deal_id).filter(Boolean) as string[]);
+    const paidByLead = new Set(closed.map((p) => p.lead_id).filter(Boolean) as string[]);
+    const paidByAccountId = new Set(closed.map((p) => p.account_id).filter((v): v is string => !!v));
+    const paidEmails = new Set<string>();
+    const paidNames = new Set<string>();
+    for (const p of closed) {
+      const acct = p.account_id ? accountById.get(p.account_id) : null;
+      const email = normEmail(acct?.email) ?? normEmail(p.recipient_email);
+      if (email) paidEmails.add(email);
+      const name = normName(acct?.business_name);
+      if (name) paidNames.add(name);
+    }
+
     const closedQuotes = quotesInPeriod.filter((q) => {
-      if (q.deal_id && paidByDeal.has(q.deal_id)) return true;
-      const accountId = (q as { account_id?: string | null }).account_id;
-      if (accountId && paidAccountSet.has(accountId)) return true;
+      const qq = q as {
+        deal_id: string | null;
+        account_id: string | null;
+        lead_id?: string | null;
+        recipient_email?: string | null;
+      };
+      if (qq.deal_id && paidByDeal.has(qq.deal_id)) return true;
+      if (qq.lead_id && paidByLead.has(qq.lead_id)) return true;
+      if (qq.account_id && paidByAccountId.has(qq.account_id)) return true;
+      const acct = qq.account_id ? accountById.get(qq.account_id) : null;
+      const qEmail = normEmail(acct?.email) ?? normEmail(qq.recipient_email);
+      if (qEmail && paidEmails.has(qEmail)) return true;
+      const qName = normName(acct?.business_name);
+      if (qName && paidNames.has(qName)) return true;
       return false;
     }).length;
     closeRate = closedQuotes / quotesInPeriod.length;

--- a/src/app/api/sales/workload/route.ts
+++ b/src/app/api/sales/workload/route.ts
@@ -231,14 +231,14 @@ export async function GET(req: NextRequest) {
   }
 
   // ─── Sales orders/quotes for close-rate ───────────────────────────
-  // Match quotes to paid orders permissively — a quote counts as
-  // closed if its deal_id ended up paid OR the same account_id has a
-  // paid order created at/after the quote. Deal-flow-less pipelines
-  // otherwise read 0% close rate because deal_id is rarely populated
-  // on either quote or order.
+  // See executive-snapshot for the full explanation of why we match
+  // through normalized sales_accounts identity instead of raw
+  // account_id: quotes and paid orders come from different creation
+  // flows that produce different sales_accounts rows for the same
+  // real customer. Real fix is a dedup guard + backfill.
   const { data: quoteRows } = await supabaseAdmin
     .from("sales_orders")
-    .select("id, deal_id, account_id, created_by, document_type, created_at")
+    .select("id, deal_id, account_id, lead_id, recipient_email, created_by, document_type, created_at")
     .in("created_by", staffIds)
     .eq("document_type", "quote")
     .gte("created_at", since);
@@ -246,60 +246,84 @@ export async function GET(req: NextRequest) {
     id: string;
     deal_id: string | null;
     account_id: string | null;
+    lead_id: string | null;
+    recipient_email: string | null;
     created_by: string;
     created_at: string;
   }[];
-  const quoteDealIds = Array.from(
-    new Set(quoteRowsList.map((q) => q.deal_id).filter(Boolean) as string[]),
-  );
-  const quoteAccountIds = Array.from(
-    new Set(quoteRowsList.map((q) => q.account_id).filter(Boolean) as string[]),
-  );
 
-  const paidByDeal = new Set<string>();
-  const paidByAccount = new Map<string, string[]>();
-  if (quoteRowsList.length > 0 && (quoteDealIds.length > 0 || quoteAccountIds.length > 0)) {
-    let paidQuery = supabaseAdmin
-      .from("sales_orders")
-      .select("deal_id, account_id, created_at, created_by")
-      .in("created_by", staffIds)
-      // Accept payment_status='paid' OR either of the two status
-      // columns being 'completed' — matches Won Revenue's definition
-      // and matches the executive snapshot.
-      .or("payment_status.eq.paid,status.eq.completed,order_status.eq.completed")
-      .eq("document_type", "order");
-    const clauses: string[] = [];
-    if (quoteDealIds.length > 0) clauses.push(`deal_id.in.(${quoteDealIds.join(",")})`);
-    if (quoteAccountIds.length > 0) clauses.push(`account_id.in.(${quoteAccountIds.join(",")})`);
-    paidQuery = paidQuery.or(clauses.join(","));
-    const { data: paidRows } = await paidQuery;
-    for (const p of (paidRows ?? []) as { deal_id: string | null; account_id: string | null; created_at: string }[]) {
-      if (p.deal_id) paidByDeal.add(p.deal_id);
-      if (p.account_id) {
-        const list = paidByAccount.get(p.account_id) ?? [];
-        list.push(p.created_at);
-        paidByAccount.set(p.account_id, list);
-      }
-    }
-    for (const [k, v] of paidByAccount) {
-      v.sort();
-      paidByAccount.set(k, v);
-    }
-  }
-
-  // Match on ANY of deal_id, account_id (no timestamp guard —
-  // repeat customers whose paid orders predate a new quote were
-  // being dropped).
-  const paidByAccountSet = new Set(paidByAccount.keys());
   const quotesSentByUser = new Map<string, number>();
   const quotesClosedByUser = new Map<string, number>();
-  for (const q of quoteRowsList) {
-    quotesSentByUser.set(q.created_by, (quotesSentByUser.get(q.created_by) ?? 0) + 1);
-    const closed =
-      (q.deal_id && paidByDeal.has(q.deal_id)) ||
-      (q.account_id && paidByAccountSet.has(q.account_id));
-    if (closed) {
-      quotesClosedByUser.set(q.created_by, (quotesClosedByUser.get(q.created_by) ?? 0) + 1);
+
+  if (quoteRowsList.length > 0) {
+    // Pull every closed order in scope (any date, any doc_type).
+    const { data: paidRowsAll } = await supabaseAdmin
+      .from("sales_orders")
+      .select("deal_id, account_id, lead_id, recipient_email, created_at, created_by, document_type")
+      .in("created_by", staffIds)
+      .or("payment_status.eq.paid,status.eq.completed,order_status.eq.completed");
+    const paid = ((paidRowsAll ?? []) as Array<{
+      deal_id: string | null;
+      account_id: string | null;
+      lead_id: string | null;
+      recipient_email: string | null;
+      created_at: string;
+      created_by: string;
+      document_type: string | null;
+    }>).filter((p) => p.document_type !== "quote");
+
+    // Resolve every referenced account_id to its normalized identity.
+    const allAccountIds = Array.from(
+      new Set(
+        [
+          ...quoteRowsList.map((q) => q.account_id),
+          ...paid.map((p) => p.account_id),
+        ].filter((v): v is string => !!v),
+      ),
+    );
+    const accountById = new Map<string, { email: string | null; business_name: string | null }>();
+    if (allAccountIds.length > 0) {
+      const { data: accts } = await supabaseAdmin
+        .from("sales_accounts")
+        .select("id, email, business_name")
+        .in("id", allAccountIds);
+      for (const a of accts ?? []) {
+        accountById.set(a.id, { email: a.email, business_name: a.business_name });
+      }
+    }
+
+    const normEmail = (s: string | null | undefined) =>
+      s ? s.trim().toLowerCase() || null : null;
+    const normName = (s: string | null | undefined) =>
+      s ? s.trim().toLowerCase().replace(/\s+/g, " ") || null : null;
+
+    const paidByDeal = new Set(paid.map((p) => p.deal_id).filter(Boolean) as string[]);
+    const paidByLead = new Set(paid.map((p) => p.lead_id).filter(Boolean) as string[]);
+    const paidByAccountId = new Set(paid.map((p) => p.account_id).filter((v): v is string => !!v));
+    const paidEmails = new Set<string>();
+    const paidNames = new Set<string>();
+    for (const p of paid) {
+      const acct = p.account_id ? accountById.get(p.account_id) : null;
+      const email = normEmail(acct?.email) ?? normEmail(p.recipient_email);
+      if (email) paidEmails.add(email);
+      const name = normName(acct?.business_name);
+      if (name) paidNames.add(name);
+    }
+
+    for (const q of quoteRowsList) {
+      quotesSentByUser.set(q.created_by, (quotesSentByUser.get(q.created_by) ?? 0) + 1);
+      const acct = q.account_id ? accountById.get(q.account_id) : null;
+      const qEmail = normEmail(acct?.email) ?? normEmail(q.recipient_email);
+      const qName = normName(acct?.business_name);
+      const closed =
+        (q.deal_id && paidByDeal.has(q.deal_id)) ||
+        (q.lead_id && paidByLead.has(q.lead_id)) ||
+        (q.account_id && paidByAccountId.has(q.account_id)) ||
+        (qEmail && paidEmails.has(qEmail)) ||
+        (qName && paidNames.has(qName));
+      if (closed) {
+        quotesClosedByUser.set(q.created_by, (quotesClosedByUser.get(q.created_by) ?? 0) + 1);
+      }
     }
   }
 


### PR DESCRIPTION
Root cause identified: sales_accounts has no dedup guard, and quotes vs paid orders come from different creation flows that each spawn a fresh account row for the same real customer. Rep types "Bob's Cafe <orders@bobscafe.com>" via /sales/orders/new; the coffee checkout mirror lands with the buyer's platform-auth email "bob@gmail.com" and mints yet another sales_accounts row. Direct account_id comparison therefore fails on 100% of pairs.

Short-term fix (this commit): normalize both sides to a customer identity (email lowercased/trimmed, business_name whitespace- collapsed lower) resolved via sales_accounts, and match on that. Direct FK matches still short-circuit first — additive, not replacement — so no cleanly-linked pipeline regresses.

Match order (high to low confidence):
  1. deal_id (exact)
  2. lead_id (exact)
  3. account_id (exact)
  4. normalized email (account.email OR recipient_email)
  5. normalized business_name

Applied identically to /api/sales/executive-snapshot, per-rep close rate in /api/sales/workload, and /api/sales/results.

Debug counters added to snapshot ?debug=1:
  matched_by_deal / matched_by_lead / matched_by_account /
  matched_by_email / matched_by_business_name — so we can verify
  the fix hits real data before merging (last two "fixes" looked
  right but still produced 0). Also paid_side_distinct_emails /
  paid_side_distinct_names and 3-row samples.

TODO left in code (real fix): find-or-create dedup guard on every sales_accounts insert site (traced by the investigator agent — src/lib/coffeeCrmMirror.ts, src/app/api/sales/accounts/route.ts, src/app/api/sales/leads/route.ts, src/lib/paymentHandlers.ts, plus several intake and admin flows) + one-shot backfill merging existing duplicates and updating downstream FKs. Once that ships this normalized-identity path can collapse back to direct account_id comparison.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2