### PR TITLE
CRM: remove Pipelines from the sales sidebar

### DIFF
--- a/src/app/sales/layout.tsx
+++ b/src/app/sales/layout.tsx
@@ -14,7 +14,6 @@ import {
   PhoneCall,
   DollarSign,
   TrendingUp,
-  GitBranch,
   UserCog,
   UserPlus,
   Zap,
@@ -38,7 +37,10 @@ const NAV_ITEMS = [
   { href: "/sales", label: "Dashboard", icon: LayoutDashboard, minLevel: 4 as const },
   { href: "/sales/results", label: "Results", icon: TrendingUp, minLevel: 4 as const },
   { href: "/sales/leads", label: "Leads", icon: Users, minLevel: 4 as const },
-  { href: "/sales/pipelines", label: "Pipelines", icon: GitBranch, minLevel: 4 as const },
+  // Pipelines nav entry removed from the CRM sidebar per product
+  // request — the /sales/pipelines routes still exist for direct
+  // links and any deep-linked flows that reach them, but the nav
+  // tile no longer surfaces them.
   { href: "/sales/deals", label: "Deal Dashboard", icon: Kanban, minLevel: 4 as const },
   { href: "/sales/accounts", label: "Accounts", icon: Building2, minLevel: 4 as const },
   { href: "/sales/orders", label: "Orders / Quotes", icon: ClipboardList, minLevel: 4 as const },


### PR DESCRIPTION
Per product request. The /sales/pipelines routes still exist for any direct links and admin-only flows that deep-link into them, but the sidebar nav entry is gone so the CRM shell no longer surfaces it as a top-level destination.

- src/app/sales/layout.tsx: dropped the "/sales/pipelines" NAV_ITEMS entry and its now-unused GitBranch lucide import.

Typecheck clean.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2