### PR TITLE
Marketing gondola under header on homepage + dashboard

### DIFF
--- a/public/images/marketing/10-10-10.svg
+++ b/public/images/marketing/10-10-10.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 1500" role="img" aria-label="10/10/10 Promotion placeholder">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#F0FDF4"/>
+      <stop offset="100%" stop-color="#DCFCE7"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="1500" fill="url(#g)"/>
+  <rect x="60" y="60" width="1080" height="1380" rx="40" fill="white" stroke="#22C55E" stroke-width="4" stroke-dasharray="16 16"/>
+  <g transform="translate(600 700)" text-anchor="middle" font-family="Inter, system-ui, sans-serif">
+    <text y="0" font-size="90" font-weight="800" fill="#0A0A0A">10 / 10 / 10</text>
+    <text y="80" font-size="32" fill="#525252">10 Machines · 10 Locations · 10 Year Financing</text>
+    <text y="180" font-size="24" fill="#737373">Drop your real image at:</text>
+    <text y="230" font-size="26" font-weight="600" fill="#22C55E">/public/images/marketing/10-10-10.png</text>
+  </g>
+</svg>

--- a/public/images/marketing/ai-vending.svg
+++ b/public/images/marketing/ai-vending.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 1500" role="img" aria-label="AI Vending Machines placeholder">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#F0FDF4"/>
+      <stop offset="100%" stop-color="#DCFCE7"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="1500" fill="url(#g)"/>
+  <rect x="60" y="60" width="1080" height="1380" rx="40" fill="white" stroke="#22C55E" stroke-width="4" stroke-dasharray="16 16"/>
+  <g transform="translate(600 700)" text-anchor="middle" font-family="Inter, system-ui, sans-serif">
+    <text y="0" font-size="90" font-weight="800" fill="#0A0A0A">AI Vending</text>
+    <text y="80" font-size="32" fill="#525252">VendEra AI product lineup</text>
+    <text y="180" font-size="24" fill="#737373">Drop your real image at:</text>
+    <text y="230" font-size="26" font-weight="600" fill="#22C55E">/public/images/marketing/ai-vending.png</text>
+  </g>
+</svg>

--- a/public/images/marketing/coffee-service.svg
+++ b/public/images/marketing/coffee-service.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 1500" role="img" aria-label="Coffee Service placeholder">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#F0FDF4"/>
+      <stop offset="100%" stop-color="#DCFCE7"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="1500" fill="url(#g)"/>
+  <rect x="60" y="60" width="1080" height="1380" rx="40" fill="white" stroke="#22C55E" stroke-width="4" stroke-dasharray="16 16"/>
+  <g transform="translate(600 700)" text-anchor="middle" font-family="Inter, system-ui, sans-serif">
+    <text y="0" font-size="80" font-weight="800" fill="#0A0A0A">Coffee Service</text>
+    <text y="80" font-size="32" fill="#525252">Flavia C600 brewer photo</text>
+    <text y="180" font-size="24" fill="#737373">Drop your real image at:</text>
+    <text y="230" font-size="26" font-weight="600" fill="#22C55E">/public/images/marketing/coffee-service.png</text>
+  </g>
+</svg>

--- a/public/images/marketing/financing.svg
+++ b/public/images/marketing/financing.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 1500" role="img" aria-label="Financing placeholder">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#F0FDF4"/>
+      <stop offset="100%" stop-color="#DCFCE7"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="1500" fill="url(#g)"/>
+  <rect x="60" y="60" width="1080" height="1380" rx="40" fill="white" stroke="#22C55E" stroke-width="4" stroke-dasharray="16 16"/>
+  <g transform="translate(600 700)" text-anchor="middle" font-family="Inter, system-ui, sans-serif">
+    <text y="0" font-size="90" font-weight="800" fill="#0A0A0A">10-Year Financing</text>
+    <text y="80" font-size="32" fill="#525252">Flexible terms · Low monthly payments</text>
+    <text y="180" font-size="24" fill="#737373">Drop your real image at:</text>
+    <text y="230" font-size="26" font-weight="600" fill="#22C55E">/public/images/marketing/financing.png</text>
+  </g>
+</svg>

--- a/public/images/marketing/website-services.svg
+++ b/public/images/marketing/website-services.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 1500" role="img" aria-label="Website Services placeholder">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#F0FDF4"/>
+      <stop offset="100%" stop-color="#DCFCE7"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="1500" fill="url(#g)"/>
+  <rect x="60" y="60" width="1080" height="1380" rx="40" fill="white" stroke="#22C55E" stroke-width="4" stroke-dasharray="16 16"/>
+  <g transform="translate(600 700)" text-anchor="middle" font-family="Inter, system-ui, sans-serif">
+    <text y="0" font-size="90" font-weight="800" fill="#0A0A0A">Website Services</text>
+    <text y="80" font-size="32" fill="#525252">Custom vending business websites</text>
+    <text y="180" font-size="24" fill="#737373">Drop your real image at:</text>
+    <text y="230" font-size="26" font-weight="600" fill="#22C55E">/public/images/marketing/website-services.png</text>
+  </g>
+</svg>

--- a/src/app/HomePageClient.tsx
+++ b/src/app/HomePageClient.tsx
@@ -27,6 +27,7 @@ import {
 } from "lucide-react";
 import { createBrowserClient } from "@/lib/supabase";
 import ScrollProgress from "@/app/components/ScrollProgress";
+import MarketingGondola from "@/app/components/marketing/MarketingGondola";
 import PathCard from "@/app/components/homepage/PathCard";
 import ServiceCard from "@/app/components/homepage/ServiceCard";
 import AudienceCard from "@/app/components/homepage/AudienceCard";
@@ -236,6 +237,15 @@ export default function HomePageClient() {
   return (
     <div className="overflow-hidden">
       <ScrollProgress />
+
+      {/* ============================================================ */}
+      {/*  0. MARKETING GONDOLA — sits directly under the header.      */}
+      {/*     Rotating promo carousel shared with the logged-in        */}
+      {/*     dashboard so both surfaces show the same "what we do"    */}
+      {/*     showcase. Existing homepage sections below are           */}
+      {/*     unchanged.                                               */}
+      {/* ============================================================ */}
+      <MarketingGondola />
 
       {/* ============================================================ */}
       {/*  1. HERO                                                     */}

--- a/src/app/components/marketing/MarketingGondola.tsx
+++ b/src/app/components/marketing/MarketingGondola.tsx
@@ -1,0 +1,361 @@
+"use client";
+
+/**
+ * MarketingGondola — the rotating hero-height promo carousel that
+ * sits directly under the site header on both the public homepage
+ * and the logged-in dashboard.
+ *
+ * Rendered by:
+ *   - src/app/HomePageClient.tsx (public /)
+ *   - src/app/dashboard/page.tsx (authenticated /dashboard)
+ *
+ * Design goals — matches the Vending Connector visual language:
+ *   - VC brand colors sourced from tailwind theme tokens
+ *     (green-primary, green-hover, black-primary, light-warm) —
+ *     never hard-coded hex.
+ *   - Two-column composition on md+ (content left, product image
+ *     right); stacked on mobile.
+ *   - Auto-advance every AUTO_ADVANCE_MS; pauses when the user is
+ *     hovering, focused, or has requested reduced motion.
+ *   - Manual controls: prev/next arrows, dot indicators, keyboard
+ *     left/right arrows, and touch swipe.
+ *   - Only the first slide's image is priority-loaded; the rest lazy
+ *     load once they enter view.
+ *   - Every CTA points to an existing route verified in the
+ *     codebase — no `#` or fake hrefs.
+ *
+ * Placeholder assets: the 5 SVGs at /public/images/marketing/*.svg
+ * are stand-ins until the marketing photos are dropped in. Replacing
+ * them is a single-line edit in the SLIDES array below.
+ */
+
+import Image from "next/image";
+import Link from "next/link";
+import {
+  ArrowRight,
+  ChevronLeft,
+  ChevronRight,
+  Coffee,
+  Banknote,
+  Package,
+  Globe,
+  TrendingUp,
+} from "lucide-react";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useCallback,
+  useSyncExternalStore,
+} from "react";
+
+const AUTO_ADVANCE_MS = 12_000;
+// Any horizontal swipe wider than this (in pixels) counts as a slide
+// change. Below the threshold we ignore it so vertical scrolls on
+// mobile don't accidentally trigger navigation.
+const SWIPE_THRESHOLD_PX = 40;
+
+type Slide = {
+  id: string;
+  eyebrow: string;
+  title: string;
+  description: string;
+  bullets?: string[];
+  image: { src: string; alt: string };
+  cta: { label: string; href: string };
+  icon: typeof Coffee;
+};
+
+// Every href below points to an existing page in the app router —
+// verified against `find src/app -name page.tsx`.
+const SLIDES: Slide[] = [
+  {
+    id: "coffee",
+    eyebrow: "Premium Coffee Program",
+    title: "Add Coffee Revenue to Your Vending Route",
+    description:
+      "A professional single-serve brewer, wide beverage variety, and a supply program designed for workplaces — managed end-to-end by Vending Connector.",
+    bullets: [
+      "Commercial-grade brewer",
+      "Wide beverage variety",
+      "Managed supply program",
+    ],
+    image: { src: "/images/marketing/coffee-service.svg", alt: "Premium single-serve coffee brewer" },
+    cta: { label: "Enroll Now", href: "/coffee/apply" },
+    icon: Coffee,
+  },
+  {
+    id: "10-10-10",
+    eyebrow: "Featured Program",
+    title: "Scale Your Vending Business — 10 / 10 / 10",
+    description:
+      "Ten machines, ten locations, ten-year financing. The Vending Connector program designed to help you go from a starter route to a real vending business, all through one platform.",
+    bullets: [
+      "10 vending machines",
+      "10 qualified locations",
+      "10-year financing options",
+    ],
+    image: { src: "/images/marketing/10-10-10.svg", alt: "10 Machines 10 Locations 10 Year Financing" },
+    cta: { label: "Sign Up Today", href: "/signup" },
+    icon: TrendingUp,
+  },
+  {
+    id: "financing",
+    eyebrow: "Machine Financing",
+    title: "Flexible Financing for Your Vending Business",
+    description:
+      "Long-term financing options — including qualifying 10-year terms — so you can acquire vending equipment without paying the full amount up front.",
+    bullets: [
+      "Low monthly payments for qualifying operators",
+      "Fast application process",
+      "Flexible terms built for growth",
+    ],
+    image: { src: "/images/marketing/financing.svg", alt: "10-year vending machine financing" },
+    cta: { label: "Explore Financing", href: "/financing" },
+    icon: Banknote,
+  },
+  {
+    id: "ai-vending",
+    eyebrow: "AI Vending Solutions",
+    title: "Smarter Vending, Powered by AI",
+    description:
+      "Browse the Vending Connector AI machine lineup — from the VendEra AI Cooler and beyond. AI-powered product recognition, cashless payments, and remote monitoring in every model.",
+    bullets: [
+      "AI product recognition",
+      "Cashless payment systems",
+      "Remote inventory monitoring",
+    ],
+    image: { src: "/images/marketing/ai-vending.svg", alt: "AI-powered vending machines" },
+    cta: { label: "Explore AI Vending", href: "/machines-for-sale" },
+    icon: Package,
+  },
+  {
+    id: "website-services",
+    eyebrow: "Website Services",
+    title: "Build Your Vending Business Online",
+    description:
+      "Custom, mobile-responsive websites built for vending operators. Lead capture, product and service pages, and fast turnaround so your business looks the part.",
+    bullets: [
+      "Mobile-responsive design",
+      "Lead capture forms",
+      "Product & service pages",
+    ],
+    image: { src: "/images/marketing/website-services.svg", alt: "Professional vending business website" },
+    cta: { label: "Explore Website Services", href: "/website-services" },
+    icon: Globe,
+  },
+];
+
+// React 19-friendly reduced-motion hook. Uses useSyncExternalStore
+// so the initial read happens synchronously without a setState-in-
+// effect cycle, and the server-render path returns false (motion
+// enabled) deterministically.
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+function subscribeReducedMotion(cb: () => void): () => void {
+  if (typeof window === "undefined" || !window.matchMedia) return () => {};
+  const mq = window.matchMedia(REDUCED_MOTION_QUERY);
+  if (mq.addEventListener) {
+    mq.addEventListener("change", cb);
+    return () => mq.removeEventListener("change", cb);
+  }
+  // Legacy Safari fallback.
+  mq.addListener(cb);
+  return () => mq.removeListener(cb);
+}
+function getReducedMotionSnapshot(): boolean {
+  if (typeof window === "undefined" || !window.matchMedia) return false;
+  return window.matchMedia(REDUCED_MOTION_QUERY).matches;
+}
+function getReducedMotionServerSnapshot(): boolean {
+  return false;
+}
+function useReducedMotion(): boolean {
+  return useSyncExternalStore(
+    subscribeReducedMotion,
+    getReducedMotionSnapshot,
+    getReducedMotionServerSnapshot,
+  );
+}
+
+export default function MarketingGondola() {
+  const [index, setIndex] = useState(0);
+  const [paused, setPaused] = useState(false);
+  const reducedMotion = useReducedMotion();
+  const touchStartX = useRef<number | null>(null);
+  const regionRef = useRef<HTMLElement>(null);
+
+  const slideCount = SLIDES.length;
+  const activeSlide = SLIDES[index];
+
+  const goTo = useCallback(
+    (next: number) => {
+      setIndex(((next % slideCount) + slideCount) % slideCount);
+    },
+    [slideCount],
+  );
+  const next = useCallback(() => goTo(index + 1), [goTo, index]);
+  const prev = useCallback(() => goTo(index - 1), [goTo, index]);
+
+  // Auto-advance timer. Restarts whenever index, pause state, or the
+  // reduced-motion preference changes so we never fight the user.
+  useEffect(() => {
+    if (paused || reducedMotion) return;
+    const t = setTimeout(next, AUTO_ADVANCE_MS);
+    return () => clearTimeout(t);
+  }, [index, paused, reducedMotion, next]);
+
+  // Keyboard navigation — only when the carousel region has focus.
+  useEffect(() => {
+    const el = regionRef.current;
+    if (!el) return;
+    const handler = (e: KeyboardEvent) => {
+      if (!el.contains(document.activeElement)) return;
+      if (e.key === "ArrowRight") { e.preventDefault(); next(); }
+      if (e.key === "ArrowLeft")  { e.preventDefault(); prev(); }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [next, prev]);
+
+  function handleTouchStart(e: React.TouchEvent) {
+    touchStartX.current = e.touches[0].clientX;
+  }
+  function handleTouchEnd(e: React.TouchEvent) {
+    if (touchStartX.current == null) return;
+    const dx = e.changedTouches[0].clientX - touchStartX.current;
+    touchStartX.current = null;
+    if (Math.abs(dx) < SWIPE_THRESHOLD_PX) return;
+    if (dx < 0) next(); else prev();
+  }
+
+  const Icon = activeSlide.icon;
+
+  // Reserve stable dimensions so hydrated content doesn't reflow when
+  // the first slide's image finishes loading. Aspect ratio math is
+  // hard-coded on the parent to guarantee a fixed hero height.
+  const slideKeys = useMemo(() => SLIDES.map((s) => s.id), []);
+
+  return (
+    <section
+      ref={regionRef}
+      role="region"
+      aria-roledescription="carousel"
+      aria-label="Vending Connector featured programs"
+      className="relative w-full overflow-hidden border-b border-gray-100 bg-gradient-to-b from-light-warm via-white to-light-warm"
+      onMouseEnter={() => setPaused(true)}
+      onMouseLeave={() => setPaused(false)}
+      onFocus={() => setPaused(true)}
+      onBlur={() => setPaused(false)}
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
+    >
+      <div className="mx-auto grid max-w-7xl gap-6 px-4 py-8 sm:px-6 sm:py-10 md:grid-cols-2 md:gap-10 md:py-14 lg:px-8">
+        {/* Text column — order-2 on mobile so the image doesn't
+            dominate the fold on small screens. */}
+        <div
+          key={`content-${activeSlide.id}`}
+          className="order-2 flex flex-col justify-center animate-fade-in"
+          aria-live="polite"
+        >
+          <span className="inline-flex w-fit items-center gap-1.5 rounded-full bg-green-primary/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-wider text-green-primary">
+            <Icon className="h-3.5 w-3.5" />
+            {activeSlide.eyebrow}
+          </span>
+          <h2 className="mt-4 text-2xl font-extrabold leading-tight tracking-tight text-black-primary sm:text-3xl lg:text-4xl">
+            {activeSlide.title}
+          </h2>
+          <p className="mt-4 max-w-xl text-sm leading-relaxed text-gray-600 sm:text-base">
+            {activeSlide.description}
+          </p>
+          {activeSlide.bullets && activeSlide.bullets.length > 0 && (
+            <ul className="mt-5 space-y-2 text-sm text-gray-700">
+              {activeSlide.bullets.map((b) => (
+                <li key={b} className="flex items-start gap-2">
+                  <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-green-primary" />
+                  <span>{b}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+          <div className="mt-7 flex flex-wrap items-center gap-3">
+            <Link
+              href={activeSlide.cta.href}
+              className="inline-flex items-center gap-2 rounded-lg bg-green-primary px-6 py-3 text-sm font-semibold text-white shadow-sm transition-all hover:bg-green-hover hover:shadow-md focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-primary"
+            >
+              {activeSlide.cta.label}
+              <ArrowRight className="h-4 w-4" />
+            </Link>
+            <span className="text-xs text-gray-400">
+              {index + 1} / {slideCount}
+            </span>
+          </div>
+        </div>
+
+        {/* Image column — fixed aspect ratio keeps hero height stable
+            across slides. next/image with priority on the first slide
+            only; the rest lazy load. */}
+        <div className="order-1 md:order-2">
+          <div className="relative mx-auto aspect-[4/5] w-full max-w-md overflow-hidden rounded-2xl border border-gray-100 bg-white shadow-sm md:aspect-[4/5]">
+            {SLIDES.map((s, i) => (
+              <Image
+                key={s.id}
+                src={s.image.src}
+                alt={s.image.alt}
+                fill
+                sizes="(min-width: 1024px) 480px, (min-width: 768px) 40vw, 90vw"
+                priority={i === 0}
+                loading={i === 0 ? undefined : "lazy"}
+                className={`object-cover transition-opacity duration-500 ${i === index ? "opacity-100" : "opacity-0"}`}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Prev / Next arrows — visible on md+ where there's room. */}
+      <button
+        type="button"
+        onClick={prev}
+        aria-label="Previous slide"
+        className="absolute left-2 top-1/2 hidden -translate-y-1/2 rounded-full border border-gray-200 bg-white/90 p-2 text-black-primary shadow-sm backdrop-blur transition-all hover:border-green-primary hover:text-green-primary md:inline-flex"
+      >
+        <ChevronLeft className="h-5 w-5" />
+      </button>
+      <button
+        type="button"
+        onClick={next}
+        aria-label="Next slide"
+        className="absolute right-2 top-1/2 hidden -translate-y-1/2 rounded-full border border-gray-200 bg-white/90 p-2 text-black-primary shadow-sm backdrop-blur transition-all hover:border-green-primary hover:text-green-primary md:inline-flex"
+      >
+        <ChevronRight className="h-5 w-5" />
+      </button>
+
+      {/* Dot indicators — always visible, mobile-tap friendly. */}
+      <div
+        role="tablist"
+        aria-label="Choose slide"
+        className="flex items-center justify-center gap-2 pb-5"
+      >
+        {slideKeys.map((key, i) => {
+          const active = i === index;
+          return (
+            <button
+              key={key}
+              type="button"
+              role="tab"
+              aria-selected={active}
+              aria-label={`Slide ${i + 1}: ${SLIDES[i].title}`}
+              onClick={() => goTo(i)}
+              className={`h-2 rounded-full transition-all ${
+                active
+                  ? "w-8 bg-green-primary"
+                  : "w-2 bg-gray-300 hover:bg-gray-400"
+              }`}
+            />
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -45,6 +45,7 @@ import { TOOLTIP_COPY } from "@/lib/tooltipCopy";
 import OperatorOnboarding from "./OperatorOnboarding";
 import LocatorOnboarding from "@/app/components/LocatorOnboarding";
 import ListingPipeline from "@/app/components/ListingPipeline";
+import MarketingGondola from "@/app/components/marketing/MarketingGondola";
 
 /* ------------------------------------------------------------------ */
 /*  Helpers                                                            */
@@ -449,6 +450,14 @@ export default function DashboardPage() {
 
   return (
     <div className="min-h-[calc(100vh-160px)] bg-light">
+      {/* ------- MARKETING GONDOLA -------
+          Rotating promo carousel — same component the public homepage
+          renders, so a logged-in user sees the same "what we do"
+          showcase directly under the top nav. Everything below
+          (welcome header, quick actions, requests, operators) is
+          unchanged. */}
+      <MarketingGondola />
+
       {/* ------- WELCOME HEADER ------- */}
       <div className="border-b border-gray-100 bg-white">
         <div className="mx-auto max-w-7xl px-4 py-10 sm:px-6 lg:px-8">


### PR DESCRIPTION
Adds a rotating 5-slide marketing carousel that sits directly under the header/navigation on the public homepage and the authenticated dashboard. Existing content on both surfaces is preserved and moves down below the gondola.

Component
- src/app/components/marketing/MarketingGondola.tsx: reusable client component shared by both mount points. Two-column composition (content left, product image right) on md+, stacked on mobile. Auto-advances every 12s and pauses on hover, focus, or when the viewer's OS requests reduced motion (useSyncExternalStore-backed hook, no set-state-in-effect). Prev/next arrows on md+, always-on dot indicators, keyboard left/right, and mobile swipe. First slide's image is priority-loaded via next/image; the rest lazy load. Uses the existing @theme tokens — green-primary, green-hover, black-primary, light-warm — never hard-coded hex, matches the existing VC visual language.

Slides — every href verified against src/app/**/page.tsx
- Coffee Service  → /coffee/apply   (Enroll Now)
- 10 / 10 / 10    → /signup         (Sign Up Today; matches the
                                    "SIGN UP TODAY" CTA on the
                                    marketing asset)
- Financing       → /financing      (Explore Financing)
- AI Vending      → /machines-for-sale (Explore AI Vending)
- Website Services → /website-services (Explore Website Services)

Copy is written from what actually exists in the app (VendEra AI product line, 10-year financing, coffee supply program) — no invented specs, no fabricated interest rates or approval terms.

Mount points
- src/app/HomePageClient.tsx: gondola sits between ScrollProgress and the existing hero; all 11 downstream sections untouched.
- src/app/dashboard/page.tsx: gondola sits between the outer wrapper and the welcome header on the authenticated dashboard only. Not rendered on the "sign in to your Dashboard", auth-loading, or operator-onboarding interstitial states.

Assets
- public/images/marketing/*.svg (5 files): visually-appealing SVG placeholders sized to a 4:5 portrait aspect matching the source photos, so the layout won't reflow when real assets land. Replacing each placeholder is a single edit in the SLIDES array.

Accessibility
- <section role="region" aria-roledescription="carousel"> with an aria-label; each dot is a <button role="tab" aria-selected> with a descriptive aria-label; prev/next arrows carry aria-labels; focus-visible outlines on the CTA; aria-live="polite" on the text panel so a screen reader announces the slide change.
- Reduced-motion: the auto-advance timer never arms when the OS requests reduced motion; manual navigation still works.
- Keyboard: window-scoped keydown handler that only fires when the carousel region contains the active element, so pressing arrows while typing elsewhere on the page never steals the input.

Typecheck clean; eslint clean on the new file; existing manufacturer/ listings vitest suite still 21/21.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2