### PR TITLE
Exec dashboard — Overdue row always red on Workflows tile

### DIFF
--- a/src/app/sales/page.tsx
+++ b/src/app/sales/page.tsx
@@ -574,11 +574,14 @@ function ExecutiveSnapshot({ data }: { data: SnapshotResponse }) {
           denominator={w.active}
           progressLabel={w.active === 0 ? "—" : `${w.active - w.overdue - w.unassigned} on track`}
           rows={[
-            // Overdue row flips red when > 0 so the exec eye can catch
-            // it at a glance. The `deadline.overdue` cron simultaneously
-            // fires an email to every admin the first time each
-            // workflow crosses its deadline (send_once per admin).
-            [`Overdue`, `${w.overdue}`, w.overdue > 0 ? "danger" : undefined],
+            // Overdue row is ALWAYS red — even at 0. The visual weight
+            // is intentional: it's the metric the exec is scanning for,
+            // and the red label keeps the eye trained on it whether the
+            // count is currently non-zero or not. The daily
+            // deadline.overdue cron also emails every admin the first
+            // time each workflow crosses its deadline (send_once per
+            // admin).
+            [`Overdue`, `${w.overdue}`, "danger"],
             [`Unassigned`, `${w.unassigned}`],
             [`Due within 7d`, `${w.due_7d}`],
           ]}


### PR DESCRIPTION
Previously the row only turned red when overdue count was >0; at 0 it faded into gray. The exec ask is to make it always red so the label carries visual weight as the metric to watch even when today's number happens to be 0.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2