### PR TITLE
Coffee minimum order + one-click out-of-stock toggle

### DIFF
--- a/src/app/admin/coffee/page.tsx
+++ b/src/app/admin/coffee/page.tsx
@@ -24,10 +24,11 @@ import {
   Play,
   RefreshCw,
   DollarSign,
+  Settings as SettingsIcon,
 } from "lucide-react";
 import { createBrowserClient } from "@/lib/supabase";
 
-type Tab = "products" | "orders" | "applications" | "guides" | "categories";
+type Tab = "products" | "orders" | "applications" | "guides" | "categories" | "settings";
 
 interface Category {
   id: string;
@@ -522,6 +523,29 @@ export default function AdminCoffeePage() {
     } catch {}
   }
 
+  async function handleStockStatusChange(product: Product, next: string) {
+    if (next === product.stock_status) return;
+    try {
+      const res = await fetch("/api/admin/coffee/products", {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ id: product.id, stock_status: next }),
+      });
+      if (res.ok) {
+        fetchProducts();
+        setToast({ type: "success", message: `Stock marked "${next.replace("_", " ")}"` });
+      } else {
+        const err = await res.json().catch(() => ({}));
+        setToast({ type: "error", message: err.error || "Failed to update stock" });
+      }
+    } catch (e) {
+      setToast({ type: "error", message: e instanceof Error ? e.message : "Failed to update stock" });
+    }
+  }
+
   async function handleUpdateOrderStatus(orderId: string, status: string) {
     setUpdatingOrder(orderId);
     try {
@@ -806,6 +830,7 @@ export default function AdminCoffeePage() {
     { key: "applications", label: "Applications", icon: <FileText className="h-4 w-4" />, count: applications.filter((a) => a.status === "pending").length },
     { key: "guides", label: "How-to Guides", icon: <BookOpen className="h-4 w-4" />, count: guides.length },
     { key: "categories", label: "Categories", icon: <Tag className="h-4 w-4" />, count: categories.length },
+    { key: "settings", label: "Settings", icon: <SettingsIcon className="h-4 w-4" />, count: 0 },
   ];
 
   return (
@@ -1106,13 +1131,24 @@ export default function AdminCoffeePage() {
                         <td className="px-5 py-3 text-right font-medium text-gray-900">${Number(product.price).toFixed(2)}</td>
                         <td className="px-5 py-3 text-right text-gray-600">{Number(product.shipping_cost) > 0 ? `$${Number(product.shipping_cost).toFixed(2)}` : "Free"}</td>
                         <td className="px-5 py-3">
-                          <span className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${
-                            product.stock_status === "in_stock" ? "bg-green-100 text-green-700" :
-                            product.stock_status === "low_stock" ? "bg-yellow-100 text-yellow-700" :
-                            "bg-red-100 text-red-700"
-                          }`}>
-                            {product.stock_status.replace("_", " ")}
-                          </span>
+                          {/* Inline stock-status select — a one-click way for
+                              admins to block ordering of a specific SKU. The
+                              coffee checkout API already rejects lines whose
+                              product.stock_status === "out_of_stock", so
+                              flipping this dropdown is the whole enforcement. */}
+                          <select
+                            value={product.stock_status}
+                            onChange={(e) => handleStockStatusChange(product, e.target.value)}
+                            className={`cursor-pointer rounded-full px-2 py-0.5 text-xs font-medium border-0 focus:outline-none focus:ring-1 focus:ring-green-500 ${
+                              product.stock_status === "in_stock" ? "bg-green-100 text-green-700" :
+                              product.stock_status === "low_stock" ? "bg-yellow-100 text-yellow-700" :
+                              "bg-red-100 text-red-700"
+                            }`}
+                          >
+                            <option value="in_stock">In Stock</option>
+                            <option value="low_stock">Low Stock</option>
+                            <option value="out_of_stock">Out of Stock</option>
+                          </select>
                         </td>
                         <td className="px-5 py-3 text-center">
                           <button
@@ -1779,7 +1815,157 @@ export default function AdminCoffeePage() {
         </div>
       )}
 
+      {activeTab === "settings" && (
+        <SettingsPanel token={token} showToast={(t, m) => setToast({ type: t, message: m })} />
+      )}
+
       {toast && <Toast message={toast.message} type={toast.type} />}
+    </div>
+  );
+}
+
+function SettingsPanel({
+  token,
+  showToast,
+}: {
+  token: string;
+  showToast: (type: "success" | "error", message: string) => void;
+}) {
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [minDollars, setMinDollars] = useState("500");
+  const [enforced, setEnforced] = useState(true);
+  const [updatedAt, setUpdatedAt] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!token) return;
+    (async () => {
+      setLoading(true);
+      try {
+        const res = await fetch("/api/admin/coffee/settings", {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (res.ok) {
+          const data = await res.json();
+          setMinDollars(((data.minimum_order_cents || 0) / 100).toString());
+          setEnforced(!!data.minimum_order_enforced);
+          setUpdatedAt(data.updated_at ?? null);
+        }
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [token]);
+
+  async function save() {
+    const n = Number(minDollars);
+    if (!Number.isFinite(n) || n < 0) {
+      showToast("error", "Minimum must be a non-negative number");
+      return;
+    }
+    setSaving(true);
+    try {
+      const res = await fetch("/api/admin/coffee/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+        body: JSON.stringify({
+          minimum_order_cents: Math.round(n * 100),
+          minimum_order_enforced: enforced,
+        }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setMinDollars(((data.minimum_order_cents || 0) / 100).toString());
+        setEnforced(!!data.minimum_order_enforced);
+        setUpdatedAt(data.updated_at ?? null);
+        showToast("success", "Settings saved");
+      } else {
+        const err = await res.json().catch(() => ({}));
+        showToast("error", err.error || "Save failed");
+      }
+    } catch (e) {
+      showToast("error", e instanceof Error ? e.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <Loader2 className="h-6 w-6 animate-spin text-green-600" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-xl">
+      <div className="rounded-2xl border border-gray-100 bg-white p-6 shadow-sm">
+        <h2 className="text-lg font-bold text-gray-900 mb-1">Order Policies</h2>
+        <p className="text-sm text-gray-500 mb-6">
+          Applies to every coffee order — authenticated operators and guest checkouts alike.
+        </p>
+
+        <div className="space-y-6">
+          <div>
+            <label className="mb-1.5 block text-sm font-medium text-gray-700">
+              Minimum order (subtotal, USD)
+            </label>
+            <div className="relative">
+              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">$</span>
+              <input
+                type="number"
+                min="0"
+                step="1"
+                value={minDollars}
+                onChange={(e) => setMinDollars(e.target.value)}
+                className={`${inputClass} pl-7`}
+                placeholder="500"
+              />
+            </div>
+            <p className="mt-1.5 text-xs text-gray-500">
+              Checkout blocks any order whose subtotal (line items, not counting shipping) is below this amount.
+              The buyer sees the exact shortfall in the error message.
+            </p>
+          </div>
+
+          <div>
+            <label className="flex items-start gap-3 text-sm text-gray-700">
+              <input
+                type="checkbox"
+                checked={enforced}
+                onChange={(e) => setEnforced(e.target.checked)}
+                className="mt-0.5 h-4 w-4 rounded border-gray-300 text-green-600 focus:ring-green-500"
+              />
+              <span>
+                <span className="font-medium">Enforce minimum at checkout</span>
+                <span className="block text-xs text-gray-500 mt-0.5">
+                  Uncheck to temporarily let smaller orders through (e.g. a one-off exception) without deploying a code change.
+                  The minimum stays configured; only enforcement pauses.
+                </span>
+              </span>
+            </label>
+          </div>
+
+          {updatedAt && (
+            <p className="text-xs text-gray-400">
+              Last updated {new Date(updatedAt).toLocaleString()}
+            </p>
+          )}
+
+          <div className="flex gap-2 pt-2 border-t border-gray-100">
+            <button
+              type="button"
+              onClick={save}
+              disabled={saving}
+              className="flex items-center gap-1.5 rounded-lg bg-green-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-green-700 disabled:opacity-50 cursor-pointer"
+            >
+              {saving && <Loader2 className="h-4 w-4 animate-spin" />}
+              Save settings
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/app/api/admin/coffee/settings/route.ts
+++ b/src/app/api/admin/coffee/settings/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { getAdminUserId } from "@/lib/adminAuth";
+import { getCoffeeSettings, updateCoffeeSettings } from "@/lib/coffeeSettings";
+
+/**
+ * GET  /api/admin/coffee/settings — read singleton settings row
+ * PATCH /api/admin/coffee/settings — update minimum_order_cents /
+ *   minimum_order_enforced. Admin-only; every write stamps updated_by
+ *   so we can trace who moved the number in an audit later.
+ *
+ * Public / operator callers don't need to hit this — the checkout
+ * paths read via getCoffeeSettings() directly, and the shop/cart UI
+ * pulls from a lightweight public endpoint (see /api/coffee/settings)
+ * so unauth visitors see the minimum before signing in.
+ */
+
+const patchSchema = z.object({
+  minimum_order_cents: z.number().int().min(0).max(1_000_000).optional(),
+  minimum_order_enforced: z.boolean().optional(),
+});
+
+export async function GET(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const settings = await getCoffeeSettings();
+  return NextResponse.json(settings);
+}
+
+export async function PATCH(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const body = await req.json().catch(() => ({}));
+  const parsed = patchSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid input", details: parsed.error.format() },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const updated = await updateCoffeeSettings(parsed.data, adminId);
+    return NextResponse.json(updated);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Update failed";
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/api/coffee/checkout/route.ts
+++ b/src/app/api/coffee/checkout/route.ts
@@ -7,6 +7,7 @@ import { createInvoice, sendInvoiceEmail, getInvoice } from "@/lib/quickbooks";
 import { sendCoffeeOrderNotification, sendCoffeeOrderConfirmation } from "@/lib/coffeeEmail";
 import { requireExecutedCoffeeSupplyAgreement } from "@/lib/placementAgreements";
 import { resolveCoffeeProductsPricing } from "@/lib/coffeePricing";
+import { getCoffeeSettings } from "@/lib/coffeeSettings";
 
 export async function POST(req: NextRequest) {
   try {
@@ -123,6 +124,24 @@ export async function POST(req: NextRequest) {
     const subtotal = orderItems.reduce((sum, i) => sum + i.unit_price * i.quantity, 0);
     const shippingTotal = orderItems.reduce((sum, i) => sum + i.shipping_cost * i.quantity, 0);
     const total = subtotal + shippingTotal;
+
+    // Enforce the org-wide minimum-order gate BEFORE we insert the
+    // order row or fire the QB/Stripe request. Shipping is excluded
+    // from the check — the minimum is about the operator committing
+    // to actual product volume, not an inflated shipping line.
+    const settings = await getCoffeeSettings();
+    if (settings.minimum_order_enforced && subtotal * 100 < settings.minimum_order_cents) {
+      const minDollars = (settings.minimum_order_cents / 100).toFixed(2);
+      const shortDollars = ((settings.minimum_order_cents / 100) - subtotal).toFixed(2);
+      return NextResponse.json(
+        {
+          error: `Coffee orders have a $${minDollars} minimum. Add $${shortDollars} more to your cart to check out.`,
+          minimum_order_cents: settings.minimum_order_cents,
+          subtotal_cents: Math.round(subtotal * 100),
+        },
+        { status: 400 },
+      );
+    }
 
     const { data: order, error: orderError } = await supabaseAdmin
       .from("coffee_orders")

--- a/src/app/api/coffee/guest-checkout/route.ts
+++ b/src/app/api/coffee/guest-checkout/route.ts
@@ -5,6 +5,7 @@ import { isQuickBooks } from "@/lib/paymentProvider";
 import { createInvoice, sendInvoiceEmail, getInvoice } from "@/lib/quickbooks";
 import { sendCoffeeOrderNotification, sendCoffeeOrderConfirmation } from "@/lib/coffeeEmail";
 import { resolveCoffeeProductsPricing } from "@/lib/coffeePricing";
+import { getCoffeeSettings } from "@/lib/coffeeSettings";
 import {
   provisionAccountForGuestCheckout,
   generateGuestToken,
@@ -171,6 +172,23 @@ export async function POST(req: NextRequest) {
     const subtotal = orderItems.reduce((sum, i) => sum + i.unit_price * i.quantity, 0);
     const shippingTotal = orderItems.reduce((sum, i) => sum + i.shipping_cost * i.quantity, 0);
     const total = subtotal + shippingTotal;
+
+    // Same minimum-order gate as the authenticated path. Runs after
+    // pricing resolution and stock check so the error message can
+    // quote the exact shortfall in dollars.
+    const settings = await getCoffeeSettings();
+    if (settings.minimum_order_enforced && subtotal * 100 < settings.minimum_order_cents) {
+      const minDollars = (settings.minimum_order_cents / 100).toFixed(2);
+      const shortDollars = ((settings.minimum_order_cents / 100) - subtotal).toFixed(2);
+      return NextResponse.json(
+        {
+          error: `Coffee orders have a $${minDollars} minimum. Add $${shortDollars} more to your cart to check out.`,
+          minimum_order_cents: settings.minimum_order_cents,
+          subtotal_cents: Math.round(subtotal * 100),
+        },
+        { status: 400 },
+      );
+    }
 
     const { data: order, error: orderError } = await supabaseAdmin
       .from("coffee_orders")

--- a/src/app/api/coffee/settings/route.ts
+++ b/src/app/api/coffee/settings/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { getCoffeeSettings } from "@/lib/coffeeSettings";
+
+/**
+ * GET /api/coffee/settings — public read of policy knobs the shop /
+ * cart / checkout UIs need to show the minimum order threshold to
+ * every visitor (including guests). Only exposes fields safe to
+ * publish; admin-only fields would live at /api/admin/coffee/settings.
+ */
+export async function GET() {
+  const settings = await getCoffeeSettings();
+  return NextResponse.json({
+    minimum_order_cents: settings.minimum_order_cents,
+    minimum_order_enforced: settings.minimum_order_enforced,
+  });
+}

--- a/src/app/coffee/guest-checkout/page.tsx
+++ b/src/app/coffee/guest-checkout/page.tsx
@@ -40,6 +40,8 @@ function GuestCheckoutContent() {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [canceled] = useState(searchParams.get("canceled") === "true");
+  const [minOrderCents, setMinOrderCents] = useState<number>(0);
+  const [minOrderEnforced, setMinOrderEnforced] = useState<boolean>(true);
 
   const [form, setForm] = useState({
     shipping_business_name: "",
@@ -64,6 +66,19 @@ function GuestCheckoutContent() {
   const [acceptTerms, setAcceptTerms] = useState(false);
 
   useEffect(() => {
+    // Fetch the org-wide minimum-order policy so we can render a
+    // banner and disable Place Order until the cart clears it —
+    // matches what /api/coffee/guest-checkout enforces server-side.
+    fetch("/api/coffee/settings")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((s) => {
+        if (s) {
+          setMinOrderCents(Number(s.minimum_order_cents) || 0);
+          setMinOrderEnforced(!!s.minimum_order_enforced);
+        }
+      })
+      .catch(() => {});
+
     const localCart = readGuestCart();
     setCart(localCart);
     if (localCart.length === 0) {
@@ -355,9 +370,33 @@ function GuestCheckoutContent() {
                   <span className="text-green-400">${total.toFixed(2)}</span>
                 </div>
               </div>
+              {(() => {
+                const minDollars = minOrderCents / 100;
+                const belowMin = minOrderEnforced && minOrderCents > 0 && subtotal < minDollars;
+                if (minOrderCents > 0 && minOrderEnforced) {
+                  return (
+                    <div
+                      className={`mt-4 rounded-lg border px-3 py-2 text-xs ${
+                        belowMin
+                          ? "border-yellow-500/40 bg-yellow-900/30 text-yellow-100"
+                          : "border-green-500/40 bg-green-900/20 text-green-100/90"
+                      }`}
+                    >
+                      {belowMin
+                        ? `Minimum coffee order is $${minDollars.toFixed(2)}. Add $${(minDollars - subtotal).toFixed(2)} more to check out.`
+                        : `Meets the $${minDollars.toFixed(2)} coffee order minimum.`}
+                    </div>
+                  );
+                }
+                return null;
+              })()}
               <button
                 type="submit"
-                disabled={submitting || !acceptTerms}
+                disabled={
+                  submitting
+                  || !acceptTerms
+                  || (minOrderEnforced && minOrderCents > 0 && subtotal < minOrderCents / 100)
+                }
                 className="mt-6 w-full inline-flex items-center justify-center gap-2 bg-green-500 text-black font-semibold px-6 py-3 rounded-lg hover:bg-green-400 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {submitting ? (

--- a/src/lib/coffeeSettings.ts
+++ b/src/lib/coffeeSettings.ts
@@ -1,0 +1,91 @@
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+
+/**
+ * Coffee marketplace settings — org-wide policy knobs read at checkout
+ * time and rendered on the shop / cart / checkout UIs.
+ *
+ * Singleton table (see migration 142). We always read the newest row
+ * so if an admin ever forks a second row through direct SQL it still
+ * behaves sanely. Missing row → defaults (never a crash).
+ */
+
+export interface CoffeeSettings {
+  id: string | null;
+  minimum_order_cents: number;
+  minimum_order_enforced: boolean;
+  updated_at: string | null;
+}
+
+const DEFAULTS: CoffeeSettings = {
+  id: null,
+  minimum_order_cents: 50000, // $500
+  minimum_order_enforced: true,
+  updated_at: null,
+};
+
+export async function getCoffeeSettings(): Promise<CoffeeSettings> {
+  const { data } = await supabaseAdmin
+    .from("coffee_settings")
+    .select("id, minimum_order_cents, minimum_order_enforced, updated_at")
+    .order("updated_at", { ascending: false, nullsFirst: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (!data) return DEFAULTS;
+  return {
+    id: data.id,
+    minimum_order_cents: Number(data.minimum_order_cents) || 0,
+    minimum_order_enforced: !!data.minimum_order_enforced,
+    updated_at: data.updated_at,
+  };
+}
+
+export async function updateCoffeeSettings(
+  patch: Partial<Pick<CoffeeSettings, "minimum_order_cents" | "minimum_order_enforced">>,
+  updatedBy: string,
+): Promise<CoffeeSettings> {
+  const current = await getCoffeeSettings();
+
+  const nextMinimum =
+    patch.minimum_order_cents != null ? Math.max(0, Math.floor(patch.minimum_order_cents)) : current.minimum_order_cents;
+  const nextEnforced = patch.minimum_order_enforced != null ? !!patch.minimum_order_enforced : current.minimum_order_enforced;
+
+  if (current.id) {
+    const { data, error } = await supabaseAdmin
+      .from("coffee_settings")
+      .update({
+        minimum_order_cents: nextMinimum,
+        minimum_order_enforced: nextEnforced,
+        updated_at: new Date().toISOString(),
+        updated_by: updatedBy,
+      })
+      .eq("id", current.id)
+      .select("id, minimum_order_cents, minimum_order_enforced, updated_at")
+      .single();
+    if (error) throw new Error(error.message);
+    return {
+      id: data.id,
+      minimum_order_cents: Number(data.minimum_order_cents),
+      minimum_order_enforced: !!data.minimum_order_enforced,
+      updated_at: data.updated_at,
+    };
+  }
+
+  // No row yet — insert the first singleton with the requested values.
+  const { data, error } = await supabaseAdmin
+    .from("coffee_settings")
+    .insert({
+      minimum_order_cents: nextMinimum,
+      minimum_order_enforced: nextEnforced,
+      updated_by: updatedBy,
+    })
+    .select("id, minimum_order_cents, minimum_order_enforced, updated_at")
+    .single();
+  if (error) throw new Error(error.message);
+  return {
+    id: data.id,
+    minimum_order_cents: Number(data.minimum_order_cents),
+    minimum_order_enforced: !!data.minimum_order_enforced,
+    updated_at: data.updated_at,
+  };
+}

--- a/supabase/migrations/142_coffee_settings.sql
+++ b/supabase/migrations/142_coffee_settings.sql
@@ -1,0 +1,46 @@
+-- Coffee marketplace settings — singleton row
+--
+-- Holds the org-wide policy knobs the admin UI at /admin/coffee needs
+-- to enforce at checkout time. Right now that's just a minimum-order
+-- gate ($500 default) but the table is shaped so future policy toggles
+-- (shipping thresholds, wholesale gates, cutoffs) can slot in without
+-- another migration per knob.
+--
+-- Every coffee checkout path (authenticated + guest) reads this via
+-- src/lib/coffeeSettings.ts before creating an order. UI reads the
+-- same helper to display the minimum on the cart drawer / checkout
+-- page so buyers see the gate before hitting Place Order.
+
+CREATE TABLE IF NOT EXISTS public.coffee_settings (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- Minimum order subtotal (line items only, excluding shipping)
+  -- required for a coffee order to be placed. Set in cents to avoid
+  -- floating-point drift; UI converts for display.
+  minimum_order_cents integer NOT NULL DEFAULT 50000
+    CHECK (minimum_order_cents >= 0),
+  -- Kill switch — flip false to let orders under the minimum through
+  -- without a code deploy (helpful for a one-off promo or a stuck
+  -- customer we need to unblock).
+  minimum_order_enforced boolean NOT NULL DEFAULT true,
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  updated_by uuid REFERENCES auth.users(id)
+);
+
+-- Seed the singleton row so getCoffeeSettings() never returns null on
+-- a fresh install. The helper falls back to defaults if the row is
+-- missing, but seeding here is safer than relying on that path.
+INSERT INTO public.coffee_settings (minimum_order_cents, minimum_order_enforced)
+SELECT 50000, true
+WHERE NOT EXISTS (SELECT 1 FROM public.coffee_settings);
+
+ALTER TABLE public.coffee_settings ENABLE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies
+                 WHERE tablename = 'coffee_settings'
+                   AND policyname = 'service_role_coffee_settings') THEN
+    CREATE POLICY service_role_coffee_settings
+      ON public.coffee_settings FOR ALL TO service_role
+      USING (true) WITH CHECK (true);
+  END IF;
+END $$;


### PR DESCRIPTION
Minimum coffee order (default \$500, admin-configurable):

- Migration 142 adds coffee_settings singleton with minimum_order_cents + minimum_order_enforced (kill switch). Seeded at \$500. Missing-row fallback returns the same defaults so a fresh install never crashes.
- src/lib/coffeeSettings.ts — getCoffeeSettings / updateCoffeeSettings helpers. updates stamp updated_by for an audit trail.
- GET/PATCH /api/admin/coffee/settings — admin CRUD; enforces admin role, validates via zod.
- GET /api/coffee/settings — public read so unauthenticated visitors hitting /coffee/guest-checkout can see the minimum before hitting Place Order.
- Both checkout endpoints (/api/coffee/checkout + guest-checkout) block orders whose subtotal is below the minimum with a specific "add \$X more to check out" error. Enforcement is subtotal-only (shipping excluded) so an inflated shipping line can't game it.
- /coffee/guest-checkout order-summary panel shows the minimum, a yellow warning banner when the cart is short, and disables Place Order until the cart clears — server enforcement still runs regardless so a client bypass doesn't matter.
- Admin coffee page gets a new "Settings" tab with the minimum editor + enforce toggle + last-updated timestamp.

Out-of-stock as a one-click ban:

- Products list now renders stock_status as an inline select instead of a read-only badge. Admin picks In Stock / Low Stock / Out of Stock right on the row; toast confirms the save.
- The Out-of-Stock enforcement was already wired at both checkout APIs (they filter products where stock_status === "out_of_stock") — this just makes flipping the flag one click instead of buried in the full product edit form.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2