### PR TITLE
Green gondola background + VC circle logo replaces bolt icon

### DIFF
--- a/public/logo-vc.svg
+++ b/public/logo-vc.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 800" role="img" aria-label="Vending Connector logo placeholder">
+  <!-- Placeholder for public/logo-vc.png — same aspect (1:1) so the
+       Navbar/Footer layout stays put when the real PNG is dropped
+       in. Design mirrors the intent: green ring, navy VC, green
+       bolt through the middle. Overwrite with the real photo. -->
+  <circle cx="400" cy="400" r="380" fill="white" stroke="#22C55E" stroke-width="24"/>
+  <g font-family="Inter, system-ui, sans-serif" font-weight="900" font-size="380" text-anchor="middle" dominant-baseline="central">
+    <text x="240" y="410" fill="#0F1E3D">V</text>
+    <text x="560" y="410" fill="#0F1E3D">C</text>
+  </g>
+  <!-- Diagonal lightning bolt through the middle -->
+  <path d="M470 130 L300 430 L410 430 L330 670 L520 350 L410 350 Z"
+        fill="#22C55E"/>
+</svg>

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
-import { Phone, Zap } from "lucide-react";
+import Image from "next/image";
+import { Phone } from "lucide-react";
 import { TOOLTIP_COPY } from "@/lib/tooltipCopy";
 
 const footerColumns = [
@@ -45,7 +46,17 @@ export default function Footer() {
           {/* Brand Column */}
           <div className="lg:col-span-1">
             <Link href="/" className="inline-flex items-center gap-2">
-              <Zap className="h-6 w-6 text-green-600" />
+              {/* White disc so the logo's green ring + navy VC stay
+                  legible against the black footer background. */}
+              <span className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-white p-0.5">
+                <Image
+                  src="/logo-vc.svg"
+                  alt="Vending Connector"
+                  width={36}
+                  height={36}
+                  className="h-8 w-8"
+                />
+              </span>
               <span className="text-lg font-bold text-white">Vending Connector</span>
             </Link>
             <p className="mt-3 text-sm leading-relaxed text-gray-400">

--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -2,8 +2,9 @@
 
 import { useState, useEffect } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import { useRouter, usePathname } from "next/navigation";
-import { Menu, X, ChevronRight, ChevronDown, LogOut, LayoutDashboard, User, Shield, ShoppingBag, ScrollText, Heart, Briefcase, Zap, Coffee, Globe } from "lucide-react";
+import { Menu, X, ChevronRight, ChevronDown, LogOut, LayoutDashboard, User, Shield, ShoppingBag, ScrollText, Heart, Briefcase, Coffee, Globe } from "lucide-react";
 import { createBrowserClient } from "@/lib/supabase";
 import type { Profile } from "@/lib/types";
 import Tooltip from "@/app/components/Tooltip";
@@ -252,9 +253,17 @@ export default function Navbar() {
         }`}
       >
         <nav className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
-          {/* Logo */}
+          {/* Logo — circular VC mark. Replace /public/logo-vc.png (or
+              .svg) to swap. */}
           <Link href="/" className="flex shrink-0 items-center gap-2">
-            <Zap className="h-6 w-6 text-green-600" />
+            <Image
+              src="/logo-vc.svg"
+              alt="Vending Connector"
+              width={40}
+              height={40}
+              priority
+              className="h-9 w-9"
+            />
             <span className="whitespace-nowrap text-lg font-bold text-gray-900">Vending Connector</span>
           </Link>
 
@@ -499,7 +508,17 @@ export default function Navbar() {
         {/* Drawer Header */}
         <div className="flex items-center justify-between border-b border-white/20 px-4 py-4">
           <div className="flex items-center gap-2">
-            <Zap className="h-5 w-5 text-white" />
+            {/* White background disc so the green ring + navy VC of
+                the logo stay legible on the green drawer header. */}
+            <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-white p-0.5">
+              <Image
+                src="/logo-vc.svg"
+                alt="Vending Connector"
+                width={32}
+                height={32}
+                className="h-7 w-7"
+              />
+            </span>
             <span className="text-base font-bold text-white">Vending Connector</span>
           </div>
           <button

--- a/src/app/components/marketing/MarketingGondola.tsx
+++ b/src/app/components/marketing/MarketingGondola.tsx
@@ -262,7 +262,9 @@ export default function MarketingGondola() {
       role="region"
       aria-roledescription="carousel"
       aria-label="Vending Connector featured programs"
-      className="relative w-full overflow-hidden border-b border-gray-100 bg-gradient-to-b from-light-warm via-white to-light-warm"
+      // Green feature background — brand green wash that ties the
+      // gondola to the VC palette without swamping body text.
+      className="relative w-full overflow-hidden border-b border-green-200 bg-gradient-to-br from-green-50 via-green-100 to-green-50"
       onMouseEnter={() => setPaused(true)}
       onMouseLeave={() => setPaused(false)}
       onFocus={() => setPaused(true)}
@@ -278,7 +280,9 @@ export default function MarketingGondola() {
           className="order-2 flex flex-col justify-center animate-fade-in"
           aria-live="polite"
         >
-          <span className="inline-flex w-fit items-center gap-1.5 rounded-full bg-green-primary/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-wider text-green-primary">
+          {/* White pill for the eyebrow — on the green background the
+              previous translucent-green pill lost contrast. */}
+          <span className="inline-flex w-fit items-center gap-1.5 rounded-full bg-white px-3 py-1 text-[11px] font-semibold uppercase tracking-wider text-green-primary shadow-sm ring-1 ring-inset ring-green-200">
             <Icon className="h-3.5 w-3.5" />
             {activeSlide.eyebrow}
           </span>
@@ -378,10 +382,12 @@ export default function MarketingGondola() {
               aria-selected={active}
               aria-label={`Slide ${i + 1}: ${SLIDES[i].title}`}
               onClick={() => goTo(i)}
+              // Inactive dots use a green tone so they read on the
+              // green background without disappearing.
               className={`h-2 rounded-full transition-all ${
                 active
                   ? "w-8 bg-green-primary"
-                  : "w-2 bg-gray-300 hover:bg-gray-400"
+                  : "w-2 bg-green-primary/30 hover:bg-green-primary/50"
               }`}
             />
           );


### PR DESCRIPTION
Two visual tweaks matching the new VC brand mark.

Gondola background
- src/app/components/marketing/MarketingGondola.tsx: swapped the neutral light-warm gradient for a green feature wash (bg-gradient-to-br from-green-50 via-green-100 to-green-50) with a green-200 bottom border. Adjusted the eyebrow pill to a white chip with green ring and text so it reads on green, and switched inactive slide-indicator dots from gray to a translucent green so they don't disappear against the new background.

Logo replacement
- public/logo-vc.svg: new placeholder mirroring the VC circular mark — green ring, navy VC letters, green diagonal bolt — sized 1:1 so layout is stable. Replace with /public/logo-vc.png (or overwrite the .svg) to swap in the real photo.
- src/app/components/Navbar.tsx: dropped the Zap lucide icon on both the desktop header and the mobile drawer; both now render next/image at /logo-vc.svg. Mobile drawer wraps the mark in a white disc so the green ring + navy VC stay legible against the drawer's green background.
- src/app/components/Footer.tsx: same swap in the brand column, with the same white-disc wrap so the mark reads on the black footer.

Typecheck clean; the only lint output is a pre-existing 'pathname' unused warning in Navbar.tsx (untouched by this diff).


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2