### PR TITLE
Agreements show source Order/Quote #; orders sort by owner

### DIFF
--- a/src/app/api/sales/agreements/route.ts
+++ b/src/app/api/sales/agreements/route.ts
@@ -13,9 +13,12 @@ export async function GET(req: NextRequest) {
   const status = searchParams.get("status");
   const agreementType = searchParams.get("type");
 
+  // Join the source order (if any) so the list can display the
+  // originating order/quote number — "Agreement from Order #147" is
+  // what the sales team wants to see, not a bare UUID.
   let query = supabaseAdmin
     .from("purchase_agreements")
-    .select("*")
+    .select("*, sales_orders(order_number, document_type)")
     .order("created_at", { ascending: false });
 
   if (status && status !== "all") {

--- a/src/app/sales/agreements/page.tsx
+++ b/src/app/sales/agreements/page.tsx
@@ -43,6 +43,10 @@ interface AgreementRow {
   // "Sales Person" column for accountability tracking.
   rep_name: string | null;
   rep_email: string | null;
+  // Joined from the source sales_orders row (if any) — lets us show
+  // "Agreement from Order #147" or "…from Quote #147" rather than
+  // burying the origin behind an opaque order_id UUID.
+  sales_orders: { order_number: number | null; document_type: string | null } | null;
 }
 
 const STATUS_COLORS: Record<string, string> = {
@@ -311,6 +315,7 @@ export default function AgreementsListPage() {
                   <th className="text-left px-4 py-3 font-medium text-gray-500">Term</th>
                   <th className="text-right px-4 py-3 font-medium text-gray-500">Commission</th>
                   <th className="text-left px-4 py-3 font-medium text-gray-500">Created</th>
+                  <th className="text-left px-4 py-3 font-medium text-gray-500">Source</th>
                 </tr>
               ) : (
                 <tr>
@@ -359,6 +364,23 @@ export default function AgreementsListPage() {
                       <td className="px-4 py-3 text-xs text-gray-500">
                         {new Date(ag.created_at).toLocaleDateString()}
                       </td>
+                      <td className="px-4 py-3">
+                        {ag.sales_orders?.order_number != null ? (
+                          <span
+                            className={`text-xs px-2 py-0.5 rounded-full font-mono ${
+                              ag.sales_orders.document_type === "quote"
+                                ? "text-indigo-700 bg-indigo-50"
+                                : "text-blue-700 bg-blue-50"
+                            }`}
+                          >
+                            {ag.sales_orders.document_type === "quote" ? "Quote" : "Order"} #{ag.sales_orders.order_number}
+                          </span>
+                        ) : (
+                          <span className="text-xs text-gray-500 bg-gray-100 px-2 py-0.5 rounded-full">
+                            Standalone
+                          </span>
+                        )}
+                      </td>
                     </tr>
                   );
                 }
@@ -395,7 +417,17 @@ export default function AgreementsListPage() {
                       {new Date(ag.created_at).toLocaleDateString()}
                     </td>
                     <td className="px-4 py-3">
-                      {ag.order_id ? (
+                      {ag.sales_orders?.order_number != null ? (
+                        <span
+                          className={`text-xs px-2 py-0.5 rounded-full font-mono ${
+                            ag.sales_orders.document_type === "quote"
+                              ? "text-indigo-700 bg-indigo-50"
+                              : "text-blue-700 bg-blue-50"
+                          }`}
+                        >
+                          {ag.sales_orders.document_type === "quote" ? "Quote" : "Order"} #{ag.sales_orders.order_number}
+                        </span>
+                      ) : ag.order_id ? (
                         <span className="text-xs text-blue-600 bg-blue-50 px-2 py-0.5 rounded-full">
                           Order
                         </span>

--- a/src/app/sales/orders/page.tsx
+++ b/src/app/sales/orders/page.tsx
@@ -101,6 +101,8 @@ export default function OrdersPage() {
   const [token, setToken] = useState("");
   const [statusFilter, setStatusFilter] = useState("all");
   const [search, setSearch] = useState("");
+  const [ownerFilter, setOwnerFilter] = useState<string>("all");
+  const [sortBy, setSortBy] = useState<"newest" | "oldest" | "owner_az" | "amount_desc" | "amount_asc">("newest");
   // Read ?doc=quote on first render so the Executive Snapshot's Quotes
   // card can deep-link straight into the quotes toggle without an extra
   // click. Undefined/other values keep the default (orders).
@@ -157,6 +159,44 @@ export default function OrdersPage() {
 
   const isQuote = docType === "quote";
   const docLabel = isQuote ? "Quote" : "Order";
+
+  // Distinct owners in the currently-loaded list — used to populate
+  // the owner filter dropdown. "Owner" here means the assigned rep
+  // (assigned_profile) since that's the person accountable day-to-day;
+  // created_by is a separate concept (e.g. an admin filing the order
+  // for a rep). Sort alphabetically so the dropdown is scannable.
+  const uniqueOwners = Array.from(
+    new Map(
+      orders
+        .filter((o) => o.assigned_profile?.full_name)
+        .map((o) => [o.assigned_profile!.full_name, o.assigned_profile!.full_name]),
+    ).values(),
+  ).sort((a, b) => a.localeCompare(b));
+
+  const displayOrders = orders
+    .filter((o) => {
+      if (ownerFilter === "all") return true;
+      if (ownerFilter === "unassigned") return !o.assigned_profile?.full_name;
+      return o.assigned_profile?.full_name === ownerFilter;
+    })
+    .slice()
+    .sort((a, b) => {
+      const ta = a.created_at ? new Date(a.created_at).getTime() : 0;
+      const tb = b.created_at ? new Date(b.created_at).getTime() : 0;
+      switch (sortBy) {
+        case "oldest": return ta - tb;
+        case "owner_az": {
+          const na = a.assigned_profile?.full_name || "￿"; // unassigned last
+          const nb = b.assigned_profile?.full_name || "￿";
+          const c = na.localeCompare(nb);
+          return c !== 0 ? c : tb - ta;
+        }
+        case "amount_desc": return Number(b.total_value || 0) - Number(a.total_value || 0);
+        case "amount_asc": return Number(a.total_value || 0) - Number(b.total_value || 0);
+        case "newest":
+        default: return tb - ta;
+      }
+    });
 
   async function deleteOrder(orderId: string, orderNumber: number | string) {
     const label = `${docLabel} #${orderNumber || orderId.slice(0, 6).toUpperCase()}`;
@@ -296,6 +336,41 @@ export default function OrdersPage() {
         </div>
       </div>
 
+      {/* Owner filter + sort — client-side over the already-loaded
+          page. Owner options come from the assigned reps present in
+          the current result set, so managers see who's on the board
+          without having to remember names. */}
+      <div className="mb-4 flex flex-wrap items-center gap-3 text-sm">
+        <label className="flex items-center gap-2 text-gray-500">
+          <span>Owner:</span>
+          <select
+            value={ownerFilter}
+            onChange={(e) => setOwnerFilter(e.target.value)}
+            className="rounded-lg border border-gray-200 px-2 py-1.5 text-sm focus:border-green-500 focus:outline-none cursor-pointer"
+          >
+            <option value="all">All</option>
+            <option value="unassigned">Unassigned</option>
+            {uniqueOwners.map((name) => (
+              <option key={name} value={name}>{name}</option>
+            ))}
+          </select>
+        </label>
+        <label className="flex items-center gap-2 text-gray-500">
+          <span>Sort:</span>
+          <select
+            value={sortBy}
+            onChange={(e) => setSortBy(e.target.value as typeof sortBy)}
+            className="rounded-lg border border-gray-200 px-2 py-1.5 text-sm focus:border-green-500 focus:outline-none cursor-pointer"
+          >
+            <option value="newest">Newest first</option>
+            <option value="oldest">Oldest first</option>
+            <option value="owner_az">Owner (A → Z)</option>
+            <option value="amount_desc">Amount (high → low)</option>
+            <option value="amount_asc">Amount (low → high)</option>
+          </select>
+        </label>
+      </div>
+
       {/* Orders List */}
       {loading ? (
         <div className="flex justify-center py-16">
@@ -307,16 +382,18 @@ export default function OrdersPage() {
           <p className="text-sm text-red-500">{fetchError}</p>
           <button onClick={fetchOrders} className="mt-3 text-sm text-green-600 hover:text-green-700 cursor-pointer">Try again</button>
         </div>
-      ) : orders.length === 0 ? (
+      ) : displayOrders.length === 0 ? (
         <div className="py-16 text-center">
           {isQuote ? <FileText className="mx-auto h-10 w-10 text-gray-300 mb-3" /> : <ClipboardList className="mx-auto h-10 w-10 text-gray-300 mb-3" />}
           <p className="text-sm text-gray-400">
-            {statusFilter !== "all" ? `No ${docLabel.toLowerCase()}s match this filter.` : `No ${docLabel.toLowerCase()}s yet. Create one to get started.`}
+            {statusFilter !== "all" || ownerFilter !== "all"
+              ? `No ${docLabel.toLowerCase()}s match these filters.`
+              : `No ${docLabel.toLowerCase()}s yet. Create one to get started.`}
           </p>
         </div>
       ) : (
         <div className="space-y-2">
-          {orders.map((order) => {
+          {displayOrders.map((order) => {
             const Icon = order.order_items?.[0]?.item_type
               ? ITEM_ICONS[order.order_items[0].item_type] || Wrench
               : isQuote ? FileText : ClipboardList;


### PR DESCRIPTION
Agreement list now surfaces the originating order/quote number in the Source column instead of an unlabeled "Order" pill. Joined via purchase_agreements.order_id → sales_orders(order_number, document_type) in the /api/sales/agreements list query, then rendered as "Order #147" or "Quote #147" (indigo tint for quotes so the two are visually distinct at a glance). Standalone agreements — no source order — keep the "Standalone" pill. Same badge added to the Location Placement tab, which previously had no Source column.

Orders/Quotes page gains a client-side Owner filter + Sort dropdown. Owner options are drawn from the reps present in the current result set (assigned_profile.full_name), plus Unassigned. Sort options: Newest, Oldest, Owner A→Z, Amount high→low, Amount low→high. Empty state respects the new filter — "No orders match these filters" when either owner or status is narrowed.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2