### PR TITLE
Restrict workflow visibility to admins + add machine_type to /request…

### DIFF
--- a/src/app/api/request-location/route.ts
+++ b/src/app/api/request-location/route.ts
@@ -11,6 +11,15 @@ const FROM_EMAIL = process.env.FROM_EMAIL || "receipts@bytebitevending.com";
 // request pays $100.
 const DEPOSIT_CENTS_PER_LOCATION = 10000;
 
+// Allowlist for machine_type. Kept in sync with the /request-location
+// page selector and with the sales_leads_machine_type_check CHECK
+// constraint (migration 152).
+const MACHINE_TYPES = ["Combo", "AI", "Water", "Coffee", "ATM"] as const;
+type MachineType = (typeof MACHINE_TYPES)[number];
+function isMachineType(v: unknown): v is MachineType {
+  return typeof v === "string" && (MACHINE_TYPES as readonly string[]).includes(v);
+}
+
 function clean(v: unknown): string {
   return typeof v === "string" ? v.trim().slice(0, 500) : "";
 }
@@ -30,6 +39,7 @@ export async function POST(req: Request) {
   const address = clean(body.address);
   const state = clean(body.state);
   const machine_count_raw = body.machine_count;
+  const machine_type_raw = body.machine_type;
 
   const rawZips = Array.isArray(body.zip_codes) ? body.zip_codes : body.zip_code ? [body.zip_code] : [];
   const zip_codes: string[] = rawZips.map((z: unknown) => (typeof z === "string" ? z.trim() : "")).filter(Boolean);
@@ -64,6 +74,14 @@ export async function POST(req: Request) {
       { status: 400 }
     );
   }
+
+  if (!isMachineType(machine_type_raw)) {
+    return NextResponse.json(
+      { error: `Machine type must be one of: ${MACHINE_TYPES.join(", ")}` },
+      { status: 400 }
+    );
+  }
+  const machine_type: MachineType = machine_type_raw;
 
   const depositCents = machine_count * DEPOSIT_CENTS_PER_LOCATION;
   const depositDollars = depositCents / 100;
@@ -108,17 +126,33 @@ export async function POST(req: Request) {
     machine_count,
     status: "new",
     source: referringRep ? "request-location-referral" : "request-location",
-    notes: `Location services request — ${machine_count} machine(s) requested for ZIP(s) ${zip_code} in ${state}${referringRepName ? ` (referred by ${referringRepName})` : ""}`,
+    notes: `Location services request — ${machine_count} ${machine_type} machine(s) requested for ZIP(s) ${zip_code} in ${state}${referringRepName ? ` (referred by ${referringRepName})` : ""}`,
     created_by: referringRep,
     assigned_to: referringRep,
   };
 
-  // Try with deposit columns (requires migration 081)
+  // Try with deposit + machine_type columns (deposit_* needs migration
+  // 081, machine_type needs migration 152). Failures on either column
+  // fall back to smaller insert shapes so an old DB still accepts the
+  // request instead of a hard 500.
   let { data: lead, error: dbError } = await supabaseAdmin.from("sales_leads").insert({
     ...leadRow,
     deposit_status: "pending",
     deposit_amount_cents: depositCents,
+    machine_type,
   }).select("id").single();
+
+  // Fallback: machine_type column missing (migration 152 not run).
+  if (dbError && dbError.message?.includes("machine_type")) {
+    console.warn("[request-location] machine_type column missing, inserting without it");
+    const retry = await supabaseAdmin.from("sales_leads").insert({
+      ...leadRow,
+      deposit_status: "pending",
+      deposit_amount_cents: depositCents,
+    }).select("id").single();
+    lead = retry.data;
+    dbError = retry.error;
+  }
 
   // Fallback if deposit columns don't exist yet
   if (dbError && dbError.message?.includes("deposit_")) {
@@ -186,7 +220,7 @@ export async function POST(req: Request) {
           fulfillment_status: "pending",
           next_required_action: "Awaiting deposit payment",
           recipient_email: email,
-          notes: `Location services request — ${machine_count} location${machine_count > 1 ? "s" : ""} in ${state} (ZIP ${zip_code}). Address: ${address}. $100 deposit + $500 placement fee per location.`,
+          notes: `Location services request — ${machine_count} ${machine_type} location${machine_count > 1 ? "s" : ""} in ${state} (ZIP ${zip_code}). Address: ${address}. $100 deposit + $500 placement fee per location.`,
         })
         .select("id")
         .single();
@@ -199,9 +233,9 @@ export async function POST(req: Request) {
           .from("order_items")
           .insert({
             order_id: order.id,
-            service_name: `Location Services — ${machine_count} location${machine_count > 1 ? "s" : ""}`,
+            service_name: `Location Services — ${machine_count} ${machine_type} location${machine_count > 1 ? "s" : ""}`,
             price: totalValueDollars,
-            notes: `${machine_count} location(s) in ${state} (ZIP ${zip_code}). $100 deposit + $500 placement fee per location.`,
+            notes: `${machine_count} ${machine_type} location(s) in ${state} (ZIP ${zip_code}). $100 deposit + $500 placement fee per location.`,
           });
         if (itemErr) {
           console.error("[request-location] order_items insert failed:", itemErr);
@@ -221,11 +255,11 @@ export async function POST(req: Request) {
       customerPhone: phone,
       lineItems: [
         {
-          description: `Location Services Deposit — ${business_name} (${machine_count} location${machine_count > 1 ? "s" : ""} in ${state}, $100 per location)`,
+          description: `Location Services Deposit — ${business_name} (${machine_count} ${machine_type} location${machine_count > 1 ? "s" : ""} in ${state}, $100 per location)`,
           amount: depositDollars,
         },
       ],
-      memo: `Location services deposit for ${business_name} — ${machine_count} location(s) at $100 each`,
+      memo: `Location services deposit for ${business_name} — ${machine_count} ${machine_type} location(s) at $100 each`,
       metadata: {
         type: "location_services_deposit",
         lead_id: lead.id,
@@ -262,7 +296,7 @@ export async function POST(req: Request) {
 
     // Send admin notification email
     sendAdminNotification({
-      business_name, contact_name, phone, email, address, state, zip_code, machine_count,
+      business_name, contact_name, phone, email, address, state, zip_code, machine_count, machine_type,
       depositDollars,
     }).catch((e) => console.error("[request-location] email error", e));
 
@@ -321,6 +355,7 @@ export async function POST(req: Request) {
               zip_codes,
               zip_code,
               machine_count,
+              machine_type,
               referring_sales_rep_name: referringRepName,
             },
           },
@@ -378,9 +413,10 @@ async function sendAdminNotification(params: {
   state: string;
   zip_code: string;
   machine_count: number;
+  machine_type: string;
   depositDollars: number;
 }) {
-  const { business_name, contact_name, phone, email, address, state, zip_code, machine_count, depositDollars } = params;
+  const { business_name, contact_name, phone, email, address, state, zip_code, machine_count, machine_type, depositDollars } = params;
   const resend = new Resend(process.env.RESEND_API_KEY);
   const html = `
     <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 560px; margin: 0 auto; padding: 24px;">
@@ -397,6 +433,7 @@ async function sendAdminNotification(params: {
         <tr><td style="padding:6px 0;color:#6b7280;">State</td><td style="padding:6px 0;color:#111827;">${state}</td></tr>
         <tr><td style="padding:6px 0;color:#6b7280;">ZIP Code(s)</td><td style="padding:6px 0;color:#111827;">${zip_code}</td></tr>
         <tr><td style="padding:6px 0;color:#6b7280;">Machines Requested</td><td style="padding:6px 0;color:#111827;font-weight:600;">${machine_count}</td></tr>
+        <tr><td style="padding:6px 0;color:#6b7280;">Machine Type</td><td style="padding:6px 0;color:#111827;font-weight:600;">${machine_type}</td></tr>
       </table>
     </div>
   `;

--- a/src/app/api/workflows/metrics/route.ts
+++ b/src/app/api/workflows/metrics/route.ts
@@ -1,12 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
-import { getWorkflowActor, isStaff } from "@/lib/workflows/permissions";
+import { getWorkflowActor, isStaff, type WorkflowActor } from "@/lib/workflows/permissions";
 
 /**
  * GET /api/workflows/metrics
  *
- * Aggregated numbers for the CRM dashboard. Staff-only. All queries
- * use indexed columns (workflow_type, overall_status, due_date).
+ * Aggregated numbers for the CRM dashboard. Staff-only. Admins see
+ * org-wide counts; every other staff role sees only workflows they
+ * are personally assigned to (matching the /api/workflows list-scope
+ * rule). All queries use indexed columns.
  */
 export async function GET(req: NextRequest) {
   const actor = await getWorkflowActor(req);
@@ -15,6 +17,11 @@ export async function GET(req: NextRequest) {
 
   const now = new Date().toISOString();
   const in7 = new Date(Date.now() + 7 * 86400_000).toISOString();
+
+  // Non-admin staff get the pre-filtered set of workflow ids they can
+  // see. Everything below narrows to that set via .in("id", ids). null
+  // means "no restriction" — admin path.
+  const visibleIds = await resolveVisibleWorkflowIds(actor);
 
   const [
     totalActive,
@@ -28,20 +35,20 @@ export async function GET(req: NextRequest) {
     coffeeAwaitingShipment,
     financingInProgress,
   ] = await Promise.all([
-    countWhere({ ne_status: ["completed", "cancelled", "refunded", "expired"] }),
-    countWhere({ ne_status: ["completed", "cancelled", "refunded", "expired"], assigned_null: true }),
-    countWhere({
+    countWhere(visibleIds, { ne_status: ["completed", "cancelled", "refunded", "expired"] }),
+    countWhere(visibleIds, { ne_status: ["completed", "cancelled", "refunded", "expired"], assigned_null: true }),
+    countWhere(visibleIds, {
       ne_status: ["completed", "cancelled", "refunded", "expired"],
       due_before: in7,
       due_after: now,
     }),
-    countWhere({ ne_status: ["completed", "cancelled", "refunded", "expired"], due_before: now }),
-    groupByType(),
-    sumStageQuantity("ai_machine_fulfillment", "shipped"),
-    sumStageQuantity("ai_machine_fulfillment", "delivered"),
-    locationsSecuredMetric(),
-    countCoffeeAwaitingShipment(),
-    countFinancingInProgress(),
+    countWhere(visibleIds, { ne_status: ["completed", "cancelled", "refunded", "expired"], due_before: now }),
+    groupByType(visibleIds),
+    sumStageQuantity(visibleIds, "ai_machine_fulfillment", "shipped"),
+    sumStageQuantity(visibleIds, "ai_machine_fulfillment", "delivered"),
+    locationsSecuredMetric(visibleIds),
+    countCoffeeAwaitingShipment(visibleIds),
+    countFinancingInProgress(visibleIds),
   ]);
 
   return NextResponse.json({
@@ -58,13 +65,39 @@ export async function GET(req: NextRequest) {
   });
 }
 
-async function countWhere(f: {
-  ne_status?: string[];
-  assigned_null?: boolean;
-  due_before?: string;
-  due_after?: string;
-}): Promise<number> {
+/**
+ * For non-admin staff, return the exhaustive list of workflow ids the
+ * actor is allowed to see (primary_owner OR active collaborator).
+ * Returns null for admin (meaning "no restriction").
+ */
+async function resolveVisibleWorkflowIds(actor: WorkflowActor): Promise<string[] | null> {
+  if (actor.scope === "all") return null;
+  const [assignedRes, collabRes] = await Promise.all([
+    supabaseAdmin.from("workflows").select("id").eq("assigned_user_id", actor.id),
+    supabaseAdmin
+      .from("workflow_assignments")
+      .select("workflow_id")
+      .eq("user_id", actor.id)
+      .eq("active", true),
+  ]);
+  const ids = new Set<string>();
+  for (const r of assignedRes.data ?? []) if (r.id) ids.add(r.id as string);
+  for (const r of collabRes.data ?? []) if (r.workflow_id) ids.add(r.workflow_id as string);
+  return Array.from(ids);
+}
+
+async function countWhere(
+  visibleIds: string[] | null,
+  f: {
+    ne_status?: string[];
+    assigned_null?: boolean;
+    due_before?: string;
+    due_after?: string;
+  },
+): Promise<number> {
+  if (visibleIds !== null && visibleIds.length === 0) return 0;
   let q = supabaseAdmin.from("workflows").select("id", { count: "exact", head: true });
+  if (visibleIds !== null) q = q.in("id", visibleIds);
   if (f.ne_status) q = q.not("overall_status", "in", `(${f.ne_status.map((s) => `"${s}"`).join(",")})`);
   if (f.assigned_null) q = q.is("assigned_user_id", null);
   if (f.due_before) q = q.lte("due_date", f.due_before);
@@ -73,11 +106,14 @@ async function countWhere(f: {
   return count ?? 0;
 }
 
-async function groupByType(): Promise<Record<string, number>> {
-  const { data } = await supabaseAdmin
+async function groupByType(visibleIds: string[] | null): Promise<Record<string, number>> {
+  if (visibleIds !== null && visibleIds.length === 0) return {};
+  let q = supabaseAdmin
     .from("workflows")
     .select("workflow_type")
     .not("overall_status", "in", '("completed","cancelled","refunded","expired")');
+  if (visibleIds !== null) q = q.in("id", visibleIds);
+  const { data } = await q;
   const out: Record<string, number> = {};
   for (const row of data ?? []) {
     const key = (row as { workflow_type: string }).workflow_type;
@@ -86,37 +122,56 @@ async function groupByType(): Promise<Record<string, number>> {
   return out;
 }
 
-async function sumStageQuantity(workflowType: string, stageKey: string): Promise<number> {
-  // Sum completed_quantity of the named stage across all workflows of this type.
-  const { data } = await supabaseAdmin
+async function sumStageQuantity(
+  visibleIds: string[] | null,
+  workflowType: string,
+  stageKey: string,
+): Promise<number> {
+  if (visibleIds !== null && visibleIds.length === 0) return 0;
+  // Sum completed_quantity of the named stage across visible workflows of this type.
+  let q = supabaseAdmin
     .from("workflow_stages")
-    .select("completed_quantity, workflow_id!inner(workflow_type)")
+    .select("completed_quantity, workflow_id!inner(id, workflow_type)")
     .eq("stage_key", stageKey);
+  if (visibleIds !== null) q = q.in("workflow_id", visibleIds);
+  const { data } = await q;
   const rows = (data ?? []) as unknown as { completed_quantity: number; workflow_id: { workflow_type: string } }[];
   return rows
     .filter((r) => r.workflow_id.workflow_type === workflowType)
     .reduce((sum, r) => sum + Number(r.completed_quantity ?? 0), 0);
 }
 
-async function locationsSecuredMetric(): Promise<{ secured: number; purchased: number; percent: number }> {
-  const { data: purchased } = await supabaseAdmin
+async function locationsSecuredMetric(
+  visibleIds: string[] | null,
+): Promise<{ secured: number; purchased: number; percent: number }> {
+  if (visibleIds !== null && visibleIds.length === 0) {
+    return { secured: 0, purchased: 0, percent: 0 };
+  }
+  let q = supabaseAdmin
     .from("workflows")
     .select("quantity_purchased")
     .eq("workflow_type", "location_services");
-  const totalPurchased = (purchased ?? []).reduce((s, r) => s + Number((r as { quantity_purchased: number }).quantity_purchased ?? 0), 0);
+  if (visibleIds !== null) q = q.in("id", visibleIds);
+  const { data: purchased } = await q;
+  const totalPurchased = (purchased ?? []).reduce(
+    (s, r) => s + Number((r as { quantity_purchased: number }).quantity_purchased ?? 0),
+    0,
+  );
 
-  const securedNum = await sumStageQuantity("location_services", "secured");
+  const securedNum = await sumStageQuantity(visibleIds, "location_services", "secured");
   const pct = totalPurchased > 0 ? Math.round((securedNum / totalPurchased) * 100) : 0;
   return { secured: securedNum, purchased: totalPurchased, percent: pct };
 }
 
-async function countCoffeeAwaitingShipment(): Promise<number> {
-  // coffee_equipment workflows in progress with shipped < committed.
-  const { data } = await supabaseAdmin
+async function countCoffeeAwaitingShipment(visibleIds: string[] | null): Promise<number> {
+  if (visibleIds !== null && visibleIds.length === 0) return 0;
+  let q = supabaseAdmin
     .from("workflows")
     .select("id, quantity_purchased")
     .eq("workflow_type", "coffee_equipment")
     .not("overall_status", "in", '("completed","cancelled","refunded","expired")');
+  if (visibleIds !== null) q = q.in("id", visibleIds);
+  const { data } = await q;
   const rows = (data ?? []) as { id: string; quantity_purchased: number }[];
   let awaiting = 0;
   for (const w of rows) {
@@ -132,11 +187,14 @@ async function countCoffeeAwaitingShipment(): Promise<number> {
   return awaiting;
 }
 
-async function countFinancingInProgress(): Promise<number> {
-  const { count } = await supabaseAdmin
+async function countFinancingInProgress(visibleIds: string[] | null): Promise<number> {
+  if (visibleIds !== null && visibleIds.length === 0) return 0;
+  let q = supabaseAdmin
     .from("workflows")
     .select("id", { count: "exact", head: true })
     .eq("workflow_type", "financing")
     .not("overall_status", "in", '("completed","cancelled","refunded","expired")');
+  if (visibleIds !== null) q = q.in("id", visibleIds);
+  const { count } = await q;
   return count ?? 0;
 }

--- a/src/app/request-location/page.tsx
+++ b/src/app/request-location/page.tsx
@@ -13,6 +13,7 @@ interface FormState {
   state: string;
   zip_codes: string[];
   machine_count: string;
+  machine_type: string;
 }
 
 const initial: FormState = {
@@ -24,7 +25,13 @@ const initial: FormState = {
   state: "",
   zip_codes: [""],
   machine_count: "",
+  machine_type: "",
 };
+
+// The five product lines the operator can request a location for.
+// Kept in one place so the label rendered in the receipt matches the
+// select value byte-for-byte (the API validates against this list).
+const MACHINE_TYPES = ["Combo", "AI", "Water", "Coffee", "ATM"] as const;
 
 const US_STATES = [
   "AL","AK","AZ","AR","CA","CO","CT","DE","FL","GA","HI","ID","IL","IN","IA",
@@ -104,6 +111,7 @@ function RequestLocationInner() {
     const validZips = form.zip_codes.map((z) => z.trim()).filter(Boolean);
     if (validZips.length === 0) { setError("Please enter at least one ZIP code."); return; }
     if (!form.machine_count.trim()) { setError("Please fill in number of machines."); return; }
+    if (!form.machine_type) { setError("Please select a machine type."); return; }
 
     setSubmitting(true);
     try {
@@ -121,6 +129,7 @@ function RequestLocationInner() {
           state: form.state,
           zip_codes: validZips,
           machine_count: Number(form.machine_count),
+          machine_type: form.machine_type,
           ref: ref || undefined,
         }),
       });
@@ -174,6 +183,9 @@ function RequestLocationInner() {
                     <tr><td className="py-1.5 pr-4 text-gray-500">State</td><td className="py-1.5 text-gray-900">{receiptData.state}</td></tr>
                     <tr><td className="py-1.5 pr-4 text-gray-500">ZIP Code(s)</td><td className="py-1.5 text-gray-900">{receiptData.zip_codes.filter(Boolean).join(", ")}</td></tr>
                     <tr><td className="py-1.5 pr-4 text-gray-500">Machines Requested</td><td className="py-1.5 font-medium text-gray-900">{receiptData.machine_count}</td></tr>
+                    {receiptData.machine_type && (
+                      <tr><td className="py-1.5 pr-4 text-gray-500">Machine Type</td><td className="py-1.5 text-gray-900">{receiptData.machine_type}</td></tr>
+                    )}
                     <tr className="border-t border-gray-200">
                       <td className="pt-3 pr-4 text-gray-500 font-medium">Deposit Paid</td>
                       <td className="pt-3 font-bold text-green-700 text-lg">$100.00</td>
@@ -256,6 +268,21 @@ function RequestLocationInner() {
               </label>
               <Field label="Number of Machines Needed" type="number" value={form.machine_count} onChange={(v) => update("machine_count", v)} />
             </div>
+
+            <label className="block">
+              <span className="mb-1.5 block text-sm font-medium text-black-primary">Machine Type</span>
+              <select
+                value={form.machine_type}
+                onChange={(e) => update("machine_type", e.target.value)}
+                required
+                className="w-full rounded-lg border border-gray-200 px-4 py-2.5 text-sm text-black-primary outline-none transition-colors focus:border-green-primary focus:ring-2 focus:ring-green-100 cursor-pointer"
+              >
+                <option value="">Select Machine Type</option>
+                {MACHINE_TYPES.map((t) => (
+                  <option key={t} value={t}>{t}</option>
+                ))}
+              </select>
+            </label>
 
             <div>
               <div className="flex items-center justify-between mb-1.5">

--- a/src/lib/marketplace/contracts.ts
+++ b/src/lib/marketplace/contracts.ts
@@ -76,6 +76,14 @@ export async function ensureContractForLocationServicesWorkflow(
     typeof intake.business_name === "string"
       ? intake.business_name.trim()
       : "";
+  // machine_type came from the /request-location selector (Combo / AI
+  // / Water / Coffee / ATM). placement_contracts.machine_type is free
+  // text — the marketplace card renders whatever we stamp here, so
+  // pass it through verbatim when present.
+  const machineType =
+    typeof intake.machine_type === "string" && intake.machine_type.trim()
+      ? intake.machine_type.trim()
+      : null;
 
   const settings = await getMarketplaceSettings();
   const platformFeeDollars = Math.min(
@@ -101,6 +109,7 @@ export async function ensureContractForLocationServicesWorkflow(
       platform_fee: platformFeeDollars,
       market_state: marketState || null,
       market_city: null,
+      machine_type: machineType,
       contract_type: locationsNeeded > 1 ? "multi" : "single",
       locations_needed: locationsNeeded,
       locations_filled: 0,

--- a/src/lib/workflows/permissions.ts
+++ b/src/lib/workflows/permissions.ts
@@ -18,18 +18,16 @@ export interface WorkflowActor {
   scope: "all" | "assigned" | "own";
 }
 
-// Every staff role now views ALL workflows — visibility is not what
-// gates write access. Editing is gated per-workflow via
-// canOperationallyEditWorkflow() (elevated role OR active assignment).
-const ROLES_VIEW_ALL = new Set([
-  "admin",
-  "director_of_sales",
-  "market_leader",
-  "sales_manager",
-  "sales",
-]);
+// Only admins may view every workflow across the org. Every other
+// staff role — including director_of_sales, market_leader, and
+// sales_manager — is scoped to workflows they are personally assigned
+// to (primary_owner or active collaborator via workflow_assignments).
+// Managers who need visibility across their reports get it by being
+// added as a collaborator on those workflows.
+const ROLES_VIEW_ALL = new Set(["admin"]);
 
-// Every staff role can add internal notes and view all workflows.
+// Staff roles — the population that can act inside the CRM at all.
+// This is unchanged; visibility scoping happens separately below.
 const STAFF_ROLES = new Set([
   "admin",
   "director_of_sales",
@@ -59,9 +57,14 @@ export async function getWorkflowActor(req: NextRequest): Promise<WorkflowActor 
   if (!profile) return null;
 
   const role = profile.role ?? "";
+  // admin → "all"; every other staff role → "assigned" (own +
+  // collaborator); anyone else (customer, PP, manufacturer_partner)
+  // → "own" (only workflows where they ARE the customer).
   const scope: "all" | "assigned" | "own" = ROLES_VIEW_ALL.has(role)
     ? "all"
-    : "own";
+    : STAFF_ROLES.has(role)
+      ? "assigned"
+      : "own";
 
   return {
     id: profile.id,

--- a/supabase/migrations/152_sales_leads_machine_type.sql
+++ b/supabase/migrations/152_sales_leads_machine_type.sql
@@ -1,0 +1,31 @@
+-- Migration 152: machine_type on sales_leads
+--
+-- Adds a nullable machine_type column to sales_leads so the
+-- /request-location form can capture which product line the operator
+-- wants placed. Legacy rows stay NULL; the CHECK constraint only
+-- validates NEW values so backfill isn't required.
+--
+-- The five accepted values match the /request-location page selector
+-- exactly: Combo, AI, Water, Coffee, ATM. Kept as text (not enum) so
+-- future additions don't need a schema migration on every enum change.
+
+ALTER TABLE public.sales_leads
+  ADD COLUMN IF NOT EXISTS machine_type text;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'sales_leads_machine_type_check'
+  ) THEN
+    ALTER TABLE public.sales_leads
+      ADD CONSTRAINT sales_leads_machine_type_check
+      CHECK (machine_type IS NULL OR machine_type IN ('Combo', 'AI', 'Water', 'Coffee', 'ATM'));
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS sales_leads_machine_type_idx
+  ON public.sales_leads (machine_type)
+  WHERE machine_type IS NOT NULL;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
…-location

Two related fixes on the operator-facing side of the CRM.

1. Workflow visibility (admin-only view-all)
   - src/lib/workflows/permissions.ts: ROLES_VIEW_ALL narrowed from {admin, DOS, market_leader, sales_manager, sales} to {admin}. Every other staff role now resolves to scope="assigned" — they only see workflows where they are primary_owner OR active collaborator via workflow_assignments. Non-staff (customers, PPs, manufacturer_partners) still fall through to scope="own", which the staff-only /api/workflows endpoint already forbids.
   - src/app/api/workflows/metrics/route.ts: rewrite so every aggregate query narrows to visible workflow ids for non-admin staff. Admin path is unchanged (visibleIds=null → no filter).
   - Editing permissions are intentionally untouched — a sales_manager/DOS/market_leader still has ROLES_EDIT rights on workflows they can see; they just don't see workflows they're not on.

2. machine_type on /request-location
   - supabase/migrations/152_sales_leads_machine_type.sql: adds nullable machine_type text column to sales_leads with CHECK for the 5 allowed values (Combo, AI, Water, Coffee, ATM) and a partial index for filtering. Idempotent.
   - src/app/request-location/page.tsx: required select added underneath State/Machine Count, receipt line renders the picked value.
   - src/app/api/request-location/route.ts: strict allowlist validation, persistence into sales_leads.machine_type with graceful fallback if migration 152 hasn't run, threaded into lead notes, order notes, order_items, QB line description, workflow.metadata.source_intake, and admin notification email.
   - src/lib/marketplace/contracts.ts: reads machine_type from the workflow's source_intake and stamps it onto the auto-created placement_contracts row so placement providers see the machine line-of-business when browsing the marketplace.

Typecheck clean; manufacturer + machine-listings tests still pass (21/21). Pre-existing locationPricing test failures are unrelated to this diff.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2