### PR TITLE
Workflows list: Assigned column falls back to workflow_assignments

### DIFF
--- a/src/app/api/workflows/route.ts
+++ b/src/app/api/workflows/route.ts
@@ -82,14 +82,56 @@ export async function GET(req: NextRequest) {
   const { data, error, count } = await query;
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
-  // Batch-fetch customer + assignee names for the returned page so
-  // the CRM table can show "who this workflow is for" and "who
-  // owns it" without an N+1 lookup. One profiles round-trip covers
-  // both roles since customer_id and assigned_user_id both point at
-  // profiles.id.
   const rows = data ?? [];
+
+  // Collaborator fallback: workflows.assigned_user_id is only set
+  // when the assignment is role='primary_owner'. Other roles
+  // (sales_rep, location_specialist, financing_coordinator, etc.)
+  // sit in workflow_assignments without touching the workflow row.
+  // We look up the active assignments for every workflow on this
+  // page so the "Assigned" column reflects real ownership rather
+  // than falsely showing "Unassigned" when a collaborator exists.
+  const workflowIds = rows.map((r) => r.id);
+  const assignmentsByWorkflow: Record<string, Array<{ user_id: string; role: string; assigned_at: string }>> = {};
+  if (workflowIds.length > 0) {
+    const { data: assignRows } = await supabaseAdmin
+      .from("workflow_assignments")
+      .select("workflow_id, user_id, role, assigned_at")
+      .in("workflow_id", workflowIds)
+      .eq("active", true)
+      .order("assigned_at", { ascending: true });
+    for (const a of assignRows ?? []) {
+      if (!a.workflow_id || !a.user_id) continue;
+      if (!assignmentsByWorkflow[a.workflow_id]) assignmentsByWorkflow[a.workflow_id] = [];
+      assignmentsByWorkflow[a.workflow_id].push({
+        user_id: a.user_id,
+        role: a.role,
+        assigned_at: a.assigned_at,
+      });
+    }
+  }
+
+  // Effective assignee per workflow: prefer workflows.assigned_user_id
+  // (the historical primary), then the first primary_owner assignment,
+  // then the earliest active assignment of any role.
+  function effectiveAssignee(r: typeof rows[number]): {
+    userId: string | null;
+    role: string | null;
+  } {
+    if (r.assigned_user_id) return { userId: r.assigned_user_id, role: "primary_owner" };
+    const assigns = assignmentsByWorkflow[r.id] ?? [];
+    const primary = assigns.find((a) => a.role === "primary_owner");
+    if (primary) return { userId: primary.user_id, role: primary.role };
+    const first = assigns[0];
+    if (first) return { userId: first.user_id, role: first.role };
+    return { userId: null, role: null };
+  }
+
+  // Batch-fetch customer + effective-assignee names in one round trip.
   const customerIds = Array.from(new Set(rows.map((r) => r.customer_id).filter(Boolean)));
-  const assigneeIds = Array.from(new Set(rows.map((r) => r.assigned_user_id).filter(Boolean)));
+  const assigneeIds = Array.from(
+    new Set(rows.map((r) => effectiveAssignee(r).userId).filter((v): v is string => !!v)),
+  );
   const profileIds = Array.from(new Set([...customerIds, ...assigneeIds]));
   const profileMap: Record<string, { full_name: string | null; email: string | null }> = {};
   if (profileIds.length > 0) {
@@ -102,13 +144,21 @@ export async function GET(req: NextRequest) {
     }
   }
 
-  const workflowsWithCustomer = rows.map((r) => ({
-    ...r,
-    customer_name: profileMap[r.customer_id]?.full_name ?? null,
-    customer_email: profileMap[r.customer_id]?.email ?? null,
-    assigned_user_name: r.assigned_user_id ? profileMap[r.assigned_user_id]?.full_name ?? null : null,
-    assigned_user_email: r.assigned_user_id ? profileMap[r.assigned_user_id]?.email ?? null : null,
-  }));
+  const workflowsWithCustomer = rows.map((r) => {
+    const eff = effectiveAssignee(r);
+    return {
+      ...r,
+      customer_name: profileMap[r.customer_id]?.full_name ?? null,
+      customer_email: profileMap[r.customer_id]?.email ?? null,
+      // Historical: keep the column pointing at the primary. UI
+      // reads assigned_user_name/email for display, so downstream
+      // consumers don't need to know about the fallback.
+      assigned_user_name: eff.userId ? profileMap[eff.userId]?.full_name ?? null : null,
+      assigned_user_email: eff.userId ? profileMap[eff.userId]?.email ?? null : null,
+      assigned_user_id_effective: eff.userId,
+      assigned_user_role: eff.role,
+    };
+  });
 
   return NextResponse.json({
     workflows: workflowsWithCustomer,

--- a/src/app/sales/workflows/page.tsx
+++ b/src/app/sales/workflows/page.tsx
@@ -44,6 +44,12 @@ interface WorkflowRow {
   customer_email: string | null;
   assigned_user_name: string | null;
   assigned_user_email: string | null;
+  // Populated by the API when the historical assigned_user_id is
+  // null but there's an active collaborator in workflow_assignments
+  // (sales_rep, location_specialist, etc.). Drives the "Assigned"
+  // column so real ownership shows through instead of "Unassigned".
+  assigned_user_id_effective: string | null;
+  assigned_user_role: string | null;
   updated_at: string;
 }
 
@@ -515,14 +521,21 @@ function WorkflowRowRender({
         </div>
       </td>
       <td className="px-4 py-3">
-        {workflow.assigned_user_id ? (
+        {workflow.assigned_user_id_effective ? (
           <>
             <div className="text-sm font-medium text-gray-900">
               {workflow.assigned_user_name ?? workflow.assigned_user_email ?? "—"}
             </div>
-            {workflow.assigned_user_email && workflow.assigned_user_name && (
-              <div className="text-xs text-gray-500 truncate max-w-[200px]">{workflow.assigned_user_email}</div>
-            )}
+            <div className="mt-0.5 flex items-center gap-1.5">
+              {workflow.assigned_user_role && workflow.assigned_user_role !== "primary_owner" && (
+                <span className="inline-flex items-center rounded-full bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-600 uppercase tracking-wide">
+                  {workflow.assigned_user_role.replace(/_/g, " ")}
+                </span>
+              )}
+              {workflow.assigned_user_email && workflow.assigned_user_name && (
+                <span className="text-xs text-gray-500 truncate max-w-[180px]">{workflow.assigned_user_email}</span>
+              )}
+            </div>
           </>
         ) : (
           <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700 ring-1 ring-inset ring-amber-200">


### PR DESCRIPTION
Workflows can carry ownership in two places:
  1. workflows.assigned_user_id — set only when the current assignment is role='primary_owner'.
  2. workflow_assignments (active=true) — every other role (sales_rep, location_specialist, financing_coordinator, shipping_coordinator, coffee_service_rep, manager, collaborator) lives here without touching the workflow row.

The new Assigned column only read column #1, so collaborator-only workflows falsely rendered as Unassigned even when a rep clearly owned them.

- src/app/api/workflows/route.ts: batch-fetch active workflow_assignments for every workflow on the page, then compute an effective assignee per row: prefer assigned_user_id, else the first primary_owner assignment, else the earliest active assignment of any role. Response now carries assigned_user_id_effective + assigned_user_role alongside the hydrated name/email.
- src/app/sales/workflows/page.tsx: WorkflowRow gains the two new fields; the Assigned cell reads assigned_user_id_effective for the "have a real assignee?" branch, and shows the role as a small uppercase pill when it's NOT primary_owner so admins can tell at a glance whether the row has an explicit primary vs a collaborator handling it. Amber "Unassigned" pill only fires when neither column nor assignments have anyone.

No schema change. Typecheck clean.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2