### PR TITLE
Inventory bugfixes — supplier validation + marketplace SKU import

### DIFF
--- a/src/app/admin/inventory/setup/skus/page.tsx
+++ b/src/app/admin/inventory/setup/skus/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { createBrowserClient } from "@/lib/supabase";
-import { Loader2, Package, ChevronLeft, Plus, Pencil, X, Search } from "lucide-react";
+import { Loader2, Package, ChevronLeft, Plus, Pencil, X, Search, Download } from "lucide-react";
 
 interface SKU {
   id: string;
@@ -37,7 +37,46 @@ export default function SkusPage() {
   const [search, setSearch] = useState("");
   const [categoryFilter, setCategoryFilter] = useState<string>("all");
   const [reloadKey, setReloadKey] = useState(0);
+  const [importing, setImporting] = useState(false);
+  const [importSummary, setImportSummary] = useState<{
+    total_products: number;
+    created: number;
+    skipped_already_linked: number;
+    skipped_sku_conflict: number;
+    errors: Array<{ product_name: string; reason: string }>;
+  } | null>(null);
   const reload = () => setReloadKey((k) => k + 1);
+
+  async function runImport() {
+    if (!token) return;
+    if (
+      !window.confirm(
+        "Import every unlinked marketplace coffee product as an inventory SKU?\n\nSkips products that already have an inventory SKU linked.\nSkips codes that collide with an existing non-linked SKU (surfaced for manual review).",
+      )
+    )
+      return;
+    setImporting(true);
+    setImportSummary(null);
+    const res = await fetch("/api/admin/inventory/skus/import-from-coffee-products", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    setImporting(false);
+    if (res.ok) {
+      const summary = await res.json();
+      setImportSummary(summary);
+      reload();
+    } else {
+      const err = await res.json().catch(() => ({}));
+      setImportSummary({
+        total_products: 0,
+        created: 0,
+        skipped_already_linked: 0,
+        skipped_sku_conflict: 0,
+        errors: [{ product_name: "—", reason: err.error ?? "Import failed" }],
+      });
+    }
+  }
 
   useEffect(() => {
     let cancelled = false;
@@ -130,14 +169,55 @@ export default function SkusPage() {
             Everything countable. Link a marketplace coffee product so fulfillment consumption bridges into the ledger automatically.
           </p>
         </div>
-        <button
-          type="button"
-          onClick={() => setCreating(true)}
-          className="inline-flex items-center gap-1.5 rounded-md bg-emerald-600 text-white px-3 py-2 text-sm font-medium hover:bg-emerald-700"
-        >
-          <Plus className="h-4 w-4" /> New SKU
-        </button>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={runImport}
+            disabled={importing}
+            className="inline-flex items-center gap-1.5 rounded-md border border-gray-200 bg-white text-gray-700 px-3 py-2 text-sm font-medium hover:bg-gray-50 disabled:opacity-50"
+            title="Create inventory SKUs from every marketplace coffee product that doesn't have one yet"
+          >
+            {importing ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
+            Import from Marketplace
+          </button>
+          <button
+            type="button"
+            onClick={() => setCreating(true)}
+            className="inline-flex items-center gap-1.5 rounded-md bg-emerald-600 text-white px-3 py-2 text-sm font-medium hover:bg-emerald-700"
+          >
+            <Plus className="h-4 w-4" /> New SKU
+          </button>
+        </div>
       </div>
+
+      {importSummary && (
+        <div className="mb-4 rounded-lg border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-900">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <strong>Import complete.</strong> Created {importSummary.created} · already linked {importSummary.skipped_already_linked} · sku-code conflicts {importSummary.skipped_sku_conflict}
+              {importSummary.errors.length > 0 && (
+                <ul className="mt-2 text-xs text-red-700 list-disc list-inside">
+                  {importSummary.errors.slice(0, 10).map((e, i) => (
+                    <li key={i}>
+                      <strong>{e.product_name}</strong>: {e.reason}
+                    </li>
+                  ))}
+                  {importSummary.errors.length > 10 && (
+                    <li>…and {importSummary.errors.length - 10} more</li>
+                  )}
+                </ul>
+              )}
+            </div>
+            <button
+              type="button"
+              onClick={() => setImportSummary(null)}
+              className="text-emerald-700 hover:text-emerald-900 text-xs"
+            >
+              Dismiss
+            </button>
+          </div>
+        </div>
+      )}
 
       {unlinkedCoffeeCount > 0 && (
         <div className="mb-4 rounded-lg bg-amber-50 border border-amber-200 text-amber-800 p-3 text-sm">

--- a/src/app/api/admin/inventory/skus/import-from-coffee-products/route.ts
+++ b/src/app/api/admin/inventory/skus/import-from-coffee-products/route.ts
@@ -1,0 +1,109 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+
+/**
+ * POST /api/admin/inventory/skus/import-from-coffee-products
+ *
+ * One-click bulk import: for every coffee_products row that doesn't
+ * already have a matching inventory_skus (linked by coffee_product_id
+ * or by sku_code collision), create one. Uses coffee_products.sku as
+ * the SKU code, name, description, unit, min_order_qty (as pack_size),
+ * and active flag. Category defaults to "coffee".
+ *
+ * Idempotent — running twice creates nothing the second time. Returns
+ * per-row outcomes so the UI can show "created N, skipped N already
+ * linked, N had SKU code collisions".
+ */
+export async function POST(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  // Every coffee product.
+  const { data: products, error: pErr } = await supabaseAdmin
+    .from("coffee_products")
+    .select("id, sku, name, description, unit, min_order_qty, active")
+    .order("name", { ascending: true });
+  if (pErr) return NextResponse.json({ error: pErr.message }, { status: 500 });
+  const productList = (products ?? []) as Array<{
+    id: string;
+    sku: string;
+    name: string;
+    description: string | null;
+    unit: string | null;
+    min_order_qty: number | null;
+    active: boolean;
+  }>;
+
+  if (productList.length === 0) {
+    return NextResponse.json({
+      total_products: 0,
+      created: 0,
+      skipped_already_linked: 0,
+      skipped_sku_conflict: 0,
+      errors: [],
+    });
+  }
+
+  // What's already linked or code-taken?
+  const { data: existingSkusData } = await supabaseAdmin
+    .from("inventory_skus")
+    .select("id, sku_code, coffee_product_id");
+  const existingSkus = (existingSkusData ?? []) as Array<{
+    id: string;
+    sku_code: string;
+    coffee_product_id: string | null;
+  }>;
+  const linkedProductIds = new Set(
+    existingSkus.map((s) => s.coffee_product_id).filter(Boolean) as string[],
+  );
+  const takenSkuCodes = new Set(existingSkus.map((s) => s.sku_code.toLowerCase()));
+
+  let created = 0;
+  let skippedAlreadyLinked = 0;
+  let skippedSkuConflict = 0;
+  const errors: Array<{ product_id: string; product_name: string; reason: string }> = [];
+
+  for (const p of productList) {
+    if (linkedProductIds.has(p.id)) {
+      skippedAlreadyLinked += 1;
+      continue;
+    }
+    if (takenSkuCodes.has(p.sku.toLowerCase())) {
+      // Another inventory SKU already claims this code but isn't linked
+      // to this product — surface it rather than silently overwrite.
+      skippedSkuConflict += 1;
+      errors.push({
+        product_id: p.id,
+        product_name: p.name,
+        reason: `sku_code "${p.sku}" already taken by a non-linked inventory SKU — link manually`,
+      });
+      continue;
+    }
+
+    const { error } = await supabaseAdmin.from("inventory_skus").insert({
+      sku_code: p.sku,
+      name: p.name,
+      description: p.description ?? null,
+      category: "coffee",
+      unit_of_measure: p.unit ?? "each",
+      pack_size: Math.max(1, Number(p.min_order_qty ?? 1)),
+      coffee_product_id: p.id,
+      active: p.active,
+      created_by: adminId,
+    });
+    if (error) {
+      errors.push({ product_id: p.id, product_name: p.name, reason: error.message });
+    } else {
+      created += 1;
+    }
+  }
+
+  return NextResponse.json({
+    total_products: productList.length,
+    created,
+    skipped_already_linked: skippedAlreadyLinked,
+    skipped_sku_conflict: skippedSkuConflict,
+    errors,
+  });
+}

--- a/src/app/api/admin/inventory/suppliers/[id]/route.ts
+++ b/src/app/api/admin/inventory/suppliers/[id]/route.ts
@@ -3,16 +3,30 @@ import { z } from "zod";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { getAdminUserId } from "@/lib/adminAuth";
 
+const nullableStr = (max: number) =>
+  z.preprocess(
+    (v) => (typeof v === "string" && v.trim() === "" ? null : v),
+    z.string().max(max).nullable().optional(),
+  );
+const nullableInt = (min: number) =>
+  z.preprocess(
+    (v) => (v === "" || v === null || v === undefined ? null : Number(v)),
+    z.number().int().min(min).nullable().optional(),
+  );
+
 const patchSchema = z.object({
   name: z.string().min(1).max(200).optional(),
-  contact_name: z.string().max(200).nullable().optional(),
-  contact_email: z.string().email().nullable().optional(),
-  contact_phone: z.string().max(50).nullable().optional(),
-  address: z.string().max(1000).nullable().optional(),
-  lead_time_days: z.number().int().min(0).optional(),
-  minimum_order_qty: z.number().int().min(0).nullable().optional(),
-  payment_terms: z.string().max(200).nullable().optional(),
-  notes: z.string().max(2000).nullable().optional(),
+  contact_name: nullableStr(200),
+  contact_email: nullableStr(200), // free-text, no email format check
+  contact_phone: nullableStr(50),
+  address: nullableStr(1000),
+  lead_time_days: z.preprocess(
+    (v) => (v === "" || v === null || v === undefined ? undefined : Number(v)),
+    z.number().int().min(0).optional(),
+  ),
+  minimum_order_qty: nullableInt(0),
+  payment_terms: nullableStr(200),
+  notes: nullableStr(2000),
   active: z.boolean().optional(),
 });
 
@@ -26,7 +40,12 @@ export async function PATCH(
 
   const parsed = patchSchema.safeParse(await req.json().catch(() => ({})));
   if (!parsed.success) {
-    return NextResponse.json({ error: "Invalid input", details: parsed.error.format() }, { status: 400 });
+    const first = parsed.error.issues[0];
+    const path = first?.path?.join(".") || "unknown_field";
+    return NextResponse.json(
+      { error: `Invalid input on ${path}: ${first?.message ?? "validation failed"}`, details: parsed.error.format() },
+      { status: 400 },
+    );
   }
   const { data, error } = await supabaseAdmin
     .from("suppliers")

--- a/src/app/api/admin/inventory/suppliers/route.ts
+++ b/src/app/api/admin/inventory/suppliers/route.ts
@@ -3,16 +3,35 @@ import { z } from "zod";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { getAdminUserId } from "@/lib/adminAuth";
 
+// Empty strings from the modal's text inputs should be treated as
+// null on optional fields — otherwise "" fails max/type validation.
+const nullableStr = (max: number) =>
+  z.preprocess(
+    (v) => (typeof v === "string" && v.trim() === "" ? null : v),
+    z.string().max(max).nullable().optional(),
+  );
+const nullableInt = (min: number) =>
+  z.preprocess(
+    (v) => (v === "" || v === null || v === undefined ? null : Number(v)),
+    z.number().int().min(min).nullable().optional(),
+  );
+
 const createSchema = z.object({
   name: z.string().min(1).max(200),
-  contact_name: z.string().max(200).nullable().optional(),
-  contact_email: z.string().email().nullable().optional(),
-  contact_phone: z.string().max(50).nullable().optional(),
-  address: z.string().max(1000).nullable().optional(),
-  lead_time_days: z.number().int().min(0).default(7),
-  minimum_order_qty: z.number().int().min(0).nullable().optional(),
-  payment_terms: z.string().max(200).nullable().optional(),
-  notes: z.string().max(2000).nullable().optional(),
+  contact_name: nullableStr(200),
+  // contact_email is descriptive not authentication — accept any free
+  // text up to 200 chars rather than reject when an admin types e.g.
+  // "sales at company dot com" or a name here.
+  contact_email: nullableStr(200),
+  contact_phone: nullableStr(50),
+  address: nullableStr(1000),
+  lead_time_days: z.preprocess(
+    (v) => (v === "" || v === null || v === undefined ? 7 : Number(v)),
+    z.number().int().min(0).default(7),
+  ),
+  minimum_order_qty: nullableInt(0),
+  payment_terms: nullableStr(200),
+  notes: nullableStr(2000),
   active: z.boolean().default(true),
 });
 
@@ -38,7 +57,12 @@ export async function POST(req: NextRequest) {
 
   const parsed = createSchema.safeParse(await req.json().catch(() => ({})));
   if (!parsed.success) {
-    return NextResponse.json({ error: "Invalid input", details: parsed.error.format() }, { status: 400 });
+    const first = parsed.error.issues[0];
+    const path = first?.path?.join(".") || "unknown_field";
+    return NextResponse.json(
+      { error: `Invalid input on ${path}: ${first?.message ?? "validation failed"}`, details: parsed.error.format() },
+      { status: 400 },
+    );
   }
   const { data, error } = await supabaseAdmin
     .from("suppliers")


### PR DESCRIPTION
Two bugs from initial inventory system rollout:

1) Adding a new supplier returned "Invalid input" with no clue why.
   Root cause: zod schema had contact_email: z.string().email(),
   which rejects anything that isn't a valid RFC email — an admin
   typing "sales at company" or accidentally putting a name in that
   field would fail silently. Also empty-string values from text
   inputs failed max()/type validation on optional fields.

   Fix on both POST + PATCH:
   - Drop .email() on contact_email (descriptive not authentication, accept any free text up to 200 chars).
   - New nullableStr()/nullableInt() preprocess helpers coerce "" and null/undefined to null before validation on every optional string/int field.
   - lead_time_days uses the same preprocess so a blank field falls back to the default (7) instead of failing.
   - Error payload now names the failed field: "Invalid input on contact_email: ..." instead of generic "Invalid input".

2) Every marketplace coffee product had to be manually re-created as
   an inventory SKU before Phase 2 consumption could flow. Admins
   asked for a one-click import.

   Fix: new endpoint POST /api/admin/inventory/skus/import-from-
   coffee-products, plus an "Import from Marketplace" button on the
   /admin/inventory/setup/skus page.

   Import behavior:
   - Fetches every coffee_products row
   - For each: creates an inventory_skus row with coffee_products.sku as sku_code, name, description, unit, min_order_qty as pack_size, and coffee_product_id linked back
   - Skips products already linked (idempotent — safe to re-run)
   - Skips products whose SKU code is already claimed by a non-linked inventory SKU, and surfaces those in an errors list so admin can resolve manually
   - Returns per-outcome counts (created / already_linked / sku_conflict) plus the errors list

   UI surfaces the summary as an inline emerald card after import,
   with dismissable per-product error rows for anything the import
   couldn't handle.

typecheck + lint clean.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2