### PR TITLE
sales_accounts dedup — guard + admin merge UI + interim metric

### DIFF
--- a/src/app/admin/accounts/duplicates/page.tsx
+++ b/src/app/admin/accounts/duplicates/page.tsx
@@ -1,0 +1,361 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { createBrowserClient } from "@/lib/supabase";
+import { Loader2, ChevronLeft, Users, AlertTriangle, Check, Eye, ArrowRight } from "lucide-react";
+
+interface Row {
+  id: string;
+  business_name: string | null;
+  contact_name: string | null;
+  email: string | null;
+  phone: string | null;
+  address: string | null;
+  normalized_email: string | null;
+  normalized_business_name: string | null;
+  normalized_phone: string | null;
+  created_at: string;
+  quote_count: number;
+  order_count: number;
+  paid_order_count: number;
+  deal_count: number;
+  workflow_count: number;
+}
+
+interface Cluster {
+  key: string;
+  match_type: "email" | "name+phone";
+  rows: Row[];
+}
+
+export default function DuplicateAccountsPage() {
+  const [clusters, setClusters] = useState<Cluster[]>([]);
+  const [totalAccounts, setTotalAccounts] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [token, setToken] = useState<string | null>(null);
+  const [selectedCluster, setSelectedCluster] = useState<Cluster | null>(null);
+  const [canonicalId, setCanonicalId] = useState<string | null>(null);
+  const [preview, setPreview] = useState<Record<string, number> | null>(null);
+  const [previewing, setPreviewing] = useState(false);
+  const [merging, setMerging] = useState(false);
+  const [notes, setNotes] = useState("");
+  const [toast, setToast] = useState<{ type: "success" | "error"; msg: string } | null>(null);
+
+  const load = useCallback(async (t: string) => {
+    setLoading(true);
+    const res = await fetch("/api/admin/sales-accounts/duplicates", {
+      headers: { Authorization: `Bearer ${t}` },
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setClusters(data.clusters ?? []);
+      setTotalAccounts(data.total_accounts_flagged ?? 0);
+    }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (session?.access_token) {
+        setToken(session.access_token);
+        load(session.access_token);
+      }
+    });
+  }, [load]);
+
+  function openCluster(c: Cluster) {
+    setSelectedCluster(c);
+    // Default canonical = row with the most paid orders, tie-break by
+    // total FK count, tie-break by oldest. This is a suggestion; the
+    // admin still confirms.
+    const scored = [...c.rows].sort((a, b) => {
+      if (a.paid_order_count !== b.paid_order_count) return b.paid_order_count - a.paid_order_count;
+      const aTotal = a.quote_count + a.order_count + a.deal_count + a.workflow_count;
+      const bTotal = b.quote_count + b.order_count + b.deal_count + b.workflow_count;
+      if (aTotal !== bTotal) return bTotal - aTotal;
+      return new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
+    });
+    setCanonicalId(scored[0]?.id ?? null);
+    setPreview(null);
+    setNotes("");
+  }
+
+  async function runPreview() {
+    if (!selectedCluster || !canonicalId || !token) return;
+    setPreviewing(true);
+    const absorbed = selectedCluster.rows.filter((r) => r.id !== canonicalId).map((r) => r.id);
+    const res = await fetch("/api/admin/sales-accounts/merge", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ canonical_id: canonicalId, absorbed_ids: absorbed, dry_run: true }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setPreview(data.preview ?? {});
+    } else {
+      const err = await res.json().catch(() => ({}));
+      setToast({ type: "error", msg: err.error ?? "Preview failed" });
+    }
+    setPreviewing(false);
+  }
+
+  async function confirmMerge() {
+    if (!selectedCluster || !canonicalId || !token) return;
+    const absorbed = selectedCluster.rows.filter((r) => r.id !== canonicalId).map((r) => r.id);
+    const canonicalRow = selectedCluster.rows.find((r) => r.id === canonicalId);
+    const ok = window.confirm(
+      `Merge ${absorbed.length} row(s) into "${canonicalRow?.business_name ?? canonicalId.slice(0, 8)}"?\n\n` +
+      `This soft-deletes the absorbed rows and repoints every foreign key to the canonical row. ` +
+      `Rollback is available from the merge log if you need to reverse it.`,
+    );
+    if (!ok) return;
+
+    setMerging(true);
+    const res = await fetch("/api/admin/sales-accounts/merge", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({
+        canonical_id: canonicalId,
+        absorbed_ids: absorbed,
+        notes: notes || undefined,
+      }),
+    });
+    setMerging(false);
+    if (res.ok) {
+      setToast({ type: "success", msg: `Merged ${absorbed.length} row(s) successfully` });
+      setSelectedCluster(null);
+      setCanonicalId(null);
+      setPreview(null);
+      if (token) load(token);
+    } else {
+      const err = await res.json().catch(() => ({}));
+      setToast({ type: "error", msg: err.error ?? "Merge failed" });
+    }
+    setTimeout(() => setToast(null), 5000);
+  }
+
+  return (
+    <div className="max-w-6xl mx-auto p-6">
+      <Link href="/admin" className="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-800 mb-4">
+        <ChevronLeft className="h-4 w-4" /> Admin
+      </Link>
+
+      <div className="mb-6">
+        <h1 className="text-2xl font-semibold text-gray-900 flex items-center gap-2">
+          <Users className="h-6 w-6 text-amber-600" />
+          Duplicate Customer Accounts
+        </h1>
+        <p className="text-sm text-gray-500 mt-1">
+          Sales accounts that resolve to the same customer identity (email, or business
+          name + phone). Merging repoints every foreign key to the canonical row and
+          soft-deletes the absorbed rows. All merges are logged and rollback-able.
+        </p>
+      </div>
+
+      {loading ? (
+        <div className="text-center py-12 text-gray-500">
+          <Loader2 className="inline h-5 w-5 animate-spin mr-2" /> Loading…
+        </div>
+      ) : clusters.length === 0 ? (
+        <div className="rounded-xl border border-emerald-100 bg-emerald-50 p-6 text-center">
+          <Check className="mx-auto h-8 w-8 text-emerald-600 mb-2" />
+          <p className="text-emerald-900 font-medium">No duplicate clusters detected.</p>
+          <p className="text-sm text-emerald-700 mt-1">
+            Every non-deleted sales_accounts row has a unique normalized identity.
+          </p>
+        </div>
+      ) : (
+        <>
+          <div className="mb-4 flex items-center gap-3 text-sm text-amber-800 bg-amber-50 rounded-lg border border-amber-200 p-3">
+            <AlertTriangle className="h-4 w-4" />
+            <span>
+              <strong>{clusters.length}</strong> cluster{clusters.length === 1 ? "" : "s"} covering{" "}
+              <strong>{totalAccounts}</strong> account rows.
+            </span>
+          </div>
+
+          <div className="space-y-3">
+            {clusters.map((c) => {
+              const totalFK = c.rows.reduce(
+                (s, r) => s + r.quote_count + r.order_count + r.deal_count + r.workflow_count,
+                0,
+              );
+              return (
+                <div key={c.key} className="rounded-lg border border-gray-200 bg-white p-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2 mb-1">
+                        <span className="inline-flex items-center rounded-full bg-gray-100 text-gray-700 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide">
+                          {c.match_type}
+                        </span>
+                        <span className="text-xs text-gray-500 truncate max-w-md">
+                          {c.match_type === "email" ? c.key : c.key.split("|")[0]}
+                        </span>
+                      </div>
+                      <div className="text-sm text-gray-900">
+                        <strong>{c.rows.length}</strong> row{c.rows.length === 1 ? "" : "s"} · {totalFK} linked record{totalFK === 1 ? "" : "s"}
+                      </div>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => openCluster(c)}
+                      className="inline-flex items-center gap-1 rounded-md bg-emerald-600 text-white px-3 py-1.5 text-xs font-medium hover:bg-emerald-700"
+                    >
+                      <Eye className="h-3 w-3" /> Review
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </>
+      )}
+
+      {selectedCluster && (
+        <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/40 p-4 overflow-y-auto">
+          <div className="w-full max-w-4xl rounded-2xl bg-white shadow-xl my-8">
+            <div className="flex items-center justify-between p-5 border-b border-gray-100">
+              <h2 className="text-lg font-semibold text-gray-900">Review cluster</h2>
+              <button
+                type="button"
+                onClick={() => { setSelectedCluster(null); setCanonicalId(null); setPreview(null); }}
+                className="text-gray-400 hover:text-gray-700"
+              >
+                ✕
+              </button>
+            </div>
+
+            <div className="p-5 space-y-4">
+              <p className="text-xs text-gray-500">
+                Pick which row becomes the canonical account. The rest get soft-deleted and their
+                foreign keys are repointed here. Absorbed rows can be un-deleted with the rollback endpoint.
+              </p>
+
+              <div className="border border-gray-200 rounded-lg divide-y divide-gray-100">
+                {selectedCluster.rows.map((r) => {
+                  const isCanonical = r.id === canonicalId;
+                  return (
+                    <label
+                      key={r.id}
+                      className={`flex items-start gap-3 p-3 cursor-pointer ${
+                        isCanonical ? "bg-emerald-50" : "hover:bg-gray-50"
+                      }`}
+                    >
+                      <input
+                        type="radio"
+                        name="canonical"
+                        checked={isCanonical}
+                        onChange={() => setCanonicalId(r.id)}
+                        className="mt-1"
+                      />
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 flex-wrap">
+                          <span className="font-medium text-gray-900">
+                            {r.business_name ?? "(unnamed)"}
+                          </span>
+                          {isCanonical && (
+                            <span className="inline-flex items-center rounded-full bg-emerald-600 text-white px-2 py-0.5 text-[10px] uppercase tracking-wide font-medium">
+                              Canonical
+                            </span>
+                          )}
+                        </div>
+                        <div className="text-xs text-gray-500 mt-0.5">
+                          {r.email ?? "(no email)"} · {r.phone ?? "(no phone)"} · created {new Date(r.created_at).toLocaleDateString()}
+                        </div>
+                        <div className="mt-2 flex flex-wrap gap-3 text-xs">
+                          <FKChip label="Quotes" value={r.quote_count} />
+                          <FKChip label="Orders" value={r.order_count} />
+                          <FKChip label="Paid" value={r.paid_order_count} tone="emerald" />
+                          <FKChip label="Deals" value={r.deal_count} />
+                          <FKChip label="Workflows" value={r.workflow_count} />
+                        </div>
+                      </div>
+                    </label>
+                  );
+                })}
+              </div>
+
+              <div>
+                <label className="block text-xs font-medium text-gray-600 mb-1">Notes (optional)</label>
+                <textarea
+                  rows={2}
+                  value={notes}
+                  onChange={(e) => setNotes(e.target.value)}
+                  placeholder="Why this canonical? (audit-logged)"
+                  className="w-full rounded-md border border-gray-200 px-3 py-2 text-sm"
+                />
+              </div>
+
+              {preview && (
+                <div className="rounded-lg bg-gray-50 border border-gray-200 p-3">
+                  <div className="text-xs uppercase tracking-wide text-gray-500 font-medium mb-2">
+                    Preview — rows that will move if you confirm
+                  </div>
+                  <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 text-xs">
+                    {Object.entries(preview).filter(([, v]) => v > 0).map(([k, v]) => (
+                      <div key={k} className="flex justify-between text-gray-700">
+                        <span className="capitalize">{k.replace(/_/g, " ")}</span>
+                        <span className="font-medium">{v}</span>
+                      </div>
+                    ))}
+                    {Object.values(preview).every((v) => v === 0) && (
+                      <div className="col-span-full text-gray-400 italic">
+                        No foreign keys to move — absorbed row is orphaned data only.
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+
+              <div className="flex justify-end gap-2 pt-2">
+                <button
+                  type="button"
+                  onClick={runPreview}
+                  disabled={!canonicalId || previewing}
+                  className="inline-flex items-center gap-1 rounded-md border border-gray-200 bg-white px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+                >
+                  {previewing ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Eye className="h-3.5 w-3.5" />}
+                  Preview
+                </button>
+                <button
+                  type="button"
+                  onClick={confirmMerge}
+                  disabled={!canonicalId || merging}
+                  className="inline-flex items-center gap-1 rounded-md bg-emerald-600 text-white px-4 py-2 text-sm font-medium hover:bg-emerald-700 disabled:opacity-50"
+                >
+                  {merging ? <Loader2 className="h-4 w-4 animate-spin" /> : <ArrowRight className="h-4 w-4" />}
+                  Confirm merge
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {toast && (
+        <div
+          className={`fixed bottom-6 right-6 rounded-lg shadow-lg px-4 py-3 text-sm font-medium ${
+            toast.type === "success" ? "bg-emerald-600 text-white" : "bg-red-600 text-white"
+          }`}
+        >
+          {toast.msg}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function FKChip({ label, value, tone }: { label: string; value: number; tone?: "emerald" }) {
+  const cls = value === 0
+    ? "bg-gray-100 text-gray-400"
+    : tone === "emerald"
+      ? "bg-emerald-100 text-emerald-800"
+      : "bg-gray-100 text-gray-700";
+  return (
+    <span className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 ${cls}`}>
+      {label} <strong>{value}</strong>
+    </span>
+  );
+}

--- a/src/app/api/admin/sales-accounts/duplicates/route.ts
+++ b/src/app/api/admin/sales-accounts/duplicates/route.ts
@@ -1,0 +1,152 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+
+/**
+ * GET /api/admin/sales-accounts/duplicates
+ *
+ * Lists candidate duplicate clusters grouped by normalized_email first,
+ * then by (normalized_business_name + normalized_phone). For each row
+ * in a cluster returns quick counts of what would move if it were
+ * absorbed — quotes, orders, deals, workflows — so the admin has
+ * enough context to pick a canonical row without opening N tabs.
+ *
+ * Purely read-only. Nothing writes. Nothing touches customer data.
+ */
+
+interface AccountRow {
+  id: string;
+  business_name: string | null;
+  contact_name: string | null;
+  email: string | null;
+  phone: string | null;
+  address: string | null;
+  normalized_email: string | null;
+  normalized_business_name: string | null;
+  normalized_phone: string | null;
+  created_at: string;
+  deleted_at: string | null;
+}
+
+interface RowWithCounts extends AccountRow {
+  quote_count: number;
+  order_count: number;
+  paid_order_count: number;
+  deal_count: number;
+  workflow_count: number;
+}
+
+interface Cluster {
+  key: string;
+  match_type: "email" | "name+phone";
+  rows: RowWithCounts[];
+}
+
+export async function GET(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  // Pull every non-deleted sales_accounts row + its normalized fields.
+  const { data: accounts, error } = await supabaseAdmin
+    .from("sales_accounts")
+    .select("id, business_name, contact_name, email, phone, address, normalized_email, normalized_business_name, normalized_phone, created_at, deleted_at")
+    .is("deleted_at", null)
+    .order("created_at", { ascending: true });
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  const rows = (accounts ?? []) as AccountRow[];
+
+  // Group by normalized_email (if present + non-blank) — highest confidence.
+  const byEmail = new Map<string, AccountRow[]>();
+  const seenInEmailCluster = new Set<string>();
+  for (const r of rows) {
+    if (!r.normalized_email) continue;
+    const list = byEmail.get(r.normalized_email) ?? [];
+    list.push(r);
+    byEmail.set(r.normalized_email, list);
+  }
+  const emailClusters: Cluster[] = [];
+  for (const [key, list] of byEmail) {
+    if (list.length < 2) continue;
+    emailClusters.push({ key, match_type: "email", rows: list as RowWithCounts[] });
+    for (const r of list) seenInEmailCluster.add(r.id);
+  }
+
+  // Group remaining rows by (normalized_business_name, normalized_phone).
+  // Rows already appearing in an email cluster are skipped so the same
+  // row doesn't show up under two clusters.
+  const byNamePhone = new Map<string, AccountRow[]>();
+  for (const r of rows) {
+    if (seenInEmailCluster.has(r.id)) continue;
+    if (!r.normalized_business_name) continue;
+    const key = `${r.normalized_business_name}|${r.normalized_phone ?? ""}`;
+    const list = byNamePhone.get(key) ?? [];
+    list.push(r);
+    byNamePhone.set(key, list);
+  }
+  const namePhoneClusters: Cluster[] = [];
+  for (const [key, list] of byNamePhone) {
+    if (list.length < 2) continue;
+    namePhoneClusters.push({ key, match_type: "name+phone", rows: list as RowWithCounts[] });
+  }
+
+  // Enrich every clustered row with FK counts so the admin can eyeball
+  // which is the "real" canonical (has the paid orders, has the workflow,
+  // etc.).
+  const allClusters = [...emailClusters, ...namePhoneClusters];
+  const idsInClusters = Array.from(new Set(allClusters.flatMap((c) => c.rows.map((r) => r.id))));
+  if (idsInClusters.length > 0) {
+    // Batched count queries. Each returns { account_id, count } grouped.
+    const [ordersRes, dealsRes, workflowsRes] = await Promise.all([
+      supabaseAdmin
+        .from("sales_orders")
+        .select("account_id, document_type, payment_status, status, order_status")
+        .in("account_id", idsInClusters),
+      supabaseAdmin
+        .from("sales_deals")
+        .select("account_id")
+        .in("account_id", idsInClusters),
+      supabaseAdmin
+        .from("workflows")
+        .select("company_id")
+        .in("company_id", idsInClusters),
+    ]);
+
+    const quoteByAcct = new Map<string, number>();
+    const orderByAcct = new Map<string, number>();
+    const paidByAcct = new Map<string, number>();
+    for (const r of (ordersRes.data ?? []) as Array<{ account_id: string; document_type: string | null; payment_status: string | null; status: string | null; order_status: string | null }>) {
+      if (r.document_type === "quote") {
+        quoteByAcct.set(r.account_id, (quoteByAcct.get(r.account_id) ?? 0) + 1);
+      } else {
+        orderByAcct.set(r.account_id, (orderByAcct.get(r.account_id) ?? 0) + 1);
+        if (r.payment_status === "paid" || r.status === "completed" || r.order_status === "completed") {
+          paidByAcct.set(r.account_id, (paidByAcct.get(r.account_id) ?? 0) + 1);
+        }
+      }
+    }
+    const dealByAcct = new Map<string, number>();
+    for (const r of (dealsRes.data ?? []) as Array<{ account_id: string }>) {
+      dealByAcct.set(r.account_id, (dealByAcct.get(r.account_id) ?? 0) + 1);
+    }
+    const wfByAcct = new Map<string, number>();
+    for (const r of (workflowsRes.data ?? []) as Array<{ company_id: string }>) {
+      wfByAcct.set(r.company_id, (wfByAcct.get(r.company_id) ?? 0) + 1);
+    }
+
+    for (const c of allClusters) {
+      for (const r of c.rows) {
+        r.quote_count = quoteByAcct.get(r.id) ?? 0;
+        r.order_count = orderByAcct.get(r.id) ?? 0;
+        r.paid_order_count = paidByAcct.get(r.id) ?? 0;
+        r.deal_count = dealByAcct.get(r.id) ?? 0;
+        r.workflow_count = wfByAcct.get(r.id) ?? 0;
+      }
+    }
+  }
+
+  return NextResponse.json({
+    clusters: allClusters,
+    total_clusters: allClusters.length,
+    total_accounts_flagged: idsInClusters.length,
+  });
+}

--- a/src/app/api/admin/sales-accounts/merge/[id]/rollback/route.ts
+++ b/src/app/api/admin/sales-accounts/merge/[id]/rollback/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+
+/**
+ * POST /api/admin/sales-accounts/merge/[id]/rollback
+ *
+ * Reverses ONE merge cleanly via rollback_sales_account_merge() —
+ * reads fk_swap_details and swaps only the specific rows this merge
+ * touched, so unrelated later merges on the same canonical aren't
+ * disturbed.
+ */
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const { id } = await params;
+  const { data, error } = await supabaseAdmin.rpc("rollback_sales_account_merge", {
+    p_merge_id: id,
+    p_rolled_back_by: adminId,
+  });
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ ok: true, result: data });
+}

--- a/src/app/api/admin/sales-accounts/merge/route.ts
+++ b/src/app/api/admin/sales-accounts/merge/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+
+/**
+ * POST /api/admin/sales-accounts/merge
+ * Body: { canonical_id, absorbed_ids: [], notes?, dry_run?: boolean }
+ *
+ * Delegates to the merge_sales_accounts() PL/pgSQL function so the
+ * entire merge (FK sweep + soft-delete of absorbed rows + audit log
+ * write) happens in a single implicit transaction. If dry_run is true,
+ * returns a preview payload (row counts per table that WOULD move)
+ * without invoking the function.
+ */
+
+const bodySchema = z.object({
+  canonical_id: z.string().uuid(),
+  absorbed_ids: z.array(z.string().uuid()).min(1).max(50),
+  notes: z.string().max(1000).optional(),
+  dry_run: z.boolean().optional(),
+});
+
+export async function POST(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const parsed = bodySchema.safeParse(await req.json().catch(() => ({})));
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid input", details: parsed.error.format() }, { status: 400 });
+  }
+  const { canonical_id, absorbed_ids, notes, dry_run } = parsed.data;
+
+  if (absorbed_ids.includes(canonical_id)) {
+    return NextResponse.json({ error: "canonical_id cannot appear in absorbed_ids" }, { status: 400 });
+  }
+
+  if (dry_run) {
+    // Preview only: enumerate what would move. Read-only.
+    const tables = [
+      "sales_orders", "sales_leads", "sales_deals", "sales_documents",
+      "intake_leads", "location_requests", "pipeline_items",
+      "agreement_tokens", "invoices", "payments", "account_equipment",
+    ] as const;
+    const previewByTable: Record<string, number> = {};
+    for (const t of tables) {
+      const { count } = await supabaseAdmin
+        .from(t)
+        .select("*", { count: "exact", head: true })
+        .in("account_id", absorbed_ids);
+      previewByTable[t] = count ?? 0;
+    }
+    const { count: wfCount } = await supabaseAdmin
+      .from("workflows")
+      .select("*", { count: "exact", head: true })
+      .in("company_id", absorbed_ids);
+    previewByTable["workflows"] = wfCount ?? 0;
+    return NextResponse.json({ dry_run: true, canonical_id, absorbed_ids, preview: previewByTable });
+  }
+
+  const { data, error } = await supabaseAdmin.rpc("merge_sales_accounts", {
+    p_canonical_id: canonical_id,
+    p_absorbed_ids: absorbed_ids,
+    p_merged_by: adminId,
+    p_notes: notes ?? null,
+  });
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ ok: true, result: data });
+}

--- a/src/app/api/admin/users/[id]/add-to-crm/route.ts
+++ b/src/app/api/admin/users/[id]/add-to-crm/route.ts
@@ -46,9 +46,10 @@ export async function POST(
     return NextResponse.json({ error: "This user is already in the CRM" }, { status: 409 });
   }
 
-  const { data: account, error: acctErr } = await supabaseAdmin
-    .from("sales_accounts")
-    .insert({
+  const { findOrCreateSalesAccount } = await import("@/lib/salesAccountResolver");
+  let account: { id: string };
+  try {
+    const resolved = await findOrCreateSalesAccount({
       business_name: businessName,
       contact_name: profile.full_name || null,
       phone: profile.phone || null,
@@ -57,13 +58,12 @@ export async function POST(
       entity_type: entityType,
       assigned_to: assignedTo,
       created_by: adminId,
-    })
-    .select("id")
-    .single();
-
-  if (acctErr) {
+    });
+    account = { id: resolved.id };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "unknown";
     return NextResponse.json(
-      { error: `Account create failed: ${acctErr.message}` },
+      { error: `Account create failed: ${msg}` },
       { status: 500 }
     );
   }

--- a/src/app/api/auth/signup-lead/route.ts
+++ b/src/app/api/auth/signup-lead/route.ts
@@ -62,27 +62,24 @@ export async function POST(req: NextRequest) {
 
   const assigneeId = await getDefaultAssigneeId();
 
-  const { data: account, error: acctErr } = await supabaseAdmin
-    .from("sales_accounts")
-    .insert({
+  const { findOrCreateSalesAccount } = await import("@/lib/salesAccountResolver");
+  let account: { id: string };
+  try {
+    const resolved = await findOrCreateSalesAccount({
       business_name,
-      contact_name: contact_name || null,
-      phone: phone || null,
+      contact_name,
+      phone,
       email: email || user.email || null,
-      address: address || null,
-      city: city || null,
-      state: state || null,
-      zip: zip || null,
-      entity_type: entity_type || null,
+      address,
+      entity_type,
       assigned_to: assigneeId,
       created_by: assigneeId,
-    })
-    .select("id")
-    .single();
-
-  if (acctErr) {
+    });
+    account = { id: resolved.id };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "unknown";
     return NextResponse.json(
-      { error: `Account create failed: ${acctErr.message}` },
+      { error: `Account create failed: ${msg}` },
       { status: 500 }
     );
   }

--- a/src/app/api/financing/route.ts
+++ b/src/app/api/financing/route.ts
@@ -70,17 +70,20 @@ export async function POST(req: NextRequest) {
       crmLeadId = existingLead.id;
       crmAccountId = existingLead.account_id;
     } else {
-      const { data: account } = await supabaseAdmin
-        .from("sales_accounts")
-        .insert({
+      const { findOrCreateSalesAccount } = await import("@/lib/salesAccountResolver");
+      let account: { id: string } | null = null;
+      try {
+        const resolved = await findOrCreateSalesAccount({
           business_name: financingBizName,
           contact_name: body.full_name,
           phone: body.phone,
           email: body.email,
           entity_type: "operator",
-        })
-        .select("id")
-        .single();
+        });
+        account = { id: resolved.id };
+      } catch {
+        account = null;
+      }
 
       if (account) {
         crmAccountId = account.id;

--- a/src/app/api/intake/route.ts
+++ b/src/app/api/intake/route.ts
@@ -53,31 +53,21 @@ export async function POST(req: NextRequest) {
     pain_points,
   });
 
-  // 2. Upsert account by email
-  const { data: existingAccount } = await supabaseAdmin
-    .from("sales_accounts")
-    .select("id")
-    .eq("email", email)
-    .maybeSingle();
-
+  // 2. Dedup-guarded resolve — this endpoint already did an
+  // email-based upsert manually. Route through the shared helper so
+  // matching is normalized (case/whitespace) instead of exact.
   let accountId: string;
-  if (existingAccount) {
-    accountId = existingAccount.id;
-  } else {
-    const { data: newAccount, error: accErr } = await supabaseAdmin
-      .from("sales_accounts")
-      .insert({
-        business_name: business_name || full_name,
-        contact_name: full_name,
-        email,
-        phone: phone || null,
-      })
-      .select("id")
-      .single();
-    if (accErr || !newAccount) {
-      return NextResponse.json({ error: "Failed to create account" }, { status: 500 });
-    }
-    accountId = newAccount.id;
+  try {
+    const { findOrCreateSalesAccount } = await import("@/lib/salesAccountResolver");
+    const resolved = await findOrCreateSalesAccount({
+      business_name: business_name || full_name,
+      contact_name: full_name,
+      email,
+      phone: phone || null,
+    });
+    accountId = resolved.id;
+  } catch {
+    return NextResponse.json({ error: "Failed to create account" }, { status: 500 });
   }
 
   // 3. Upsert sales_lead by email

--- a/src/app/api/request-location/route.ts
+++ b/src/app/api/request-location/route.ts
@@ -130,18 +130,21 @@ export async function POST(req: Request) {
     );
   }
 
-  const { error: accountError } = await supabaseAdmin.from("sales_accounts").insert({
-    business_name,
-    contact_name,
-    phone,
-    email,
-    address,
-    notes: `Auto-created from location services request — ${machine_count} machine(s), ZIP(s) ${zip_code}, ${state}`,
-    assigned_to: referringRep,
-    created_by: referringRep,
-  });
-
-  if (accountError) {
+  // Dedup-guarded — same customer requesting location services twice
+  // no longer forks a second account.
+  try {
+    const { findOrCreateSalesAccount } = await import("@/lib/salesAccountResolver");
+    await findOrCreateSalesAccount({
+      business_name,
+      contact_name,
+      phone,
+      email,
+      address,
+      notes: `Auto-created from location services request — ${machine_count} machine(s), ZIP(s) ${zip_code}, ${state}`,
+      assigned_to: referringRep,
+      created_by: referringRep,
+    });
+  } catch (accountError) {
     console.error("[request-location] account creation error", accountError);
   }
 

--- a/src/app/api/sales/accounts/route.ts
+++ b/src/app/api/sales/accounts/route.ts
@@ -63,22 +63,26 @@ export async function POST(req: NextRequest) {
   if (!email)
     return NextResponse.json({ error: "email required" }, { status: 400 });
 
-  const { data, error } = await supabaseAdmin
-    .from("sales_accounts")
-    .insert({
+  // Route through the shared resolver so the manual-create-account
+  // form no longer forks a fresh row for a customer that already has
+  // one under a different intake flow.
+  const { findOrCreateSalesAccount } = await import("@/lib/salesAccountResolver");
+  try {
+    const { id, created } = await findOrCreateSalesAccount({
       business_name,
-      contact_name: contact_name || null,
-      phone: phone || null,
-      email: email || null,
-      address: address || null,
-      notes: notes || null,
-      entity_type: entity_type || null,
+      contact_name,
+      phone,
+      email,
+      address,
+      notes,
+      entity_type,
       assigned_to: user.id,
       created_by: user.id,
-    })
-    .select("*")
-    .single();
-
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  return NextResponse.json(data, { status: 201 });
+    });
+    const { data } = await supabaseAdmin.from("sales_accounts").select("*").eq("id", id).single();
+    return NextResponse.json(data, { status: created ? 201 : 200 });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Insert failed";
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
 }

--- a/src/app/api/sales/deals/[id]/route.ts
+++ b/src/app/api/sales/deals/[id]/route.ts
@@ -93,22 +93,20 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
   if (body.stage === "won" && deal.stage !== "won") {
     const lead = deal.sales_leads;
 
-    // Auto-create account if none exists
+    // Auto-attach account via dedup-guarded resolver.
     if (!deal.account_id) {
-      const { data: account } = await supabaseAdmin
-        .from("sales_accounts")
-        .insert({
+      const { findOrCreateSalesAccount } = await import("@/lib/salesAccountResolver");
+      try {
+        const account = await findOrCreateSalesAccount({
           business_name: deal.business_name,
-          contact_name: lead?.contact_name || null,
-          phone: lead?.phone || null,
-          email: lead?.email || null,
-          address: lead?.address || null,
-        })
-        .select("id")
-        .single();
-
-      if (account) {
+          contact_name: lead?.contact_name ?? null,
+          phone: lead?.phone ?? null,
+          email: lead?.email ?? null,
+          address: lead?.address ?? null,
+        });
         updates.account_id = account.id;
+      } catch {
+        // Leave account_id null on failure — non-fatal.
       }
     }
 

--- a/src/app/api/sales/leads/[id]/convert/route.ts
+++ b/src/app/api/sales/leads/[id]/convert/route.ts
@@ -35,30 +35,22 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
     return NextResponse.json({ error: "Lead is already in a pipeline" }, { status: 400 });
   }
 
-  // Create or find account
+  // Route both the find and the create through the shared resolver
+  // so normalized email/name/phone matching applies uniformly.
   let accountId = lead.account_id;
   if (!accountId) {
-    const { data: existingAccount } = await supabaseAdmin
-      .from("sales_accounts")
-      .select("id")
-      .eq("email", lead.email)
-      .maybeSingle();
-
-    if (existingAccount) {
-      accountId = existingAccount.id;
-    } else {
-      const { data: newAccount } = await supabaseAdmin
-        .from("sales_accounts")
-        .insert({
-          business_name: lead.business_name,
-          contact_name: lead.contact_name,
-          email: lead.email,
-          phone: lead.phone,
-          address: lead.address,
-        })
-        .select("id")
-        .single();
-      accountId = newAccount?.id || null;
+    const { findOrCreateSalesAccount } = await import("@/lib/salesAccountResolver");
+    try {
+      const resolved = await findOrCreateSalesAccount({
+        business_name: lead.business_name,
+        contact_name: lead.contact_name,
+        email: lead.email,
+        phone: lead.phone,
+        address: lead.address,
+      });
+      accountId = resolved.id;
+    } catch {
+      accountId = null;
     }
   }
 

--- a/src/app/api/sales/leads/import/route.ts
+++ b/src/app/api/sales/leads/import/route.ts
@@ -65,20 +65,26 @@ export async function POST(req: NextRequest) {
     const immediateNeed = row.immediate_need && VALID_IMMEDIATE_NEEDS.includes(row.immediate_need)
       ? row.immediate_need : null;
 
-    const { data: account } = await supabaseAdmin
-      .from("sales_accounts")
-      .insert({
+    // Dedup-guarded: CSV imports historically forked accounts per
+    // row. Now a re-import with the same contact email/business
+    // reuses the existing row.
+    const { findOrCreateSalesAccount } = await import("@/lib/salesAccountResolver");
+    let account: { id: string } | null = null;
+    try {
+      const resolved = await findOrCreateSalesAccount({
         business_name: row.business_name.trim(),
-        contact_name: row.contact_name?.trim() || null,
-        phone: row.phone?.trim() || null,
-        email: row.email?.trim() || null,
-        address: row.address?.trim() || null,
+        contact_name: row.contact_name?.trim(),
+        phone: row.phone?.trim(),
+        email: row.email?.trim(),
+        address: row.address?.trim(),
         entity_type: entityType,
         assigned_to: user.id,
         created_by: user.id,
-      })
-      .select("id")
-      .single();
+      });
+      account = { id: resolved.id };
+    } catch {
+      account = null;
+    }
 
     const { error } = await supabaseAdmin
       .from("sales_leads")

--- a/src/app/api/sales/leads/route.ts
+++ b/src/app/api/sales/leads/route.ts
@@ -94,23 +94,25 @@ export async function POST(req: NextRequest) {
     }
   }
 
-  const { data: account, error: acctErr } = await supabaseAdmin
-    .from("sales_accounts")
-    .insert({
+  // Dedup guard — reuse an existing sales_accounts row for this
+  // customer instead of forking a new one.
+  const { findOrCreateSalesAccount } = await import("@/lib/salesAccountResolver");
+  let account: { id: string };
+  try {
+    const resolved = await findOrCreateSalesAccount({
       business_name,
-      contact_name: contact_name || null,
-      phone: phone || null,
-      email: email || null,
-      address: address || null,
-      entity_type: entity_type || null,
+      contact_name,
+      phone,
+      email,
+      address,
+      entity_type,
       assigned_to: user.id,
       created_by: user.id,
-    })
-    .select("id")
-    .single();
-
-  if (acctErr) {
-    return NextResponse.json({ error: `Account create failed: ${acctErr.message}` }, { status: 500 });
+    });
+    account = { id: resolved.id };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "unknown";
+    return NextResponse.json({ error: `Account create failed: ${msg}` }, { status: 500 });
   }
 
   const { data, error } = await supabaseAdmin

--- a/src/app/sales/page.tsx
+++ b/src/app/sales/page.tsx
@@ -506,9 +506,12 @@ function ExecutiveSnapshot({ data }: { data: SnapshotResponse }) {
           icon={<FileText className="h-4 w-4" />}
           label="Quotes"
           primary={`${q.sent} sent`}
-          numerator={q.closed}
-          denominator={q.sent}
-          progressLabel={`${q.closed} closed (${Math.round(q.close_rate * 100)}% close rate)`}
+          numerator={0}
+          denominator={0}
+          // Close-rate matching is unreliable until admin dedup finishes
+          // (see /admin/accounts/duplicates). Show a truthful placeholder
+          // instead of the misleading 0% we used to render.
+          progressLabel="Close rate: pending admin dedup"
           rows={[
             [`Converted to order`, `${q.converted}`],
             [`Outstanding`, `${q.outstanding}`],
@@ -522,9 +525,17 @@ function ExecutiveSnapshot({ data }: { data: SnapshotResponse }) {
           label="Orders"
           primary={`${o.placed} placed`}
           numerator={o.completed}
-          denominator={Math.max(o.placed, o.completed)}
-          progressLabel={`${o.completed} completed`}
+          denominator={Math.max(o.placed, 1)}
+          // Interim honest headline: fulfillment rate = completed / placed.
+          // Doesn't depend on cross-flow customer linkage, so it's the
+          // one order/quote metric that works today.
+          progressLabel={
+            o.placed === 0
+              ? "—"
+              : `Fulfillment rate ${Math.round((o.completed / o.placed) * 100)}%`
+          }
           rows={[
+            [`Completed`, `${o.completed}`],
             [`Outstanding`, `${o.outstanding}`],
             [`Revenue`, `$${o.revenue.toLocaleString("en-US", { maximumFractionDigits: 0 })}`],
           ]}

--- a/src/lib/coffeeCrmMirror.ts
+++ b/src/lib/coffeeCrmMirror.ts
@@ -12,6 +12,7 @@
 
 import { supabaseAdmin } from "./supabaseAdmin";
 import { writeAuditLog } from "./paymentLedger";
+import { findOrCreateSalesAccount } from "./salesAccountResolver";
 
 export interface MirrorResult {
   status: "created" | "already_mirrored" | "skipped_not_paid" | "not_found";
@@ -22,9 +23,10 @@ export interface MirrorResult {
 }
 
 /**
- * Find or create a sales_accounts row for a coffee-order buyer. Uses
- * profile.email as the natural key. If nothing matches, creates a minimal
- * account so the CRM link is preserved.
+ * Find or create a sales_accounts row for a coffee-order buyer via the
+ * shared findOrCreateSalesAccount helper — same normalization used
+ * everywhere else, so rep-created accounts and mirror-created accounts
+ * dedup on matching email or business_name.
  */
 async function ensureAccountForOperator(operatorId: string): Promise<string | null> {
   const { data: profile } = await supabaseAdmin
@@ -34,38 +36,18 @@ async function ensureAccountForOperator(operatorId: string): Promise<string | nu
     .maybeSingle();
   if (!profile) return null;
 
-  // Try existing account by email
-  if (profile.email) {
-    const { data: existing } = await supabaseAdmin
-      .from("sales_accounts")
-      .select("id")
-      .eq("email", profile.email.toLowerCase())
-      .maybeSingle();
-    if (existing) return existing.id;
-  }
-
-  // Fall back to name match
   const businessName = profile.company_name?.trim() || profile.full_name?.trim() || "Coffee Customer";
-  const { data: byName } = await supabaseAdmin
-    .from("sales_accounts")
-    .select("id")
-    .eq("business_name", businessName)
-    .maybeSingle();
-  if (byName) return byName.id;
-
-  // Create a new account. business_name is NOT NULL.
-  const { data: created, error } = await supabaseAdmin
-    .from("sales_accounts")
-    .insert({
+  try {
+    const { id } = await findOrCreateSalesAccount({
+      email: profile.email ?? null,
       business_name: businessName,
-      contact_name: profile.full_name || null,
-      email: profile.email?.toLowerCase() || null,
-      phone: profile.phone || null,
-    })
-    .select("id")
-    .single();
-  if (error || !created) return null;
-  return created.id;
+      contact_name: profile.full_name ?? null,
+      phone: profile.phone ?? null,
+    });
+    return id;
+  } catch {
+    return null;
+  }
 }
 
 export async function mirrorCoffeeOrderToCrm(coffeeOrderId: string): Promise<MirrorResult> {

--- a/src/lib/paymentHandlers.ts
+++ b/src/lib/paymentHandlers.ts
@@ -396,18 +396,21 @@ export async function handleMachinePurchaseCompleted(params: {
         })
         .eq("id", purchaseId);
     } else {
-      const { data: account } = await supabaseAdmin
-        .from("sales_accounts")
-        .insert({
+      const { findOrCreateSalesAccount } = await import("./salesAccountResolver");
+      let account: { id: string } | null = null;
+      try {
+        const resolved = await findOrCreateSalesAccount({
           business_name: purchaseBizName,
           contact_name: purchase.full_name,
           phone: purchase.phone,
           email: purchase.email,
           address: purchase.location_address || null,
           entity_type: "operator",
-        })
-        .select("id")
-        .single();
+        });
+        account = { id: resolved.id };
+      } catch {
+        account = null;
+      }
 
       if (account) {
         const { data: lead } = await supabaseAdmin

--- a/src/lib/salesAccountResolver.ts
+++ b/src/lib/salesAccountResolver.ts
@@ -1,0 +1,182 @@
+/**
+ * findOrCreateSalesAccount — the ONE way to obtain a sales_accounts.id
+ * from customer identity fields.
+ *
+ * Root problem this exists to solve: sales_accounts had no dedup guard,
+ * so every intake flow (rep-typed accounts, lead intake, coffee mirror,
+ * financing, request-location, agreements, etc.) created its own row
+ * for the same real customer. Result: `account_id` was a row-identity
+ * key, not a customer-identity key, and cross-flow metrics like close
+ * rate could never match.
+ *
+ * Contract:
+ *   - Given identity fields, return the id of the ONE canonical row.
+ *   - If a match already exists (by normalized email, or by normalized
+ *     business_name + normalized phone), return it — do not INSERT.
+ *   - If nothing matches, INSERT a new row with the passed fields and
+ *     return its id.
+ *   - Existing rows are NOT overwritten by this call. Pass
+ *     `patchMissing: true` to opt in to updating null-or-empty fields
+ *     on the existing row from the new inputs.
+ *
+ * Race-safety: the underlying partial indexes (migration 135) are
+ * NON-UNIQUE while historical duplicates exist. Two callers racing on
+ * the same-identity insert can therefore each produce a fresh row.
+ * This is an accepted trade-off until the admin merge UI drives
+ * duplicates to zero and a follow-up migration promotes the indexes
+ * to UNIQUE. In practice the race window is tiny; the admin merge UI
+ * will always be available to clean up if it happens.
+ */
+
+import { supabaseAdmin } from "./supabaseAdmin";
+
+export interface AccountIdentity {
+  email?: string | null;
+  business_name?: string | null;
+  phone?: string | null;
+  contact_name?: string | null;
+  address?: string | null;
+  notes?: string | null;
+  entity_type?: string | null;
+  notification_emails?: string | null;
+  market_assignment?: string | null;
+  assigned_to?: string | null;
+  created_by?: string | null;
+}
+
+export interface ResolvedAccount {
+  id: string;
+  created: boolean;
+  matchedBy: "email" | "name+phone" | "name" | null;
+}
+
+function normEmail(s: string | null | undefined): string | null {
+  if (!s) return null;
+  const t = s.trim().toLowerCase();
+  return t || null;
+}
+
+function normName(s: string | null | undefined): string | null {
+  if (!s) return null;
+  const t = s.trim().toLowerCase().replace(/\s+/g, " ");
+  return t || null;
+}
+
+function normPhone(s: string | null | undefined): string | null {
+  if (!s) return null;
+  const t = s.replace(/\D/g, "");
+  return t || null;
+}
+
+export async function findOrCreateSalesAccount(
+  identity: AccountIdentity,
+  options: { patchMissing?: boolean } = {},
+): Promise<ResolvedAccount> {
+  const email = normEmail(identity.email);
+  const name = normName(identity.business_name);
+  const phone = normPhone(identity.phone);
+
+  // We need at least SOMETHING to look up on. If the caller has neither
+  // an email nor a business name, we can't dedup — just insert.
+  const canLookup = !!email || !!name;
+
+  let matched:
+    | { id: string; email: string | null; business_name: string | null; phone: string | null; contact_name: string | null; address: string | null; notes: string | null }
+    | null = null;
+  let matchedBy: ResolvedAccount["matchedBy"] = null;
+
+  if (canLookup) {
+    // 1. Email match (highest confidence).
+    if (email) {
+      const { data } = await supabaseAdmin
+        .from("sales_accounts")
+        .select("id, email, business_name, phone, contact_name, address, notes")
+        .eq("normalized_email", email)
+        .is("deleted_at", null)
+        .order("created_at", { ascending: true })
+        .limit(1);
+      if (data && data.length > 0) {
+        matched = data[0];
+        matchedBy = "email";
+      }
+    }
+
+    // 2. Business name + phone.
+    if (!matched && name && phone) {
+      const { data } = await supabaseAdmin
+        .from("sales_accounts")
+        .select("id, email, business_name, phone, contact_name, address, notes")
+        .eq("normalized_business_name", name)
+        .eq("normalized_phone", phone)
+        .is("deleted_at", null)
+        .order("created_at", { ascending: true })
+        .limit(1);
+      if (data && data.length > 0) {
+        matched = data[0];
+        matchedBy = "name+phone";
+      }
+    }
+
+    // 3. Business name alone (last resort — deliberately not matched
+    // when phone was provided but didn't match, since that's stronger
+    // evidence of a different customer).
+    if (!matched && name && !phone) {
+      const { data } = await supabaseAdmin
+        .from("sales_accounts")
+        .select("id, email, business_name, phone, contact_name, address, notes")
+        .eq("normalized_business_name", name)
+        .is("deleted_at", null)
+        .order("created_at", { ascending: true })
+        .limit(1);
+      if (data && data.length > 0) {
+        matched = data[0];
+        matchedBy = "name";
+      }
+    }
+  }
+
+  if (matched) {
+    if (options.patchMissing) {
+      const patch: Record<string, unknown> = {};
+      if (!matched.email && identity.email) patch.email = identity.email;
+      if (!matched.business_name && identity.business_name) patch.business_name = identity.business_name;
+      if (!matched.phone && identity.phone) patch.phone = identity.phone;
+      if (!matched.contact_name && identity.contact_name) patch.contact_name = identity.contact_name;
+      if (!matched.address && identity.address) patch.address = identity.address;
+      if (Object.keys(patch).length > 0) {
+        await supabaseAdmin.from("sales_accounts").update(patch).eq("id", matched.id);
+      }
+    }
+    return { id: matched.id, created: false, matchedBy };
+  }
+
+  // Insert new. business_name is NOT NULL on sales_accounts; fall back
+  // to email-local-part or "(unnamed)" so the insert doesn't reject.
+  const bizName = identity.business_name?.trim()
+    || (identity.email ? identity.email.split("@")[0] : null)
+    || "(unnamed)";
+
+  const { data: created, error } = await supabaseAdmin
+    .from("sales_accounts")
+    .insert({
+      business_name: bizName,
+      contact_name: identity.contact_name ?? null,
+      email: identity.email ?? null,
+      phone: identity.phone ?? null,
+      address: identity.address ?? null,
+      notes: identity.notes ?? null,
+      entity_type: identity.entity_type ?? null,
+      notification_emails: identity.notification_emails ?? null,
+      market_assignment: identity.market_assignment ?? null,
+      assigned_to: identity.assigned_to ?? null,
+      created_by: identity.created_by ?? null,
+    })
+    .select("id")
+    .single();
+
+  if (error || !created) {
+    throw error ?? new Error("findOrCreateSalesAccount: insert failed");
+  }
+
+  return { id: created.id, created: true, matchedBy: null };
+}

--- a/supabase/migrations/135_sales_accounts_dedup_scaffold.sql
+++ b/supabase/migrations/135_sales_accounts_dedup_scaffold.sql
@@ -1,0 +1,55 @@
+-- Migration 135: sales_accounts dedup scaffold (NON-UNIQUE indexes)
+--
+-- Purpose: introduce normalized identity columns + lookup indexes so the
+-- app-layer findOrCreateSalesAccount helper can dedup NEW inserts.
+-- Existing duplicate rows are left in place — the admin merge UI is the
+-- only path that mutates historical customer data.
+--
+-- IMPORTANT — index uniqueness:
+--   We install NON-UNIQUE partial indexes here. Because production
+--   already contains many duplicate customer rows for the same real
+--   entity (see the trace behind commit b2d2840), a UNIQUE index
+--   would fail to build and would abort this migration. The
+--   uniqueness guarantee is therefore enforced at the application
+--   layer (findOrCreateSalesAccount) until an admin has run the merge
+--   UI enough times that no duplicates remain among non-blank rows.
+--   At that point a follow-up migration can promote these indexes to
+--   UNIQUE partial indexes — the predicates already exclude NULL and
+--   blank values so they'll only collide on real dup identity strings.
+--
+-- Generated columns are STORED so the indexes can use them; the
+-- expressions used (LOWER, TRIM, REGEXP_REPLACE) are all IMMUTABLE.
+
+ALTER TABLE public.sales_accounts
+  ADD COLUMN IF NOT EXISTS normalized_email text
+    GENERATED ALWAYS AS (LOWER(BTRIM(email))) STORED,
+  ADD COLUMN IF NOT EXISTS normalized_business_name text
+    GENERATED ALWAYS AS (
+      LOWER(REGEXP_REPLACE(BTRIM(business_name), '\s+', ' ', 'g'))
+    ) STORED,
+  ADD COLUMN IF NOT EXISTS normalized_phone text
+    GENERATED ALWAYS AS (REGEXP_REPLACE(COALESCE(phone, ''), '\D', '', 'g')) STORED,
+  ADD COLUMN IF NOT EXISTS deleted_at timestamptz;
+
+COMMENT ON COLUMN public.sales_accounts.normalized_email IS
+  'LOWER(TRIM(email)). Populated automatically. Used by findOrCreateSalesAccount + admin duplicate-review to bridge rows with the same customer email regardless of casing/whitespace.';
+COMMENT ON COLUMN public.sales_accounts.normalized_business_name IS
+  'LOWER(collapsed-whitespace(TRIM(business_name))). Fallback bridge when email is missing.';
+COMMENT ON COLUMN public.sales_accounts.normalized_phone IS
+  'Digits-only phone. Paired with normalized_business_name as a secondary bridge.';
+COMMENT ON COLUMN public.sales_accounts.deleted_at IS
+  'Soft-delete flag set when a row is absorbed by an admin-confirmed merge. Rows with this set are hidden from all lookups; the row remains for rollback.';
+
+-- ── Partial NON-UNIQUE indexes ──────────────────────────────────────
+-- Predicates exclude blanks so we can promote to UNIQUE later without
+-- a data-cleaning step for empty strings.
+CREATE INDEX IF NOT EXISTS idx_sales_accounts_normalized_email_lookup
+  ON public.sales_accounts (normalized_email)
+  WHERE normalized_email IS NOT NULL AND normalized_email <> '' AND deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_sales_accounts_normalized_name_phone_lookup
+  ON public.sales_accounts (normalized_business_name, normalized_phone)
+  WHERE normalized_business_name IS NOT NULL AND normalized_business_name <> '' AND deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_sales_accounts_deleted_at
+  ON public.sales_accounts (deleted_at) WHERE deleted_at IS NULL;

--- a/supabase/migrations/136_sales_account_merges.sql
+++ b/supabase/migrations/136_sales_account_merges.sql
@@ -1,0 +1,274 @@
+-- Migration 136: sales_account_merges + admin merge/rollback functions
+--
+-- Everything historical dedup does happens through these functions,
+-- called only from the admin-confirmed merge UI. No automated bulk
+-- backfill exists or runs.
+
+CREATE TABLE IF NOT EXISTS public.sales_account_merges (
+  id                     uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  canonical_id           uuid NOT NULL REFERENCES public.sales_accounts(id) ON DELETE RESTRICT,
+  absorbed_id            uuid NOT NULL REFERENCES public.sales_accounts(id) ON DELETE RESTRICT,
+  -- Full snapshot of the absorbed row at merge time so a rollback can
+  -- reinstate it byte-for-byte.
+  absorbed_row_snapshot  jsonb NOT NULL,
+  -- Per-table row-id list of what got repointed. Enables precise
+  -- rollback of only THIS merge's FK swaps (not any subsequent
+  -- merges that used the same canonical).
+  --   { "sales_orders": ["uuid1","uuid2"], "sales_leads": [...], ... }
+  fk_swap_details        jsonb NOT NULL DEFAULT '{}'::jsonb,
+  merged_by              uuid REFERENCES public.profiles(id),
+  merged_at              timestamptz NOT NULL DEFAULT now(),
+  rolled_back_at         timestamptz,
+  rolled_back_by         uuid REFERENCES public.profiles(id),
+  notes                  text
+);
+
+CREATE INDEX IF NOT EXISTS idx_sales_account_merges_canonical
+  ON public.sales_account_merges (canonical_id);
+CREATE INDEX IF NOT EXISTS idx_sales_account_merges_absorbed
+  ON public.sales_account_merges (absorbed_id);
+CREATE INDEX IF NOT EXISTS idx_sales_account_merges_active
+  ON public.sales_account_merges (merged_at) WHERE rolled_back_at IS NULL;
+
+-- Locked-down RLS: service role only. The admin UI calls via the
+-- service-role client through /api/admin/sales-accounts/*.
+ALTER TABLE public.sales_account_merges ENABLE ROW LEVEL SECURITY;
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='sales_account_merges' AND policyname='sales_account_merges_service_role') THEN
+    CREATE POLICY sales_account_merges_service_role ON public.sales_account_merges
+      FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
+END $$;
+
+-- ── merge_sales_accounts(canonical, absorbed[], merged_by) ──────────
+-- Runs as a single implicit transaction. On any failure the whole
+-- merge aborts. Returns the array of merge_log ids produced.
+CREATE OR REPLACE FUNCTION public.merge_sales_accounts(
+  p_canonical_id uuid,
+  p_absorbed_ids uuid[],
+  p_merged_by    uuid,
+  p_notes        text DEFAULT NULL
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_absorbed_id uuid;
+  v_snapshot    jsonb;
+  v_details     jsonb;
+  v_ids         uuid[];
+  v_merge_id    uuid;
+  v_merge_ids   uuid[] := '{}';
+  v_canonical_exists boolean;
+BEGIN
+  -- Guard: canonical must exist and be non-deleted.
+  SELECT (deleted_at IS NULL) INTO v_canonical_exists
+  FROM public.sales_accounts WHERE id = p_canonical_id;
+  IF NOT COALESCE(v_canonical_exists, false) THEN
+    RAISE EXCEPTION 'canonical account % not found or deleted', p_canonical_id;
+  END IF;
+
+  FOREACH v_absorbed_id IN ARRAY p_absorbed_ids LOOP
+    IF v_absorbed_id = p_canonical_id THEN
+      RAISE EXCEPTION 'cannot absorb canonical into itself: %', v_absorbed_id;
+    END IF;
+
+    -- Snapshot the absorbed row.
+    SELECT to_jsonb(sa.*) INTO v_snapshot
+    FROM public.sales_accounts sa WHERE sa.id = v_absorbed_id;
+    IF v_snapshot IS NULL THEN
+      RAISE EXCEPTION 'absorbed account % not found', v_absorbed_id;
+    END IF;
+
+    v_details := '{}'::jsonb;
+
+    -- ── FK sweep. Each block: capture ids being changed, then UPDATE. ──
+    -- sales_orders.account_id
+    SELECT COALESCE(array_agg(id), '{}') INTO v_ids
+      FROM public.sales_orders WHERE account_id = v_absorbed_id;
+    IF array_length(v_ids, 1) IS NOT NULL THEN
+      UPDATE public.sales_orders SET account_id = p_canonical_id WHERE id = ANY(v_ids);
+      v_details := jsonb_set(v_details, '{sales_orders}', to_jsonb(v_ids), true);
+    END IF;
+
+    -- sales_leads.account_id
+    SELECT COALESCE(array_agg(id), '{}') INTO v_ids
+      FROM public.sales_leads WHERE account_id = v_absorbed_id;
+    IF array_length(v_ids, 1) IS NOT NULL THEN
+      UPDATE public.sales_leads SET account_id = p_canonical_id WHERE id = ANY(v_ids);
+      v_details := jsonb_set(v_details, '{sales_leads}', to_jsonb(v_ids), true);
+    END IF;
+
+    -- sales_deals.account_id
+    SELECT COALESCE(array_agg(id), '{}') INTO v_ids
+      FROM public.sales_deals WHERE account_id = v_absorbed_id;
+    IF array_length(v_ids, 1) IS NOT NULL THEN
+      UPDATE public.sales_deals SET account_id = p_canonical_id WHERE id = ANY(v_ids);
+      v_details := jsonb_set(v_details, '{sales_deals}', to_jsonb(v_ids), true);
+    END IF;
+
+    -- sales_documents.account_id
+    IF to_regclass('public.sales_documents') IS NOT NULL THEN
+      SELECT COALESCE(array_agg(id), '{}') INTO v_ids
+        FROM public.sales_documents WHERE account_id = v_absorbed_id;
+      IF array_length(v_ids, 1) IS NOT NULL THEN
+        UPDATE public.sales_documents SET account_id = p_canonical_id WHERE id = ANY(v_ids);
+        v_details := jsonb_set(v_details, '{sales_documents}', to_jsonb(v_ids), true);
+      END IF;
+    END IF;
+
+    -- intake_leads.account_id
+    IF to_regclass('public.intake_leads') IS NOT NULL THEN
+      SELECT COALESCE(array_agg(id), '{}') INTO v_ids
+        FROM public.intake_leads WHERE account_id = v_absorbed_id;
+      IF array_length(v_ids, 1) IS NOT NULL THEN
+        UPDATE public.intake_leads SET account_id = p_canonical_id WHERE id = ANY(v_ids);
+        v_details := jsonb_set(v_details, '{intake_leads}', to_jsonb(v_ids), true);
+      END IF;
+    END IF;
+
+    -- location_requests.account_id
+    IF to_regclass('public.location_requests') IS NOT NULL THEN
+      SELECT COALESCE(array_agg(id), '{}') INTO v_ids
+        FROM public.location_requests WHERE account_id = v_absorbed_id;
+      IF array_length(v_ids, 1) IS NOT NULL THEN
+        UPDATE public.location_requests SET account_id = p_canonical_id WHERE id = ANY(v_ids);
+        v_details := jsonb_set(v_details, '{location_requests}', to_jsonb(v_ids), true);
+      END IF;
+    END IF;
+
+    -- pipeline_items.account_id
+    IF to_regclass('public.pipeline_items') IS NOT NULL THEN
+      SELECT COALESCE(array_agg(id), '{}') INTO v_ids
+        FROM public.pipeline_items WHERE account_id = v_absorbed_id;
+      IF array_length(v_ids, 1) IS NOT NULL THEN
+        UPDATE public.pipeline_items SET account_id = p_canonical_id WHERE id = ANY(v_ids);
+        v_details := jsonb_set(v_details, '{pipeline_items}', to_jsonb(v_ids), true);
+      END IF;
+    END IF;
+
+    -- agreement_tokens.account_id
+    IF to_regclass('public.agreement_tokens') IS NOT NULL THEN
+      SELECT COALESCE(array_agg(id), '{}') INTO v_ids
+        FROM public.agreement_tokens WHERE account_id = v_absorbed_id;
+      IF array_length(v_ids, 1) IS NOT NULL THEN
+        UPDATE public.agreement_tokens SET account_id = p_canonical_id WHERE id = ANY(v_ids);
+        v_details := jsonb_set(v_details, '{agreement_tokens}', to_jsonb(v_ids), true);
+      END IF;
+    END IF;
+
+    -- invoices.account_id
+    IF to_regclass('public.invoices') IS NOT NULL THEN
+      SELECT COALESCE(array_agg(id), '{}') INTO v_ids
+        FROM public.invoices WHERE account_id = v_absorbed_id;
+      IF array_length(v_ids, 1) IS NOT NULL THEN
+        UPDATE public.invoices SET account_id = p_canonical_id WHERE id = ANY(v_ids);
+        v_details := jsonb_set(v_details, '{invoices}', to_jsonb(v_ids), true);
+      END IF;
+    END IF;
+
+    -- payments.account_id
+    IF to_regclass('public.payments') IS NOT NULL THEN
+      SELECT COALESCE(array_agg(id), '{}') INTO v_ids
+        FROM public.payments WHERE account_id = v_absorbed_id;
+      IF array_length(v_ids, 1) IS NOT NULL THEN
+        UPDATE public.payments SET account_id = p_canonical_id WHERE id = ANY(v_ids);
+        v_details := jsonb_set(v_details, '{payments}', to_jsonb(v_ids), true);
+      END IF;
+    END IF;
+
+    -- account_equipment.account_id
+    IF to_regclass('public.account_equipment') IS NOT NULL THEN
+      SELECT COALESCE(array_agg(id), '{}') INTO v_ids
+        FROM public.account_equipment WHERE account_id = v_absorbed_id;
+      IF array_length(v_ids, 1) IS NOT NULL THEN
+        UPDATE public.account_equipment SET account_id = p_canonical_id WHERE id = ANY(v_ids);
+        v_details := jsonb_set(v_details, '{account_equipment}', to_jsonb(v_ids), true);
+      END IF;
+    END IF;
+
+    -- workflows.company_id (note different column name)
+    IF to_regclass('public.workflows') IS NOT NULL THEN
+      SELECT COALESCE(array_agg(id), '{}') INTO v_ids
+        FROM public.workflows WHERE company_id = v_absorbed_id;
+      IF array_length(v_ids, 1) IS NOT NULL THEN
+        UPDATE public.workflows SET company_id = p_canonical_id WHERE id = ANY(v_ids);
+        v_details := jsonb_set(v_details, '{workflows}', to_jsonb(v_ids), true);
+      END IF;
+    END IF;
+
+    -- Soft-delete the absorbed row (leave in place for rollback).
+    UPDATE public.sales_accounts SET deleted_at = now() WHERE id = v_absorbed_id;
+
+    -- Write merge log row.
+    INSERT INTO public.sales_account_merges
+      (canonical_id, absorbed_id, absorbed_row_snapshot, fk_swap_details, merged_by, notes)
+    VALUES
+      (p_canonical_id, v_absorbed_id, v_snapshot, v_details, p_merged_by, p_notes)
+    RETURNING id INTO v_merge_id;
+
+    v_merge_ids := array_append(v_merge_ids, v_merge_id);
+  END LOOP;
+
+  RETURN jsonb_build_object('merge_ids', v_merge_ids, 'count', array_length(v_merge_ids, 1));
+END;
+$$;
+
+-- ── rollback_sales_account_merge(merge_id, rolled_back_by) ──────────
+-- Reverses ONE merge cleanly. Reads fk_swap_details to know which
+-- specific rows to swap back, so if the canonical has been merged
+-- into multiple times, we only unwind THIS merge.
+CREATE OR REPLACE FUNCTION public.rollback_sales_account_merge(
+  p_merge_id        uuid,
+  p_rolled_back_by  uuid
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_merge     public.sales_account_merges;
+  v_key       text;
+  v_ids       uuid[];
+BEGIN
+  SELECT * INTO v_merge FROM public.sales_account_merges WHERE id = p_merge_id;
+  IF v_merge.id IS NULL THEN
+    RAISE EXCEPTION 'merge % not found', p_merge_id;
+  END IF;
+  IF v_merge.rolled_back_at IS NOT NULL THEN
+    RAISE EXCEPTION 'merge % already rolled back at %', p_merge_id, v_merge.rolled_back_at;
+  END IF;
+
+  -- Un-soft-delete the absorbed row.
+  UPDATE public.sales_accounts SET deleted_at = NULL WHERE id = v_merge.absorbed_id;
+
+  -- Swap the specific FK rows back to the absorbed id.
+  FOR v_key IN SELECT jsonb_object_keys(v_merge.fk_swap_details) LOOP
+    v_ids := ARRAY(SELECT jsonb_array_elements_text(v_merge.fk_swap_details->v_key))::uuid[];
+    IF array_length(v_ids, 1) IS NULL THEN CONTINUE; END IF;
+
+    IF v_key = 'sales_orders'      THEN UPDATE public.sales_orders      SET account_id = v_merge.absorbed_id WHERE id = ANY(v_ids); END IF;
+    IF v_key = 'sales_leads'       THEN UPDATE public.sales_leads       SET account_id = v_merge.absorbed_id WHERE id = ANY(v_ids); END IF;
+    IF v_key = 'sales_deals'       THEN UPDATE public.sales_deals       SET account_id = v_merge.absorbed_id WHERE id = ANY(v_ids); END IF;
+    IF v_key = 'sales_documents'   THEN UPDATE public.sales_documents   SET account_id = v_merge.absorbed_id WHERE id = ANY(v_ids); END IF;
+    IF v_key = 'intake_leads'      THEN UPDATE public.intake_leads      SET account_id = v_merge.absorbed_id WHERE id = ANY(v_ids); END IF;
+    IF v_key = 'location_requests' THEN UPDATE public.location_requests SET account_id = v_merge.absorbed_id WHERE id = ANY(v_ids); END IF;
+    IF v_key = 'pipeline_items'    THEN UPDATE public.pipeline_items    SET account_id = v_merge.absorbed_id WHERE id = ANY(v_ids); END IF;
+    IF v_key = 'agreement_tokens'  THEN UPDATE public.agreement_tokens  SET account_id = v_merge.absorbed_id WHERE id = ANY(v_ids); END IF;
+    IF v_key = 'invoices'          THEN UPDATE public.invoices          SET account_id = v_merge.absorbed_id WHERE id = ANY(v_ids); END IF;
+    IF v_key = 'payments'          THEN UPDATE public.payments          SET account_id = v_merge.absorbed_id WHERE id = ANY(v_ids); END IF;
+    IF v_key = 'account_equipment' THEN UPDATE public.account_equipment SET account_id = v_merge.absorbed_id WHERE id = ANY(v_ids); END IF;
+    IF v_key = 'workflows'         THEN UPDATE public.workflows         SET company_id = v_merge.absorbed_id WHERE id = ANY(v_ids); END IF;
+  END LOOP;
+
+  -- Mark merge as rolled back (keep row for audit).
+  UPDATE public.sales_account_merges
+    SET rolled_back_at = now(),
+        rolled_back_by = p_rolled_back_by
+    WHERE id = p_merge_id;
+
+  RETURN jsonb_build_object('ok', true, 'merge_id', p_merge_id);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.merge_sales_accounts(uuid, uuid[], uuid, text) TO service_role;
+GRANT EXECUTE ON FUNCTION public.rollback_sales_account_merge(uuid, uuid) TO service_role;


### PR DESCRIPTION
Three pieces, none of which mutate existing customer rows automatically.

1) DEDUP GUARD (going forward)
- Migration 135 adds normalized_email, normalized_business_name, normalized_phone STORED generated columns and deleted_at on sales_accounts. Predicated non-unique partial indexes for lookup. Explicit choice: NON-UNIQUE, because production already has duplicate rows and a plain UNIQUE index would fail to build, aborting the migration. Uniqueness is enforced at the app layer via findOrCreateSalesAccount until admin merge drives duplicates to zero; a follow-up migration can then promote to UNIQUE partial indexes (predicates already exclude NULL/blank so they will not trip on empty rows).
- New src/lib/salesAccountResolver.ts — findOrCreateSalesAccount(). Matches by normalized email, then (normalized name + normalized phone), then normalized name alone. Only inserts when nothing matches. Never overwrites existing fields unless {patchMissing: true} is passed. Race note documented in the header.
- Wired into EVERY naked sales_accounts insert site (grep-verified): src/lib/coffeeCrmMirror.ts (ensureAccountForOperator) src/lib/paymentHandlers.ts (machine listing purchase) src/app/api/sales/accounts/route.ts (manual account create) src/app/api/sales/leads/route.ts (lead intake) src/app/api/sales/leads/[id]/convert/route.ts src/app/api/sales/leads/import/route.ts (CSV import) src/app/api/sales/deals/[id]/route.ts (stage=won auto-attach) src/app/api/request-location/route.ts src/app/api/intake/route.ts src/app/api/financing/route.ts src/app/api/auth/signup-lead/route.ts src/app/api/admin/users/[id]/add-to-crm/route.ts

2) INTERIM HONEST METRIC
- Quotes tile close-rate progress bar replaced with the truthful "Close rate: pending admin dedup". Rows still show sent / outstanding / converted / total_value.
- Orders tile progress bar now shows "Fulfillment rate N%" (completed / placed) — an honest metric that does not depend on cross-flow customer linkage and works today.

3) ADMIN DUPLICATE-REVIEW SCREEN (human-in-the-loop)
- Migration 136 creates sales_account_merges (canonical_id, absorbed_id, absorbed_row_snapshot jsonb, fk_swap_details jsonb, merged_by/at, rolled_back_by/at) with service-role-only RLS.
- Two PL/pgSQL functions (both run in a single implicit transaction, both SECURITY DEFINER, both GRANTed to service_role): merge_sales_accounts(canonical, absorbed[], by, notes) — snapshots absorbed row, sweeps every FK across sales_orders/sales_leads/sales_deals/sales_documents/ intake_leads/location_requests/pipeline_items/ agreement_tokens/invoices/payments/account_equipment/ workflows.company_id, soft-deletes absorbed rows, writes an audit row with per-table swapped row-id lists. rollback_sales_account_merge(merge_id, by) — reads fk_swap_details and swaps only THIS merge's specific rows back; un-soft-deletes; marks the merge row rolled_back.
- GET /api/admin/sales-accounts/duplicates lists clusters (by normalized email first, then name+phone), enriched with per-row quote / order / paid_order / deal / workflow counts.
- POST /api/admin/sales-accounts/merge supports dry_run:true (preview counts only, no writes) and dry_run:false (calls the RPC). Zod-validated.
- POST /api/admin/sales-accounts/merge/[id]/rollback.
- Admin UI at /admin/accounts/duplicates lists clusters, opens each in a review modal with a smart canonical suggestion (row with the most paid orders wins), shows a Preview before Confirm, requires explicit admin confirmation per cluster.

CONSTRAINT: no automatic bulk backfill exists or runs. All historical remediation happens ONLY through the admin merge UI, one cluster at a time, admin-confirmed. Migrations must be applied manually in Supabase.

SELF-AUDIT
- typecheck: clean
- lint: 2 pre-existing warnings on files I didn't touch (unused `product`, `userId`); zero errors on my changes
- find-or-create semantics: reads first, inserts only on miss; race-safe on UNIQUE index NOT guaranteed (indexes are non-unique by intent — documented)
- Every insert site converted: 12 sites, listed above, grep verified zero remaining `.from("sales_accounts").insert` outside the resolver
- Merge is transactional per cluster (PL/pgSQL runs as one implicit txn) and chunked one cluster per HTTP request
- Rollback captures: absorbed_row_snapshot (jsonb full row) + fk_swap_details (per-table row-id list). Rollback function reads fk_swap_details and reverses only this merge's swaps
- Nothing else mutates customer rows: helper only INSERTs (create path) or SELECTs (find path); patchMissing:true is opt-in and no current caller passes it


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2