### PR TITLE
Orders: manual "Send to Workflows" fallback button

### DIFF
--- a/src/app/api/sales/orders/[id]/send-to-workflow/route.ts
+++ b/src/app/api/sales/orders/[id]/send-to-workflow/route.ts
@@ -1,0 +1,97 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser } from "@/lib/salesAuth";
+import { spawnLocationServicesWorkflowFromPaidOrder } from "@/lib/workflows/paymentSync";
+
+/**
+ * POST /api/sales/orders/[id]/send-to-workflow
+ *
+ * Admin-only manual fallback for the auto-spawn path. Force-creates
+ * the workflow linked to this sales_order using the same helper the
+ * QB webhook + manual mark-paid path use.
+ *
+ * Idempotent: if a workflow is already linked, returns that one
+ * instead of creating a duplicate.
+ *
+ * Today: only wired for order_type = 'location_services'. Other
+ * types can be added by extending the switch below — most other
+ * order types (AI machines, financing, coffee) spawn their
+ * workflows from different upstream signals (agreement signed,
+ * coffee_order placed, etc.) that don't route through sales_orders.
+ */
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const user = await getSalesUser(req);
+  if (!user || user.role !== "admin") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  const { id } = await params;
+
+  const { data: order, error: orderErr } = await supabaseAdmin
+    .from("sales_orders")
+    .select("id, order_type")
+    .eq("id", id)
+    .maybeSingle();
+  if (orderErr) {
+    return NextResponse.json({ error: orderErr.message }, { status: 500 });
+  }
+  if (!order) {
+    return NextResponse.json({ error: "Order not found" }, { status: 404 });
+  }
+
+  // Existing workflow — return early rather than create a duplicate.
+  const { data: existing } = await supabaseAdmin
+    .from("workflows")
+    .select("id, workflow_number")
+    .eq("order_id", order.id)
+    .limit(1)
+    .maybeSingle();
+  if (existing) {
+    return NextResponse.json({
+      ok: true,
+      already_linked: true,
+      workflow_id: existing.id,
+      workflow_number: (existing as { workflow_number?: string }).workflow_number ?? null,
+    });
+  }
+
+  if (order.order_type === "location_services") {
+    try {
+      const workflowId = await spawnLocationServicesWorkflowFromPaidOrder(order.id);
+      if (!workflowId) {
+        return NextResponse.json(
+          {
+            error:
+              "Could not spawn the workflow — the spawn helper returned null. Most likely the underlying sales_lead is missing data, or provisional-profile provisioning failed. Check the server logs and try again.",
+          },
+          { status: 500 },
+        );
+      }
+      const { data: created } = await supabaseAdmin
+        .from("workflows")
+        .select("id, workflow_number")
+        .eq("id", workflowId)
+        .maybeSingle();
+      return NextResponse.json({
+        ok: true,
+        already_linked: false,
+        workflow_id: workflowId,
+        workflow_number: created?.workflow_number ?? null,
+      });
+    } catch (err) {
+      return NextResponse.json(
+        { error: err instanceof Error ? err.message : "Spawn failed" },
+        { status: 500 },
+      );
+    }
+  }
+
+  return NextResponse.json(
+    {
+      error: `Send-to-workflow isn't wired for order_type '${order.order_type ?? "(none)"}' yet. Location Services is the only supported type today — other types spawn workflows from different upstream signals (agreement signed, coffee order placed, etc.).`,
+    },
+    { status: 400 },
+  );
+}

--- a/src/app/sales/orders/[id]/page.tsx
+++ b/src/app/sales/orders/[id]/page.tsx
@@ -203,6 +203,33 @@ export default function OrderDetailPage() {
     setActionLoading("");
   }
 
+  async function handleSendToWorkflow() {
+    if (!confirm(
+      "Manually create a workflow from this order?\n\n" +
+      "Use this as a fallback if the automatic spawn didn't fire " +
+      "(e.g. QB webhook missed, or manual mark-paid predated the fix). " +
+      "Idempotent — if a workflow is already linked, nothing new is created.",
+    )) return;
+    setActionLoading("send_to_workflow");
+    try {
+      const res = await fetch(`/api/sales/orders/${id}/send-to-workflow`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        alert(data.error || "Failed to send to workflow");
+      } else if (data.already_linked) {
+        alert(`This order is already linked to workflow ${data.workflow_number ?? data.workflow_id}.`);
+      } else {
+        alert(`Workflow ${data.workflow_number ?? data.workflow_id} created and linked.`);
+      }
+    } finally {
+      await fetchOrder();
+      setActionLoading("");
+    }
+  }
+
   async function handleSendRemainingBalance() {
     if (!confirm("Send the Location Services remaining balance invoice to the customer? This typically goes out once secured locations have been fulfilled.")) return;
     setActionLoading("send_remaining_balance");
@@ -741,6 +768,21 @@ export default function OrderDetailPage() {
                     {actionLoading === sa.action ? "..." : sa.label}
                   </button>
                 ))}
+                {/* Manual fallback for the auto-spawn path — only
+                    shows on location_services orders today since
+                    that's the type the send-to-workflow endpoint
+                    supports. Idempotent — clicking on an already-
+                    linked order returns the existing workflow. */}
+                {order.order_type === "location_services" && (
+                  <button
+                    onClick={handleSendToWorkflow}
+                    disabled={actionLoading === "send_to_workflow"}
+                    className="w-full rounded-lg px-3 py-2 text-xs font-medium text-white transition-colors cursor-pointer disabled:opacity-50 bg-amber-600 hover:bg-amber-700"
+                    title="Manually create a workflow from this order — use as a fallback if the auto-spawn didn't fire"
+                  >
+                    {actionLoading === "send_to_workflow" ? "..." : "Send to Workflows"}
+                  </button>
+                )}
               </div>
             </div>
           )}


### PR DESCRIPTION
Adds a per-order admin action to force-create a workflow from a sales_order using the shared spawn helper. Fallback for cases where the auto-spawn path missed (QB webhook missed, or an old mark-paid predated the auto-spawn wire-up).

- src/app/api/sales/orders/[id]/send-to-workflow/route.ts (new): admin-only POST. Confirms the order exists, returns early with the existing workflow if one is already linked (idempotent), otherwise calls spawnLocationServicesWorkflowFromPaidOrder. Wired for order_type = 'location_services' today; other types fall through with a readable "not wired for this type yet" 400 (their workflows spawn from different upstream signals — agreement signed, coffee order placed, etc.).
- src/app/sales/orders/[id]/page.tsx: amber "Send to Workflows" button in the Actions panel, only shown for location_services orders. Confirms first, calls the endpoint, surfaces the resulting workflow number (or "already linked" acknowledgment) in an alert.

Typecheck clean.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2