### PR TITLE
Team: Send Credentials — admin-only onboarding email

### DIFF
--- a/src/app/api/admin/team/[id]/credential-history/route.ts
+++ b/src/app/api/admin/team/[id]/credential-history/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+
+/**
+ * GET /api/admin/team/[id]/credential-history
+ *
+ * Admin-only. Returns the non-sensitive audit records for every
+ * Send-Credentials event fired at this team member. Never returns
+ * usernames or passwords — the audit table doesn't store them.
+ */
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const { id: teamMemberId } = await params;
+  if (!teamMemberId) {
+    return NextResponse.json({ error: "Team member id required" }, { status: 400 });
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from("team_credential_email_sends")
+    .select("id, recipient_email, sent_by_user_id, sent_at, system_names, send_status, error_message")
+    .eq("team_member_id", teamMemberId)
+    .order("sent_at", { ascending: false })
+    .limit(100);
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  const senderIds = Array.from(
+    new Set((data ?? []).map((r) => r.sent_by_user_id).filter(Boolean)),
+  );
+  const senderById: Record<string, { full_name: string | null; email: string | null }> = {};
+  if (senderIds.length > 0) {
+    const { data: senders } = await supabaseAdmin
+      .from("profiles")
+      .select("id, full_name, email")
+      .in("id", senderIds);
+    for (const s of senders ?? []) {
+      senderById[s.id] = { full_name: s.full_name, email: s.email };
+    }
+  }
+
+  return NextResponse.json({
+    history: (data ?? []).map((r) => ({
+      id: r.id,
+      recipient_email: r.recipient_email,
+      sent_by: senderById[r.sent_by_user_id] ?? null,
+      sent_at: r.sent_at,
+      system_names: r.system_names,
+      send_status: r.send_status,
+      error_message: r.error_message,
+    })),
+  });
+}

--- a/src/app/api/admin/team/[id]/send-credentials/route.ts
+++ b/src/app/api/admin/team/[id]/send-credentials/route.ts
@@ -1,0 +1,154 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+import {
+  isValidHttpUrl,
+  sendCredentialsEmail,
+  type CredentialRow,
+} from "@/lib/teamCredentials/emails";
+
+/**
+ * POST /api/admin/team/[id]/send-credentials
+ *   Body: {
+ *     recipient_email?: string,   // defaults to team member's profile email
+ *     credentials: CredentialRow[]
+ *   }
+ *
+ * Admin-only. Sends a branded onboarding-credentials email to the
+ * named team member's email address and writes a NON-SENSITIVE
+ * audit row (recipient, sender, timestamp, system names — never
+ * passwords or usernames).
+ *
+ * Security notes
+ *   - The request body carries plaintext passwords; the handler
+ *     intentionally does NOT console.log the body, and the audit
+ *     row it writes stores only the system-name array.
+ *   - Auth is enforced server-side via getAdminUserId — hiding the
+ *     button in the UI is not sufficient (per spec §9).
+ *   - Duplicated log statements below deliberately omit the
+ *     credentials arg to keep passwords off every logging sink.
+ */
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const { id: teamMemberId } = await params;
+  if (!teamMemberId) {
+    return NextResponse.json({ error: "Team member id required" }, { status: 400 });
+  }
+
+  const body = await req.json().catch(() => ({}));
+  const recipientOverride = typeof body?.recipient_email === "string"
+    ? body.recipient_email.trim()
+    : "";
+  const credsRaw = Array.isArray(body?.credentials) ? body.credentials : [];
+
+  // Look up the team member — need their name + fallback email.
+  const { data: member, error: memberErr } = await supabaseAdmin
+    .from("profiles")
+    .select("id, full_name, email")
+    .eq("id", teamMemberId)
+    .maybeSingle();
+  if (memberErr) {
+    return NextResponse.json({ error: memberErr.message }, { status: 500 });
+  }
+  if (!member) {
+    return NextResponse.json({ error: "Team member not found" }, { status: 404 });
+  }
+
+  const recipientEmail = recipientOverride || member.email || "";
+  if (!recipientEmail || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(recipientEmail)) {
+    return NextResponse.json(
+      { error: "A valid recipient email is required." },
+      { status: 400 },
+    );
+  }
+
+  // Normalize + validate each credential row. Reject empty rows and
+  // any obviously malformed URL. Trims but does not modify passwords.
+  const credentials: CredentialRow[] = [];
+  const systemNames: string[] = [];
+  for (const raw of credsRaw) {
+    const systemName = typeof raw?.system_name === "string" ? raw.system_name.trim() : "";
+    const loginUrl = typeof raw?.login_url === "string" ? raw.login_url.trim() : "";
+    const username = typeof raw?.username === "string" ? raw.username.trim() : "";
+    // Password kept as-is — trailing/leading spaces are allowed and
+    // could be intentional.
+    const password = typeof raw?.password === "string" ? raw.password : "";
+    if (!systemName || !username || !password) continue;
+    if (loginUrl && !isValidHttpUrl(loginUrl)) {
+      return NextResponse.json(
+        { error: `Invalid login URL for "${systemName}". Must start with http:// or https://.` },
+        { status: 400 },
+      );
+    }
+    credentials.push({
+      system_name: systemName,
+      login_url: loginUrl || null,
+      username,
+      password,
+    });
+    systemNames.push(systemName);
+  }
+
+  if (credentials.length === 0) {
+    return NextResponse.json(
+      { error: "Add at least one credential (system name, username, and password all required)." },
+      { status: 400 },
+    );
+  }
+
+  // Send first, audit after — status reflects reality.
+  try {
+    await sendCredentialsEmail({
+      toEmail: recipientEmail,
+      recipient_name: member.full_name,
+      credentials,
+    });
+  } catch (mailErr) {
+    // Audit the failure so admins have a paper trail of attempts.
+    // The error message from Resend is non-sensitive (SDK error
+    // codes, throttle/reject reasons) but we defensively cap length.
+    const msg = mailErr instanceof Error ? mailErr.message.slice(0, 500) : "Send failed";
+    await supabaseAdmin.from("team_credential_email_sends").insert({
+      team_member_id: teamMemberId,
+      recipient_email: recipientEmail,
+      sent_by_user_id: adminId,
+      system_names: systemNames,
+      send_status: "failed",
+      error_message: msg,
+    });
+    // Bare log — no body, no credentials.
+    console.error("[send-credentials] delivery failed:", { teamMemberId, recipientEmail, msg });
+    return NextResponse.json(
+      { error: "Unable to send credentials. Please verify the email address or try again." },
+      { status: 502 },
+    );
+  }
+
+  const { error: auditErr } = await supabaseAdmin
+    .from("team_credential_email_sends")
+    .insert({
+      team_member_id: teamMemberId,
+      recipient_email: recipientEmail,
+      sent_by_user_id: adminId,
+      system_names: systemNames,
+      send_status: "sent",
+    });
+  if (auditErr) {
+    // Send succeeded, audit failed — return success with a warning
+    // so the admin knows to look at logs, but never fail the
+    // response (the email is already out the door).
+    console.error("[send-credentials] audit write failed:", auditErr.message);
+  }
+
+  return NextResponse.json({
+    ok: true,
+    sent_to: recipientEmail,
+    team_member: { id: member.id, full_name: member.full_name },
+    system_names: systemNames,
+  });
+}

--- a/src/app/api/admin/team/credential-presets/[id]/route.ts
+++ b/src/app/api/admin/team/credential-presets/[id]/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+
+/**
+ * DELETE /api/admin/team/credential-presets/[id]  — admin-only
+ * Removes a preset. Existing audit history is untouched.
+ */
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const { id } = await params;
+  if (!id) return NextResponse.json({ error: "Preset id required" }, { status: 400 });
+
+  const { error } = await supabaseAdmin
+    .from("team_credential_presets")
+    .delete()
+    .eq("id", id);
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/admin/team/credential-presets/route.ts
+++ b/src/app/api/admin/team/credential-presets/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getAdminUserId } from "@/lib/adminAuth";
+import { isValidHttpUrl } from "@/lib/teamCredentials/emails";
+
+/**
+ * GET  /api/admin/team/credential-presets  — admin-only
+ * POST /api/admin/team/credential-presets  — admin-only
+ *   Body: { name: string, default_login_url?: string }
+ *
+ * Presets carry ONLY a system name + optional login URL — never
+ * credentials. Admins pick a preset to prefill the system-name and
+ * URL fields on a new credential row; usernames and passwords are
+ * always entered fresh.
+ */
+export async function GET(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const { data, error } = await supabaseAdmin
+    .from("team_credential_presets")
+    .select("id, name, default_login_url")
+    .order("name", { ascending: true });
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ presets: data ?? [] });
+}
+
+export async function POST(req: NextRequest) {
+  const adminId = await getAdminUserId(req);
+  if (!adminId) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const body = await req.json().catch(() => ({}));
+  const name = typeof body?.name === "string" ? body.name.trim() : "";
+  const url  = typeof body?.default_login_url === "string" ? body.default_login_url.trim() : "";
+
+  if (!name) return NextResponse.json({ error: "Preset name is required." }, { status: 400 });
+  if (name.length > 80) return NextResponse.json({ error: "Preset name too long." }, { status: 400 });
+  if (url && !isValidHttpUrl(url)) {
+    return NextResponse.json(
+      { error: "Login URL must start with http:// or https://." },
+      { status: 400 },
+    );
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from("team_credential_presets")
+    .insert({
+      name,
+      default_login_url: url || null,
+      created_by: adminId,
+    })
+    .select("id, name, default_login_url")
+    .single();
+
+  if (error) {
+    if (/duplicate key value/i.test(error.message)) {
+      return NextResponse.json(
+        { error: "A preset with that name already exists." },
+        { status: 409 },
+      );
+    }
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ preset: data });
+}

--- a/src/app/sales/team/SendCredentialsModal.tsx
+++ b/src/app/sales/team/SendCredentialsModal.tsx
@@ -1,0 +1,543 @@
+"use client";
+
+/**
+ * SendCredentialsModal
+ *
+ * Opened from /sales/team when an admin clicks the Send Credentials
+ * icon on a team-member row. Lets the admin:
+ *   - override the destination email (defaults to profile.email)
+ *   - add / remove any number of credential rows
+ *   - pick from saved presets to prefill System Name + Login URL
+ *   - toggle show/hide on the password field
+ *   - preview the exact HTML the recipient will receive
+ *   - confirm the recipient before firing the send
+ *
+ * All password handling is client-side plaintext (necessary — the
+ * admin is typing them and needs to see them briefly). We never
+ * write them to localStorage, sessionStorage, analytics, or the
+ * console. Server audit records the send WITHOUT the passwords or
+ * usernames (see /api/admin/team/[id]/send-credentials).
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  X,
+  Plus,
+  Trash2,
+  Eye,
+  EyeOff,
+  Key,
+  Send,
+  Loader2,
+  AlertCircle,
+  CheckCircle2,
+  ChevronLeft,
+} from "lucide-react";
+
+type CredentialRow = {
+  id: string;              // client-only, for React keys
+  system_name: string;
+  login_url: string;
+  username: string;
+  password: string;
+  show_password: boolean;
+};
+
+type Preset = { id: string; name: string; default_login_url: string | null };
+
+export interface SendCredentialsModalProps {
+  memberId: string;
+  memberName: string;
+  memberEmail: string;
+  token: string;
+  onClose: () => void;
+  onSent?: (result: { sent_to: string; system_names: string[] }) => void;
+}
+
+const MAX_ROWS = 20;
+
+function makeRow(): CredentialRow {
+  return {
+    // Not cryptographic — just for React keys. crypto.randomUUID is
+    // available in every browser we support.
+    id: (typeof crypto !== "undefined" && "randomUUID" in crypto)
+      ? crypto.randomUUID()
+      : `r-${Math.random().toString(36).slice(2)}`,
+    system_name: "",
+    login_url: "",
+    username: "",
+    password: "",
+    show_password: false,
+  };
+}
+
+function esc(s: string | null | undefined): string {
+  if (s == null) return "";
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function firstNameOf(full: string): string {
+  const t = full.trim().split(/\s+/)[0];
+  return t || "there";
+}
+
+/** Build the same HTML preview the server will send. Kept in sync
+ *  with src/lib/teamCredentials/emails.ts renderCredentialsEmailHtml. */
+function buildPreviewHtml(name: string, rows: CredentialRow[]): string {
+  const first = firstNameOf(name);
+  const sections = rows
+    .filter((r) => r.system_name.trim() && r.username.trim() && r.password)
+    .map((c) => {
+      const url = c.login_url.trim()
+        ? `<div style="margin:6px 0"><span style="color:#6b7280;font-size:12px;text-transform:uppercase;letter-spacing:.06em;font-weight:600">Login</span><br><a href="${esc(c.login_url)}" style="color:#16A34A;word-break:break-all">${esc(c.login_url)}</a></div>`
+        : "";
+      return `<div style="background:#f9fafb;border:1px solid #e5e7eb;border-radius:10px;padding:16px;margin:12px 0"><div style="font-size:15px;font-weight:700;color:#111827;margin-bottom:6px">${esc(c.system_name)}</div>${url}<div style="margin:6px 0"><span style="color:#6b7280;font-size:12px;text-transform:uppercase;letter-spacing:.06em;font-weight:600">Username</span><br><span style="font-family:ui-monospace,SFMono-Regular,Menlo,monospace;color:#111827">${esc(c.username)}</span></div><div style="margin:6px 0"><span style="color:#6b7280;font-size:12px;text-transform:uppercase;letter-spacing:.06em;font-weight:600">Password</span><br><span style="font-family:ui-monospace,SFMono-Regular,Menlo,monospace;color:#111827">${esc(c.password)}</span></div></div>`;
+    })
+    .join("");
+
+  return `<div style="font-family:-apple-system,'Segoe UI',Inter,Arial,sans-serif;max-width:600px;margin:0 auto;padding:24px;color:#111"><div style="margin-bottom:20px"><div style="font-size:11px;font-weight:700;letter-spacing:0.15em;color:#16A34A;text-transform:uppercase">Vending Connector · Apex AI Vending</div></div><h1 style="font-size:22px;font-weight:700;color:#0A0A0A;margin:0 0 12px">Welcome to the team, ${esc(first)} 👋</h1><p style="line-height:1.6;color:#374151;margin:0 0 12px">Congratulations again on your new journey with Vending Connector / Apex AI Vending — we're excited to have you on board.</p><p style="line-height:1.6;color:#374151;margin:0 0 16px">To get started, please use the links and login credentials below to access the systems you'll need for your role.</p>${sections}<p style="line-height:1.6;color:#374151;margin:20px 0 12px">You will also need to check your email for information regarding your <strong>training session</strong>.</p><p style="line-height:1.6;color:#374151;margin:0 0 12px">Please make sure you can successfully access each of the systems above before your training session. If you experience any issues logging in, let your manager know.</p><p style="line-height:1.6;color:#374151;margin:20px 0 0">Looking forward to working with you and helping you get started.<br><br>— The Vending Connector / Apex AI Vending Team</p></div>`;
+}
+
+export default function SendCredentialsModal(props: SendCredentialsModalProps) {
+  const [recipient, setRecipient] = useState(props.memberEmail);
+  const [rows, setRows] = useState<CredentialRow[]>(() => [makeRow()]);
+  const [presets, setPresets] = useState<Preset[]>([]);
+  const [phase, setPhase] = useState<"edit" | "preview" | "confirm" | "sending" | "done">("edit");
+  const [error, setError] = useState<string | null>(null);
+  const [okMessage, setOkMessage] = useState<string | null>(null);
+  const closeBtnRef = useRef<HTMLButtonElement | null>(null);
+
+  // Focus close button on mount so Esc / Tab flow works.
+  useEffect(() => {
+    closeBtnRef.current?.focus();
+  }, []);
+
+  // Load presets — non-fatal if it fails.
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/admin/team/credential-presets", {
+      headers: { Authorization: `Bearer ${props.token}` },
+    })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((json) => {
+        if (cancelled || !json?.presets) return;
+        setPresets(json.presets as Preset[]);
+      })
+      .catch(() => { /* silent */ });
+    return () => { cancelled = true; };
+  }, [props.token]);
+
+  const patchRow = useCallback(
+    (id: string, patch: Partial<CredentialRow>) => {
+      setRows((prev) => prev.map((r) => (r.id === id ? { ...r, ...patch } : r)));
+    },
+    [],
+  );
+
+  function addRow() {
+    setRows((prev) => (prev.length >= MAX_ROWS ? prev : [...prev, makeRow()]));
+  }
+  function removeRow(id: string) {
+    setRows((prev) => (prev.length === 1 ? prev : prev.filter((r) => r.id !== id)));
+  }
+  function applyPreset(rowId: string, presetId: string) {
+    const p = presets.find((x) => x.id === presetId);
+    if (!p) return;
+    patchRow(rowId, {
+      system_name: p.name,
+      login_url: p.default_login_url ?? "",
+    });
+  }
+
+  // Pre-flight validation for the current form.
+  const validation = useMemo(() => {
+    const errs: string[] = [];
+    if (!recipient.trim() || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(recipient.trim())) {
+      errs.push("Enter a valid recipient email address.");
+    }
+    const filled = rows.filter(
+      (r) => r.system_name.trim() && r.username.trim() && r.password,
+    );
+    if (filled.length === 0) {
+      errs.push("Add at least one complete credential (name, username, password).");
+    }
+    for (const r of filled) {
+      const url = r.login_url.trim();
+      if (url) {
+        try {
+          const u = new URL(url);
+          if (u.protocol !== "http:" && u.protocol !== "https:") {
+            errs.push(`Login URL for "${r.system_name}" must start with http:// or https://.`);
+          }
+        } catch {
+          errs.push(`Login URL for "${r.system_name}" is not a valid URL.`);
+        }
+      }
+    }
+    return errs;
+  }, [recipient, rows]);
+
+  async function performSend() {
+    setPhase("sending");
+    setError(null);
+    try {
+      const payload = {
+        recipient_email: recipient.trim(),
+        credentials: rows
+          .filter((r) => r.system_name.trim() && r.username.trim() && r.password)
+          .map((r) => ({
+            system_name: r.system_name.trim(),
+            login_url: r.login_url.trim() || null,
+            username: r.username.trim(),
+            password: r.password,
+          })),
+      };
+      const res = await fetch(`/api/admin/team/${props.memberId}/send-credentials`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${props.token}`,
+        },
+        body: JSON.stringify(payload),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(json.error || `Send failed (${res.status})`);
+
+      const systemNames = (json.system_names ?? []) as string[];
+      setOkMessage(
+        `Credentials sent successfully to ${props.memberName} at ${json.sent_to}.`,
+      );
+      setPhase("done");
+      // Clear password material from memory as soon as the send is
+      // confirmed. Non-sensitive fields stay so the admin can see
+      // what they just sent.
+      setRows((prev) => prev.map((r) => ({ ...r, password: "", show_password: false })));
+      props.onSent?.({ sent_to: json.sent_to as string, system_names: systemNames });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to send credentials.");
+      setPhase("edit");
+    }
+  }
+
+  const previewHtml = useMemo(
+    () => buildPreviewHtml(props.memberName, rows),
+    [props.memberName, rows],
+  );
+
+  return (
+    <div
+      className="fixed inset-0 z-[9999] flex items-start justify-center bg-black/50 p-4 overflow-y-auto"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Send Login Credentials"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && phase !== "sending") props.onClose();
+      }}
+    >
+      <div className="mt-10 w-full max-w-2xl rounded-2xl bg-white shadow-2xl mb-10">
+        {/* Header */}
+        <div className="flex items-start justify-between gap-4 border-b border-gray-100 px-6 py-5">
+          <div>
+            <div className="flex items-center gap-2">
+              <Key className="h-5 w-5 text-green-primary" />
+              <h2 className="text-lg font-semibold text-gray-900">Send Login Credentials</h2>
+            </div>
+            <p className="mt-1 text-sm text-gray-500">
+              Team Member: <span className="font-medium text-gray-800">{props.memberName}</span>
+            </p>
+          </div>
+          <button
+            ref={closeBtnRef}
+            type="button"
+            onClick={props.onClose}
+            className="rounded-lg p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-700"
+            aria-label="Close"
+            disabled={phase === "sending"}
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {/* PHASE: edit */}
+        {phase === "edit" && (
+          <div className="p-6 space-y-5">
+            {/* Recipient */}
+            <div>
+              <label className="block text-xs font-semibold uppercase tracking-wider text-gray-500 mb-1.5">
+                Send To
+              </label>
+              <input
+                type="email"
+                value={recipient}
+                onChange={(e) => setRecipient(e.target.value)}
+                autoComplete="off"
+                spellCheck={false}
+                className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm text-gray-900 focus:border-green-primary focus:outline-none"
+              />
+              <p className="mt-1 text-xs text-gray-500">
+                Defaults to the team member&apos;s on-file email. Change only if you need to send to a different address.
+              </p>
+            </div>
+
+            {/* Credentials */}
+            <div className="space-y-4">
+              {rows.map((row, idx) => (
+                <div
+                  key={row.id}
+                  className="rounded-xl border border-gray-200 bg-gray-50/50 p-4"
+                >
+                  <div className="mb-3 flex items-center justify-between">
+                    <div className="text-xs font-semibold uppercase tracking-wider text-gray-500">
+                      Login #{idx + 1}
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => removeRow(row.id)}
+                      disabled={rows.length === 1}
+                      className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-red-600 hover:bg-red-50 disabled:opacity-30 disabled:cursor-not-allowed"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                      Remove
+                    </button>
+                  </div>
+
+                  <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                    <div>
+                      <label className="block text-xs font-medium text-gray-600 mb-1">System / Credential Name</label>
+                      <input
+                        type="text"
+                        value={row.system_name}
+                        onChange={(e) => patchRow(row.id, { system_name: e.target.value })}
+                        placeholder="e.g. Vending Connector CRM"
+                        autoComplete="off"
+                        spellCheck={false}
+                        className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm focus:border-green-primary focus:outline-none"
+                      />
+                      {presets.length > 0 && (
+                        <select
+                          value=""
+                          onChange={(e) => e.target.value && applyPreset(row.id, e.target.value)}
+                          className="mt-1 w-full rounded-md border border-gray-100 bg-white px-2 py-1 text-xs text-gray-600 focus:outline-none"
+                        >
+                          <option value="">Or pick a preset…</option>
+                          {presets.map((p) => (
+                            <option key={p.id} value={p.id}>{p.name}</option>
+                          ))}
+                        </select>
+                      )}
+                    </div>
+
+                    <div>
+                      <label className="block text-xs font-medium text-gray-600 mb-1">Login URL (optional)</label>
+                      <input
+                        type="url"
+                        value={row.login_url}
+                        onChange={(e) => patchRow(row.id, { login_url: e.target.value })}
+                        placeholder="https://…"
+                        autoComplete="off"
+                        spellCheck={false}
+                        className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm focus:border-green-primary focus:outline-none"
+                      />
+                    </div>
+
+                    <div>
+                      <label className="block text-xs font-medium text-gray-600 mb-1">Username / Email</label>
+                      <input
+                        type="text"
+                        value={row.username}
+                        onChange={(e) => patchRow(row.id, { username: e.target.value })}
+                        autoComplete="off"
+                        spellCheck={false}
+                        className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm focus:border-green-primary focus:outline-none"
+                      />
+                    </div>
+
+                    <div>
+                      <label className="block text-xs font-medium text-gray-600 mb-1">Password</label>
+                      <div className="relative">
+                        <input
+                          type={row.show_password ? "text" : "password"}
+                          value={row.password}
+                          onChange={(e) => patchRow(row.id, { password: e.target.value })}
+                          autoComplete="new-password"
+                          spellCheck={false}
+                          className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 pr-9 text-sm font-mono focus:border-green-primary focus:outline-none"
+                        />
+                        <button
+                          type="button"
+                          onClick={() => patchRow(row.id, { show_password: !row.show_password })}
+                          className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-700"
+                          aria-label={row.show_password ? "Hide password" : "Show password"}
+                        >
+                          {row.show_password ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              ))}
+
+              <button
+                type="button"
+                onClick={addRow}
+                disabled={rows.length >= MAX_ROWS}
+                className="inline-flex items-center gap-1.5 rounded-lg border border-dashed border-green-primary/60 bg-white px-4 py-2 text-sm font-medium text-green-primary hover:bg-green-50 disabled:opacity-40"
+              >
+                <Plus className="h-4 w-4" />
+                Add Another Credential
+              </button>
+            </div>
+
+            {error && (
+              <div className="flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+                <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+                <span>{error}</span>
+              </div>
+            )}
+            {validation.length > 0 && (
+              <ul className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800 space-y-1">
+                {validation.map((v) => <li key={v}>• {v}</li>)}
+              </ul>
+            )}
+
+            <div className="flex flex-wrap items-center justify-end gap-2 border-t border-gray-100 pt-4">
+              <button
+                type="button"
+                onClick={props.onClose}
+                className="rounded-lg px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-100"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => setPhase("preview")}
+                disabled={validation.length > 0}
+                className="inline-flex items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:border-green-primary hover:text-green-primary disabled:opacity-50"
+              >
+                <Eye className="h-4 w-4" />
+                Preview Email
+              </button>
+              <button
+                type="button"
+                onClick={() => setPhase("confirm")}
+                disabled={validation.length > 0}
+                className="inline-flex items-center gap-1.5 rounded-lg bg-green-primary px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-green-hover disabled:opacity-50"
+              >
+                <Send className="h-4 w-4" />
+                Send Credentials
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* PHASE: preview */}
+        {phase === "preview" && (
+          <div className="p-6 space-y-4">
+            <div className="flex items-center justify-between">
+              <button
+                type="button"
+                onClick={() => setPhase("edit")}
+                className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-sm text-gray-600 hover:bg-gray-100"
+              >
+                <ChevronLeft className="h-4 w-4" />
+                Back to edit
+              </button>
+              <span className="text-xs text-gray-500">Live preview — this is exactly what will send.</span>
+            </div>
+            <div className="max-h-[60vh] overflow-y-auto rounded-lg border border-gray-200 bg-white p-4">
+              <div dangerouslySetInnerHTML={{ __html: previewHtml }} />
+            </div>
+            <div className="flex items-center justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setPhase("edit")}
+                className="rounded-lg px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-100"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => setPhase("confirm")}
+                className="inline-flex items-center gap-1.5 rounded-lg bg-green-primary px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-green-hover"
+              >
+                <Send className="h-4 w-4" />
+                Send Credentials
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* PHASE: confirm */}
+        {phase === "confirm" && (
+          <div className="p-6 space-y-5">
+            <div className="rounded-xl border border-amber-200 bg-amber-50 p-5">
+              <h3 className="text-base font-semibold text-amber-900">Send Credentials?</h3>
+              <p className="mt-2 text-sm text-amber-800">
+                You are about to email login credentials to:
+              </p>
+              <div className="mt-3 rounded-lg bg-white/70 px-4 py-3">
+                <div className="text-sm font-semibold text-gray-900">{props.memberName}</div>
+                <div className="text-sm text-gray-700">{recipient}</div>
+              </div>
+              <p className="mt-3 text-xs text-amber-800">
+                Confirm the email address is correct before continuing. This will send the message immediately.
+              </p>
+            </div>
+            <div className="flex items-center justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setPhase("edit")}
+                className="rounded-lg px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-100"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={performSend}
+                className="inline-flex items-center gap-1.5 rounded-lg bg-green-primary px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-green-hover"
+              >
+                <Send className="h-4 w-4" />
+                Send Credentials
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* PHASE: sending */}
+        {phase === "sending" && (
+          <div className="flex flex-col items-center justify-center gap-3 p-10 text-sm text-gray-600">
+            <Loader2 className="h-6 w-6 animate-spin text-green-primary" />
+            Sending credentials…
+          </div>
+        )}
+
+        {/* PHASE: done */}
+        {phase === "done" && (
+          <div className="p-6 space-y-5">
+            <div className="flex flex-col items-center gap-3 rounded-xl border border-emerald-200 bg-emerald-50 p-6 text-center">
+              <CheckCircle2 className="h-8 w-8 text-emerald-600" />
+              <p className="text-sm font-semibold text-emerald-800">{okMessage}</p>
+              <p className="text-xs text-emerald-700">
+                Passwords have been cleared from this form. To resend, re-enter the credentials.
+              </p>
+            </div>
+            <div className="flex items-center justify-end gap-2">
+              <button
+                type="button"
+                onClick={props.onClose}
+                className="rounded-lg bg-green-primary px-4 py-2 text-sm font-semibold text-white hover:bg-green-hover"
+              >
+                Done
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/sales/team/page.tsx
+++ b/src/app/sales/team/page.tsx
@@ -4,7 +4,8 @@ import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { createBrowserClient } from "@/lib/supabase";
-import { Users, Loader2, Search, CheckCircle2, Clock, UserX, AlertTriangle, Plus, X, Eye, EyeOff, UserPlus, Trash2, Send, FileSignature, ClipboardCheck } from "lucide-react";
+import { Users, Loader2, Search, CheckCircle2, Clock, UserX, AlertTriangle, Plus, X, Eye, EyeOff, UserPlus, Trash2, Send, FileSignature, ClipboardCheck, Key } from "lucide-react";
+import SendCredentialsModal from "./SendCredentialsModal";
 
 interface TeamMember {
   id: string;
@@ -76,6 +77,9 @@ export default function TeamPage() {
   const [currentUserRole, setCurrentUserRole] = useState("");
   const [roleUpdating, setRoleUpdating] = useState<string | null>(null);
   const [roleError, setRoleError] = useState<string | null>(null);
+  // Send Credentials modal — one open at a time, keyed by member.
+  const [credentialsTarget, setCredentialsTarget] = useState<TeamMember | null>(null);
+  const [credentialsToast, setCredentialsToast] = useState<string | null>(null);
 
   const loadTeamMembers = useCallback(async (t: string) => {
     const res = await fetch("/api/sales/users", { headers: { Authorization: `Bearer ${t}` } });
@@ -469,6 +473,15 @@ export default function TeamPage() {
                         >
                           <FileSignature className="h-4 w-4" />
                         </button>
+                        <button
+                          type="button"
+                          onClick={() => setCredentialsTarget(m)}
+                          className="inline-flex items-center gap-1 rounded-md p-1.5 text-gray-300 hover:bg-green-50 hover:text-green-600 transition-colors"
+                          title={`Send login credentials to ${m.full_name || m.email}`}
+                          aria-label={`Send credentials to ${m.full_name || m.email}`}
+                        >
+                          <Key className="h-4 w-4" />
+                        </button>
                         {m.id !== currentUserId && (
                           <button
                             type="button"
@@ -736,6 +749,34 @@ export default function TeamPage() {
               </button>
             </div>
           </div>
+        </div>
+      )}
+
+      {/* Send Credentials modal — mounted at page root so it overlays
+          every UI beneath it. Only opens when a target row is set. */}
+      {credentialsTarget && (
+        <SendCredentialsModal
+          memberId={credentialsTarget.id}
+          memberName={credentialsTarget.full_name || credentialsTarget.email}
+          memberEmail={credentialsTarget.email}
+          token={token}
+          onClose={() => setCredentialsTarget(null)}
+          onSent={(res) => {
+            setCredentialsToast(
+              `Credentials sent to ${credentialsTarget?.full_name || credentialsTarget?.email} at ${res.sent_to}.`,
+            );
+            window.setTimeout(() => setCredentialsToast(null), 6_000);
+          }}
+        />
+      )}
+
+      {/* Non-blocking success toast for send-credentials. */}
+      {credentialsToast && (
+        <div
+          role="status"
+          className="fixed bottom-6 right-6 z-[10000] max-w-sm rounded-lg border border-emerald-200 bg-white px-4 py-3 text-sm text-emerald-800 shadow-lg"
+        >
+          {credentialsToast}
         </div>
       )}
     </div>

--- a/src/lib/teamCredentials/emails.ts
+++ b/src/lib/teamCredentials/emails.ts
@@ -1,0 +1,156 @@
+import { Resend } from "resend";
+
+/**
+ * Send Credentials — transactional email builder + sender.
+ *
+ * Security notes
+ *   * Passwords appear only inside the immediate email body render
+ *     and the outbound Resend payload. They are never logged,
+ *     persisted, or exposed to the caller after send.
+ *   * Every string that ends up in HTML is HTML-escaped so passwords
+ *     containing < > & " ' don't produce broken markup or accidental
+ *     injection.
+ *   * The renderer is exported so the admin can preview the exact
+ *     body that will be sent — same code path.
+ */
+
+const FROM = process.env.FROM_EMAIL || "onboarding@bytebitevending.com";
+const REPLY_TO = process.env.CREDENTIALS_REPLY_TO || "james@apexaivending.com";
+
+let _resend: Resend | null = null;
+function getResend(): Resend {
+  if (!_resend) {
+    const key = process.env.RESEND_API_KEY;
+    if (!key) throw new Error("RESEND_API_KEY not configured");
+    _resend = new Resend(key);
+  }
+  return _resend;
+}
+
+export interface CredentialRow {
+  system_name: string;
+  login_url?: string | null;
+  username: string;
+  password: string;
+}
+
+export function isValidHttpUrl(u: string | null | undefined): boolean {
+  if (!u) return true; // empty/null is allowed
+  try {
+    const parsed = new URL(u);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+// Minimal HTML escape — passwords may contain <, >, &, ", ' and we
+// must not break the markup or leak markup into the rendered value.
+function esc(s: string | null | undefined): string {
+  if (s == null) return "";
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function firstNameFromFull(full: string | null | undefined): string {
+  if (!full) return "there";
+  const cut = full.trim().split(/\s+/)[0];
+  return cut || "there";
+}
+
+/**
+ * Renders the full HTML body an admin will see in Preview and the
+ * team member will receive. Kept pure so it's safe to call from both
+ * the send route and the client-side preview (client re-implements
+ * the render for local preview; keeping this exported keeps the
+ * shape in one place for the server-authoritative send).
+ */
+export function renderCredentialsEmailHtml(args: {
+  recipient_name: string | null;
+  credentials: CredentialRow[];
+}): string {
+  const first = firstNameFromFull(args.recipient_name);
+
+  const credentialSections = args.credentials
+    .map((c) => {
+      const url = c.login_url && c.login_url.trim()
+        ? `<div style="margin:6px 0"><span style="color:#6b7280;font-size:12px;text-transform:uppercase;letter-spacing:.06em;font-weight:600">Login</span><br><a href="${esc(c.login_url)}" style="color:#16A34A;word-break:break-all">${esc(c.login_url)}</a></div>`
+        : "";
+      return `
+        <div style="background:#f9fafb;border:1px solid #e5e7eb;border-radius:10px;padding:16px;margin:12px 0">
+          <div style="font-size:15px;font-weight:700;color:#111827;margin-bottom:6px">${esc(c.system_name)}</div>
+          ${url}
+          <div style="margin:6px 0"><span style="color:#6b7280;font-size:12px;text-transform:uppercase;letter-spacing:.06em;font-weight:600">Username</span><br><span style="font-family:ui-monospace,SFMono-Regular,Menlo,monospace;color:#111827">${esc(c.username)}</span></div>
+          <div style="margin:6px 0"><span style="color:#6b7280;font-size:12px;text-transform:uppercase;letter-spacing:.06em;font-weight:600">Password</span><br><span style="font-family:ui-monospace,SFMono-Regular,Menlo,monospace;color:#111827">${esc(c.password)}</span></div>
+        </div>`;
+    })
+    .join("");
+
+  return `<div style="font-family:-apple-system,'Segoe UI',Inter,Arial,sans-serif;max-width:600px;margin:0 auto;padding:24px;color:#111">
+    <div style="margin-bottom:20px">
+      <div style="font-size:11px;font-weight:700;letter-spacing:0.15em;color:#16A34A;text-transform:uppercase">
+        Vending Connector · Apex AI Vending
+      </div>
+    </div>
+    <h1 style="font-size:22px;font-weight:700;color:#0A0A0A;margin:0 0 12px">Welcome to the team, ${esc(first)} 👋</h1>
+    <p style="line-height:1.6;color:#374151;margin:0 0 12px">
+      Congratulations again on your new journey with Vending Connector / Apex AI Vending — we're excited to have you on board.
+    </p>
+    <p style="line-height:1.6;color:#374151;margin:0 0 16px">
+      To get started, please use the links and login credentials below to access the systems you'll need for your role.
+    </p>
+
+    ${credentialSections}
+
+    <p style="line-height:1.6;color:#374151;margin:20px 0 12px">
+      You will also need to check your email for information regarding your <strong>training session</strong>.
+    </p>
+    <p style="line-height:1.6;color:#374151;margin:0 0 12px">
+      Please make sure you can successfully access each of the systems above before your training session. If you experience any issues logging in, let your manager know.
+    </p>
+    <p style="line-height:1.6;color:#374151;margin:20px 0 0">
+      Looking forward to working with you and helping you get started.<br><br>
+      — The Vending Connector / Apex AI Vending Team
+    </p>
+
+    <p style="color:#888;font-size:11px;margin-top:32px;border-top:1px solid #eee;padding-top:12px;line-height:1.6">
+      This message is from Vending Connector / Apex AI Vending LLP.<br>
+      Questions? Reply to this email or contact <a href="mailto:${esc(REPLY_TO)}" style="color:#16A34A">${esc(REPLY_TO)}</a>.
+    </p>
+  </div>`;
+}
+
+/**
+ * Send the credentials email via Resend. Throws on failure so the
+ * calling route can surface an actionable error to the admin.
+ * NEVER logs the credentials.
+ */
+export async function sendCredentialsEmail(args: {
+  toEmail: string;
+  recipient_name: string | null;
+  credentials: CredentialRow[];
+}): Promise<{ id: string | null }> {
+  const html = renderCredentialsEmailHtml({
+    recipient_name: args.recipient_name,
+    credentials: args.credentials,
+  });
+
+  const result = await getResend().emails.send({
+    from: FROM,
+    to: [args.toEmail],
+    replyTo: REPLY_TO,
+    subject: "Welcome to Vending Connector / Apex AI Vending — Your Login Credentials",
+    html,
+  });
+
+  if (result.error) {
+    // Do NOT include the request body in the error — passwords must
+    // not surface in logs or error-reporting sinks.
+    throw new Error(`Resend rejected credentials email: ${result.error.message}`);
+  }
+  return { id: result.data?.id ?? null };
+}

--- a/supabase/migrations/156_team_credential_emails.sql
+++ b/supabase/migrations/156_team_credential_emails.sql
@@ -1,0 +1,88 @@
+-- Migration 156: Send Credentials — audit + presets tables
+--
+-- Backs the /sales/team "Send Credentials" flow that lets an admin
+-- email one-time login credentials to a team member's on-file email.
+--
+-- CRITICAL: no passwords are ever stored server-side. The admin
+-- enters the credentials in the modal, the API sends the email
+-- immediately, and only NON-SENSITIVE metadata (recipient, sender,
+-- timestamp, list of system NAMES) is persisted to audit.
+--
+-- Data model
+-- ─────────
+--   team_credential_email_sends
+--     id                uuid PK
+--     team_member_id    uuid NOT NULL — recipient profile
+--     recipient_email   text NOT NULL — actual send-to (may differ
+--                                        from profile.email if the
+--                                        admin overrode for this send)
+--     sent_by_user_id   uuid NOT NULL — profile of the admin
+--     sent_at           timestamptz NOT NULL default now()
+--     system_names      text[] NOT NULL — labels only; passwords/
+--                                        usernames NEVER stored
+--     send_status       text NOT NULL — 'sent' | 'failed'
+--     error_message     text          — non-sensitive failure detail
+--
+--   team_credential_presets
+--     id                uuid PK
+--     name              text NOT NULL — e.g. "Vending Connector CRM"
+--     default_login_url text          — optional
+--     created_by        uuid          — admin who created the preset
+--     created_at        timestamptz NOT NULL default now()
+--
+-- All writes gated server-side by the admin route using
+-- supabaseAdmin (service-role bypasses RLS). Reads are admin-only
+-- via the API. Same pattern as every other admin-managed table.
+
+CREATE TABLE IF NOT EXISTS public.team_credential_email_sends (
+  id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  team_member_id   uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  recipient_email  text NOT NULL,
+  sent_by_user_id  uuid NOT NULL REFERENCES public.profiles(id) ON DELETE RESTRICT,
+  sent_at          timestamptz NOT NULL DEFAULT now(),
+  system_names     text[] NOT NULL DEFAULT '{}',
+  send_status      text NOT NULL DEFAULT 'sent'
+                     CHECK (send_status IN ('sent', 'failed')),
+  error_message    text
+);
+
+CREATE INDEX IF NOT EXISTS team_credential_email_sends_member_idx
+  ON public.team_credential_email_sends (team_member_id, sent_at DESC);
+
+CREATE INDEX IF NOT EXISTS team_credential_email_sends_sender_idx
+  ON public.team_credential_email_sends (sent_by_user_id, sent_at DESC);
+
+ALTER TABLE public.team_credential_email_sends ENABLE ROW LEVEL SECURITY;
+-- No policies granted — writes + reads flow through admin API using
+-- the service-role key (bypasses RLS), same pattern as
+-- marketing_gondola_images and every other admin-only table.
+
+CREATE TABLE IF NOT EXISTS public.team_credential_presets (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name              text NOT NULL,
+  default_login_url text,
+  created_by        uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+  created_at        timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS team_credential_presets_name_key
+  ON public.team_credential_presets (lower(name));
+
+ALTER TABLE public.team_credential_presets ENABLE ROW LEVEL SECURITY;
+
+-- Seed the common ones per the spec's suggested list. ON CONFLICT
+-- so re-running the migration is a no-op if any of these already
+-- exist.
+INSERT INTO public.team_credential_presets (name, default_login_url)
+VALUES
+  ('Vending Connector CRM',   'https://vendingconnector.com/login'),
+  ('Company Email',           'https://outlook.office.com'),
+  ('Microsoft Teams',         'https://teams.microsoft.com'),
+  ('Dialer',                  NULL),
+  ('Training Portal',         NULL),
+  ('Calendly',                'https://calendly.com'),
+  ('VOIP System',             NULL),
+  ('Vendor Portal',           NULL)
+ON CONFLICT DO NOTHING;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
New CRM feature: from /sales/team an admin can click a Key icon on any team-member row, enter one or more credential sets, preview the exact email that will send, confirm the recipient, and fire a branded Resend delivery to the member's on-file email.

Feature surface
- Button per row: Key icon next to the existing FileSignature onboard icon. Admin-only (currentUserRole === "admin").
- Modal: SendCredentialsModal with dynamic credential rows (System Name, Login URL, Username, Password with show/hide toggle), preset-picker dropdown per row (from team_credential_presets), Add / Remove buttons, Preview Email step, Confirm-recipient dialog, and a success toast on completion.
- Sidebar navigation is unchanged; the feature lives inside Team.

Server
- POST /api/admin/team/[id]/send-credentials — admin-only via getAdminUserId (server-side auth enforcement, not UI-hiding). Validates recipient email, per-row http(s) URL format, and that at least one complete credential is present. Sends via Resend, then writes a NON-SENSITIVE audit row. Never console.logs the request body. On send failure, records status='failed' with a capped error string (no credentials) and returns a user-friendly "Unable to send credentials" message.
- GET /api/admin/team/[id]/credential-history — admin-only. Serves the audit rows for a member (system names, sender, timestamp, status). Never returns passwords or usernames — they aren't stored.
- GET / POST /api/admin/team/credential-presets + DELETE /api/admin/team/credential-presets/[id] — admin-only preset management. Presets carry System Name + optional Login URL only; no universal passwords.

DB (migration 156)
- team_credential_email_sends: id, team_member_id, recipient_email, sent_by_user_id, sent_at, system_names text[], send_status ('sent' | 'failed'), error_message. RLS on, no policies — admin routes flow through service role, matching every other admin-only table. Indexes on (member, sent_at desc) and (sender, sent_at desc).
- team_credential_presets: id, name (unique on lower(name)), default_login_url, created_by, created_at. Seeded with the spec's suggested list (Vending Connector CRM, Company Email, Teams, Dialer, Training Portal, Calendly, VOIP System, Vendor Portal).

Email
- src/lib/teamCredentials/emails.ts: renderCredentialsEmailHtml() builds the exact HTML the recipient sees (branded shell matching contractor onboarding, credentials in gray cards, closing note reminding them to check their inbox for training info). sendCredentialsEmail() calls Resend with { data, error } inspection so silent failures throw. HTML-escapes every user value so passwords containing < > & " ' render literally without breaking markup.

Security
- Passwords never touch: application logs, browser console, analytics, audit rows, URL params, error-reporting payloads.
- Request-body handler intentionally omits credentials from every console.error path. Only { teamMemberId, recipientEmail, msg } is logged on delivery failure.
- Modal clears every password field on successful send so a distracted admin can't accidentally leave sensitive material on screen; on resend the admin re-enters values.
- Server enforces admin auth via getAdminUserId; hiding the button in the UI is not the security control.

Migration 156 must be run in Supabase before the button is functional. Typecheck clean, eslint clean, manufacturer + listings vitest still 21/21.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2