### PR TITLE
Contractor onboarding — 148b safeguards + Resend error checking + com…

### DIFF
--- a/src/lib/contractorOnboarding/emails.ts
+++ b/src/lib/contractorOnboarding/emails.ts
@@ -97,13 +97,24 @@ export async function sendContractorInvitationEmail(args: {
     </p>
   `);
 
-  await getResend().emails.send({
+  // Resend's SDK returns { data, error } on non-2xx instead of
+  // throwing. Silently ignoring `error` was the reason the admin UI
+  // showed "sent" while nothing left Resend. Explicit inspection +
+  // throw ensures the caller flips status to needs_attention.
+  const result = await getResend().emails.send({
     from: FROM,
     to: args.toEmail,
     replyTo: REPLY_TO,
     subject: "Congratulations & Welcome to Vending Connector / Apex AI Vending",
     html,
   });
+  if (result.error) {
+    const msg =
+      typeof result.error === "object" && result.error && "message" in result.error
+        ? String((result.error as { message?: unknown }).message ?? JSON.stringify(result.error))
+        : String(result.error);
+    throw new Error(`Resend rejected invitation email: ${msg}`);
+  }
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -154,20 +165,31 @@ export async function sendContractorCompletionNotification(args: {
     </p>
   `);
 
+  // Send in parallel. Each promise inspects Resend's { error } so a
+  // rejection is logged (not swallowed) — same silent-failure bug
+  // that hit the invitation email. One recipient failing does not
+  // block the other two.
   await Promise.all(
-    CONTRACTOR_ONBOARDING_NOTIFY.map((to) =>
-      getResend()
-        .emails.send({
+    CONTRACTOR_ONBOARDING_NOTIFY.map(async (to) => {
+      try {
+        const result = await getResend().emails.send({
           from: FROM,
           to,
           replyTo: REPLY_TO,
           subject: `Contractor Onboarding Complete — ${args.contractorName}`,
           html,
-        })
-        .catch((err) => {
-          console.error(`[contractor-onboarding] completion notify to ${to} failed:`, err);
-        }),
-    ),
+        });
+        if (result.error) {
+          const msg =
+            typeof result.error === "object" && result.error && "message" in result.error
+              ? String((result.error as { message?: unknown }).message ?? JSON.stringify(result.error))
+              : String(result.error);
+          console.error(`[contractor-onboarding] completion notify to ${to} rejected:`, msg);
+        }
+      } catch (err) {
+        console.error(`[contractor-onboarding] completion notify to ${to} threw:`, err);
+      }
+    }),
   );
 }
 

--- a/supabase/migrations/148_contractor_onboarding.sql
+++ b/supabase/migrations/148_contractor_onboarding.sql
@@ -1,9 +1,10 @@
 -- ═════════════════════════════════════════════════════════════════════
 -- 148 — Contractor onboarding (post-hire 1099 packet flow)
 -- ─────────────────────────────────────────────────────────────────────
--- Distinct from the existing candidate_tokens / onboarding_candidates
--- pipeline (which is pre-hire recruiting). This one takes a signed
--- Vice President contractor through their legal packet: contractor
+-- Distinct from the existing candidate_tokens pipeline + its
+-- /api/onboarding/candidates surface (which is pre-hire recruiting).
+-- This one takes a signed Vice President contractor through their
+-- legal packet: contractor
 -- info, tax form (W-9 upload), Independent Contractor Agreement,
 -- Confidentiality, Sales/CRM Policy, Compensation acknowledgment,
 -- Payment setup (via existing Plaid/Dwolla rails), and e-signature.

--- a/supabase/migrations/148b_contractor_onboarding_safeguards.sql
+++ b/supabase/migrations/148b_contractor_onboarding_safeguards.sql
@@ -1,0 +1,52 @@
+-- ═════════════════════════════════════════════════════════════════════
+-- 148b — Contractor onboarding safeguards (best applied while empty)
+-- ─────────────────────────────────────────────────────────────────────
+-- Two defense-in-depth constraints intentionally added AFTER 148 so
+-- the initial migration stays focused. Both are safest to apply while
+-- contractor_onboarding is empty; once real packets land, a
+-- constraint violation would require row cleanup before deploy.
+--
+--   1. Partial UNIQUE index on active invitations by lowercased
+--      email. The app layer already refuses a duplicate active send
+--      via /api/admin/contractor-onboarding (409 with existing_id),
+--      but that check is TOCTOU-vulnerable under two concurrent
+--      admin POSTs. The DB index closes the race — the second
+--      insert fails and the API surface returns 409 cleanly instead
+--      of stamping two live invitations for the same person.
+--
+--   2. CHECK constraint on contractor_onboarding.step_data that
+--      forbids the JSONB from ever containing PII-shaped keys.
+--      step_data is the autosave scratchpad for form field values;
+--      real W-9 uploads live in the private bucket at
+--      w9_storage_path, and bank credentials never leave Plaid +
+--      Dwolla. This constraint hard-stops a future writer from
+--      quietly stashing an SSN / account number in the scratchpad
+--      where it would leak via any admin JSON dump of the row.
+--
+-- Idempotent: IF NOT EXISTS on the index, and the constraint is
+-- wrapped in a name-existence check.
+-- ═════════════════════════════════════════════════════════════════════
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_contractor_onboarding_active_email
+  ON public.contractor_onboarding (lower(contractor_email))
+  WHERE status IN ('sent','opened','in_progress');
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'contractor_onboarding_step_data_no_pii'
+  ) THEN
+    ALTER TABLE public.contractor_onboarding
+      ADD CONSTRAINT contractor_onboarding_step_data_no_pii
+      CHECK (
+        NOT (step_data ? 'ssn')
+        AND NOT (step_data ? 'social_security_number')
+        AND NOT (step_data ? 'tin')
+        AND NOT (step_data ? 'ein')
+        AND NOT (step_data ? 'account_number')
+        AND NOT (step_data ? 'routing_number')
+        AND NOT (step_data ? 'bank_account')
+        AND NOT (step_data ? 'card_number')
+      );
+  END IF;
+END $$;


### PR DESCRIPTION
…ment fix

Three fixes bundled:

1. Migration 148b — safeguards best applied while tables are empty:
   - Partial UNIQUE index ux_contractor_onboarding_active_email on lower(contractor_email) WHERE status IN ('sent','opened','in_progress'). The app layer already refuses a duplicate active invitation via /api/admin/contractor- onboarding (409 with existing_id), but the check is TOCTOU- vulnerable under two concurrent admin POSTs. The DB index closes the race — the second insert fails and callers see a clean 409.
   - CHECK constraint contractor_onboarding_step_data_no_pii that blocks the step_data JSONB from ever containing SSN / TIN / EIN / routing_number / account_number / bank_account / card_number keys. step_data is the autosave scratchpad for form fields; the W-9 lives in the private bucket and bank credentials never leave Plaid+Dwolla. Defense-in-depth against a future writer accidentally stashing PII where an admin row-dump would leak it.
   - Both idempotent (IF NOT EXISTS on index, pg_constraint name check on constraint).

2. Resend silent-failure fix (src/lib/contractorOnboarding/emails.ts):
   - sendContractorInvitationEmail now inspects result.error from the Resend SDK's { data, error } shape. Previously we ignored the return value, so a rejected send returned HTTP 200 to the admin UI while nothing actually left Resend — matches the reported "email said it sent but was not received" symptom.
   - Now throws with the Resend error message. The POST handler already catches, rolls status back to 'needs_attention', and returns 502 to the caller — so admin sees a real error and can Resend.
   - sendContractorCompletionNotification gets the same treatment: the per-recipient .catch() previously swallowed errors; now the inner try walks both the { error } branch and any thrown exception, and logs the specific rejection so a leadership recipient failing is visible in logs. Non-fatal at the API layer (one rejection doesn't block the others).
   - Pattern only fixed on onboarding helpers this pass — the broader codebase uses the same silent-error pattern in ~15 other *Email.ts files; separate cleanup.

3. Comment fix in migration 148 header:
   - Removed the incorrect reference to a non-existent onboarding_candidates table. The pre-hire pipeline exists at candidate_tokens (table) + /api/onboarding/candidates (API); my earlier comment conflated the API path with a table name. No code impact.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2