### PR TITLE
Contractor onboarding — add Non 10/10/10 Deal commission tier

### DIFF
--- a/src/lib/contractorOnboarding/legal.ts
+++ b/src/lib/contractorOnboarding/legal.ts
@@ -13,7 +13,7 @@
  * or legal terms here; treat every edit as a compliance change.
  */
 
-export const AGREEMENT_VERSION = "2026-01-v1";
+export const AGREEMENT_VERSION = "2026-01-v2";
 
 // Documents the contractor signs. document_key values must exactly
 // match the CHECK constraint on contractor_onboarding_signatures.
@@ -179,6 +179,12 @@ export const COMMISSION_SCHEDULE = {
       label: "10/10/10 Deal",
       amount: "$1,750 per funded 10/10/10 deal",
       description: "Paid on each qualifying 10/10/10 deal once the customer payment or lender proceeds have settled to Apex.",
+    },
+    {
+      key: "non_10_10_10_deal",
+      label: "Non 10/10/10 Deal",
+      amount: "$200 per machine",
+      description: "Paid on each funded machine sale that does not meet the 10/10/10 structure, once the customer payment or lender proceeds have settled to Apex.",
     },
     {
       key: "location_sale",


### PR DESCRIPTION
New commission line item alongside the existing four, slotted right after 10/10/10 Deal since it's the alternative structure:

  Non 10/10/10 Deal — $200 per machine
  Paid on each funded machine sale that does not meet the 10/10/10
  structure, once the customer payment or lender proceeds have
  settled to Apex.

Because compensation changed, AGREEMENT_VERSION bumped from "2026-01-v1" to "2026-01-v2". This is the versioning system doing what it's built for: any packet a contractor already signed keeps its recorded document_version on
contractor_onboarding_signatures.document_version, so the exact schedule they agreed to survives every future term change. Only new signatures from this deploy forward record v2.

Everything downstream picks it up automatically: the Compensation step renders items from COMMISSION_SCHEDULE.items, the review
+ finish flow uses AGREEMENT_VERSION from this constant, and the generated PDF pulls items from the same source.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2