### PR TITLE
Coffee — admin base price edit now propagates to Tier 1 (visible to s…

### DIFF
--- a/src/app/admin/coffee/page.tsx
+++ b/src/app/admin/coffee/page.tsx
@@ -969,6 +969,9 @@ export default function AdminCoffeePage() {
                     onChange={(e) => setProductForm((p) => ({ ...p, price: e.target.value }))}
                     className={inputClass}
                   />
+                  <p className="mt-1 text-[11px] text-gray-500">
+                    Sets Tier 1 (standard operator) pricing — what most shoppers see. Manage Tier 2 / Tier 3 pricing separately from the <span className="font-medium">Tier Prices</span> button above.
+                  </p>
                 </div>
                 <div>
                   <label className="mb-1.5 block text-sm font-medium text-gray-700">Shipping Cost</label>

--- a/src/app/api/admin/coffee/products/route.ts
+++ b/src/app/api/admin/coffee/products/route.ts
@@ -98,6 +98,41 @@ export async function PATCH(req: NextRequest) {
       return NextResponse.json({ error: error.message }, { status: 500 });
     }
 
+    // Propagate base price + shipping to the Tier 1 tier-price row.
+    // Marketplace resolver (src/lib/coffeePricing.ts) reads from
+    // coffee_product_tier_prices, not from coffee_products.price, so
+    // without this write the admin's edit is invisible to shoppers.
+    // Tier-specific pricing (Tier 2 / Tier 3) is still managed at
+    // /admin/coffee/tier-prices and is not touched here.
+    const priceChanged = "price" in fields;
+    const shippingChanged = "shipping_cost" in fields;
+    if (priceChanged || shippingChanged) {
+      try {
+        const { data: tier1 } = await supabaseAdmin
+          .from("coffee_pricing_tiers")
+          .select("id")
+          .eq("tier_key", "tier_1")
+          .maybeSingle();
+        if (tier1) {
+          const tierPatch: Record<string, unknown> = {
+            product_id: id,
+            pricing_tier_id: tier1.id,
+            updated_by: adminId,
+            updated_at: new Date().toISOString(),
+          };
+          if (priceChanged) tierPatch.price = fields.price;
+          if (shippingChanged) tierPatch.shipping_cost = fields.shipping_cost;
+          await supabaseAdmin
+            .from("coffee_product_tier_prices")
+            .upsert(tierPatch, { onConflict: "product_id,pricing_tier_id" });
+        }
+      } catch (tierErr) {
+        // Non-fatal — base price is already saved. Admin can still
+        // edit the tier price directly at /admin/coffee/tier-prices.
+        console.error("[admin/coffee/products] tier-1 propagation failed:", tierErr);
+      }
+    }
+
     return NextResponse.json({ product: data });
   } catch (e) {
     const msg = e instanceof Error ? e.message : "Unknown error";


### PR DESCRIPTION
…hoppers)

The marketplace price resolver (src/lib/coffeePricing.ts) reads from coffee_product_tier_prices, using coffee_products.price only as a bootstrap fallback when no tier row exists. As soon as any tier row exists, edits to the base price in /admin/coffee are silently invisible to shoppers.

Fix — /api/admin/coffee/products PATCH:
- After updating coffee_products.price / shipping_cost, upsert the matching Tier 1 row in coffee_product_tier_prices (looked up by tier_key='tier_1'). Onconflict is (product_id, pricing_tier_id), which the schema already declares UNIQUE, so this is idempotent.
- Tier 2 / Tier 3 rows are NOT touched — tier-specific pricing is still managed at /admin/coffee/tier-prices.
- Propagation is best-effort: if it fails the base price is already saved and the admin can still edit the tier row directly. Never breaks the PATCH.

Fix — /admin/coffee UI:
- Small helper note under the Price field explaining that this sets Tier 1 (standard operator) pricing and pointing at the Tier Prices button for tier-specific overrides.

Not touched: POST creates a new coffee_products row without any tier rows — the resolver's base-price fallback fires until the admin edits again (which now auto-creates the Tier 1 row via the PATCH upsert). Existing products were backfilled with tier rows by migration 118.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2