### PR TITLE
Location requests: defer workflow spawn until deposit is paid

### DIFF
--- a/src/app/api/request-location/route.ts
+++ b/src/app/api/request-location/route.ts
@@ -297,81 +297,17 @@ export async function POST(req: Request) {
     sendLocationRequestConfirmation({ to: email, name: contact_name })
       .catch((e) => console.error("[request-location] confirmation email error", e));
 
-    // Bridge to Workflows: if a profile already exists for this email,
-    // spawn the location_services workflow immediately with
-    // payment_status='partial' + deposit metadata so the customer sees
-    // it on their /account/workflows page as soon as they log in. If no
-    // profile exists yet, the workflow can be backfilled from
-    // /admin/workflows/backfill once the customer signs up.
-    try {
-      const { data: existingProfile } = await supabaseAdmin
-        .from("profiles")
-        .select("id")
-        .ilike("email", email)
-        .maybeSingle();
-
-      if (existingProfile) {
-        const { getOrCreateWorkflow } = await import("@/lib/workflows/service");
-        // Placement fee assumption: standard $500/location Apex Placement Fee
-        // stacked on top of the $100/location deposit. Adjust in the
-        // workflow's metadata if pricing differs; the customer's Pay
-        // Balance flow just reads workflow.total_due_cents.
-        const totalDueCents = depositCents + machine_count * 50000;
-
-        await getOrCreateWorkflow({
-          customerId: existingProfile.id,
-          workflowType: "location_services",
-          sourceType: "location_request",
-          sourceId: lead.id,
-          locationRequestId: lead.id,
-          orderId: orderId ?? undefined,
-          productKey: "location_services",
-          productName: `Location Services — ${machine_count} location${machine_count > 1 ? "s" : ""}`,
-          quantityPurchased: machine_count,
-          paymentStatus: "partial",
-          primaryTeam: "locations",
-          startDate: new Date().toISOString(),
-          metadata: {
-            source: "request-location-deposit",
-            deposit_amount_cents: depositCents,
-            deposit_paid_cents: depositCents,
-            deposit_per_location_cents: DEPOSIT_CENTS_PER_LOCATION,
-            total_due_cents: totalDueCents,
-            // source_intake = exactly what the customer submitted, so
-            // whoever picks up the workflow sees the full request.
-            source_intake: {
-              business_name,
-              contact_name,
-              phone,
-              email,
-              address, // was previously dropped — bug fix
-              state,
-              zip_codes,
-              zip_code,
-              machine_count,
-              machine_type,
-              referring_sales_rep_name: referringRepName,
-            },
-          },
-          actorType: "system",
-        });
-
-        // Set the money columns via a targeted update — the service's
-        // metadata block is a jsonb sidecar, but total_due_cents /
-        // deposit_paid_cents are dedicated columns the UI reads.
-        await supabaseAdmin
-          .from("workflows")
-          .update({
-            deposit_paid_cents: depositCents,
-            total_due_cents: totalDueCents,
-          })
-          .eq("source_type", "location_request")
-          .eq("source_id", lead.id)
-          .eq("workflow_type", "location_services");
-      }
-    } catch (workflowErr) {
-      console.error("[request-location] workflow spawn failed:", workflowErr);
-    }
+    // Workflow spawn intentionally removed from this route. We no
+    // longer create a location_services workflow at intake — the
+    // spawn is deferred until the QuickBooks invoice actually
+    // clears. See src/lib/workflows/paymentSync.ts
+    // (syncWorkflowFromSalesOrderPaid + the location_services
+    // spawn helper) — when the QB webhook lands, the sales_order
+    // is matched, and if it's a location_services order with no
+    // workflow yet, one is created in the paid state and the
+    // marketplace bridge fires. Rationale: keeps the workflows
+    // queue clean of speculative requests where the deposit was
+    // never paid.
 
     if (fullInvoice.InvoiceLink) {
       return NextResponse.json({ url: fullInvoice.InvoiceLink });

--- a/src/lib/workflows/paymentSync.ts
+++ b/src/lib/workflows/paymentSync.ts
@@ -86,7 +86,140 @@ export async function advancePaymentStageForWorkflow(args: {
 }
 
 /**
- * Mark any workflow(s) linked to this sales_order as paid.
+ * Location-services intake used to spawn a workflow at /request-location
+ * time with payment_status='partial'. That leaked speculative requests
+ * (never-paid deposits) into the workflows queue. We now defer the
+ * spawn until the QB invoice actually clears — this helper handles it.
+ *
+ * Preconditions: the sales_order was created at intake time and holds
+ * (a) the linked sales_leads row with the full customer intake,
+ * (b) account_id, and (c) order_type='location_services'.
+ *
+ * Idempotent: no-ops if a workflow is already linked to the order or
+ * to the underlying lead (source_id).
+ */
+async function spawnLocationServicesWorkflowFromPaidOrder(
+  orderId: string,
+): Promise<string | null> {
+  const { data: order } = await supabaseAdmin
+    .from("sales_orders")
+    .select("id, lead_id, account_id, recipient_email, order_type, notes")
+    .eq("id", orderId)
+    .maybeSingle();
+  if (!order) return null;
+  if (order.order_type !== "location_services") return null;
+
+  const { data: lead } = order.lead_id
+    ? await supabaseAdmin
+        .from("sales_leads")
+        .select("id, business_name, contact_name, phone, email, address, state, zip_code, machine_count, machine_type, assigned_to")
+        .eq("id", order.lead_id)
+        .maybeSingle()
+    : { data: null };
+
+  const recipientEmail = (order.recipient_email || lead?.email || "").trim();
+  if (!recipientEmail) return null;
+
+  const { data: profile } = await supabaseAdmin
+    .from("profiles")
+    .select("id")
+    .ilike("email", recipientEmail)
+    .maybeSingle();
+  if (!profile) {
+    // Customer never created an account. Nothing to attach the
+    // workflow to. When they sign up later /admin/workflows/backfill
+    // is the recovery path.
+    return null;
+  }
+
+  const machineCount = Number(lead?.machine_count ?? 0) || 1;
+  const depositPerLocationCents = 10000; // $100 — matches request-location constant
+  const depositCents = machineCount * depositPerLocationCents;
+  // $500 placement fee per location on top of the $100 deposit.
+  const totalDueCents = depositCents + machineCount * 50000;
+
+  // Idempotency: if a workflow already exists for this lead's
+  // source_id, bail. The getOrCreateWorkflow call also enforces
+  // this, but skipping the extra work here is cheaper.
+  if (order.lead_id) {
+    const { data: existing } = await supabaseAdmin
+      .from("workflows")
+      .select("id")
+      .eq("source_type", "location_request")
+      .eq("source_id", order.lead_id)
+      .eq("workflow_type", "location_services")
+      .maybeSingle();
+    if (existing) return existing.id as string;
+  }
+
+  // Refer-rep name (for the intake snapshot). Best-effort — not fatal
+  // if the assigned_to profile lookup fails.
+  let referringRepName: string | null = null;
+  if (lead?.assigned_to) {
+    const { data: rep } = await supabaseAdmin
+      .from("profiles")
+      .select("full_name")
+      .eq("id", lead.assigned_to)
+      .maybeSingle();
+    referringRepName = rep?.full_name ?? null;
+  }
+
+  const { getOrCreateWorkflow } = await import("./service");
+  const { workflow } = await getOrCreateWorkflow({
+    customerId: profile.id,
+    workflowType: "location_services",
+    sourceType: "location_request",
+    sourceId: order.lead_id ?? orderId,
+    locationRequestId: order.lead_id ?? undefined,
+    orderId,
+    productKey: "location_services",
+    productName: `Location Services — ${machineCount} location${machineCount > 1 ? "s" : ""}`,
+    quantityPurchased: machineCount,
+    paymentStatus: "paid",
+    primaryTeam: "locations",
+    startDate: new Date().toISOString(),
+    metadata: {
+      source: "request-location-deposit-paid",
+      deposit_amount_cents: depositCents,
+      deposit_paid_cents: depositCents,
+      deposit_per_location_cents: depositPerLocationCents,
+      total_due_cents: totalDueCents,
+      source_intake: {
+        business_name: lead?.business_name ?? null,
+        contact_name: lead?.contact_name ?? null,
+        phone: lead?.phone ?? null,
+        email: recipientEmail,
+        address: lead?.address ?? null,
+        state: lead?.state ?? null,
+        zip_code: lead?.zip_code ?? null,
+        machine_count: machineCount,
+        machine_type: lead?.machine_type ?? null,
+        referring_sales_rep_name: referringRepName,
+      },
+    },
+    actorType: "system",
+  });
+
+  // Stamp the deposit money columns (mirrors what the intake path
+  // used to do — the UI reads these directly rather than the
+  // metadata sidecar).
+  await supabaseAdmin
+    .from("workflows")
+    .update({
+      deposit_paid_cents: depositCents,
+      total_due_cents: totalDueCents,
+    })
+    .eq("id", workflow.id);
+
+  return workflow.id;
+}
+
+/**
+ * Mark any workflow(s) linked to this sales_order as paid. For
+ * location_services orders that have no linked workflow yet (intake
+ * no longer spawns one — we wait for the deposit to clear), also
+ * spawn the workflow in the paid state before running the mark-paid
+ * loop.
  */
 export async function syncWorkflowFromSalesOrderPaid(args: {
   orderId: string;
@@ -94,6 +227,25 @@ export async function syncWorkflowFromSalesOrderPaid(args: {
   source: string;
   changeKey?: string;
 }): Promise<number> {
+  // Payment-time spawn for location_services intake. Only fires when
+  // no workflow is linked; helper is idempotent.
+  try {
+    const { data: existingLinked } = await supabaseAdmin
+      .from("workflows")
+      .select("id")
+      .eq("order_id", args.orderId)
+      .limit(1)
+      .maybeSingle();
+    if (!existingLinked) {
+      await spawnLocationServicesWorkflowFromPaidOrder(args.orderId);
+    }
+  } catch (spawnErr) {
+    console.error(
+      "[paymentSync] location_services workflow spawn on paid order failed:",
+      spawnErr,
+    );
+  }
+
   const { data: workflows } = await supabaseAdmin
     .from("workflows")
     .select("id, payment_status, deposit_paid_cents, total_due_cents, version")


### PR DESCRIPTION
Fixes the "workflow fires before payment" complaint. /request-location used to spawn a location_services workflow immediately at intake with payment_status='partial', which polluted the workflows queue with speculative requests whose deposit never actually cleared.

Now the workflow only exists after the QB invoice pays.

- src/app/api/request-location/route.ts: removed the intake-time getOrCreateWorkflow(...) block. sales_lead + sales_account + sales_order + QB invoice still get created up front (so accounting and lead tracking are unchanged); only the workflow spawn is deferred.
- src/lib/workflows/paymentSync.ts:
    * New helper spawnLocationServicesWorkflowFromPaidOrder(orderId) that resolves the linked sales_lead + customer profile, then spawns the workflow with payment_status='paid' and the full intake snapshot (business, contact, phone, email, address, state, zip, machine_count, machine_type, referring rep). Idempotent — no-ops if a workflow already exists for the order or the underlying lead's source_id.
    * syncWorkflowFromSalesOrderPaid runs that helper first when the QB webhook lands and no workflow is linked to the order, then continues its existing "mark paid" loop. The mark-paid loop is a no-op for newly-spawned workflows (already paid) and the marketplace bridge still fires afterward to expose the request to placement providers.
    * Non-fatal on failure — spawn errors are logged and don't break the payment sync.

Two edge cases:
- No profile exists for the customer's email at payment time (they never signed up): helper returns null, no workflow. Same behavior as the intake path had. /admin/workflows/backfill remains the recovery route.
- The QB webhook fires multiple times for the same invoice: the existing-workflow check + getOrCreateWorkflow's idempotency key keep this safe.

Typecheck clean.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2