### PR TITLE
Workflows — everyone sees all, assignees can edit theirs

### DIFF
--- a/src/app/api/workflows/[id]/deadline/route.ts
+++ b/src/app/api/workflows/[id]/deadline/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getWorkflowActor, hasPermission } from "@/lib/workflows/permissions";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { canOperationallyEditWorkflow, getWorkflowActor } from "@/lib/workflows/permissions";
 import { changeDeadlineSchema } from "@/lib/workflows/schemas";
 import { changeDeadline } from "@/lib/workflows/service";
 
@@ -9,11 +10,21 @@ export async function PATCH(
 ) {
   const actor = await getWorkflowActor(req);
   if (!actor) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  if (!hasPermission(actor, "workflows.edit_deadline")) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
 
   const { id } = await params;
+
+  // Deadline nudges are an operational edit — elevated roles OR the
+  // assignee/collaborator on this specific workflow can change it.
+  const { data: workflow } = await supabaseAdmin
+    .from("workflows")
+    .select("id, customer_id, assigned_user_id")
+    .eq("id", id)
+    .maybeSingle();
+  if (!workflow) return NextResponse.json({ error: "Workflow not found" }, { status: 404 });
+  if (!(await canOperationallyEditWorkflow(actor, workflow))) {
+    return NextResponse.json({ error: "Forbidden — you must be assigned to change this workflow's deadline" }, { status: 403 });
+  }
+
   const body = await req.json().catch(() => ({}));
   const parsed = changeDeadlineSchema.safeParse({ ...body, workflowId: id });
   if (!parsed.success) {
@@ -21,8 +32,8 @@ export async function PATCH(
   }
 
   try {
-    const workflow = await changeDeadline({ ...parsed.data, changedBy: actor.id });
-    return NextResponse.json({ ok: true, workflow });
+    const updated = await changeDeadline({ ...parsed.data, changedBy: actor.id });
+    return NextResponse.json({ ok: true, workflow: updated });
   } catch (err) {
     return NextResponse.json({ error: err instanceof Error ? err.message : "Failed" }, { status: 400 });
   }

--- a/src/app/api/workflows/[id]/stages/[stageKey]/route.ts
+++ b/src/app/api/workflows/[id]/stages/[stageKey]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
-import { getWorkflowActor, hasPermission } from "@/lib/workflows/permissions";
+import { canOperationallyEditWorkflow, getWorkflowActor, hasPermission, isStaff } from "@/lib/workflows/permissions";
 import { updateStageSchema } from "@/lib/workflows/schemas";
 import { updateStage } from "@/lib/workflows/service";
 
@@ -35,34 +35,41 @@ export async function PATCH(
 
   const input = parsed.data;
 
-  // Permission checks by field.
-  if (input.completedQuantity !== undefined && !hasPermission(actor, "workflows.edit_quantity")) {
-    return NextResponse.json({ error: "Forbidden — cannot edit quantity" }, { status: 403 });
-  }
-  if (input.status !== undefined && !hasPermission(actor, "workflows.edit_status")) {
-    return NextResponse.json({ error: "Forbidden — cannot edit status" }, { status: 403 });
-  }
-  if (input.internalNotes !== undefined && !hasPermission(actor, "workflows.add_internal_notes")) {
-    return NextResponse.json({ error: "Forbidden — cannot add internal notes" }, { status: 403 });
-  }
-  if (input.customerMessage !== undefined && !hasPermission(actor, "workflows.publish_customer_updates")) {
-    return NextResponse.json({ error: "Forbidden — cannot publish customer updates" }, { status: 403 });
-  }
-  // Renaming a stage is a status-class edit — sales_manager and above.
-  if (input.stageName !== undefined && !hasPermission(actor, "workflows.edit_status")) {
-    return NextResponse.json({ error: "Forbidden — cannot rename stage" }, { status: 403 });
-  }
-  if (input.allowOverTarget && !hasPermission(actor, "workflows.override_validation")) {
-    return NextResponse.json({ error: "Forbidden — cannot override validation" }, { status: 403 });
-  }
-
-  // Workflow existence check for a clean 404 (service throws otherwise).
+  // Load the workflow up front — every permission below depends on
+  // whether the actor is assigned to THIS workflow, not just their
+  // role in the abstract.
   const { data: workflow } = await supabaseAdmin
     .from("workflows")
     .select("id, customer_id, assigned_user_id")
     .eq("id", id)
     .maybeSingle();
   if (!workflow) return NextResponse.json({ error: "Workflow not found" }, { status: 404 });
+
+  // Operational edits (status / quantity / stage rename) — sales
+  // reps assigned to THIS workflow can now do these, matching how
+  // elevated roles have always been able to. Customer-visible
+  // messages, override-target, and internal-notes stay on their
+  // original gates.
+  const canOperationallyEdit = await canOperationallyEditWorkflow(actor, workflow);
+
+  if (input.completedQuantity !== undefined && !canOperationallyEdit) {
+    return NextResponse.json({ error: "Forbidden — you must be assigned to edit this workflow" }, { status: 403 });
+  }
+  if (input.status !== undefined && !canOperationallyEdit) {
+    return NextResponse.json({ error: "Forbidden — you must be assigned to edit this workflow" }, { status: 403 });
+  }
+  if (input.stageName !== undefined && !canOperationallyEdit) {
+    return NextResponse.json({ error: "Forbidden — you must be assigned to edit this workflow" }, { status: 403 });
+  }
+  if (input.internalNotes !== undefined && !isStaff(actor)) {
+    return NextResponse.json({ error: "Forbidden — cannot add internal notes" }, { status: 403 });
+  }
+  if (input.customerMessage !== undefined && !hasPermission(actor, "workflows.publish_customer_updates")) {
+    return NextResponse.json({ error: "Forbidden — cannot publish customer updates" }, { status: 403 });
+  }
+  if (input.allowOverTarget && !hasPermission(actor, "workflows.override_validation")) {
+    return NextResponse.json({ error: "Forbidden — cannot override validation" }, { status: 403 });
+  }
 
   try {
     const result = await updateStage({

--- a/src/lib/workflows/permissions.ts
+++ b/src/lib/workflows/permissions.ts
@@ -18,10 +18,18 @@ export interface WorkflowActor {
   scope: "all" | "assigned" | "own";
 }
 
-const ROLES_VIEW_ALL = new Set(["admin", "director_of_sales", "market_leader"]);
-const ROLES_VIEW_ASSIGNED = new Set(["sales_manager", "sales"]);
+// Every staff role now views ALL workflows — visibility is not what
+// gates write access. Editing is gated per-workflow via
+// canOperationallyEditWorkflow() (elevated role OR active assignment).
+const ROLES_VIEW_ALL = new Set([
+  "admin",
+  "director_of_sales",
+  "market_leader",
+  "sales_manager",
+  "sales",
+]);
 
-// Every staff role can add internal notes and view assigned/all workflows.
+// Every staff role can add internal notes and view all workflows.
 const STAFF_ROLES = new Set([
   "admin",
   "director_of_sales",
@@ -31,8 +39,9 @@ const STAFF_ROLES = new Set([
 ]);
 
 // Roles allowed to edit stage state / assign / edit deadlines / publish
-// customer updates. Individual `sales` reps can view but not edit,
-// keeping accidental writes to a minimum.
+// customer updates unconditionally (no assignment check needed). Sales
+// reps get equivalent edit rights on workflows they're ASSIGNED to via
+// the canOperationallyEditWorkflow() helper below.
 const ROLES_EDIT = new Set(["admin", "director_of_sales", "market_leader", "sales_manager"]);
 const ROLES_PUBLISH_CUSTOMER_UPDATES = new Set(["admin", "director_of_sales", "market_leader"]);
 const ROLES_ADMIN_ONLY = new Set(["admin"]);
@@ -52,9 +61,7 @@ export async function getWorkflowActor(req: NextRequest): Promise<WorkflowActor 
   const role = profile.role ?? "";
   const scope: "all" | "assigned" | "own" = ROLES_VIEW_ALL.has(role)
     ? "all"
-    : ROLES_VIEW_ASSIGNED.has(role)
-      ? "assigned"
-      : "own";
+    : "own";
 
   return {
     id: profile.id,
@@ -129,4 +136,42 @@ export async function canViewWorkflow(
 
 export function isStaff(actor: WorkflowActor): boolean {
   return STAFF_ROLES.has(actor.role);
+}
+
+/**
+ * Check whether a staff actor is currently assigned to a workflow —
+ * either as primary owner or as an active collaborator. Used by the
+ * "sales rep can edit the workflows on their plate" path.
+ */
+export async function isAssignedToWorkflow(
+  actorId: string,
+  workflow: { id: string; assigned_user_id: string | null },
+): Promise<boolean> {
+  if (workflow.assigned_user_id === actorId) return true;
+  const { data } = await supabaseAdmin
+    .from("workflow_assignments")
+    .select("id")
+    .eq("workflow_id", workflow.id)
+    .eq("user_id", actorId)
+    .eq("active", true)
+    .maybeSingle();
+  return !!data;
+}
+
+/**
+ * The single gate for "day-to-day" workflow edits — stage status,
+ * completed quantity, stage rename, deadline nudge, internal notes.
+ * Returns true when the actor has an unconditional edit role (admin
+ * / DOS / market_leader / sales_manager) OR is assigned to this
+ * specific workflow. Elevated actions (cancel / reopen / delete /
+ * publish customer updates / payment override) stay strictly
+ * role-based via hasPermission.
+ */
+export async function canOperationallyEditWorkflow(
+  actor: WorkflowActor,
+  workflow: { id: string; assigned_user_id: string | null },
+): Promise<boolean> {
+  if (ROLES_EDIT.has(actor.role)) return true;
+  if (!isStaff(actor)) return false;
+  return isAssignedToWorkflow(actor.id, workflow);
 }


### PR DESCRIPTION
Visibility change:
- ROLES_VIEW_ALL now includes every staff role (sales_manager, sales). All staff members see every workflow — the CRM list at /sales/workflows shows the whole org, not just what's assigned.
- Retired the "assigned" scope entirely; getWorkflowActor now returns "all" for staff and "own" for customers/others.

Interaction change:
- New canOperationallyEditWorkflow(actor, workflow) helper: returns true when the actor has an unconditional edit role (admin / DOS / market_leader / sales_manager) OR is currently the primary owner or an active collaborator on this specific workflow.
- Stage PATCH endpoint routes status / quantity / stage-rename edits through this gate. Sales reps assigned to a workflow can now update its stages; sales reps NOT assigned still can't.
- Deadline PATCH endpoint same treatment — assignees can nudge their own workflow's due date.
- internal_notes stays permissive to all staff (low-stakes collaboration).
- customer_message, cancel, reopen, delete, payment override, manage_templates all stay strictly role-based via hasPermission.

Also added an isAssignedToWorkflow() export for callers that just need the "is this actor on the assignment list" test without the role part.

typecheck + lint clean.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2