### PR TITLE
Gondola: drop auto-advance from 12s to 5s

### DIFF
--- a/src/app/components/marketing/MarketingGondola.tsx
+++ b/src/app/components/marketing/MarketingGondola.tsx
@@ -52,7 +52,7 @@ import {
 } from "react";
 import type { GondolaSlot } from "@/lib/marketingGondola";
 
-const AUTO_ADVANCE_MS = 12_000;
+const AUTO_ADVANCE_MS = 5_000;
 // Any horizontal swipe wider than this (in pixels) counts as a slide
 // change. Below the threshold we ignore it so vertical scrolls on
 // mobile don't accidentally trigger navigation.


### PR DESCRIPTION
Faster rotation per product request — every slide gets a turn on screen inside 30s instead of the prior 60s.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2