### PR TITLE
Admin uploader for marketing gondola images

### DIFF
--- a/src/app/admin/marketing/gondola/page.tsx
+++ b/src/app/admin/marketing/gondola/page.tsx
@@ -1,0 +1,330 @@
+"use client";
+
+/**
+ * /admin/marketing/gondola
+ *
+ * Admin-only uploader for the 5 marketing gondola images that render
+ * on the public homepage and the logged-in dashboard. Each slot shows
+ * the current image (with source label — Uploaded / Placeholder), a
+ * "Choose file" input, and a Revert button that drops the override
+ * so the shipped placeholder SVG takes over again.
+ *
+ * Access is gated server-side by the PUT/DELETE endpoints — this
+ * page is a UI convenience; a non-admin who navigates here gets 403s
+ * on every action they try.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import Image from "next/image";
+import { createBrowserClient } from "@/lib/supabase";
+import {
+  GONDOLA_SLOTS,
+  GONDOLA_SLOT_LABELS,
+  GONDOLA_MAX_BYTES,
+  type GondolaSlot,
+} from "@/lib/marketingGondola";
+import {
+  ArrowLeft,
+  ImageIcon,
+  Loader2,
+  RotateCcw,
+  Upload,
+  CheckCircle2,
+  AlertCircle,
+} from "lucide-react";
+
+type SlotImage = { url: string; uploaded_at: string } | null;
+type SlotState = {
+  status: "idle" | "uploading" | "reverting";
+  error: string | null;
+  ok: string | null;
+};
+
+const PLACEHOLDER_SRC: Record<GondolaSlot, string> = {
+  coffee: "/images/marketing/coffee-service.svg",
+  "10-10-10": "/images/marketing/10-10-10.svg",
+  financing: "/images/marketing/financing.svg",
+  "ai-vending": "/images/marketing/ai-vending.svg",
+  "website-services": "/images/marketing/website-services.svg",
+};
+
+export default function GondolaAdminPage() {
+  const [token, setToken] = useState<string>("");
+  const [authChecked, setAuthChecked] = useState(false);
+  const [images, setImages] = useState<Record<GondolaSlot, SlotImage>>({
+    coffee: null,
+    "10-10-10": null,
+    financing: null,
+    "ai-vending": null,
+    "website-services": null,
+  });
+  const [slotState, setSlotState] = useState<Record<GondolaSlot, SlotState>>(() => {
+    const init: Record<string, SlotState> = {};
+    for (const s of GONDOLA_SLOTS) init[s] = { status: "idle", error: null, ok: null };
+    return init as Record<GondolaSlot, SlotState>;
+  });
+  const fileInputs = useRef<Record<GondolaSlot, HTMLInputElement | null>>(
+    Object.fromEntries(GONDOLA_SLOTS.map((s) => [s, null])) as Record<GondolaSlot, HTMLInputElement | null>,
+  );
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      setToken(session?.access_token ?? "");
+      setAuthChecked(true);
+    });
+  }, []);
+
+  const refresh = useCallback(async () => {
+    const res = await fetch("/api/marketing/gondola", { cache: "no-store" });
+    if (!res.ok) return;
+    const data = await res.json();
+    setImages(data.images ?? {});
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  async function uploadForSlot(slot: GondolaSlot, file: File) {
+    if (file.size > GONDOLA_MAX_BYTES) {
+      setSlotState((s) => ({
+        ...s,
+        [slot]: {
+          status: "idle",
+          error: `File is larger than ${GONDOLA_MAX_BYTES / (1024 * 1024)} MB.`,
+          ok: null,
+        },
+      }));
+      return;
+    }
+    setSlotState((s) => ({ ...s, [slot]: { status: "uploading", error: null, ok: null } }));
+    try {
+      const form = new FormData();
+      form.append("file", file);
+      const res = await fetch(`/api/admin/marketing/gondola/${slot}`, {
+        method: "PUT",
+        headers: { Authorization: `Bearer ${token}` },
+        body: form,
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(json.error || `Upload failed (${res.status})`);
+      setImages((prev) => ({
+        ...prev,
+        [slot]: { url: json.url, uploaded_at: json.uploaded_at },
+      }));
+      setSlotState((s) => ({ ...s, [slot]: { status: "idle", error: null, ok: "Uploaded — live on the gondola." } }));
+    } catch (err) {
+      setSlotState((s) => ({
+        ...s,
+        [slot]: {
+          status: "idle",
+          error: err instanceof Error ? err.message : "Upload failed",
+          ok: null,
+        },
+      }));
+    }
+  }
+
+  async function revertSlot(slot: GondolaSlot) {
+    if (!window.confirm(`Revert the "${GONDOLA_SLOT_LABELS[slot]}" slide to the placeholder image?`)) return;
+    setSlotState((s) => ({ ...s, [slot]: { status: "reverting", error: null, ok: null } }));
+    try {
+      const res = await fetch(`/api/admin/marketing/gondola/${slot}`, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(json.error || `Revert failed (${res.status})`);
+      setImages((prev) => ({ ...prev, [slot]: null }));
+      setSlotState((s) => ({ ...s, [slot]: { status: "idle", error: null, ok: "Reverted to placeholder." } }));
+    } catch (err) {
+      setSlotState((s) => ({
+        ...s,
+        [slot]: {
+          status: "idle",
+          error: err instanceof Error ? err.message : "Revert failed",
+          ok: null,
+        },
+      }));
+    }
+  }
+
+  if (!authChecked) {
+    return (
+      <div className="mx-auto max-w-4xl px-4 py-16 sm:px-6">
+        <Loader2 className="h-6 w-6 animate-spin text-green-primary" />
+      </div>
+    );
+  }
+  if (!token) {
+    return (
+      <div className="mx-auto max-w-4xl px-4 py-16 sm:px-6">
+        <h1 className="text-xl font-semibold text-black-primary">Sign in required</h1>
+        <p className="mt-2 text-sm text-gray-600">
+          Log in with an admin account to manage marketing gondola images.
+        </p>
+        <Link
+          href="/login"
+          className="mt-4 inline-flex items-center gap-2 rounded-lg bg-green-primary px-4 py-2 text-sm font-semibold text-white hover:bg-green-hover"
+        >
+          Go to Log In
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-light">
+      <div className="border-b border-gray-100 bg-white">
+        <div className="mx-auto max-w-5xl px-4 py-8 sm:px-6">
+          <Link
+            href="/admin"
+            className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-green-primary"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Back to Admin
+          </Link>
+          <h1 className="mt-3 text-2xl font-bold text-black-primary sm:text-3xl">
+            Marketing Gondola Images
+          </h1>
+          <p className="mt-2 max-w-2xl text-sm text-gray-600">
+            Swap the 5 photos that rotate under the header on the homepage and the logged-in dashboard.
+            Uploads go live immediately — no code push required. Reverting a slot restores the shipped
+            placeholder image.
+          </p>
+          <p className="mt-2 text-xs text-gray-500">
+            PNG, JPEG, or WebP · up to {GONDOLA_MAX_BYTES / (1024 * 1024)} MB · portrait 4:5 works best.
+          </p>
+        </div>
+      </div>
+
+      <div className="mx-auto max-w-5xl px-4 py-8 sm:px-6 space-y-6">
+        {GONDOLA_SLOTS.map((slot) => {
+          const label = GONDOLA_SLOT_LABELS[slot];
+          const uploaded = images[slot];
+          const state = slotState[slot];
+          const src = uploaded?.url ?? PLACEHOLDER_SRC[slot];
+          return (
+            <div
+              key={slot}
+              className="grid grid-cols-1 gap-5 rounded-2xl border border-gray-100 bg-white p-5 shadow-sm sm:grid-cols-[220px_1fr] sm:gap-6"
+            >
+              {/* Preview */}
+              <div className="relative aspect-[4/5] w-full max-w-[220px] overflow-hidden rounded-xl border border-gray-100 bg-gray-50">
+                <Image
+                  key={src}
+                  src={src}
+                  alt={`${label} preview`}
+                  fill
+                  sizes="220px"
+                  unoptimized
+                  className="object-cover"
+                />
+              </div>
+
+              {/* Controls */}
+              <div className="flex flex-col">
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <h2 className="text-lg font-semibold text-black-primary">{label}</h2>
+                    <p className="mt-1 text-xs uppercase tracking-wider text-gray-500">
+                      Slot ID: <code className="font-mono">{slot}</code>
+                    </p>
+                  </div>
+                  <span
+                    className={
+                      uploaded
+                        ? "inline-flex items-center gap-1 rounded-full bg-green-50 px-2.5 py-1 text-xs font-semibold text-green-700 ring-1 ring-inset ring-green-200"
+                        : "inline-flex items-center gap-1 rounded-full bg-amber-50 px-2.5 py-1 text-xs font-semibold text-amber-700 ring-1 ring-inset ring-amber-200"
+                    }
+                  >
+                    <ImageIcon className="h-3.5 w-3.5" />
+                    {uploaded ? "Uploaded" : "Placeholder"}
+                  </span>
+                </div>
+
+                {uploaded && (
+                  <p className="mt-2 text-xs text-gray-500">
+                    Last uploaded: {new Date(uploaded.uploaded_at).toLocaleString()}
+                  </p>
+                )}
+
+                <input
+                  ref={(el) => {
+                    fileInputs.current[slot] = el;
+                  }}
+                  type="file"
+                  accept="image/png,image/jpeg,image/webp"
+                  className="hidden"
+                  onChange={(e) => {
+                    const file = e.target.files?.[0];
+                    if (file) uploadForSlot(slot, file);
+                    // Reset so the same file can be re-selected after a
+                    // failed upload without needing to pick a different file.
+                    e.target.value = "";
+                  }}
+                />
+
+                <div className="mt-4 flex flex-wrap items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => fileInputs.current[slot]?.click()}
+                    disabled={state.status !== "idle"}
+                    className="inline-flex items-center gap-2 rounded-lg bg-green-primary px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-green-hover disabled:opacity-50"
+                  >
+                    {state.status === "uploading" ? (
+                      <>
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                        Uploading…
+                      </>
+                    ) : (
+                      <>
+                        <Upload className="h-4 w-4" />
+                        {uploaded ? "Replace image" : "Upload image"}
+                      </>
+                    )}
+                  </button>
+                  {uploaded && (
+                    <button
+                      type="button"
+                      onClick={() => revertSlot(slot)}
+                      disabled={state.status !== "idle"}
+                      className="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-4 py-2 text-sm font-semibold text-gray-600 hover:border-red-200 hover:bg-red-50 hover:text-red-700 disabled:opacity-50"
+                    >
+                      {state.status === "reverting" ? (
+                        <>
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                          Reverting…
+                        </>
+                      ) : (
+                        <>
+                          <RotateCcw className="h-4 w-4" />
+                          Revert to placeholder
+                        </>
+                      )}
+                    </button>
+                  )}
+                </div>
+
+                {state.error && (
+                  <div className="mt-3 flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+                    <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+                    <span>{state.error}</span>
+                  </div>
+                )}
+                {state.ok && (
+                  <div className="mt-3 flex items-start gap-2 rounded-lg border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700">
+                    <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0" />
+                    <span>{state.ok}</span>
+                  </div>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -30,6 +30,7 @@ import {
   DollarSign,
   UserPlus,
   Coffee,
+  Image as ImageIcon,
 } from "lucide-react";
 import Link from "next/link";
 import { createBrowserClient } from "@/lib/supabase";
@@ -4715,6 +4716,14 @@ export default function AdminPage() {
                 <DollarSign className="h-4 w-4" />
                 <span className="hidden sm:inline">Financial Center</span>
                 <span className="sm:hidden">$</span>
+              </Link>
+              <Link
+                href="/admin/marketing/gondola"
+                className="inline-flex items-center gap-2 rounded-xl border border-green-primary px-4 py-2.5 text-sm font-medium text-green-primary shadow-sm transition-colors hover:bg-green-50"
+              >
+                <ImageIcon className="h-4 w-4" />
+                <span className="hidden sm:inline">Gondola Images</span>
+                <span className="sm:hidden">Gondola</span>
               </Link>
               <Link
                 href="/sales"

--- a/src/app/api/admin/marketing/gondola/[slot]/route.ts
+++ b/src/app/api/admin/marketing/gondola/[slot]/route.ts
@@ -1,0 +1,181 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+import {
+  GONDOLA_ALLOWED_MIME,
+  GONDOLA_BUCKET,
+  GONDOLA_MAX_BYTES,
+  isGondolaSlot,
+} from "@/lib/marketingGondola";
+
+/**
+ * PUT /api/admin/marketing/gondola/[slot]
+ *   multipart/form-data:
+ *     file — the image (png/jpeg/webp, <= 15 MB)
+ *
+ * Admin-only. Uploads the file into the public 'marketing-gondola'
+ * bucket, upserts marketing_gondola_images by slot, and removes the
+ * previous storage object so we don't accumulate orphans. The
+ * gondola component picks up the new image on the next
+ * /api/marketing/gondola fetch — the response URL carries a
+ * ?v=<epoch> cache-buster so viewers see the swap immediately.
+ */
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: Promise<{ slot: string }> },
+) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const { slot } = await params;
+  if (!isGondolaSlot(slot)) {
+    return NextResponse.json({ error: "Unknown gondola slot" }, { status: 400 });
+  }
+
+  const contentType = req.headers.get("content-type") || "";
+  if (!contentType.includes("multipart/form-data")) {
+    return NextResponse.json(
+      { error: "multipart/form-data required" },
+      { status: 400 },
+    );
+  }
+
+  const form = await req.formData();
+  const file = form.get("file");
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: "file is required" }, { status: 400 });
+  }
+
+  const mime = file.type || "application/octet-stream";
+  if (!GONDOLA_ALLOWED_MIME.has(mime)) {
+    return NextResponse.json(
+      { error: `Unsupported file type: ${mime}. Use PNG, JPEG, or WebP.` },
+      { status: 415 },
+    );
+  }
+  if (file.size > GONDOLA_MAX_BYTES) {
+    return NextResponse.json(
+      { error: `File exceeds ${GONDOLA_MAX_BYTES / (1024 * 1024)} MB limit.` },
+      { status: 413 },
+    );
+  }
+
+  const ext = extensionFromMime(mime);
+  // Timestamped filename so successive uploads never collide inside
+  // the CDN's URL cache — the previous object is removed below.
+  const key = `${slot}/${Date.now()}${ext}`;
+
+  const buffer = Buffer.from(await file.arrayBuffer());
+  const { error: uploadErr } = await supabaseAdmin.storage
+    .from(GONDOLA_BUCKET)
+    .upload(key, buffer, {
+      contentType: mime,
+      upsert: false,
+      cacheControl: "3600",
+    });
+  if (uploadErr) {
+    return NextResponse.json({ error: uploadErr.message }, { status: 500 });
+  }
+
+  const { data: prior } = await supabaseAdmin
+    .from("marketing_gondola_images")
+    .select("storage_path")
+    .eq("slot", slot)
+    .maybeSingle();
+
+  const { data: row, error: upsertErr } = await supabaseAdmin
+    .from("marketing_gondola_images")
+    .upsert(
+      {
+        slot,
+        storage_path: key,
+        content_type: mime,
+        uploaded_at: new Date().toISOString(),
+        uploaded_by: adminId,
+      },
+      { onConflict: "slot" },
+    )
+    .select("slot, storage_path, uploaded_at")
+    .single();
+
+  if (upsertErr || !row) {
+    // Roll back the storage upload so we don't leave an orphan.
+    await supabaseAdmin.storage.from(GONDOLA_BUCKET).remove([key]).catch(() => {});
+    return NextResponse.json(
+      { error: upsertErr?.message ?? "Failed to record upload" },
+      { status: 500 },
+    );
+  }
+
+  if (prior?.storage_path && prior.storage_path !== key) {
+    await supabaseAdmin.storage
+      .from(GONDOLA_BUCKET)
+      .remove([prior.storage_path])
+      .catch(() => {
+        /* orphaned old object is not fatal */
+      });
+  }
+
+  const { data: pub } = supabaseAdmin.storage
+    .from(GONDOLA_BUCKET)
+    .getPublicUrl(row.storage_path);
+  const v = new Date(row.uploaded_at).getTime();
+
+  return NextResponse.json({
+    ok: true,
+    slot: row.slot,
+    url: pub?.publicUrl ? `${pub.publicUrl}?v=${v}` : null,
+    uploaded_at: row.uploaded_at,
+  });
+}
+
+/**
+ * DELETE /api/admin/marketing/gondola/[slot]
+ *
+ * Admin-only. Reverts a slot to its shipped placeholder SVG —
+ * removes the storage object and the marketing_gondola_images row.
+ */
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ slot: string }> },
+) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const { slot } = await params;
+  if (!isGondolaSlot(slot)) {
+    return NextResponse.json({ error: "Unknown gondola slot" }, { status: 400 });
+  }
+
+  const { data: prior } = await supabaseAdmin
+    .from("marketing_gondola_images")
+    .select("storage_path")
+    .eq("slot", slot)
+    .maybeSingle();
+
+  const { error } = await supabaseAdmin
+    .from("marketing_gondola_images")
+    .delete()
+    .eq("slot", slot);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  if (prior?.storage_path) {
+    await supabaseAdmin.storage
+      .from(GONDOLA_BUCKET)
+      .remove([prior.storage_path])
+      .catch(() => {
+        /* orphaned old object is not fatal */
+      });
+  }
+
+  return NextResponse.json({ ok: true, slot });
+}
+
+function extensionFromMime(mime: string): string {
+  switch (mime) {
+    case "image/png":  return ".png";
+    case "image/jpeg": return ".jpg";
+    case "image/webp": return ".webp";
+    default:           return "";
+  }
+}

--- a/src/app/api/marketing/gondola/route.ts
+++ b/src/app/api/marketing/gondola/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import {
+  GONDOLA_BUCKET,
+  GONDOLA_SLOTS,
+  type GondolaSlot,
+} from "@/lib/marketingGondola";
+
+/**
+ * GET /api/marketing/gondola
+ *
+ * Public endpoint (no auth). Returns the current admin-uploaded
+ * image for each of the 5 gondola slots, or null when a slot has
+ * no override and the client should fall back to the built-in
+ * placeholder SVG at /public/images/marketing/<slot>.svg.
+ *
+ * Response shape (stable — the gondola component depends on this):
+ *   {
+ *     images: {
+ *       coffee:            { url, uploaded_at } | null,
+ *       "10-10-10":        { url, uploaded_at } | null,
+ *       financing:         { url, uploaded_at } | null,
+ *       "ai-vending":      { url, uploaded_at } | null,
+ *       "website-services":{ url, uploaded_at } | null,
+ *     }
+ *   }
+ *
+ * URLs include a `?v=<uploaded_at_epoch>` cache-buster so a swapped
+ * image reaches every viewer on the next page load without waiting
+ * for the CDN to purge the old public URL.
+ *
+ * Cached at the CDN for 60s — the gondola isn't real-time and the
+ * cache-buster query string handles genuine updates.
+ */
+export async function GET() {
+  const { data, error } = await supabaseAdmin
+    .from("marketing_gondola_images")
+    .select("slot, storage_path, uploaded_at");
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  const bySlot: Record<GondolaSlot, { url: string; uploaded_at: string } | null> = {
+    coffee: null,
+    "10-10-10": null,
+    financing: null,
+    "ai-vending": null,
+    "website-services": null,
+  };
+
+  for (const row of data ?? []) {
+    const slot = row.slot as GondolaSlot;
+    if (!(GONDOLA_SLOTS as readonly string[]).includes(slot)) continue;
+    const { data: pub } = supabaseAdmin.storage
+      .from(GONDOLA_BUCKET)
+      .getPublicUrl(row.storage_path);
+    if (!pub?.publicUrl) continue;
+    const v = new Date(row.uploaded_at).getTime();
+    bySlot[slot] = {
+      url: `${pub.publicUrl}?v=${v}`,
+      uploaded_at: row.uploaded_at,
+    };
+  }
+
+  return NextResponse.json(
+    { images: bySlot },
+    { headers: { "Cache-Control": "public, max-age=60, s-maxage=60" } },
+  );
+}

--- a/src/app/components/marketing/MarketingGondola.tsx
+++ b/src/app/components/marketing/MarketingGondola.tsx
@@ -49,6 +49,7 @@ import {
   useCallback,
   useSyncExternalStore,
 } from "react";
+import type { GondolaSlot } from "@/lib/marketingGondola";
 
 const AUTO_ADVANCE_MS = 12_000;
 // Any horizontal swipe wider than this (in pixels) counts as a slide
@@ -184,6 +185,25 @@ export default function MarketingGondola() {
   const reducedMotion = useReducedMotion();
   const touchStartX = useRef<number | null>(null);
   const regionRef = useRef<HTMLElement>(null);
+  // Admin-uploaded overrides. When a slot is null we render the
+  // shipped placeholder SVG from SLIDES[i].image.src. The API is
+  // public so we can fetch on the logged-out homepage too.
+  const [overrides, setOverrides] = useState<
+    Partial<Record<GondolaSlot, { url: string; uploaded_at: string } | null>>
+  >({});
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/marketing/gondola", { cache: "no-store" })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((json) => {
+        if (cancelled || !json?.images) return;
+        setOverrides(json.images);
+      })
+      .catch(() => { /* placeholders keep rendering — non-fatal */ });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const slideCount = SLIDES.length;
   const activeSlide = SLIDES[index];
@@ -297,18 +317,29 @@ export default function MarketingGondola() {
             only; the rest lazy load. */}
         <div className="order-1 md:order-2">
           <div className="relative mx-auto aspect-[4/5] w-full max-w-md overflow-hidden rounded-2xl border border-gray-100 bg-white shadow-sm md:aspect-[4/5]">
-            {SLIDES.map((s, i) => (
-              <Image
-                key={s.id}
-                src={s.image.src}
-                alt={s.image.alt}
-                fill
-                sizes="(min-width: 1024px) 480px, (min-width: 768px) 40vw, 90vw"
-                priority={i === 0}
-                loading={i === 0 ? undefined : "lazy"}
-                className={`object-cover transition-opacity duration-500 ${i === index ? "opacity-100" : "opacity-0"}`}
-              />
-            ))}
+            {SLIDES.map((s, i) => {
+              // Prefer the admin-uploaded override when present; fall
+              // back to the shipped placeholder SVG. Uploaded URLs
+              // point at Supabase Storage — bypass next/image
+              // optimization for them (unoptimized) so the ?v=<epoch>
+              // cache-buster reaches the browser unmangled.
+              const override = overrides[s.id as GondolaSlot];
+              const src = override?.url ?? s.image.src;
+              const isRemote = !!override;
+              return (
+                <Image
+                  key={s.id}
+                  src={src}
+                  alt={s.image.alt}
+                  fill
+                  sizes="(min-width: 1024px) 480px, (min-width: 768px) 40vw, 90vw"
+                  priority={i === 0}
+                  loading={i === 0 ? undefined : "lazy"}
+                  unoptimized={isRemote}
+                  className={`object-cover transition-opacity duration-500 ${i === index ? "opacity-100" : "opacity-0"}`}
+                />
+              );
+            })}
           </div>
         </div>
       </div>

--- a/src/lib/marketingGondola.ts
+++ b/src/lib/marketingGondola.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared constants for the marketing gondola image uploader flow.
+ * Kept in one place so the migration CHECK constraint, the public
+ * fetch endpoint, the admin upload endpoint, the admin page, and
+ * the gondola component all agree on the same 5 slot ids.
+ */
+
+export const GONDOLA_SLOTS = [
+  "coffee",
+  "10-10-10",
+  "financing",
+  "ai-vending",
+  "website-services",
+] as const;
+
+export type GondolaSlot = (typeof GONDOLA_SLOTS)[number];
+
+export function isGondolaSlot(v: unknown): v is GondolaSlot {
+  return typeof v === "string" && (GONDOLA_SLOTS as readonly string[]).includes(v);
+}
+
+export const GONDOLA_BUCKET = "marketing-gondola";
+
+// Human-readable label per slot for the admin uploader UI.
+export const GONDOLA_SLOT_LABELS: Record<GondolaSlot, string> = {
+  coffee: "Coffee Service",
+  "10-10-10": "10 / 10 / 10 Promotion",
+  financing: "Financing",
+  "ai-vending": "AI Vending Machines",
+  "website-services": "Website Services",
+};
+
+// 15 MB per image — matches the website-request media cap and is
+// well within Supabase Storage's per-object default.
+export const GONDOLA_MAX_BYTES = 15 * 1024 * 1024;
+
+export const GONDOLA_ALLOWED_MIME = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+]);

--- a/supabase/migrations/153_marketing_gondola.sql
+++ b/supabase/migrations/153_marketing_gondola.sql
@@ -1,0 +1,91 @@
+-- Migration 153: marketing gondola image overrides
+--
+-- Backs the /admin/marketing/gondola uploader that lets an admin
+-- swap out any of the 5 marketing carousel photos without a code
+-- push. When a row exists for a slot, the public gondola component
+-- renders that image; otherwise it falls back to the placeholder
+-- SVG shipped in git under /public/images/marketing.
+--
+-- Data model
+--   marketing_gondola_images
+--     slot          text  PK  — one of the 5 gondola slot ids
+--                              (matches SLIDES[].id in
+--                               src/app/components/marketing/
+--                               MarketingGondola.tsx)
+--     storage_path  text NOT NULL — object key inside the
+--                                    'marketing-gondola' bucket
+--     content_type  text NULL
+--     uploaded_at   timestamptz NOT NULL default now()
+--     uploaded_by   uuid NULL references auth.users(id)
+--
+-- The slot is the PK — one uploaded image per slot at a time. A
+-- fresh upload UPSERTs by slot and removes the previous object.
+--
+-- Storage bucket
+--   'marketing-gondola'  — PUBLIC read (gondola renders on the
+--                          logged-out homepage, so public read is
+--                          the correct choice). Writes are gated
+--                          server-side by the admin route using the
+--                          service role key — no client-issued
+--                          uploads.
+
+CREATE TABLE IF NOT EXISTS public.marketing_gondola_images (
+  slot          text PRIMARY KEY
+                CHECK (slot IN ('coffee', '10-10-10', 'financing', 'ai-vending', 'website-services')),
+  storage_path  text NOT NULL,
+  content_type  text,
+  uploaded_at   timestamptz NOT NULL DEFAULT now(),
+  uploaded_by   uuid REFERENCES auth.users(id) ON DELETE SET NULL
+);
+
+ALTER TABLE public.marketing_gondola_images ENABLE ROW LEVEL SECURITY;
+
+-- Everyone (anon + authenticated) may read; the URLs need to render
+-- on the public homepage.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename  = 'marketing_gondola_images'
+      AND policyname = 'read_marketing_gondola_images'
+  ) THEN
+    CREATE POLICY read_marketing_gondola_images
+      ON public.marketing_gondola_images
+      FOR SELECT
+      USING (true);
+  END IF;
+END $$;
+
+-- Writes only happen through the admin API using supabaseAdmin
+-- (service-role key bypasses RLS). We intentionally do NOT grant a
+-- write policy — same pattern as manufacturer_partners and every
+-- other admin-managed table in this app.
+
+-- Public bucket for the gondola images.
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('marketing-gondola', 'marketing-gondola', true)
+ON CONFLICT (id) DO NOTHING;
+
+-- Read: anyone may fetch objects (bucket is already public=true so
+-- this policy is belt-and-suspenders in case a future migration
+-- flips public=false).
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'storage'
+      AND tablename  = 'objects'
+      AND policyname = 'marketing_gondola_public_read'
+  ) THEN
+    CREATE POLICY marketing_gondola_public_read
+      ON storage.objects
+      FOR SELECT
+      USING (bucket_id = 'marketing-gondola');
+  END IF;
+END $$;
+
+-- No client write policy — admin uploads run through the server
+-- with the service role key.
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
Adds a self-service page at /admin/marketing/gondola that lets an admin swap any of the 5 rotating carousel photos on the homepage + dashboard without a code push. Uploads are stored in a public Supabase bucket; the gondola component fetches the current overrides on mount and falls back to the shipped placeholder SVGs when a slot hasn't been uploaded.

Migration
- supabase/migrations/153_marketing_gondola.sql:
    * marketing_gondola_images(slot PK, storage_path, content_type, uploaded_at, uploaded_by) — one row per slot, CHECK constrains slot to the 5 known values.
    * Public 'marketing-gondola' storage bucket + storage-objects read policy. No client write policy — admin uploads go through the server route using the service-role key, matching every other admin-managed table in this app.
    * RLS enabled on the table with a read-anyone policy so the public homepage can render URLs.
- Idempotent — safe to re-run.

Shared constants
- src/lib/marketingGondola.ts: GONDOLA_SLOTS, isGondolaSlot, GONDOLA_BUCKET, GONDOLA_SLOT_LABELS, GONDOLA_MAX_BYTES (15 MB), GONDOLA_ALLOWED_MIME (png/jpeg/webp). Sourced by the migration's CHECK, the public fetch, the admin upload/revert, the admin page, and the gondola component so all five agree on identity.

APIs
- GET  /api/marketing/gondola — PUBLIC, no auth. Returns {images: {slot -> {url, uploaded_at} | null}} keyed by slot id. URLs carry a ?v=<uploaded_at_epoch> cache-buster so viewers pick up a swapped image on the next load. Cache-Control public, max-age 60.
- PUT /api/admin/marketing/gondola/[slot] — admin-only. Accepts multipart file (png/jpeg/webp, <=15MB). Uploads with a timestamped key, upserts the DB row, and removes the prior storage object to keep the bucket clean. Rolls back the upload on DB failure so we never leave an orphan.
- DELETE /api/admin/marketing/gondola/[slot] — admin-only. Reverts a slot to the placeholder — deletes the DB row and the storage object.

Admin page
- src/app/admin/marketing/gondola/page.tsx: 5 slot cards, each with a 4:5 preview (uploaded or placeholder), an "Uploaded"/"Placeholder" status pill, Upload/Replace and Revert buttons, per-slot success/ error banners, and last-uploaded timestamp. Uses Image with unoptimized so the ?v=<epoch> cache-buster reaches the browser unchanged.
- src/app/admin/page.tsx: added a "Gondola Images" quick-link in the header action row so admins can jump straight in.

Component wiring
- src/app/components/marketing/MarketingGondola.tsx: fetches /api/marketing/gondola on mount, stores a per-slot override map, and picks override.url over the shipped placeholder SVG when present. next/image gets unoptimized=true for remote URLs so the cache-buster query string isn't re-hashed away. Failing the fetch is non-fatal — the placeholder SVGs render.

Typecheck clean; new files lint-clean; manufacturer + machine-listings vitest still 21/21. Requires migration 153 to be run in Supabase before the admin page can accept uploads.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2