### PR TITLE
Inventory — on-hand refetches after saving a physical count

### DIFF
--- a/src/app/admin/inventory/page.tsx
+++ b/src/app/admin/inventory/page.tsx
@@ -331,6 +331,10 @@ export default function InventoryReplenishmentPage() {
         `Count saved. Ledger on-hand ${j.computedOnHandBefore} → ${j.computedOnHandAfter}.`,
       );
       setCountModal(null);
+      // Refetch so the on-hand column reflects the new count instead
+      // of the stale ledger value the recommendation was computed
+      // against. Every other action handler does this on success.
+      reload();
     } else {
       const err = await res.json().catch(() => ({}));
       showToast("error", err.error ?? "Count failed");


### PR DESCRIPTION
submitCount fired the API, showed the toast, and closed the modal — but never called reload(), so the recommendations table still showed the pre-count on-hand value the run was originally computed against. Every other action handler on this page (accept, snooze, cancel, edit) calls reload() on success; this one was the outlier.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2