### PR TITLE
Onboarding finish — bulletproof against Unicode + non-JSON errors

### DIFF
--- a/src/app/api/onboarding/contractor/[token]/finish/route.ts
+++ b/src/app/api/onboarding/contractor/[token]/finish/route.ts
@@ -39,6 +39,26 @@ export async function POST(
   req: NextRequest,
   { params }: { params: Promise<{ token: string }> },
 ) {
+  try {
+    return await handleFinish(req, params);
+  } catch (err) {
+    // Belt-and-suspenders: any unhandled throw (PDF encoder blowup,
+    // Supabase network glitch, Resend init failure) becomes a
+    // JSON response so the contractor's browser doesn't get an
+    // HTML 500 page and Safari's "the string did not match the
+    // expected pattern" JSON-parse error.
+    console.error("[contractor-onboarding/finish] unhandled:", err);
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Internal server error" },
+      { status: 500 },
+    );
+  }
+}
+
+async function handleFinish(
+  req: NextRequest,
+  params: Promise<{ token: string }>,
+) {
   const { token } = await params;
   if (!token) return NextResponse.json({ error: "Missing token" }, { status: 400 });
 

--- a/src/app/onboarding/[token]/page.tsx
+++ b/src/app/onboarding/[token]/page.tsx
@@ -823,7 +823,22 @@ function ReviewAndSignStep({
           reviewed: true,
         }),
       });
-      const data = await res.json();
+      // Read the body as text first so we can fall back to it when
+      // the server returned HTML (e.g. a 500 error page): Safari
+      // surfaces JSON.parse failure as "the string did not match
+      // the expected pattern", which is unhelpful. Prefer a real
+      // error string.
+      const rawBody = await res.text();
+      let data: { error?: string; missing?: string[] } = {};
+      try {
+        data = rawBody ? JSON.parse(rawBody) : {};
+      } catch {
+        data = {
+          error:
+            rawBody.slice(0, 300).trim() ||
+            `Server returned a non-JSON response (HTTP ${res.status}).`,
+        };
+      }
       if (!res.ok) {
         setError(data.error ?? `Failed (HTTP ${res.status})`);
         if (Array.isArray(data.missing)) setMissing(data.missing);

--- a/src/lib/pdf/contractorOnboardingPdf.ts
+++ b/src/lib/pdf/contractorOnboardingPdf.ts
@@ -141,7 +141,7 @@ export async function generateContractorPacketPdf(
   drawSectionHeading(ctx, "Commission Schedule", { newPage: true });
   for (const item of COMMISSION_SCHEDULE.items) {
     ensureRoom(ctx, LINE_H * 3);
-    ctx.page.drawText(item.label, { x: LEFT, y: ctx.y, size: 11, font: ctx.helvBold, color: DARK });
+    ctx.page.drawText(safeText(item.label), { x: LEFT, y: ctx.y, size: 11, font: ctx.helvBold, color: DARK });
     ctx.y -= LINE_H;
     drawWrappedText(ctx, item.amount, { color: GREEN });
     drawWrappedText(ctx, item.description);
@@ -164,7 +164,7 @@ export async function generateContractorPacketPdf(
   ctx.y -= LINE_H / 2;
   for (const sig of input.signatures) {
     ensureRoom(ctx, LINE_H * 6);
-    ctx.page.drawText(labelForDocumentKey(sig.document_key), {
+    ctx.page.drawText(safeText(labelForDocumentKey(sig.document_key)), {
       x: LEFT, y: ctx.y, size: 11, font: ctx.helvBold, color: DARK,
     });
     ctx.y -= LINE_H;
@@ -211,7 +211,7 @@ function drawCover(ctx: RenderCtx, input: ContractorPdfInput) {
   ctx.page.drawText("Contractor Onboarding Packet", {
     x: LEFT, y: TOP - 80, size: 22, font: ctx.helvBold, color: DARK,
   });
-  ctx.page.drawText(input.contractorName, {
+  ctx.page.drawText(safeText(input.contractorName), {
     x: LEFT, y: TOP - 110, size: 16, font: ctx.helv, color: DARK,
   });
   ctx.page.drawText(`Start Date: ${formatDate(input.startDate)}`, {
@@ -248,7 +248,7 @@ function drawCover(ctx: RenderCtx, input: ContractorPdfInput) {
 function drawSectionHeading(ctx: RenderCtx, title: string, opts?: { newPage?: boolean }) {
   if (opts?.newPage) newPage(ctx);
   ensureRoom(ctx, LINE_H * 3);
-  ctx.page.drawText(title, { x: LEFT, y: ctx.y, size: 16, font: ctx.helvBold, color: DARK });
+  ctx.page.drawText(safeText(title), { x: LEFT, y: ctx.y, size: 16, font: ctx.helvBold, color: DARK });
   ctx.y -= 8;
   ctx.page.drawLine({
     start: { x: LEFT, y: ctx.y },
@@ -262,7 +262,7 @@ function drawSectionHeading(ctx: RenderCtx, title: string, opts?: { newPage?: bo
 function drawSubsection(ctx: RenderCtx, title: string) {
   ensureRoom(ctx, LINE_H * 2);
   ctx.y -= 4;
-  ctx.page.drawText(title, { x: LEFT, y: ctx.y, size: 11, font: ctx.helvBold, color: DARK });
+  ctx.page.drawText(safeText(title), { x: LEFT, y: ctx.y, size: 11, font: ctx.helvBold, color: DARK });
   ctx.y -= LINE_H;
 }
 
@@ -275,7 +275,7 @@ function drawKeyValueTable(
   const size = opts?.small ? 9 : 10;
   for (const [k, v] of rows) {
     ensureRoom(ctx, LINE_H);
-    ctx.page.drawText(k, { x: LEFT, y: ctx.y, size, font: ctx.helvBold, color: DARK });
+    ctx.page.drawText(safeText(k), { x: LEFT, y: ctx.y, size, font: ctx.helvBold, color: DARK });
     drawWrappedText(ctx, v, { indent: keyWidth, size, alreadyAllocatedFirstLine: true });
   }
 }
@@ -283,7 +283,10 @@ function drawKeyValueTable(
 function drawBulletList(ctx: RenderCtx, items: readonly string[]) {
   for (const item of items) {
     ensureRoom(ctx, LINE_H);
-    ctx.page.drawText("•", { x: LEFT, y: ctx.y, size: 10, font: ctx.helvBold, color: GREEN });
+    // ASCII bullet (*) instead of U+2022 — Helvetica's WinAnsi
+    // encoding does include it, but some subsets fault. Belt +
+    // suspenders: use * for zero-risk render across environments.
+    ctx.page.drawText("*", { x: LEFT, y: ctx.y, size: 10, font: ctx.helvBold, color: GREEN });
     drawWrappedText(ctx, item, { indent: 14 });
   }
 }
@@ -297,12 +300,38 @@ function drawWrappedText(
   const size = opts?.size ?? 10;
   const color = opts?.color ?? DARK;
   const maxWidth = RIGHT - LEFT - indent;
-  const lines = wrap(text, maxWidth, ctx.helv, size);
+  const clean = safeText(text);
+  const lines = wrap(clean, maxWidth, ctx.helv, size);
   for (let i = 0; i < lines.length; i++) {
     if (!(i === 0 && opts?.alreadyAllocatedFirstLine)) ensureRoom(ctx, LINE_H);
     ctx.page.drawText(lines[i], { x: LEFT + indent, y: ctx.y, size, font: ctx.helv, color });
     ctx.y -= LINE_H;
   }
+}
+
+/**
+ * pdf-lib's StandardFonts.Helvetica uses WinAnsi (CP1252) encoding.
+ * Anything outside that range throws at render time and — when that
+ * error bubbles up through a Next.js API route — becomes an HTML
+ * 500 page. The client's JSON.parse then fails, and Safari surfaces
+ * "The string did not match the expected pattern", which is the
+ * user-facing symptom of a Unicode collision here.
+ *
+ * Normalize the common offenders to ASCII, then strip anything else
+ * outside Latin-1 as a final backstop. Keeps the packet legible in
+ * every environment and lets the PDF gen never throw on content.
+ */
+function safeText(s: string): string {
+  return s
+    .replace(/[‘’‚‛]/g, "'")           // curly single quotes
+    .replace(/[“”„‟]/g, '"')           // curly double quotes
+    .replace(/[–—―]/g, "-")                 // en/em dash → hyphen
+    .replace(/…/g, "...")                             // ellipsis
+    .replace(/•/g, "*")                               // bullet
+    .replace(/ /g, " ")                               // non-breaking space
+    .replace(/‑/g, "-")                               // non-breaking hyphen
+    .replace(/[→←↑↓]/g, "->")          // arrows
+    .replace(/[^\x00-\xFF]/g, "?");                        // anything else outside Latin-1
 }
 
 function wrap(text: string, maxWidth: number, font: PDFFont, size: number): string[] {


### PR DESCRIPTION
Symptom: contractor clicked Finish and saw "the string did not match the expected pattern" — Safari's SyntaxError text when JSON.parse gets a non-JSON response. That means the finish endpoint was 500-ing to a Next.js HTML error page instead of returning JSON. Three fixes, in defense-in-depth order.

1. Sanitize text before pdf-lib rendering. StandardFonts.Helvetica uses WinAnsi (CP1252) encoding; any character outside that range throws at render time. New safeText() collapses common non-WinAnsi offenders — curly quotes, en/em dashes, ellipsis, bullet, non-breaking space + hyphen, arrows — to their ASCII equivalents, then strips any remaining non-Latin-1 chars to "?". Every drawText / drawWrappedText path in contractorOnboardingPdf.ts now feeds through it. Bullet character in drawBulletList swapped from U+2022 to "*" for zero-risk render across all environments. The contractor's typed legal name goes through safeText on the cover page too — an autocorrected apostrophe (U+2019) coming from a mobile keyboard would have crashed the encoder otherwise.

2. Top-level try/catch on POST /finish. The endpoint now wraps its whole body in a try that returns a clean JSON 500 with the error message on any unhandled throw (PDF encoder blowup, transient Supabase glitch, Resend init failure). No more HTML error pages leaking back to the contractor's browser.

3. Client-side JSON fallback. handleFinish now reads response.text() first and tries JSON.parse; on failure it uses the raw body (truncated) as the error. So even if the server does return HTML somehow, the contractor sees the actual server response text — not Safari's opaque "the string did not match the expected pattern".


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2