### PR TITLE
Workflows list: new "Assigned" column showing the owner rep

### DIFF
--- a/src/app/api/workflows/route.ts
+++ b/src/app/api/workflows/route.ts
@@ -82,25 +82,32 @@ export async function GET(req: NextRequest) {
   const { data, error, count } = await query;
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
-  // Batch-fetch customer names for the returned page so the CRM table
-  // can show "who this workflow is for" without an N+1.
+  // Batch-fetch customer + assignee names for the returned page so
+  // the CRM table can show "who this workflow is for" and "who
+  // owns it" without an N+1 lookup. One profiles round-trip covers
+  // both roles since customer_id and assigned_user_id both point at
+  // profiles.id.
   const rows = data ?? [];
   const customerIds = Array.from(new Set(rows.map((r) => r.customer_id).filter(Boolean)));
-  const customerMap: Record<string, { full_name: string | null; email: string | null }> = {};
-  if (customerIds.length > 0) {
+  const assigneeIds = Array.from(new Set(rows.map((r) => r.assigned_user_id).filter(Boolean)));
+  const profileIds = Array.from(new Set([...customerIds, ...assigneeIds]));
+  const profileMap: Record<string, { full_name: string | null; email: string | null }> = {};
+  if (profileIds.length > 0) {
     const { data: profiles } = await supabaseAdmin
       .from("profiles")
       .select("id, full_name, email")
-      .in("id", customerIds);
+      .in("id", profileIds);
     for (const p of profiles ?? []) {
-      customerMap[p.id] = { full_name: p.full_name, email: p.email };
+      profileMap[p.id] = { full_name: p.full_name, email: p.email };
     }
   }
 
   const workflowsWithCustomer = rows.map((r) => ({
     ...r,
-    customer_name: customerMap[r.customer_id]?.full_name ?? null,
-    customer_email: customerMap[r.customer_id]?.email ?? null,
+    customer_name: profileMap[r.customer_id]?.full_name ?? null,
+    customer_email: profileMap[r.customer_id]?.email ?? null,
+    assigned_user_name: r.assigned_user_id ? profileMap[r.assigned_user_id]?.full_name ?? null : null,
+    assigned_user_email: r.assigned_user_id ? profileMap[r.assigned_user_id]?.email ?? null : null,
   }));
 
   return NextResponse.json({

--- a/src/app/sales/workflows/page.tsx
+++ b/src/app/sales/workflows/page.tsx
@@ -42,6 +42,8 @@ interface WorkflowRow {
   company_id: string | null;
   customer_name: string | null;
   customer_email: string | null;
+  assigned_user_name: string | null;
+  assigned_user_email: string | null;
   updated_at: string;
 }
 
@@ -400,6 +402,7 @@ export default function WorkflowsPage() {
               <th className="px-4 py-3">Workflow</th>
               <th className="px-4 py-3">Customer</th>
               <th className="px-4 py-3">Type</th>
+              <th className="px-4 py-3">Assigned</th>
               <th className="px-4 py-3">Progress</th>
               <th className="px-4 py-3">Status</th>
               <th className="px-4 py-3">Due</th>
@@ -409,14 +412,14 @@ export default function WorkflowsPage() {
           <tbody className="divide-y divide-gray-100">
             {loading ? (
               <tr>
-                <td colSpan={7} className="px-4 py-12 text-center text-gray-500">
+                <td colSpan={8} className="px-4 py-12 text-center text-gray-500">
                   <Loader2 className="inline-block h-5 w-5 animate-spin mr-2" />
                   Loading workflows…
                 </td>
               </tr>
             ) : workflows.length === 0 ? (
               <tr>
-                <td colSpan={7} className="px-4 py-12 text-center text-gray-500">
+                <td colSpan={8} className="px-4 py-12 text-center text-gray-500">
                   <Filter className="inline-block h-5 w-5 mr-2 text-gray-400" />
                   No workflows match the current filters.
                 </td>
@@ -510,6 +513,22 @@ function WorkflowRowRender({
           <Icon className="h-3.5 w-3.5" />
           {meta.label}
         </div>
+      </td>
+      <td className="px-4 py-3">
+        {workflow.assigned_user_id ? (
+          <>
+            <div className="text-sm font-medium text-gray-900">
+              {workflow.assigned_user_name ?? workflow.assigned_user_email ?? "—"}
+            </div>
+            {workflow.assigned_user_email && workflow.assigned_user_name && (
+              <div className="text-xs text-gray-500 truncate max-w-[200px]">{workflow.assigned_user_email}</div>
+            )}
+          </>
+        ) : (
+          <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700 ring-1 ring-inset ring-amber-200">
+            Unassigned
+          </span>
+        )}
       </td>
       <td className="px-4 py-3">
         {total > 0 ? (


### PR DESCRIPTION
The /sales/workflows table showed customer + type + status + due but no signal of who OWNS each workflow — admins had to open each row to see the assignee. New column between Type and Progress.

- src/app/api/workflows/route.ts: extended the batch profile hydration so one round-trip covers both customer_id AND assigned_user_id (both point at profiles.id). Response rows now carry assigned_user_name and assigned_user_email in addition to the existing customer_name / customer_email.
- src/app/sales/workflows/page.tsx:
    * WorkflowRow interface + new "Assigned" <th>.
    * Row cell renders "Full Name" + email underneath when assigned, or an amber "Unassigned" pill when assigned_user_id is null (matches the tone the existing "Unassigned" MetricPill uses so admins can spot it at a glance).
    * Loading + empty-state colSpans bumped 7 -> 8.

Typecheck clean.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2