### PR TITLE
Location services: provision profile at payment so workflow spawns fo…

### DIFF
--- a/src/lib/workflows/paymentSync.ts
+++ b/src/lib/workflows/paymentSync.ts
@@ -120,17 +120,46 @@ async function spawnLocationServicesWorkflowFromPaidOrder(
   const recipientEmail = (order.recipient_email || lead?.email || "").trim();
   if (!recipientEmail) return null;
 
-  const { data: profile } = await supabaseAdmin
+  let { data: profile } = await supabaseAdmin
     .from("profiles")
     .select("id")
     .ilike("email", recipientEmail)
     .maybeSingle();
+
+  // Guest intake: /request-location is public, so the customer may
+  // have paid without ever creating an account. Provision a real
+  // profile flagged is_provisional=true so the workflow can attach
+  // to a legitimate customer_id. Uses the same helper the coffee
+  // guest checkout relies on so the "claim your account" magic-link
+  // flow works uniformly. If provisioning fails we fall back to
+  // null and let admin backfill catch it.
   if (!profile) {
-    // Customer never created an account. Nothing to attach the
-    // workflow to. When they sign up later /admin/workflows/backfill
-    // is the recovery path.
-    return null;
+    try {
+      const { provisionAccountForGuestCheckout } = await import(
+        "@/lib/auth/provisionalAccount"
+      );
+      const provisioned = await provisionAccountForGuestCheckout({
+        email: recipientEmail,
+        business_name: lead?.business_name ?? "",
+        contact_name: lead?.contact_name ?? "",
+        phone: lead?.phone ?? "",
+        address: lead?.address ?? "",
+        city: null,
+        state: lead?.state ?? null,
+        zip: null,
+        marketing_consent: false,
+        referring_sales_rep_id: lead?.assigned_to ?? null,
+      });
+      profile = { id: provisioned.userId };
+    } catch (provisionErr) {
+      console.error(
+        "[paymentSync] provisional profile creation failed for location_services payment:",
+        provisionErr,
+      );
+      return null;
+    }
   }
+  if (!profile) return null;
 
   const machineCount = Number(lead?.machine_count ?? 0) || 1;
   const depositPerLocationCents = 10000; // $100 — matches request-location constant


### PR DESCRIPTION
…r guests

Closes the "still not appearing in Workflows on payment" gap. The /request-location page is public (guests can submit), so the customer may pay their QB invoice without ever having created an account. spawnLocationServicesWorkflowFromPaidOrder was returning null in that path because no profiles row matched the recipient email — the workflow never got attached to a customer_id.

Fix: when no profile exists at payment time, provision a real Supabase profile flagged is_provisional=true using the shared provisionAccountForGuestCheckout helper (already powering coffee guest checkout). The workflow then attaches to that profile as customer_id, and the customer can claim the account later via the magic-link flow.

- src/lib/workflows/paymentSync.ts: spawnLocationServicesWorkflowFromPaidOrder now attempts profile provisioning before giving up. Uses the lead's captured business_name / contact_name / phone / address / state to seed the provisional profile so the new account has real context. Falls back to null (admin backfill) only if provisioning itself fails.

Idempotency preserved: provisionAccountForGuestCheckout is idempotent — a second QB webhook fire for the same email returns the existing provisional profile instead of creating a duplicate.

Typecheck clean.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2