### PR TITLE
Onboarding autosave — calmer indicator (network only) + longer debounce

### DIFF
--- a/src/hooks/useDebouncedAutosave.ts
+++ b/src/hooks/useDebouncedAutosave.ts
@@ -5,26 +5,43 @@ import { useCallback, useEffect, useRef, useState } from "react";
 /**
  * Reusable debounced autosave hook.
  *
- * Modeled after the working pattern in the website-builder page but
- * lifted into a general-purpose hook so the contractor onboarding
- * flow (and future multi-step forms) don't reinvent it.
+ * Lifted from the working pattern in the website-builder page so
+ * multi-step forms don't reinvent it.
  *
  * Usage:
  *   const { queue, flush, saveState } = useDebouncedAutosave({
  *     save: (patch) => fetch(url, { method: "PATCH", body: JSON.stringify(patch) }),
- *     debounceMs: 800,
  *   });
  *   // ...on field change:
  *   queue({ step_data: { fullName: value } });
  *   // ...before advancing step:
  *   await flush();
+ *
+ * UX design notes
+ * ────────────────
+ * The visible saveState reflects ONLY actual network activity — it
+ * does not flip to "saving" the instant a keystroke is queued. That
+ * matters because a typist pressing keys shouldn't see a nervous
+ * "Saving…" flash on every character; the indicator should feel
+ * ambient. Sequence for a typing burst:
+ *
+ *   idle/saved → (user types) → indicator unchanged
+ *                → (debounceMs pause) → indicator flips to "saving"
+ *                → (network resolves ~200ms) → "saved" for savedHoldMs
+ *                → back to "idle" so the row goes quiet
+ *
+ * Default debounce is 1500ms — long enough that a normal typing
+ * cadence produces one save per completed thought, not per key.
  */
 
 export type SaveState = "idle" | "saving" | "saved" | "error";
 
 interface Options<TPatch> {
   save: (mergedPatch: TPatch) => Promise<void>;
+  /** ms of typing quiet before a save fires. Default 1500. */
   debounceMs?: number;
+  /** ms to display "saved" before fading back to idle. Default 2500. */
+  savedHoldMs?: number;
   /** How to merge two patches into one — defaults to shallow spread. */
   merge?: (a: TPatch, b: TPatch) => TPatch;
 }
@@ -32,10 +49,11 @@ interface Options<TPatch> {
 export function useDebouncedAutosave<TPatch extends Record<string, unknown>>(
   opts: Options<TPatch>,
 ) {
-  const { save, debounceMs = 800, merge } = opts;
+  const { save, debounceMs = 1500, savedHoldMs = 2500, merge } = opts;
   const [saveState, setSaveState] = useState<SaveState>("idle");
   const pendingRef = useRef<TPatch | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const holdTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const inFlightRef = useRef<boolean>(false);
 
   const shallowMerge = useCallback(
@@ -44,26 +62,46 @@ export function useDebouncedAutosave<TPatch extends Record<string, unknown>>(
   );
   const mergeFn = merge ?? shallowMerge;
 
+  const clearHold = useCallback(() => {
+    if (holdTimerRef.current) {
+      clearTimeout(holdTimerRef.current);
+      holdTimerRef.current = null;
+    }
+  }, []);
+
   const doFlush = useCallback(async (): Promise<void> => {
     if (inFlightRef.current) return;
     const payload = pendingRef.current;
     if (!payload) return;
     pendingRef.current = null;
     inFlightRef.current = true;
+    clearHold();
     setSaveState("saving");
     try {
       await save(payload);
       setSaveState("saved");
+      // Hold "saved" briefly then fade back to idle so the badge
+      // doesn't linger visually across the whole form.
+      holdTimerRef.current = setTimeout(() => {
+        holdTimerRef.current = null;
+        // Only fade if nothing new happened while we held.
+        if (!inFlightRef.current && !pendingRef.current) {
+          setSaveState("idle");
+        }
+      }, savedHoldMs);
     } catch (err) {
       console.error("[useDebouncedAutosave] save failed:", err);
       setSaveState("error");
     } finally {
       inFlightRef.current = false;
     }
-  }, [save]);
+  }, [save, savedHoldMs, clearHold]);
 
   const queue = useCallback(
     (patch: TPatch): void => {
+      // Coalesce into the pending payload. Do NOT flip saveState
+      // here — keystrokes are inputs, not save events. The indicator
+      // reflects actual network activity only.
       pendingRef.current = pendingRef.current
         ? mergeFn(pendingRef.current, patch)
         : patch;
@@ -72,7 +110,6 @@ export function useDebouncedAutosave<TPatch extends Record<string, unknown>>(
         timerRef.current = null;
         void doFlush();
       }, debounceMs);
-      setSaveState("saving");
     },
     [debounceMs, doFlush, mergeFn],
   );
@@ -90,6 +127,7 @@ export function useDebouncedAutosave<TPatch extends Record<string, unknown>>(
   useEffect(() => {
     return () => {
       if (timerRef.current) clearTimeout(timerRef.current);
+      if (holdTimerRef.current) clearTimeout(holdTimerRef.current);
       if (pendingRef.current) void doFlush();
     };
   }, [doFlush]);


### PR DESCRIPTION
Two UX fixes to useDebouncedAutosave. The indicator was flashing "Saving…" on every keystroke and pulsing "Saved" between bursts, which felt sketchy while typing.

1. queue() no longer changes saveState. Keystrokes are inputs, not save events. The visible indicator now reflects actual network activity only: idle/saved → (user types) → indicator unchanged → (debounce pause) → "saving"
                → (fetch resolves)   → "saved"
                → (savedHoldMs)      → back to "idle"
   A typing burst produces one visible transition at the end,
   not a flash per character.

2. Debounce bumped 800ms → 1500ms. Long enough that a normal typing cadence produces one save per completed thought instead of one per pause between fields.

3. New savedHoldMs option (default 2500ms) fades the "Saved" badge back to idle if nothing else is pending. The portal's SaveIndicator returns null on idle, so the whole badge quietly disappears — no permanent "Saved" hangover across the form.

Also: clean up the hold timer on unmount alongside the existing flush timer so no stray timer fires after the component tears down (e.g. navigating away mid-hold).

Existing consumers (contractor onboarding portal + future ones) get the calmer behavior automatically — the API surface didn't change.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2