### PR TITLE
Notify list: add anthony + bryan, remove katrina

### DIFF
--- a/src/app/api/agreements/sign/[token]/sign/route.ts
+++ b/src/app/api/agreements/sign/[token]/sign/route.ts
@@ -15,11 +15,10 @@ const REQUIRED_INITIALS = [
   "schedule_c",
 ];
 
+import { APEX_ADMIN_NOTIFY } from "@/lib/adminNotifyRecipients";
+
 const FROM_EMAIL = process.env.FROM_EMAIL || "receipts@bytebitevending.com";
-const ALWAYS_CC = [
-  "james@apexaivending.com",
-  "katrina.cacdac@apexaivending.com",
-];
+const ALWAYS_CC = [...APEX_ADMIN_NOTIFY];
 
 function getResend() {
   return new Resend(process.env.RESEND_API_KEY);

--- a/src/app/api/request-location/route.ts
+++ b/src/app/api/request-location/route.ts
@@ -4,7 +4,12 @@ import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { sendLocationRequestConfirmation } from "@/lib/intakeEmail";
 import { createInvoice, sendInvoiceEmail, getInvoice } from "@/lib/quickbooks";
 
-const TO_EMAILS = ["james@apexaivending.com", "louis.cirino@apexaivending.com"];
+import { APEX_ADMIN_NOTIFY } from "@/lib/adminNotifyRecipients";
+
+// Every location services request goes to the standing admin list
+// (james/anthony/bryan) plus louis, who runs the location team's
+// intake triage.
+const TO_EMAILS = [...APEX_ADMIN_NOTIFY, "louis.cirino@apexaivending.com"];
 const FROM_EMAIL = process.env.FROM_EMAIL || "receipts@bytebitevending.com";
 // Deposit is $100 PER LOCATION requested — not a flat $100 total.
 // A 10-location request pays $1,000 up front; a single-location

--- a/src/app/api/sales/agreements/[id]/send/route.ts
+++ b/src/app/api/sales/agreements/[id]/send/route.ts
@@ -3,11 +3,10 @@ import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { getSalesUser } from "@/lib/salesAuth";
 import { Resend } from "resend";
 
+import { APEX_ADMIN_NOTIFY } from "@/lib/adminNotifyRecipients";
+
 const FROM_EMAIL = process.env.FROM_EMAIL || "receipts@bytebitevending.com";
-const ALWAYS_CC = [
-  "james@apexaivending.com",
-  "katrina.cacdac@apexaivending.com",
-];
+const ALWAYS_CC = [...APEX_ADMIN_NOTIFY];
 
 function getResend() {
   return new Resend(process.env.RESEND_API_KEY);

--- a/src/app/api/sales/orders/[id]/send/route.ts
+++ b/src/app/api/sales/orders/[id]/send/route.ts
@@ -4,8 +4,10 @@ import { getSalesUser } from "@/lib/salesAuth";
 import { Resend } from "resend";
 import { createInvoice, sendInvoiceEmail } from "@/lib/quickbooks";
 
+import { APEX_ADMIN_NOTIFY } from "@/lib/adminNotifyRecipients";
+
 const FROM_EMAIL = process.env.FROM_EMAIL || "receipts@bytebitevending.com";
-const ALWAYS_CC = ["james@apexaivending.com", "katrina.cacdac@apexaivending.com"];
+const ALWAYS_CC = [...APEX_ADMIN_NOTIFY];
 
 function getResend() {
   return new Resend(process.env.RESEND_API_KEY);

--- a/src/app/sales/orders/new/page.tsx
+++ b/src/app/sales/orders/new/page.tsx
@@ -210,7 +210,7 @@ function NewOrderContent() {
         <h2 className="text-2xl font-bold text-gray-900 mb-2">{docLabel} Submitted!</h2>
         {sendResult?.ok ? (
           <p className="text-sm text-green-700 max-w-sm">
-            Email sent to <strong>{sendResult.recipient}</strong> and CC&apos;d to james@apexaivending.com &amp; katrina.cacdac@apexaivending.com
+            Email sent to <strong>{sendResult.recipient}</strong> and CC&apos;d to james@apexaivending.com, anthony.heidal@apexaivending.com &amp; bryan.rice@apexaivending.com
           </p>
         ) : (
           <div className="max-w-sm">

--- a/src/lib/adminNotifyRecipients.ts
+++ b/src/lib/adminNotifyRecipients.ts
@@ -1,0 +1,23 @@
+/**
+ * Central list of Apex admin email recipients for outbound notifications.
+ *
+ * Consumed by:
+ *   - src/app/api/sales/orders/[id]/send/route.ts     (Orders + Quotes)
+ *   - src/app/api/sales/agreements/[id]/send/route.ts (Agreement send)
+ *   - src/app/api/agreements/sign/[token]/sign/route.ts (Operator signed)
+ *   - src/app/api/request-location/route.ts           (Location Services intake)
+ *   - src/lib/workflows/notifications.ts              (Every workflow event)
+ *
+ * Change recipients here and every surface updates on the next deploy.
+ */
+
+/**
+ * Always-CC on every quote/order/agreement email the CRM fires
+ * and every location services request admin notification. Also
+ * added to every workflow notification recipient list.
+ */
+export const APEX_ADMIN_NOTIFY = [
+  "james@apexaivending.com",
+  "anthony.heidal@apexaivending.com",
+  "bryan.rice@apexaivending.com",
+] as const;

--- a/src/lib/workflows/notifications.ts
+++ b/src/lib/workflows/notifications.ts
@@ -10,6 +10,7 @@
 
 import { Resend } from "resend";
 import { supabaseAdmin } from "../supabaseAdmin";
+import { APEX_ADMIN_NOTIFY } from "../adminNotifyRecipients";
 import type { WorkflowRow } from "./types";
 
 const FROM_EMAIL = process.env.FROM_EMAIL || "receipts@bytebitevending.com";
@@ -184,7 +185,27 @@ async function resolveRecipients(
     }
   }
 
-  return recipients;
+  // Always-notify list: every workflow notification also fans out to
+  // the standing Apex admin distribution. De-duplicated below so an
+  // admin who's already on the list via role or team_email doesn't
+  // get two copies.
+  for (const email of APEX_ADMIN_NOTIFY) {
+    recipients.push({ email, audience: "team" });
+  }
+
+  // Dedupe by email — de-lowercases so "James@..." and "james@..."
+  // collapse to a single recipient. Preserves first-seen audience
+  // (customer > assignee > team) so per-audience template wording
+  // stays right.
+  const seen = new Set<string>();
+  const deduped: Recipient[] = [];
+  for (const r of recipients) {
+    const key = r.email.trim().toLowerCase();
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    deduped.push({ ...r, email: key });
+  }
+  return deduped;
 }
 
 function teamEmailFor(team: string | null): string | null {


### PR DESCRIPTION
Adds anthony.heidal@apexaivending.com and bryan.rice@apexaivending.com to every admin notification distribution and removes katrina.cacdac@apexaivending.com.

Surfaces covered
- Order + quote sends (/api/sales/orders/[id]/send)
- Agreement send to operator (/api/sales/agreements/[id]/send)
- Agreement fully-signed notification (/api/agreements/sign/[token]/sign)
- Location Services request admin notification (/api/request-location)
- Every workflow notification (src/lib/workflows/notifications.ts)

Implementation
- New src/lib/adminNotifyRecipients.ts exports APEX_ADMIN_NOTIFY = ["james", "anthony.heidal", "bryan.rice"]. Every surface above imports from it — future recipient adds/removes are one file to edit.
- Workflow notifications: dispatchNotification's resolveRecipients now appends the always-notify list after customer/assignee/team/ admins are resolved, then dedupes by lowercased email so an admin who's already on the list via role or team_email doesn't get two copies. First-seen audience is preserved so per-audience template wording stays right.
- Location Services request TO_EMAILS now [...APEX_ADMIN_NOTIFY, louis.cirino] — louis stays for location team intake triage.
- Sales/orders/new UI copy updated to name the new CC list.

No katrina references remain in src/. Typecheck clean.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2