### PR TITLE
Payroll Onboarding — full module (admin setup, secure token portal, w…

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -4734,6 +4734,14 @@ export default function AdminPage() {
                 <span className="sm:hidden">Backfill</span>
               </Link>
               <Link
+                href="/admin/payroll"
+                className="inline-flex items-center gap-2 rounded-xl border border-green-primary px-4 py-2.5 text-sm font-medium text-green-primary shadow-sm transition-colors hover:bg-green-50"
+              >
+                <DollarSign className="h-4 w-4" />
+                <span className="hidden sm:inline">Payroll</span>
+                <span className="sm:hidden">Pay</span>
+              </Link>
+              <Link
                 href="/sales"
                 className="inline-flex items-center gap-2 rounded-xl bg-green-primary px-4 py-2.5 text-sm font-medium text-white shadow-sm transition-colors hover:bg-green-primary/90"
               >

--- a/src/app/admin/payroll/[id]/page.tsx
+++ b/src/app/admin/payroll/[id]/page.tsx
@@ -1,0 +1,335 @@
+"use client";
+
+/**
+ * /admin/payroll/[id] — payroll profile detail (admin-only).
+ *
+ * Sections
+ *   - Overview: worker, classification, comp, status
+ *   - Personal information (masked SSN / DOB / address)
+ *   - Direct deposit (masked account + bank name)
+ *   - QuickBooks Setup Summary
+ *   - Actions: Resend, Revoke, Mark Payroll Active, Reveal fields
+ *   - Activity: audit log
+ *
+ * Sensitive VALUES never render by default. Admin clicks a specific
+ * field's "Reveal for QB" button, provides a short reason, and the
+ * value is shown once and then re-masked on modal close. Every
+ * reveal is audit-logged with the admin's id + reason.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import { createBrowserClient } from "@/lib/supabase";
+import {
+  AlertCircle,
+  ArrowLeft,
+  CheckCircle2,
+  Coins,
+  Eye,
+  EyeOff,
+  Loader2,
+  RefreshCw,
+  Ban,
+  ShieldCheck,
+} from "lucide-react";
+import {
+  CLASSIFICATION_LABELS,
+  STATUS_LABELS,
+  STATUS_TONES,
+} from "@/lib/payroll/constants";
+
+interface AuditEvent {
+  id: string;
+  actor_kind: string;
+  event_type: string;
+  description: string | null;
+  created_at: string;
+}
+interface DetailResponse {
+  profile: Record<string, unknown>;
+  worker: Record<string, unknown> | null;
+  team_member: { full_name: string | null; email: string | null } | null;
+  invitations: Array<{ id: string; sent_at: string | null; opened_at: string | null; used_at: string | null; revoked_at: string | null; expires_at: string; created_at: string }>;
+  audit: AuditEvent[];
+  encrypted_field_keys: string[];
+  masked_display: Record<string, string | null>;
+}
+
+export default function PayrollDetailPage() {
+  const params = useParams<{ id: string }>();
+  const router = useRouter();
+  const [data, setData] = useState<DetailResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [actionBusy, setActionBusy] = useState<string | null>(null);
+  const [revealFor, setRevealFor] = useState<string | null>(null);
+  const [revealReason, setRevealReason] = useState("");
+  const [revealValue, setRevealValue] = useState<string | null>(null);
+  const [token, setToken] = useState<string>("");
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const supabase = createBrowserClient();
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session?.access_token) { setError("Sign in required."); setLoading(false); return; }
+      setToken(session.access_token);
+      const res = await fetch(`/api/admin/payroll/profiles/${params.id}`, {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      });
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        setError(j.error || `Failed (${res.status})`);
+        return;
+      }
+      setData(await res.json());
+    } finally {
+      setLoading(false);
+    }
+  }, [params.id]);
+  useEffect(() => { load(); }, [load]);
+
+  async function fireAction(endpoint: string, key: string, body?: Record<string, unknown>) {
+    setActionBusy(key);
+    try {
+      const res = await fetch(`/api/admin/payroll/profiles/${params.id}/${endpoint}`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          ...(body ? { "Content-Type": "application/json" } : {}),
+        },
+        body: body ? JSON.stringify(body) : undefined,
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) alert(json.error || `${key} failed`);
+      await load();
+    } finally {
+      setActionBusy(null);
+    }
+  }
+
+  async function reveal() {
+    if (!revealFor || !revealReason.trim()) return;
+    setActionBusy("reveal");
+    try {
+      const res = await fetch(`/api/admin/payroll/profiles/${params.id}/reveal`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ field_key: revealFor, reason: revealReason.trim() }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) { alert(json.error || "Reveal failed"); return; }
+      setRevealValue(json.plaintext);
+    } finally {
+      setActionBusy(null);
+    }
+  }
+
+  if (loading) return <div className="p-6 text-sm text-gray-500"><Loader2 className="inline-block h-5 w-5 animate-spin mr-2" /> Loading payroll record…</div>;
+  if (error) return <div className="p-6"><div className="rounded-lg border border-red-200 bg-red-50 p-4 text-red-700 text-sm">{error}</div></div>;
+  if (!data) return null;
+
+  const profile = data.profile as {
+    classification: "w2_employee" | "1099_contractor";
+    status: keyof typeof STATUS_LABELS;
+    company_entity: string | null;
+    job_title: string | null;
+    department: string | null;
+    hire_date: string | null;
+    pay_type: string | null;
+    pay_frequency: string | null;
+    hourly_rate_cents: number | null;
+    annual_salary_cents: number | null;
+    submitted_at: string | null;
+    payroll_active_at: string | null;
+    work_state: string | null;
+    recipient_email: string | null;
+  };
+  const worker = data.worker as Record<string, string | null> | null;
+
+  return (
+    <div className="p-6 max-w-5xl mx-auto space-y-6">
+      <button onClick={() => router.push("/admin/payroll")} className="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-green-primary">
+        <ArrowLeft className="h-4 w-4" /> Back to Payroll dashboard
+      </button>
+
+      <div className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="flex items-start gap-3">
+            <Coins className="mt-1 h-6 w-6 text-green-primary" />
+            <div>
+              <h1 className="text-2xl font-semibold text-gray-900">{data.team_member?.full_name ?? "—"}</h1>
+              <p className="text-sm text-gray-500">{data.team_member?.email ?? profile.recipient_email ?? "—"}</p>
+              <p className="mt-1 text-xs text-gray-500">{CLASSIFICATION_LABELS[profile.classification]} · {profile.company_entity ?? "—"}</p>
+            </div>
+          </div>
+          <span className={`inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium ring-1 ring-inset ${STATUS_TONES[profile.status]}`}>
+            {STATUS_LABELS[profile.status]}
+          </span>
+        </div>
+
+        <div className="mt-4 grid grid-cols-2 gap-3 text-sm sm:grid-cols-4">
+          <Fact label="Job Title" value={profile.job_title ?? "—"} />
+          <Fact label="Department" value={profile.department ?? "—"} />
+          <Fact label="Hire Date" value={profile.hire_date ? new Date(profile.hire_date).toLocaleDateString() : "—"} />
+          <Fact label="Work State" value={profile.work_state ?? "—"} />
+          <Fact label="Pay Type" value={profile.pay_type ?? "—"} />
+          <Fact label="Pay Frequency" value={profile.pay_frequency ?? "—"} />
+          <Fact label="Hourly Rate" value={profile.hourly_rate_cents ? `$${(profile.hourly_rate_cents / 100).toFixed(2)} / hr` : "—"} />
+          <Fact label="Annual Salary" value={profile.annual_salary_cents ? `$${(profile.annual_salary_cents / 100).toLocaleString()}` : "—"} />
+        </div>
+      </div>
+
+      {/* Personal information */}
+      <div className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-gray-500 mb-3">Personal Information</h2>
+        {worker ? (
+          <div className="grid grid-cols-1 gap-3 text-sm sm:grid-cols-3">
+            <Fact label="Legal Name" value={[worker.legal_first_name, worker.middle_name, worker.legal_last_name].filter(Boolean).join(" ") || "—"} />
+            <Fact label="Preferred Name" value={worker.preferred_name ?? "—"} />
+            <Fact label="Date of Birth" value={worker.date_of_birth ? new Date(worker.date_of_birth as string).toLocaleDateString() : "—"} />
+            <Fact label="Personal Email" value={worker.personal_email ?? "—"} />
+            <Fact label="Mobile Phone" value={worker.mobile_phone ?? "—"} />
+            <Fact label="SSN"        value={data.masked_display.ssn ?? "—"} sensitive onReveal={data.encrypted_field_keys.includes("ssn") ? () => setRevealFor("ssn") : undefined} />
+            <Fact label="Address"    value={worker.address_street ? `${worker.address_street}${worker.address_unit ? ` ${worker.address_unit}` : ""}, ${worker.address_city}, ${worker.address_state} ${worker.address_zip}` : "—"} />
+          </div>
+        ) : <p className="text-sm text-gray-500">Worker has not submitted personal information yet.</p>}
+      </div>
+
+      {/* Direct deposit */}
+      <div className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-gray-500 mb-3">Direct Deposit</h2>
+        <div className="grid grid-cols-1 gap-3 text-sm sm:grid-cols-3">
+          <Fact label="Account Holder" value={worker?.account_holder_name ?? "—"} />
+          <Fact label="Bank" value={worker?.bank_name ?? "—"} />
+          <Fact label="Account Type" value={worker?.account_type ?? "—"} />
+          <Fact label="Routing" value={data.masked_display["bank.routing"] ?? "—"} sensitive onReveal={data.encrypted_field_keys.includes("bank.routing") ? () => setRevealFor("bank.routing") : undefined} />
+          <Fact label="Account #" value={data.masked_display["bank.account"] ?? "—"} sensitive onReveal={data.encrypted_field_keys.includes("bank.account") ? () => setRevealFor("bank.account") : undefined} />
+        </div>
+      </div>
+
+      {/* Tax */}
+      <div className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-gray-500 mb-3">Tax Information</h2>
+        {profile.classification === "w2_employee" ? (
+          <div className="grid grid-cols-1 gap-3 text-sm sm:grid-cols-3">
+            <Fact label="Filing Status" value={worker?.filing_status ?? "—"} />
+            <Fact label="Qualifying Children" value={worker?.qualifying_children_amt ?? "—"} />
+            <Fact label="Other Dependents" value={worker?.other_dependents_amt ?? "—"} />
+            <Fact label="Other Income" value={worker?.other_income_cents ? `$${(Number(worker.other_income_cents) / 100).toFixed(2)}` : "—"} />
+            <Fact label="Deductions" value={worker?.deductions_cents ? `$${(Number(worker.deductions_cents) / 100).toFixed(2)}` : "—"} />
+            <Fact label="Additional Withholding" value={data.encrypted_field_keys.includes("w4.additional_withholding_cents") ? "On file" : "—"} sensitive onReveal={data.encrypted_field_keys.includes("w4.additional_withholding_cents") ? () => setRevealFor("w4.additional_withholding_cents") : undefined} />
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 gap-3 text-sm sm:grid-cols-3">
+            <Fact label="Business Name" value={worker?.business_name ?? "—"} />
+            <Fact label="Federal Tax Class" value={worker?.federal_tax_class ?? "—"} />
+            <Fact label="TIN Type" value={worker?.tin_type ?? "—"} />
+            <Fact label="TIN" value={data.masked_display.tin ?? "—"} sensitive onReveal={data.encrypted_field_keys.includes("tin") ? () => setRevealFor("tin") : undefined} />
+          </div>
+        )}
+      </div>
+
+      {/* Actions */}
+      <div className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-gray-500 mb-3">Actions</h2>
+        <div className="flex flex-wrap gap-2">
+          <ActionBtn label="Resend Invite"      icon={RefreshCw}    tone="default" busy={actionBusy === "resend"} onClick={() => fireAction("resend", "resend")} />
+          <ActionBtn label="Revoke Invite"      icon={Ban}          tone="danger"  busy={actionBusy === "revoke"} onClick={() => { if (confirm("Revoke every active invitation?")) fireAction("revoke", "revoke"); }} />
+          <ActionBtn label="Mark Payroll Active" icon={ShieldCheck} tone="success" busy={actionBusy === "mark-active"} onClick={() => { if (confirm("Mark this worker as active in QuickBooks Payroll?")) fireAction("mark-active", "mark-active"); }} />
+        </div>
+      </div>
+
+      {/* Activity */}
+      <div className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-gray-500 mb-3">Activity</h2>
+        <ul className="divide-y divide-gray-100">
+          {data.audit.length === 0 ? (
+            <li className="py-3 text-sm text-gray-500">No activity yet.</li>
+          ) : data.audit.map((e) => (
+            <li key={e.id} className="py-2 flex items-start gap-3">
+              <span className="text-xs text-gray-400 min-w-[110px]">{new Date(e.created_at).toLocaleString()}</span>
+              <div className="text-sm">
+                <span className="font-medium text-gray-800">{e.event_type}</span>
+                {e.description && <span className="text-gray-600"> — {e.description}</span>}
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      {/* Reveal modal */}
+      {revealFor && (
+        <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50 p-4">
+          <div className="w-full max-w-md rounded-2xl bg-white shadow-2xl p-5">
+            <div className="flex items-start gap-3">
+              <ShieldCheck className="mt-0.5 h-5 w-5 text-amber-600" />
+              <div className="flex-1">
+                <h3 className="text-base font-semibold text-gray-900">Reveal sensitive field</h3>
+                <p className="mt-1 text-xs text-gray-500">
+                  Provide a short reason so the reveal is auditable. The value shows once and is not persisted anywhere else in the browser.
+                </p>
+              </div>
+            </div>
+            {!revealValue ? (
+              <>
+                <label className="mt-4 block text-xs font-semibold uppercase tracking-wider text-gray-500">Reason</label>
+                <textarea rows={2} value={revealReason} onChange={(e) => setRevealReason(e.target.value)} placeholder="e.g. entering into QuickBooks Payroll" className="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm" />
+                <div className="mt-4 flex items-center justify-end gap-2">
+                  <button onClick={() => { setRevealFor(null); setRevealReason(""); setRevealValue(null); }} className="rounded-lg px-3 py-2 text-sm text-gray-600 hover:bg-gray-100">Cancel</button>
+                  <button onClick={reveal} disabled={!revealReason.trim() || actionBusy === "reveal"} className="inline-flex items-center gap-1.5 rounded-lg bg-amber-600 px-4 py-2 text-sm font-semibold text-white hover:bg-amber-700 disabled:opacity-50">
+                    {actionBusy === "reveal" ? <Loader2 className="h-4 w-4 animate-spin" /> : <Eye className="h-4 w-4" />}
+                    Reveal
+                  </button>
+                </div>
+              </>
+            ) : (
+              <>
+                <div className="mt-4 rounded-lg border border-amber-200 bg-amber-50 p-3">
+                  <div className="text-xs font-semibold uppercase text-amber-800">{revealFor}</div>
+                  <div className="mt-1 font-mono text-sm text-amber-900 break-all">{revealValue}</div>
+                </div>
+                <div className="mt-4 flex items-center justify-end">
+                  <button onClick={() => { setRevealFor(null); setRevealReason(""); setRevealValue(null); }} className="inline-flex items-center gap-1.5 rounded-lg bg-gray-700 px-4 py-2 text-sm font-semibold text-white hover:bg-gray-800">
+                    <EyeOff className="h-4 w-4" />
+                    Close and re-mask
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Fact({ label, value, sensitive, onReveal }: { label: string; value: React.ReactNode; sensitive?: boolean; onReveal?: () => void }) {
+  return (
+    <div>
+      <div className="text-[10px] font-semibold uppercase tracking-wider text-gray-500">{label}</div>
+      <div className="mt-0.5 text-sm text-gray-900 flex items-center gap-2">
+        <span>{value}</span>
+        {sensitive && onReveal && (
+          <button onClick={onReveal} className="text-xs text-amber-700 hover:text-amber-900 underline">Reveal</button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ActionBtn({ label, icon: Icon, tone, busy, onClick }: { label: string; icon: React.ComponentType<{ className?: string }>; tone: "default" | "danger" | "success"; busy: boolean; onClick: () => void }) {
+  const cls = tone === "danger" ? "border-red-200 bg-white text-red-700 hover:bg-red-50"
+    : tone === "success" ? "bg-green-primary text-white hover:bg-green-hover"
+    : "border-gray-200 bg-white text-gray-700 hover:border-green-primary hover:text-green-primary";
+  return (
+    <button type="button" onClick={onClick} disabled={busy} className={`inline-flex items-center gap-1.5 rounded-lg border px-3 py-2 text-xs font-medium disabled:opacity-50 ${cls}`}>
+      {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Icon className="h-4 w-4" />}
+      {label}
+      {tone === "success" && !busy && <CheckCircle2 className="h-4 w-4" />}
+      {tone === "danger" && !busy && <AlertCircle className="h-4 w-4" />}
+    </button>
+  );
+}

--- a/src/app/admin/payroll/page.tsx
+++ b/src/app/admin/payroll/page.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+/**
+ * /admin/payroll — payroll onboarding dashboard.
+ *
+ * Admin-only. Lists every payroll profile with status pill,
+ * classification, hire date, and last-updated. Top-of-page tiles
+ * show status counts. Sensitive fields (SSN / TIN / bank) are
+ * NEVER surfaced in the list — display is names + statuses only.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { createBrowserClient } from "@/lib/supabase";
+import {
+  ArrowRight,
+  Coins,
+  Loader2,
+  Search,
+} from "lucide-react";
+import {
+  CLASSIFICATION_LABELS,
+  STATUS_LABELS,
+  STATUS_TONES,
+  type PayrollClassification,
+  type PayrollStatus,
+} from "@/lib/payroll/constants";
+
+interface Row {
+  id: string;
+  team_member_id: string;
+  classification: PayrollClassification;
+  status: PayrollStatus;
+  hire_date: string | null;
+  updated_at: string;
+  team_member: { full_name: string | null; email: string | null } | null;
+  submitted_at: string | null;
+  company_entity: string | null;
+}
+
+export default function PayrollDashboardPage() {
+  const [rows, setRows] = useState<Row[]>([]);
+  const [counts, setCounts] = useState<Record<string, number>>({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState<"" | PayrollStatus>("");
+  const [classFilter, setClassFilter] = useState<"" | PayrollClassification>("");
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const supabase = createBrowserClient();
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session?.access_token) { setError("Sign in required."); setLoading(false); return; }
+      const res = await fetch("/api/admin/payroll/profiles", {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      });
+      if (res.status === 403) { setError("Admin permission required."); setLoading(false); return; }
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        setError(j.error || `Failed (${res.status})`);
+        setLoading(false);
+        return;
+      }
+      const json = await res.json();
+      setRows(json.profiles ?? []);
+      setCounts(json.counts ?? {});
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+  useEffect(() => { load(); }, [load]);
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return rows.filter((r) => {
+      if (statusFilter && r.status !== statusFilter) return false;
+      if (classFilter && r.classification !== classFilter) return false;
+      if (!q) return true;
+      const name = (r.team_member?.full_name ?? "").toLowerCase();
+      const email = (r.team_member?.email ?? "").toLowerCase();
+      return name.includes(q) || email.includes(q);
+    });
+  }, [rows, search, statusFilter, classFilter]);
+
+  return (
+    <div className="p-6">
+      <div className="mb-6 flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <div className="flex items-center gap-2">
+            <Coins className="h-6 w-6 text-green-primary" />
+            <h1 className="text-2xl font-semibold text-gray-900">Payroll Onboarding</h1>
+          </div>
+          <p className="mt-1 text-sm text-gray-500">
+            Every payroll profile in one place. Sensitive fields (SSN / TIN / bank) are always masked here — reveal one field at a time on the detail page.
+          </p>
+        </div>
+        <Link
+          href="/sales/team"
+          className="inline-flex items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-700 hover:border-green-primary hover:text-green-primary"
+        >
+          <ArrowRight className="h-4 w-4 rotate-180" />
+          Back to Team
+        </Link>
+      </div>
+
+      <div className="mb-6 grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-6">
+        {(["invite_sent", "in_progress", "employee_action_required", "admin_review_required", "ready_for_quickbooks", "payroll_active"] as PayrollStatus[]).map((s) => (
+          <div key={s} className={`rounded-lg border px-3 py-2 ${STATUS_TONES[s]}`}>
+            <div className="text-[10px] font-semibold uppercase tracking-wider opacity-80">{STATUS_LABELS[s]}</div>
+            <div className="text-2xl font-bold">{counts[s] ?? 0}</div>
+          </div>
+        ))}
+      </div>
+
+      <div className="mb-4 flex flex-wrap items-center gap-3">
+        <div className="relative min-w-[240px] flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+          <input
+            type="search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search by name or email…"
+            className="w-full rounded-lg border border-gray-200 bg-white pl-10 pr-3 py-2 text-sm"
+          />
+        </div>
+        <select value={statusFilter} onChange={(e) => setStatusFilter(e.target.value as "" | PayrollStatus)} className="rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm">
+          <option value="">All Statuses</option>
+          {Object.entries(STATUS_LABELS).map(([k, v]) => <option key={k} value={k}>{v}</option>)}
+        </select>
+        <select value={classFilter} onChange={(e) => setClassFilter(e.target.value as "" | PayrollClassification)} className="rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm">
+          <option value="">All Classifications</option>
+          <option value="w2_employee">W-2 Employee</option>
+          <option value="1099_contractor">1099 Contractor</option>
+        </select>
+      </div>
+
+      {error && (
+        <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>
+      )}
+
+      <div className="overflow-x-auto rounded-lg border border-gray-200 bg-white">
+        <table className="min-w-full text-sm">
+          <thead className="bg-gray-50 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+            <tr>
+              <th className="px-4 py-3">Team Member</th>
+              <th className="px-4 py-3">Classification</th>
+              <th className="px-4 py-3">Company</th>
+              <th className="px-4 py-3">Hire Date</th>
+              <th className="px-4 py-3">Status</th>
+              <th className="px-4 py-3"></th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100">
+            {loading ? (
+              <tr><td colSpan={6} className="px-4 py-12 text-center text-gray-500"><Loader2 className="inline-block h-5 w-5 animate-spin mr-2" /> Loading…</td></tr>
+            ) : filtered.length === 0 ? (
+              <tr><td colSpan={6} className="px-4 py-12 text-center text-gray-500">No payroll profiles match these filters.</td></tr>
+            ) : filtered.map((r) => (
+              <tr key={r.id} className="hover:bg-gray-50">
+                <td className="px-4 py-3">
+                  <div className="font-medium text-gray-900">{r.team_member?.full_name ?? <span className="italic text-gray-400">Name missing</span>}</div>
+                  <div className="text-xs text-gray-500">{r.team_member?.email ?? "—"}</div>
+                </td>
+                <td className="px-4 py-3 text-sm text-gray-700">{CLASSIFICATION_LABELS[r.classification]}</td>
+                <td className="px-4 py-3 text-sm text-gray-700">{r.company_entity ?? "—"}</td>
+                <td className="px-4 py-3 text-sm text-gray-700">{r.hire_date ? new Date(r.hire_date).toLocaleDateString() : "—"}</td>
+                <td className="px-4 py-3">
+                  <span className={`inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium ring-1 ring-inset ${STATUS_TONES[r.status]}`}>
+                    {STATUS_LABELS[r.status]}
+                  </span>
+                </td>
+                <td className="px-4 py-3">
+                  <Link href={`/admin/payroll/${r.id}`} className="inline-flex items-center gap-1 rounded-lg bg-green-primary px-3 py-1.5 text-xs font-semibold text-white hover:bg-green-hover">
+                    View <ArrowRight className="h-3.5 w-3.5" />
+                  </Link>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/admin/payroll/profiles/[id]/mark-active/route.ts
+++ b/src/app/api/admin/payroll/profiles/[id]/mark-active/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser } from "@/lib/salesAuth";
+
+/**
+ * POST /api/admin/payroll/profiles/[id]/mark-active
+ *
+ * Admin-only. Flips a payroll profile to status='payroll_active' —
+ * used after the admin has manually entered the worker into
+ * QuickBooks Payroll. Also stamps a status='ready_for_quickbooks'
+ * transition if the admin skipped that intermediate marker.
+ *
+ * Body: { note?: string }
+ */
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const actor = await getSalesUser(req);
+  if (!actor || actor.role !== "admin") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  const { id } = await params;
+
+  const body = await req.json().catch(() => ({}));
+  const note = typeof body?.note === "string" ? body.note.slice(0, 500) : null;
+
+  const nowIso = new Date().toISOString();
+  const { error } = await supabaseAdmin
+    .from("payroll_profiles")
+    .update({
+      status: "payroll_active",
+      payroll_active_at: nowIso,
+      payroll_active_by: actor.id,
+      updated_at: nowIso,
+    })
+    .eq("id", id);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  await supabaseAdmin.from("payroll_audit_events").insert({
+    profile_id: id,
+    actor_user_id: actor.id,
+    actor_kind: "admin",
+    event_type: "payroll.marked_active",
+    description: note ?? "Admin marked payroll active (worker set up in QuickBooks).",
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/admin/payroll/profiles/[id]/resend/route.ts
+++ b/src/app/api/admin/payroll/profiles/[id]/resend/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser } from "@/lib/salesAuth";
+import { generatePayrollToken } from "@/lib/payroll/token";
+import { sendPayrollInvitationEmail } from "@/lib/payroll/emails";
+
+/**
+ * POST /api/admin/payroll/profiles/[id]/resend
+ *
+ * Admin-only. Issues a fresh token, marks any active older invites
+ * revoked (so the previous URL stops working), and sends the
+ * invitation email again to the profile's recipient_email.
+ */
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const actor = await getSalesUser(req);
+  if (!actor || actor.role !== "admin") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  const { id } = await params;
+
+  const { data: profile } = await supabaseAdmin
+    .from("payroll_profiles")
+    .select("id, classification, recipient_email, team_member_id, company_entity")
+    .eq("id", id)
+    .maybeSingle();
+  if (!profile) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const { data: member } = await supabaseAdmin
+    .from("profiles")
+    .select("full_name")
+    .eq("id", profile.team_member_id)
+    .maybeSingle();
+
+  const recipientEmail = (profile.recipient_email || "").trim();
+  if (!recipientEmail) {
+    return NextResponse.json({ error: "Recipient email is empty on this profile." }, { status: 400 });
+  }
+
+  // Revoke any still-active invites so the old URL stops working.
+  await supabaseAdmin
+    .from("payroll_invitations")
+    .update({ revoked_at: new Date().toISOString(), revoked_by: actor.id })
+    .eq("profile_id", id)
+    .is("revoked_at", null)
+    .is("used_at", null);
+
+  const { raw, hash, expiresAt } = generatePayrollToken();
+  const nowIso = new Date().toISOString();
+  await supabaseAdmin.from("payroll_invitations").insert({
+    profile_id: id,
+    token_hash: hash,
+    expires_at: expiresAt,
+    sent_at: nowIso,
+    created_by: actor.id,
+  });
+
+  const origin = req.headers.get("origin") || process.env.NEXT_PUBLIC_SITE_URL || "https://vendingconnector.com";
+  try {
+    await sendPayrollInvitationEmail({
+      toEmail: recipientEmail,
+      recipientName: member?.full_name ?? null,
+      classification: profile.classification,
+      packetUrl: `${origin}/payroll/${raw}`,
+      companyName: profile.company_entity ?? null,
+    });
+  } catch (mailErr) {
+    return NextResponse.json(
+      { error: `Resend failed: ${mailErr instanceof Error ? mailErr.message : "unknown error"}` },
+      { status: 502 },
+    );
+  }
+
+  await supabaseAdmin
+    .from("payroll_profiles")
+    .update({ status: "invite_sent", updated_at: nowIso })
+    .eq("id", id);
+
+  await supabaseAdmin.from("payroll_audit_events").insert({
+    profile_id: id,
+    actor_user_id: actor.id,
+    actor_kind: "admin",
+    event_type: "invite.resent",
+    description: `Invitation resent to ${recipientEmail}`,
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/admin/payroll/profiles/[id]/reveal/route.ts
+++ b/src/app/api/admin/payroll/profiles/[id]/reveal/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser } from "@/lib/salesAuth";
+import { decryptField } from "@/lib/payroll/encryption";
+
+/**
+ * POST /api/admin/payroll/profiles/[id]/reveal
+ *
+ * Admin-only. Returns the plaintext of a specific encrypted field
+ * so an authorized admin can transfer it into QuickBooks Payroll
+ * one field at a time. Every reveal is audit-logged with the admin
+ * id, the field key, and a required `reason` string.
+ *
+ * Body: { field_key: string, reason: string }
+ *
+ * The UI is expected to reveal into a modal that auto-clears on
+ * dismiss — this endpoint doesn't persist plaintext anywhere.
+ */
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const actor = await getSalesUser(req);
+  if (!actor || actor.role !== "admin") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  const { id } = await params;
+
+  const body = await req.json().catch(() => ({}));
+  const fieldKey = typeof body?.field_key === "string" ? body.field_key : "";
+  const reason = typeof body?.reason === "string" ? body.reason.trim() : "";
+  if (!fieldKey) return NextResponse.json({ error: "field_key is required" }, { status: 400 });
+  if (!reason || reason.length < 4) {
+    return NextResponse.json(
+      { error: "A short reason (≥4 chars) is required so the reveal is auditable." },
+      { status: 400 },
+    );
+  }
+
+  const { data: row } = await supabaseAdmin
+    .from("payroll_encrypted")
+    .select("ciphertext, iv, auth_tag, key_version")
+    .eq("profile_id", id)
+    .eq("field_key", fieldKey)
+    .maybeSingle();
+  if (!row) return NextResponse.json({ error: "Field not found" }, { status: 404 });
+
+  let plaintext: string;
+  try {
+    plaintext = decryptField(row);
+  } catch (err) {
+    // Never leak encryption details to the client.
+    console.error("[payroll.reveal] decrypt failed:", err);
+    return NextResponse.json({ error: "Decryption failed. Contact the platform team." }, { status: 500 });
+  }
+
+  await supabaseAdmin.from("payroll_audit_events").insert({
+    profile_id: id,
+    actor_user_id: actor.id,
+    actor_kind: "admin",
+    event_type: "sensitive.revealed",
+    description: `Admin revealed field '${fieldKey}' for: ${reason.slice(0, 200)}`,
+    metadata: { field_key: fieldKey, reason: reason.slice(0, 200) },
+  });
+
+  return NextResponse.json({ ok: true, field_key: fieldKey, plaintext });
+}

--- a/src/app/api/admin/payroll/profiles/[id]/revoke/route.ts
+++ b/src/app/api/admin/payroll/profiles/[id]/revoke/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser } from "@/lib/salesAuth";
+
+/**
+ * POST /api/admin/payroll/profiles/[id]/revoke
+ *
+ * Admin-only. Revokes every active invitation for this profile.
+ * The URL(s) become immediately invalid at the token layer.
+ */
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const actor = await getSalesUser(req);
+  if (!actor || actor.role !== "admin") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  const { id } = await params;
+
+  const { error } = await supabaseAdmin
+    .from("payroll_invitations")
+    .update({ revoked_at: new Date().toISOString(), revoked_by: actor.id })
+    .eq("profile_id", id)
+    .is("revoked_at", null)
+    .is("used_at", null);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  await supabaseAdmin.from("payroll_audit_events").insert({
+    profile_id: id,
+    actor_user_id: actor.id,
+    actor_kind: "admin",
+    event_type: "invite.revoked",
+    description: "All active invitations revoked",
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/admin/payroll/profiles/[id]/route.ts
+++ b/src/app/api/admin/payroll/profiles/[id]/route.ts
@@ -1,0 +1,137 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser } from "@/lib/salesAuth";
+import { last4, maskBankAccount, maskSsn, maskTin } from "@/lib/payroll/encryption";
+
+/**
+ * GET /api/admin/payroll/profiles/[id]
+ *
+ * Admin-only. Returns the payroll profile + worker details + audit
+ * events + a MASKED view of every encrypted field (last-4 only).
+ * Full plaintext lives behind /reveal — a separate endpoint that
+ * audit-logs each access.
+ */
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const actor = await getSalesUser(req);
+  if (!actor || actor.role !== "admin") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  const { id } = await params;
+
+  const { data: profile, error } = await supabaseAdmin
+    .from("payroll_profiles")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (!profile) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const { data: worker } = await supabaseAdmin
+    .from("payroll_worker_details")
+    .select("*")
+    .eq("profile_id", id)
+    .maybeSingle();
+
+  const { data: member } = await supabaseAdmin
+    .from("profiles")
+    .select("id, full_name, email, phone")
+    .eq("id", profile.team_member_id)
+    .maybeSingle();
+
+  const { data: invitations } = await supabaseAdmin
+    .from("payroll_invitations")
+    .select("id, sent_at, opened_at, used_at, revoked_at, expires_at, created_at")
+    .eq("profile_id", id)
+    .order("created_at", { ascending: false });
+
+  const { data: audit } = await supabaseAdmin
+    .from("payroll_audit_events")
+    .select("id, actor_kind, event_type, description, metadata, created_at")
+    .eq("profile_id", id)
+    .order("created_at", { ascending: false })
+    .limit(100);
+
+  // Masked encrypted-field view — no ciphertext or plaintext leaves
+  // the server here. UI reads `last4` + label.
+  const { data: encrypted } = await supabaseAdmin
+    .from("payroll_encrypted")
+    .select("field_key, updated_at")
+    .eq("profile_id", id);
+
+  // Derive masked display strings from the *_last4 columns on
+  // payroll_worker_details (populated on save so this endpoint never
+  // has to decrypt).
+  const masked: Record<string, string | null> = {};
+  if (worker?.account_last4) masked["bank.account"] = maskBankAccount(worker.account_last4);
+  if (worker?.routing_last4) masked["bank.routing"] = `••••${last4(worker.routing_last4)}`;
+  if (worker?.tin_type && (worker as { tin_last4?: string | null }).tin_last4) {
+    masked.tin = maskTin(
+      (worker as { tin_last4?: string | null }).tin_last4 ?? "",
+      (worker.tin_type as "ssn" | "ein") ?? null,
+    );
+  }
+  if ((worker as { ssn_last4?: string | null } | null)?.ssn_last4) {
+    masked.ssn = maskSsn((worker as { ssn_last4?: string | null }).ssn_last4 ?? "");
+  }
+
+  return NextResponse.json({
+    profile,
+    worker,
+    team_member: member,
+    invitations: invitations ?? [],
+    audit: audit ?? [],
+    encrypted_field_keys: (encrypted ?? []).map((e) => e.field_key),
+    masked_display: masked,
+  });
+}
+
+/**
+ * PATCH /api/admin/payroll/profiles/[id]
+ *
+ * Admin-only. Updates a small allowlist of admin-controlled fields.
+ * WORKER-owned fields (name/SSN/address/tax/bank) are NOT settable
+ * here — those flow through the /payroll/[token] portal only.
+ */
+const ADMIN_EDITABLE_KEYS = new Set<string>([
+  "job_title", "department", "manager_user_id", "work_location", "employment_status",
+  "hire_date", "pay_type", "pay_frequency", "hourly_rate_cents", "annual_salary_cents",
+  "commission_notes", "expected_hours_per_week", "overtime_eligible", "compensation_notes",
+  "company_entity", "recipient_email", "work_state", "i9_status",
+]);
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const actor = await getSalesUser(req);
+  if (!actor || actor.role !== "admin") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  const { id } = await params;
+
+  const body = await req.json().catch(() => ({}));
+  const updates: Record<string, unknown> = { updated_at: new Date().toISOString() };
+  for (const [k, v] of Object.entries(body ?? {})) {
+    if (ADMIN_EDITABLE_KEYS.has(k)) updates[k] = v;
+  }
+  if (Object.keys(updates).length === 1) {
+    return NextResponse.json({ error: "No editable fields supplied." }, { status: 400 });
+  }
+
+  const { error } = await supabaseAdmin.from("payroll_profiles").update(updates).eq("id", id);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  await supabaseAdmin.from("payroll_audit_events").insert({
+    profile_id: id,
+    actor_user_id: actor.id,
+    actor_kind: "admin",
+    event_type: "admin.updated",
+    description: "Admin updated payroll profile fields",
+    metadata: { keys: Object.keys(updates).filter((k) => k !== "updated_at") },
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/admin/payroll/profiles/route.ts
+++ b/src/app/api/admin/payroll/profiles/route.ts
@@ -1,0 +1,189 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { getSalesUser } from "@/lib/salesAuth";
+import { generatePayrollToken } from "@/lib/payroll/token";
+import { sendPayrollInvitationEmail } from "@/lib/payroll/emails";
+import type { PayrollClassification, PayrollStatus } from "@/lib/payroll/constants";
+
+/**
+ * GET  /api/admin/payroll/profiles — admin-only list + counts
+ * POST /api/admin/payroll/profiles — admin-only. Body:
+ *   {
+ *     team_member_id, classification, job_title?, department?, manager_user_id?,
+ *     work_location?, employment_status?, hire_date?,
+ *     pay_type?, pay_frequency?, hourly_rate_cents?, annual_salary_cents?,
+ *     commission_notes?, expected_hours_per_week?, overtime_eligible?,
+ *     compensation_notes?, company_entity?, recipient_email?
+ *   }
+ * Creates the payroll_profiles row + issues an invitation token +
+ * sends the "Complete Your Payroll Setup" email in one shot.
+ */
+export async function GET(req: NextRequest) {
+  const actor = await getSalesUser(req);
+  if (!actor || actor.role !== "admin") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from("payroll_profiles")
+    .select("*")
+    .order("created_at", { ascending: false });
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  const memberIds = Array.from(new Set((data ?? []).map((p) => p.team_member_id).filter(Boolean)));
+  const memberMap: Record<string, { full_name: string | null; email: string | null }> = {};
+  if (memberIds.length > 0) {
+    const { data: profs } = await supabaseAdmin
+      .from("profiles")
+      .select("id, full_name, email")
+      .in("id", memberIds);
+    for (const p of profs ?? []) {
+      memberMap[p.id] = { full_name: p.full_name, email: p.email };
+    }
+  }
+
+  const rows = (data ?? []).map((p) => ({
+    ...p,
+    team_member: memberMap[p.team_member_id] ?? null,
+  }));
+
+  // Simple status counts for the dashboard tiles.
+  const counts: Record<string, number> = {};
+  for (const r of rows) counts[r.status] = (counts[r.status] ?? 0) + 1;
+
+  return NextResponse.json({ profiles: rows, counts });
+}
+
+export async function POST(req: NextRequest) {
+  const actor = await getSalesUser(req);
+  if (!actor || actor.role !== "admin") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const body = await req.json().catch(() => ({}));
+
+  const teamMemberId = typeof body?.team_member_id === "string" ? body.team_member_id : "";
+  const classification = body?.classification as PayrollClassification | undefined;
+  if (!teamMemberId) return NextResponse.json({ error: "team_member_id is required" }, { status: 400 });
+  if (classification !== "w2_employee" && classification !== "1099_contractor") {
+    return NextResponse.json({ error: "classification must be w2_employee or 1099_contractor" }, { status: 400 });
+  }
+
+  const { data: member } = await supabaseAdmin
+    .from("profiles")
+    .select("id, full_name, email, phone")
+    .eq("id", teamMemberId)
+    .maybeSingle();
+  if (!member) return NextResponse.json({ error: "Team member not found" }, { status: 404 });
+
+  const recipientEmail = (typeof body?.recipient_email === "string" ? body.recipient_email : member.email ?? "").trim();
+  if (!recipientEmail || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(recipientEmail)) {
+    return NextResponse.json({ error: "A valid recipient email is required." }, { status: 400 });
+  }
+
+  // Upsert: one payroll_profiles row per team member. Re-inviting the
+  // same member updates the record and issues a fresh token — the
+  // uniqueness constraint on team_member_id enforces the one-row rule.
+  const insertPayload: Record<string, unknown> = {
+    team_member_id: teamMemberId,
+    created_by_user_id: actor.id,
+    classification,
+    job_title: strOrNull(body.job_title),
+    department: strOrNull(body.department),
+    manager_user_id: strOrNull(body.manager_user_id),
+    work_location: strOrNull(body.work_location),
+    employment_status: strOrNull(body.employment_status),
+    hire_date: strOrNull(body.hire_date),
+    pay_type: strOrNull(body.pay_type),
+    pay_frequency: strOrNull(body.pay_frequency),
+    hourly_rate_cents: intOrNull(body.hourly_rate_cents),
+    annual_salary_cents: intOrNull(body.annual_salary_cents),
+    commission_notes: strOrNull(body.commission_notes),
+    expected_hours_per_week: numOrNull(body.expected_hours_per_week),
+    overtime_eligible: typeof body.overtime_eligible === "boolean" ? body.overtime_eligible : null,
+    compensation_notes: strOrNull(body.compensation_notes),
+    company_entity: strOrNull(body.company_entity),
+    recipient_email: recipientEmail,
+    work_state: strOrNull(body.work_state),
+    status: "invite_sent" as PayrollStatus,
+    updated_at: new Date().toISOString(),
+  };
+
+  const { data: profile, error: upsertErr } = await supabaseAdmin
+    .from("payroll_profiles")
+    .upsert(insertPayload, { onConflict: "team_member_id" })
+    .select("*")
+    .single();
+  if (upsertErr || !profile) {
+    return NextResponse.json({ error: upsertErr?.message ?? "Failed to create payroll profile" }, { status: 500 });
+  }
+
+  // Issue token + send email.
+  const { raw, hash, expiresAt } = generatePayrollToken();
+  const { error: inviteErr } = await supabaseAdmin
+    .from("payroll_invitations")
+    .insert({
+      profile_id: profile.id,
+      token_hash: hash,
+      expires_at: expiresAt,
+      sent_at: new Date().toISOString(),
+      created_by: actor.id,
+    });
+  if (inviteErr) {
+    return NextResponse.json({ error: `Invitation persist failed: ${inviteErr.message}` }, { status: 500 });
+  }
+
+  const origin = req.headers.get("origin") || process.env.NEXT_PUBLIC_SITE_URL || "https://vendingconnector.com";
+  const packetUrl = `${origin}/payroll/${raw}`;
+
+  try {
+    await sendPayrollInvitationEmail({
+      toEmail: recipientEmail,
+      recipientName: member.full_name,
+      classification,
+      packetUrl,
+      companyName: typeof body.company_entity === "string" ? body.company_entity : null,
+    });
+  } catch (mailErr) {
+    // Roll status back so admin can retry via resend without losing the record.
+    await supabaseAdmin
+      .from("payroll_profiles")
+      .update({ status: "invite_ready" })
+      .eq("id", profile.id);
+    return NextResponse.json(
+      {
+        error: `Payroll profile saved but the invitation email failed to send: ${mailErr instanceof Error ? mailErr.message : "unknown error"}. Use Resend to retry.`,
+        profile_id: profile.id,
+      },
+      { status: 502 },
+    );
+  }
+
+  // Audit — never carries body values.
+  await supabaseAdmin.from("payroll_audit_events").insert({
+    profile_id: profile.id,
+    actor_user_id: actor.id,
+    actor_kind: "admin",
+    event_type: "invite.sent",
+    description: `Invitation sent to ${recipientEmail}`,
+    metadata: { classification, expires_at: expiresAt },
+  });
+
+  return NextResponse.json({ ok: true, profile_id: profile.id, status: profile.status });
+}
+
+function strOrNull(v: unknown): string | null {
+  if (typeof v !== "string") return null;
+  const t = v.trim();
+  return t.length > 0 ? t : null;
+}
+function intOrNull(v: unknown): number | null {
+  if (v == null || v === "") return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? Math.round(n) : null;
+}
+function numOrNull(v: unknown): number | null {
+  if (v == null || v === "") return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}

--- a/src/app/api/payroll/[token]/route.ts
+++ b/src/app/api/payroll/[token]/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { isTokenLive, resolveRawPayrollToken } from "@/lib/payroll/tokenLookup";
+
+/**
+ * GET /api/payroll/[token]
+ *
+ * Public endpoint (URL IS the credential). Returns just enough for
+ * the wizard to render — admin-set employment/comp info the worker
+ * needs to see read-only + whatever draft they've saved so far.
+ * NEVER returns encrypted field plaintext.
+ */
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ token: string }> },
+) {
+  const { token } = await params;
+  const resolved = await resolveRawPayrollToken(token);
+  if (!resolved) return NextResponse.json({ error: "Invalid or expired link." }, { status: 404 });
+  if (!isTokenLive(resolved)) {
+    return NextResponse.json(
+      {
+        error:
+          resolved.revoked_at ? "This invitation was revoked. Contact your manager for a new link."
+            : resolved.used_at ? "This packet has already been submitted."
+              : "This invitation has expired. Contact your manager for a new link.",
+        state: resolved.revoked_at ? "revoked" : resolved.used_at ? "used" : "expired",
+      },
+      { status: 410 },
+    );
+  }
+
+  // Mark first-open time on the invitation (once) so admins can see
+  // the recipient engaged.
+  await supabaseAdmin
+    .from("payroll_invitations")
+    .update({ opened_at: new Date().toISOString() })
+    .eq("id", resolved.invitation_id)
+    .is("opened_at", null);
+
+  const [{ data: profile }, { data: worker }] = await Promise.all([
+    supabaseAdmin.from("payroll_profiles").select("*").eq("id", resolved.profile_id).maybeSingle(),
+    supabaseAdmin.from("payroll_worker_details").select("*").eq("profile_id", resolved.profile_id).maybeSingle(),
+  ]);
+  if (!profile) return NextResponse.json({ error: "Invalid link." }, { status: 404 });
+
+  return NextResponse.json({
+    ok: true,
+    // Admin-set (read-only for worker)
+    admin: {
+      classification: profile.classification,
+      job_title: profile.job_title,
+      department: profile.department,
+      hire_date: profile.hire_date,
+      employment_status: profile.employment_status,
+      pay_type: profile.pay_type,
+      pay_frequency: profile.pay_frequency,
+      company_entity: profile.company_entity,
+      work_state: profile.work_state,
+    },
+    // Draft state (whatever they've saved so far)
+    worker: worker ?? null,
+    status: profile.status,
+    // For any encrypted field they've already saved, expose ONLY the
+    // key so the wizard shows "on file" instead of "not entered".
+    // Plaintext never leaves the server here.
+    saved_sensitive_keys: await savedEncryptedKeys(resolved.profile_id),
+  });
+}
+
+async function savedEncryptedKeys(profileId: string): Promise<string[]> {
+  const { data } = await supabaseAdmin
+    .from("payroll_encrypted")
+    .select("field_key")
+    .eq("profile_id", profileId);
+  return (data ?? []).map((r) => r.field_key);
+}

--- a/src/app/api/payroll/[token]/save-draft/route.ts
+++ b/src/app/api/payroll/[token]/save-draft/route.ts
@@ -1,0 +1,156 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { isTokenLive, resolveRawPayrollToken } from "@/lib/payroll/tokenLookup";
+import { encryptField, last4 } from "@/lib/payroll/encryption";
+
+/**
+ * PATCH /api/payroll/[token]/save-draft
+ *
+ * Public (token-based). Persists a wizard step's data. Sensitive
+ * values (SSN / TIN / full routing / full account / W-4 additional
+ * withholding) are moved to payroll_encrypted immediately and
+ * REPLACED on payroll_worker_details with just their last-4 for
+ * display. Nothing on payroll_worker_details holds full sensitive
+ * plaintext.
+ *
+ * Body shape:
+ *   {
+ *     step: string,                 // step key (e.g. 'personal', 'address', ...)
+ *     nonSensitive?: object,        // patch for payroll_worker_details
+ *     encrypted?: { [key]: string } // full plaintext of sensitive fields
+ *   }
+ *
+ * Neither the request nor the audit log ever carries the plaintext
+ * SSN / bank number — the encrypted values are captured and the
+ * audit row only records that a step advanced.
+ */
+const NON_SENSITIVE_ALLOWLIST = new Set<string>([
+  // Personal
+  "legal_first_name", "middle_name", "legal_last_name", "preferred_name",
+  "date_of_birth", "personal_email", "mobile_phone",
+  // Address
+  "address_street", "address_unit", "address_city", "address_state", "address_zip", "address_country",
+  // W-4 non-sensitive
+  "filing_status", "multiple_jobs",
+  "qualifying_children_amt", "other_dependents_amt",
+  "other_income_cents", "deductions_cents", "exempt",
+  // Bank non-sensitive
+  "account_holder_name", "bank_name", "account_type",
+  // 1099 non-sensitive
+  "business_name", "federal_tax_class", "tin_type",
+  // Emergency contact
+  "emergency_contact_name", "emergency_contact_relationship",
+  "emergency_contact_phone", "emergency_contact_email",
+]);
+
+const ENCRYPTED_ALLOWLIST = new Set<string>([
+  "ssn", "tin", "bank.routing", "bank.account", "w4.additional_withholding_cents",
+]);
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ token: string }> },
+) {
+  const { token } = await params;
+  const resolved = await resolveRawPayrollToken(token);
+  if (!resolved) return NextResponse.json({ error: "Invalid or expired link." }, { status: 404 });
+  if (!isTokenLive(resolved)) {
+    return NextResponse.json({ error: "This invitation is no longer active." }, { status: 410 });
+  }
+  const profileId = resolved.profile_id;
+
+  const body = await req.json().catch(() => ({}));
+  const step = typeof body?.step === "string" ? body.step.slice(0, 60) : "";
+  const nonSensitive = (body?.nonSensitive && typeof body.nonSensitive === "object")
+    ? body.nonSensitive as Record<string, unknown>
+    : {};
+  const encrypted = (body?.encrypted && typeof body.encrypted === "object")
+    ? body.encrypted as Record<string, unknown>
+    : {};
+
+  // 1) Filter + upsert non-sensitive fields onto payroll_worker_details.
+  const filteredNS: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(nonSensitive)) {
+    if (NON_SENSITIVE_ALLOWLIST.has(k)) filteredNS[k] = v;
+  }
+  if (Object.keys(filteredNS).length > 0 || step) {
+    const patch: Record<string, unknown> = {
+      profile_id: profileId,
+      ...filteredNS,
+      last_step_completed: step || null,
+      updated_at: new Date().toISOString(),
+    };
+    const { error: wdErr } = await supabaseAdmin
+      .from("payroll_worker_details")
+      .upsert(patch, { onConflict: "profile_id" });
+    if (wdErr) return NextResponse.json({ error: wdErr.message }, { status: 500 });
+  }
+
+  // 2) Encrypt + store each sensitive field. Also write the last-4
+  //    onto payroll_worker_details for masked display (never the
+  //    full value). Never log the plaintext.
+  const last4Patch: Record<string, unknown> = {};
+  for (const [key, rawVal] of Object.entries(encrypted)) {
+    if (!ENCRYPTED_ALLOWLIST.has(key)) continue;
+    if (typeof rawVal !== "string") continue;
+    const clean = rawVal.replace(/[^0-9A-Za-z]/g, "").trim();
+    if (!clean) continue;
+    let enc;
+    try {
+      enc = encryptField(clean);
+    } catch (encErr) {
+      console.error("[payroll.save-draft] encrypt failed:", encErr);
+      return NextResponse.json(
+        { error: "Server misconfiguration prevented saving this field. The platform team has been notified." },
+        { status: 500 },
+      );
+    }
+    await supabaseAdmin.from("payroll_encrypted").upsert(
+      {
+        profile_id: profileId,
+        field_key: key,
+        ciphertext: enc.ciphertext,
+        iv: enc.iv,
+        auth_tag: enc.auth_tag,
+        key_version: enc.key_version,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: "profile_id,field_key" },
+    );
+
+    if (key === "ssn") last4Patch.ssn_last4 = last4(clean);
+    else if (key === "tin") last4Patch.tin_last4 = last4(clean);
+    else if (key === "bank.routing") last4Patch.routing_last4 = last4(clean);
+    else if (key === "bank.account") last4Patch.account_last4 = last4(clean);
+  }
+  if (Object.keys(last4Patch).length > 0) {
+    await supabaseAdmin
+      .from("payroll_worker_details")
+      .upsert(
+        { profile_id: profileId, ...last4Patch, updated_at: new Date().toISOString() },
+        { onConflict: "profile_id" },
+      );
+  }
+
+  // 3) Bump status to in_progress on first save.
+  await supabaseAdmin
+    .from("payroll_profiles")
+    .update({ status: "in_progress", updated_at: new Date().toISOString() })
+    .eq("id", profileId)
+    .in("status", ["invite_ready", "invite_sent"]);
+
+  await supabaseAdmin.from("payroll_audit_events").insert({
+    profile_id: profileId,
+    actor_kind: "employee",
+    event_type: "draft.saved",
+    description: step ? `Employee saved step '${step}'` : "Employee saved draft",
+    metadata: {
+      step,
+      // ONLY the keys of sensitive fields we saved — never values.
+      sensitive_keys_saved: Object.keys(encrypted).filter((k) => ENCRYPTED_ALLOWLIST.has(k)),
+      non_sensitive_keys_saved: Object.keys(filteredNS),
+    },
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/payroll/[token]/submit/route.ts
+++ b/src/app/api/payroll/[token]/submit/route.ts
@@ -1,0 +1,126 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { isTokenLive, resolveRawPayrollToken } from "@/lib/payroll/tokenLookup";
+import { sendPayrollAdminReviewEmail } from "@/lib/payroll/emails";
+
+/**
+ * POST /api/payroll/[token]/submit
+ *
+ * Finalizes the packet. Verifies required fields per classification,
+ * flips status to admin_review_required, marks the invitation used
+ * (so the token stops working), captures the electronic-signature
+ * metadata (typed name, IP, UA), and fires the admin notification.
+ *
+ * Body: { signature_name: string, certified: boolean }
+ */
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ token: string }> },
+) {
+  const { token } = await params;
+  const resolved = await resolveRawPayrollToken(token);
+  if (!resolved) return NextResponse.json({ error: "Invalid or expired link." }, { status: 404 });
+  if (!isTokenLive(resolved)) {
+    return NextResponse.json({ error: "This invitation is no longer active." }, { status: 410 });
+  }
+  const profileId = resolved.profile_id;
+
+  const body = await req.json().catch(() => ({}));
+  const signatureName = typeof body?.signature_name === "string" ? body.signature_name.trim() : "";
+  const certified = !!body?.certified;
+  if (!signatureName) return NextResponse.json({ error: "Typed legal name is required." }, { status: 400 });
+  if (!certified) {
+    return NextResponse.json(
+      { error: "You must certify that the information you provided is complete and accurate." },
+      { status: 400 },
+    );
+  }
+
+  const [{ data: profile }, { data: worker }, { data: encRows }] = await Promise.all([
+    supabaseAdmin.from("payroll_profiles").select("*").eq("id", profileId).maybeSingle(),
+    supabaseAdmin.from("payroll_worker_details").select("*").eq("profile_id", profileId).maybeSingle(),
+    supabaseAdmin.from("payroll_encrypted").select("field_key").eq("profile_id", profileId),
+  ]);
+  if (!profile) return NextResponse.json({ error: "Invalid link." }, { status: 404 });
+
+  const encKeys = new Set((encRows ?? []).map((r) => r.field_key as string));
+  const missing: string[] = [];
+
+  if (!worker?.legal_first_name) missing.push("Legal first name");
+  if (!worker?.legal_last_name) missing.push("Legal last name");
+  if (!worker?.address_street || !worker?.address_city || !worker?.address_state || !worker?.address_zip) {
+    missing.push("Home address");
+  }
+  // Bank details are required for both W-2 and 1099 (direct deposit).
+  if (!encKeys.has("bank.routing") || !encKeys.has("bank.account")) missing.push("Direct deposit account");
+  if (!worker?.account_holder_name || !worker?.bank_name || !worker?.account_type) {
+    missing.push("Bank name / account type");
+  }
+
+  if (profile.classification === "w2_employee") {
+    if (!worker?.date_of_birth) missing.push("Date of birth");
+    if (!encKeys.has("ssn")) missing.push("Social Security number");
+    if (!worker?.filing_status) missing.push("Federal filing status");
+  } else if (profile.classification === "1099_contractor") {
+    if (!worker?.federal_tax_class) missing.push("Federal tax classification");
+    if (!worker?.tin_type) missing.push("TIN type");
+    if (!encKeys.has("tin")) missing.push("Taxpayer Identification Number");
+  }
+
+  if (missing.length > 0) {
+    return NextResponse.json(
+      { error: `Please complete the following before submitting: ${missing.join(", ")}.` },
+      { status: 400 },
+    );
+  }
+
+  const ip = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || null;
+  const ua = req.headers.get("user-agent") || null;
+  const nowIso = new Date().toISOString();
+
+  await supabaseAdmin
+    .from("payroll_profiles")
+    .update({
+      status: "admin_review_required",
+      submitted_at: nowIso,
+      submission_signature_name: signatureName,
+      submission_signature_at: nowIso,
+      submission_ip: ip,
+      submission_user_agent: ua,
+      updated_at: nowIso,
+    })
+    .eq("id", profileId);
+
+  // Mark invitation used — the URL stops working from this point.
+  await supabaseAdmin
+    .from("payroll_invitations")
+    .update({ used_at: nowIso })
+    .eq("id", resolved.invitation_id);
+
+  await supabaseAdmin.from("payroll_audit_events").insert({
+    profile_id: profileId,
+    actor_kind: "employee",
+    event_type: "submitted",
+    description: `Employee submitted the packet (${profile.classification}).`,
+    metadata: {
+      signature_name: signatureName,
+      ip: ip ?? undefined,
+      user_agent: ua ?? undefined,
+    },
+  });
+
+  // Admin notification — names + status only, no sensitive values.
+  const origin = req.headers.get("origin") || process.env.NEXT_PUBLIC_SITE_URL || "https://vendingconnector.com";
+  try {
+    await sendPayrollAdminReviewEmail({
+      recipientName: [worker?.legal_first_name, worker?.legal_last_name].filter(Boolean).join(" ") || null,
+      recipientEmail: profile.recipient_email ?? "",
+      classification: profile.classification,
+      reviewUrl: `${origin}/admin/payroll/${profileId}`,
+    });
+  } catch (mailErr) {
+    console.error("[payroll.submit] admin notification failed:", mailErr);
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/payroll/[token]/page.tsx
+++ b/src/app/payroll/[token]/page.tsx
@@ -1,0 +1,642 @@
+"use client";
+
+/**
+ * /payroll/[token] — employee/contractor onboarding wizard.
+ *
+ * Public route (token IS the credential). Different step set per
+ * classification. Save-and-resume on every step-Next. Sensitive
+ * fields (SSN / TIN / bank) submit through the encrypted-field
+ * pipeline (POST /api/payroll/[token]/save-draft { encrypted }) —
+ * server encrypts before persist, browser never sees plaintext
+ * again after that step.
+ *
+ * Mobile-first: single-column, large controls, mobile keyboard
+ * hints via inputMode + autoComplete.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useParams } from "next/navigation";
+import { Loader2, ShieldCheck, ChevronLeft, ChevronRight, CheckCircle2, AlertCircle, Eye, EyeOff } from "lucide-react";
+import {
+  ACCOUNT_TYPES,
+  CLASSIFICATION_LABELS,
+  FEDERAL_TAX_CLASSES,
+  FILING_STATUSES,
+  TIN_TYPES,
+} from "@/lib/payroll/constants";
+
+type Classification = "w2_employee" | "1099_contractor";
+
+const W2_STEPS = [
+  { key: "personal",       label: "Personal Info" },
+  { key: "address",        label: "Address" },
+  { key: "employment",     label: "Employment" },
+  { key: "federal_tax",    label: "Federal W-4" },
+  { key: "state_tax",      label: "State Tax" },
+  { key: "direct_deposit", label: "Direct Deposit" },
+  { key: "eligibility",    label: "Employment Eligibility" },
+  { key: "emergency",      label: "Emergency Contact" },
+  { key: "review",         label: "Review & Submit" },
+] as const;
+
+const C1099_STEPS = [
+  { key: "identity",       label: "Identity" },
+  { key: "w9",             label: "W-9 Info" },
+  { key: "address",        label: "Address" },
+  { key: "direct_deposit", label: "Direct Deposit" },
+  { key: "review",         label: "Review & Submit" },
+] as const;
+
+interface AdminInfo {
+  classification: Classification;
+  job_title: string | null;
+  department: string | null;
+  hire_date: string | null;
+  employment_status: string | null;
+  pay_type: string | null;
+  pay_frequency: string | null;
+  company_entity: string | null;
+  work_state: string | null;
+}
+
+interface WorkerDraft {
+  legal_first_name?: string;
+  middle_name?: string;
+  legal_last_name?: string;
+  preferred_name?: string;
+  date_of_birth?: string;
+  personal_email?: string;
+  mobile_phone?: string;
+  address_street?: string;
+  address_unit?: string;
+  address_city?: string;
+  address_state?: string;
+  address_zip?: string;
+  filing_status?: string;
+  multiple_jobs?: boolean;
+  qualifying_children_amt?: number;
+  other_dependents_amt?: number;
+  other_income_cents?: number;
+  deductions_cents?: number;
+  exempt?: boolean;
+  account_holder_name?: string;
+  bank_name?: string;
+  account_type?: string;
+  business_name?: string;
+  federal_tax_class?: string;
+  tin_type?: string;
+  emergency_contact_name?: string;
+  emergency_contact_relationship?: string;
+  emergency_contact_phone?: string;
+  emergency_contact_email?: string;
+  ssn_last4?: string;
+  routing_last4?: string;
+  account_last4?: string;
+  tin_last4?: string;
+}
+
+interface Loaded {
+  admin: AdminInfo;
+  worker: WorkerDraft | null;
+  saved_sensitive_keys: string[];
+  status: string;
+}
+
+export default function PayrollWizardPage() {
+  const { token } = useParams<{ token: string }>();
+  const [state, setState] = useState<Loaded | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [stepIndex, setStepIndex] = useState(0);
+  const [submitting, setSubmitting] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [done, setDone] = useState(false);
+
+  // Draft form state (both admin steps display + worker inputs)
+  const [form, setForm] = useState<WorkerDraft>({});
+  const [ssn, setSsn] = useState(""); const [ssn2, setSsn2] = useState(""); const [showSsn, setShowSsn] = useState(false);
+  const [tin, setTin] = useState("");
+  const [routing, setRouting] = useState(""); const [routing2, setRouting2] = useState("");
+  const [account, setAccount] = useState(""); const [account2, setAccount2] = useState(""); const [showAcct, setShowAcct] = useState(false);
+  const [addlWithhold, setAddlWithhold] = useState("");
+  const [signatureName, setSignatureName] = useState("");
+  const [certified, setCertified] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/payroll/${token}`);
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) { setError(json.error || `Failed (${res.status})`); return; }
+      setState(json);
+      setForm({ ...(json.worker as WorkerDraft ?? {}) });
+    } finally { setLoading(false); }
+  }, [token]);
+  useEffect(() => { load(); }, [load]);
+
+  const steps = state?.admin.classification === "1099_contractor" ? C1099_STEPS : W2_STEPS;
+  const currentStep = steps[stepIndex];
+
+  async function saveDraft(step: string, nonSensitive?: Record<string, unknown>, encrypted?: Record<string, string>): Promise<boolean> {
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/payroll/${token}/save-draft`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ step, nonSensitive, encrypted }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) { setError(json.error || `Save failed (${res.status})`); return false; }
+      // Clear sensitive input state after successful save
+      if (encrypted?.ssn) setSsn(""), setSsn2("");
+      if (encrypted?.tin) setTin("");
+      if (encrypted?.["bank.routing"]) setRouting(""), setRouting2("");
+      if (encrypted?.["bank.account"]) setAccount(""), setAccount2("");
+      if (encrypted?.["w4.additional_withholding_cents"]) setAddlWithhold("");
+      await load();
+      return true;
+    } finally { setSaving(false); }
+  }
+
+  async function nextStep() {
+    const ok = await handleStepSave();
+    if (ok) setStepIndex((i) => Math.min(i + 1, steps.length - 1));
+  }
+  function prevStep() { setStepIndex((i) => Math.max(i - 1, 0)); setError(null); }
+
+  async function handleStepSave(): Promise<boolean> {
+    if (!currentStep) return false;
+    setError(null);
+    const s = currentStep.key;
+    const enc: Record<string, string> = {};
+    const ns: Record<string, unknown> = {};
+
+    if (s === "personal") {
+      if (!form.legal_first_name || !form.legal_last_name || !form.date_of_birth) {
+        setError("Legal name and date of birth are required."); return false;
+      }
+      if (state?.admin.classification === "w2_employee") {
+        if (ssn || ssn2) {
+          if (ssn !== ssn2) { setError("Social Security numbers don't match."); return false; }
+          if (!/^\d{9}$/.test(ssn.replace(/[^0-9]/g, ""))) { setError("SSN must be 9 digits."); return false; }
+          enc.ssn = ssn.replace(/[^0-9]/g, "");
+        } else if (!state?.saved_sensitive_keys.includes("ssn")) {
+          setError("Social Security number is required."); return false;
+        }
+      }
+      ns.legal_first_name = form.legal_first_name;
+      ns.middle_name = form.middle_name;
+      ns.legal_last_name = form.legal_last_name;
+      ns.preferred_name = form.preferred_name;
+      ns.date_of_birth = form.date_of_birth;
+      ns.personal_email = form.personal_email;
+      ns.mobile_phone = form.mobile_phone;
+      return await saveDraft(s, ns, enc);
+    }
+
+    if (s === "identity") {
+      if (!form.legal_first_name || !form.legal_last_name) { setError("Legal name is required."); return false; }
+      ns.legal_first_name = form.legal_first_name;
+      ns.legal_last_name = form.legal_last_name;
+      ns.business_name = form.business_name;
+      ns.personal_email = form.personal_email;
+      ns.mobile_phone = form.mobile_phone;
+      return await saveDraft(s, ns);
+    }
+
+    if (s === "address") {
+      if (!form.address_street || !form.address_city || !form.address_state || !form.address_zip) {
+        setError("Street, city, state, and ZIP are required."); return false;
+      }
+      ns.address_street = form.address_street;
+      ns.address_unit = form.address_unit;
+      ns.address_city = form.address_city;
+      ns.address_state = form.address_state;
+      ns.address_zip = form.address_zip;
+      ns.address_country = "US";
+      return await saveDraft(s, ns);
+    }
+
+    if (s === "federal_tax") {
+      if (!form.filing_status) { setError("Filing status is required."); return false; }
+      ns.filing_status = form.filing_status;
+      ns.multiple_jobs = !!form.multiple_jobs;
+      ns.qualifying_children_amt = form.qualifying_children_amt ?? null;
+      ns.other_dependents_amt = form.other_dependents_amt ?? null;
+      ns.other_income_cents = form.other_income_cents ?? null;
+      ns.deductions_cents = form.deductions_cents ?? null;
+      ns.exempt = !!form.exempt;
+      if (addlWithhold) enc["w4.additional_withholding_cents"] = String(Math.round(Number(addlWithhold) * 100));
+      return await saveDraft(s, ns, enc);
+    }
+
+    if (s === "state_tax" || s === "employment" || s === "eligibility" || s === "emergency") {
+      if (s === "emergency") {
+        ns.emergency_contact_name = form.emergency_contact_name;
+        ns.emergency_contact_relationship = form.emergency_contact_relationship;
+        ns.emergency_contact_phone = form.emergency_contact_phone;
+        ns.emergency_contact_email = form.emergency_contact_email;
+      }
+      return await saveDraft(s, ns);
+    }
+
+    if (s === "w9") {
+      if (!form.federal_tax_class || !form.tin_type) { setError("Tax classification and TIN type are required."); return false; }
+      if (tin) {
+        const clean = tin.replace(/[^0-9]/g, "");
+        if (form.tin_type === "ssn" && clean.length !== 9) { setError("SSN must be 9 digits."); return false; }
+        if (form.tin_type === "ein" && clean.length !== 9) { setError("EIN must be 9 digits."); return false; }
+        enc.tin = clean;
+      } else if (!state?.saved_sensitive_keys.includes("tin")) {
+        setError("TIN is required."); return false;
+      }
+      ns.federal_tax_class = form.federal_tax_class;
+      ns.tin_type = form.tin_type;
+      ns.business_name = form.business_name;
+      return await saveDraft(s, ns, enc);
+    }
+
+    if (s === "direct_deposit") {
+      if (!form.account_holder_name || !form.bank_name || !form.account_type) {
+        setError("Account holder name, bank name, and account type are required."); return false;
+      }
+      if (routing || routing2) {
+        if (routing !== routing2) { setError("Routing numbers don't match."); return false; }
+        if (!/^\d{9}$/.test(routing.replace(/[^0-9]/g, ""))) { setError("Routing number must be 9 digits."); return false; }
+        enc["bank.routing"] = routing.replace(/[^0-9]/g, "");
+      } else if (!state?.saved_sensitive_keys.includes("bank.routing")) {
+        setError("Routing number is required."); return false;
+      }
+      if (account || account2) {
+        if (account !== account2) { setError("Account numbers don't match."); return false; }
+        if (account.replace(/[^0-9]/g, "").length < 4) { setError("Account number is too short."); return false; }
+        enc["bank.account"] = account.replace(/[^0-9]/g, "");
+      } else if (!state?.saved_sensitive_keys.includes("bank.account")) {
+        setError("Account number is required."); return false;
+      }
+      ns.account_holder_name = form.account_holder_name;
+      ns.bank_name = form.bank_name;
+      ns.account_type = form.account_type;
+      return await saveDraft(s, ns, enc);
+    }
+
+    if (s === "review") return true;
+    return true;
+  }
+
+  async function submit() {
+    if (!signatureName.trim()) { setError("Type your legal name to sign."); return; }
+    if (!certified) { setError("Please confirm the certification."); return; }
+    setSubmitting(true);
+    try {
+      const res = await fetch(`/api/payroll/${token}/submit`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ signature_name: signatureName.trim(), certified: true }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) { setError(json.error || `Submit failed (${res.status})`); return; }
+      setDone(true);
+    } finally { setSubmitting(false); }
+  }
+
+  const savedKeys = useMemo(() => new Set(state?.saved_sensitive_keys ?? []), [state]);
+
+  if (loading) return <Shell><Loader2 className="h-6 w-6 animate-spin text-green-primary mx-auto" /></Shell>;
+  if (error && !state) return <Shell><div className="rounded-xl border border-red-200 bg-red-50 p-5 text-sm text-red-700"><AlertCircle className="inline-block h-4 w-4 mr-1" />{error}</div></Shell>;
+  if (!state) return null;
+
+  if (done) {
+    return (
+      <Shell>
+        <div className="rounded-2xl border border-emerald-200 bg-emerald-50 p-8 text-center">
+          <CheckCircle2 className="mx-auto h-10 w-10 text-emerald-600" />
+          <h1 className="mt-3 text-2xl font-bold text-emerald-900">Payroll Setup Submitted</h1>
+          <p className="mt-2 text-sm text-emerald-800">Thank you. Your payroll information has been securely submitted.</p>
+          <p className="mt-1 text-sm text-emerald-700">Our payroll team will review your information and complete your payroll setup. If additional information is needed, we will contact you.</p>
+        </div>
+      </Shell>
+    );
+  }
+
+  return (
+    <Shell>
+      <div className="mb-6 flex items-center justify-between gap-3">
+        <div>
+          <div className="text-[11px] font-semibold uppercase tracking-[0.15em] text-green-primary">Payroll Onboarding</div>
+          <h1 className="mt-1 text-xl font-semibold text-gray-900">{CLASSIFICATION_LABELS[state.admin.classification]} · {state.admin.company_entity ?? "—"}</h1>
+        </div>
+        <span className="inline-flex items-center gap-1 rounded-full bg-white px-2.5 py-1 text-xs font-medium ring-1 ring-gray-200 text-gray-700">
+          <ShieldCheck className="h-3.5 w-3.5 text-green-primary" /> Secure
+        </span>
+      </div>
+
+      {/* Progress */}
+      <div className="mb-6 grid grid-cols-3 gap-1 sm:grid-cols-9">
+        {steps.map((s, i) => (
+          <div key={s.key} className={`h-1.5 rounded-full ${i <= stepIndex ? "bg-green-primary" : "bg-gray-200"}`} title={s.label} />
+        ))}
+      </div>
+      <div className="mb-4 text-xs text-gray-500">Step {stepIndex + 1} of {steps.length}: <span className="font-medium text-gray-800">{currentStep.label}</span></div>
+
+      <div className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm space-y-4">
+        {currentStep.key === "personal" && (
+          <>
+            <TwoCol>
+              <Field label="Legal First Name" required autoComplete="given-name" value={form.legal_first_name ?? ""} onChange={(v) => setForm({ ...form, legal_first_name: v })} />
+              <Field label="Middle Name" autoComplete="additional-name" value={form.middle_name ?? ""} onChange={(v) => setForm({ ...form, middle_name: v })} />
+            </TwoCol>
+            <TwoCol>
+              <Field label="Legal Last Name" required autoComplete="family-name" value={form.legal_last_name ?? ""} onChange={(v) => setForm({ ...form, legal_last_name: v })} />
+              <Field label="Preferred Name" value={form.preferred_name ?? ""} onChange={(v) => setForm({ ...form, preferred_name: v })} />
+            </TwoCol>
+            <TwoCol>
+              <Field label="Date of Birth" required type="date" autoComplete="bday" value={form.date_of_birth ?? ""} onChange={(v) => setForm({ ...form, date_of_birth: v })} />
+              <Field label="Personal Email" type="email" autoComplete="email" value={form.personal_email ?? ""} onChange={(v) => setForm({ ...form, personal_email: v })} />
+            </TwoCol>
+            <Field label="Mobile Phone" type="tel" autoComplete="tel" inputMode="tel" value={form.mobile_phone ?? ""} onChange={(v) => setForm({ ...form, mobile_phone: v })} />
+            {state.admin.classification === "w2_employee" && (
+              <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 space-y-3">
+                <div className="flex items-center gap-2 text-sm font-semibold text-amber-900"><ShieldCheck className="h-4 w-4" /> Social Security Number</div>
+                {savedKeys.has("ssn") ? (
+                  <div className="text-xs text-amber-800">On file. Enter a new value only if you need to replace it — otherwise leave blank and continue.</div>
+                ) : null}
+                <SensitiveField label="SSN"          value={ssn}  show={showSsn} onToggle={() => setShowSsn(!showSsn)} onChange={setSsn}  inputMode="numeric" />
+                <SensitiveField label="Confirm SSN"  value={ssn2} show={showSsn} onToggle={() => setShowSsn(!showSsn)} onChange={setSsn2} inputMode="numeric" />
+              </div>
+            )}
+          </>
+        )}
+
+        {currentStep.key === "identity" && (
+          <>
+            <TwoCol>
+              <Field label="Legal First Name" required value={form.legal_first_name ?? ""} onChange={(v) => setForm({ ...form, legal_first_name: v })} />
+              <Field label="Legal Last Name"  required value={form.legal_last_name ?? ""}  onChange={(v) => setForm({ ...form, legal_last_name: v })} />
+            </TwoCol>
+            <Field label="Business / Entity Name (if applicable)" value={form.business_name ?? ""} onChange={(v) => setForm({ ...form, business_name: v })} />
+            <TwoCol>
+              <Field label="Email" type="email" autoComplete="email" value={form.personal_email ?? ""} onChange={(v) => setForm({ ...form, personal_email: v })} />
+              <Field label="Phone" type="tel" inputMode="tel" value={form.mobile_phone ?? ""} onChange={(v) => setForm({ ...form, mobile_phone: v })} />
+            </TwoCol>
+          </>
+        )}
+
+        {currentStep.key === "address" && (
+          <>
+            <Field label="Street Address" required autoComplete="street-address" value={form.address_street ?? ""} onChange={(v) => setForm({ ...form, address_street: v })} />
+            <TwoCol>
+              <Field label="Apt / Unit" value={form.address_unit ?? ""} onChange={(v) => setForm({ ...form, address_unit: v })} />
+              <Field label="City" required autoComplete="address-level2" value={form.address_city ?? ""} onChange={(v) => setForm({ ...form, address_city: v })} />
+            </TwoCol>
+            <TwoCol>
+              <Field label="State" required autoComplete="address-level1" value={form.address_state ?? ""} onChange={(v) => setForm({ ...form, address_state: v })} />
+              <Field label="ZIP" required autoComplete="postal-code" inputMode="numeric" value={form.address_zip ?? ""} onChange={(v) => setForm({ ...form, address_zip: v })} />
+            </TwoCol>
+          </>
+        )}
+
+        {currentStep.key === "employment" && (
+          <div className="space-y-3 text-sm">
+            <p className="text-gray-500 text-xs">These fields were set by your administrator and can&apos;t be edited here. If something looks wrong, contact your manager.</p>
+            <ReadOnly label="Company"          value={state.admin.company_entity ?? "—"} />
+            <ReadOnly label="Position"         value={state.admin.job_title ?? "—"} />
+            <ReadOnly label="Department"       value={state.admin.department ?? "—"} />
+            <ReadOnly label="Hire Date"        value={state.admin.hire_date ? new Date(state.admin.hire_date).toLocaleDateString() : "—"} />
+            <ReadOnly label="Employment Status" value={state.admin.employment_status ?? "—"} />
+            <ReadOnly label="Pay Type"         value={state.admin.pay_type ?? "—"} />
+            <ReadOnly label="Pay Frequency"    value={state.admin.pay_frequency ?? "—"} />
+          </div>
+        )}
+
+        {currentStep.key === "federal_tax" && (
+          <>
+            <label className="block">
+              <span className="text-xs font-semibold uppercase tracking-wider text-gray-500">Filing Status <span className="text-red-500">*</span></span>
+              <select value={form.filing_status ?? ""} onChange={(e) => setForm({ ...form, filing_status: e.target.value })} className="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm">
+                <option value="">Select…</option>
+                {FILING_STATUSES.map((f) => <option key={f.value} value={f.value}>{f.label}</option>)}
+              </select>
+            </label>
+            <label className="flex items-center gap-2 text-sm">
+              <input type="checkbox" checked={!!form.multiple_jobs} onChange={(e) => setForm({ ...form, multiple_jobs: e.target.checked })} />
+              <span>I have multiple jobs OR my spouse works</span>
+            </label>
+            <TwoCol>
+              <Field label="Qualifying children ($)"     type="number" inputMode="numeric" value={String(form.qualifying_children_amt ?? "")} onChange={(v) => setForm({ ...form, qualifying_children_amt: v ? Number(v) : undefined })} />
+              <Field label="Other dependents ($)"        type="number" inputMode="numeric" value={String(form.other_dependents_amt ?? "")} onChange={(v) => setForm({ ...form, other_dependents_amt: v ? Number(v) : undefined })} />
+              <Field label="Other income (annual $)"     type="number" inputMode="numeric" value={String(form.other_income_cents ? form.other_income_cents / 100 : "")} onChange={(v) => setForm({ ...form, other_income_cents: v ? Math.round(Number(v) * 100) : undefined })} />
+              <Field label="Deductions ($)"              type="number" inputMode="numeric" value={String(form.deductions_cents ? form.deductions_cents / 100 : "")} onChange={(v) => setForm({ ...form, deductions_cents: v ? Math.round(Number(v) * 100) : undefined })} />
+            </TwoCol>
+            <Field label="Additional withholding per pay period ($) — encrypted at rest" type="number" inputMode="numeric" value={addlWithhold} onChange={setAddlWithhold} />
+            <label className="flex items-center gap-2 text-sm">
+              <input type="checkbox" checked={!!form.exempt} onChange={(e) => setForm({ ...form, exempt: e.target.checked })} />
+              <span>I qualify for exempt withholding</span>
+            </label>
+            <p className="text-xs text-gray-500">
+              Vending Connector does not provide tax advice. If you are unsure how to complete your withholding elections, consult a qualified tax professional.
+            </p>
+          </>
+        )}
+
+        {currentStep.key === "state_tax" && (
+          <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+            <div className="font-semibold mb-1">State withholding</div>
+            <p>Work state on file: <strong>{state.admin.work_state ?? "—"}</strong>.</p>
+            <p className="mt-2">State-specific withholding forms are handled separately by your payroll administrator after you submit this packet. No additional entry is required from you here for now.</p>
+          </div>
+        )}
+
+        {currentStep.key === "direct_deposit" && (
+          <>
+            <Field label="Account Holder Name" required autoComplete="name" value={form.account_holder_name ?? ""} onChange={(v) => setForm({ ...form, account_holder_name: v })} />
+            <Field label="Bank Name" required value={form.bank_name ?? ""} onChange={(v) => setForm({ ...form, bank_name: v })} />
+            <label className="block">
+              <span className="text-xs font-semibold uppercase tracking-wider text-gray-500">Account Type <span className="text-red-500">*</span></span>
+              <select value={form.account_type ?? ""} onChange={(e) => setForm({ ...form, account_type: e.target.value })} className="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm">
+                <option value="">Select…</option>
+                {ACCOUNT_TYPES.map((a) => <option key={a.value} value={a.value}>{a.label}</option>)}
+              </select>
+            </label>
+            <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 space-y-3">
+              <div className="flex items-center gap-2 text-sm font-semibold text-amber-900"><ShieldCheck className="h-4 w-4" /> Bank Details (encrypted)</div>
+              {savedKeys.has("bank.routing") && savedKeys.has("bank.account") ? (
+                <div className="text-xs text-amber-800">Routing + account on file. Enter new values only if you need to replace them.</div>
+              ) : null}
+              <SensitiveField label="Routing Number"          value={routing}  onChange={setRouting}  inputMode="numeric" />
+              <SensitiveField label="Confirm Routing Number"  value={routing2} onChange={setRouting2} inputMode="numeric" />
+              <SensitiveField label="Account Number"          value={account}  show={showAcct} onToggle={() => setShowAcct(!showAcct)} onChange={setAccount}  inputMode="numeric" />
+              <SensitiveField label="Confirm Account Number"  value={account2} show={showAcct} onToggle={() => setShowAcct(!showAcct)} onChange={setAccount2} inputMode="numeric" />
+            </div>
+            <p className="text-xs text-gray-500">
+              By continuing, you authorize Vending Connector / Apex AI Vending and its payroll provider to electronically deposit payroll into the specified account and make correcting entries when legally appropriate.
+            </p>
+          </>
+        )}
+
+        {currentStep.key === "w9" && (
+          <>
+            <label className="block">
+              <span className="text-xs font-semibold uppercase tracking-wider text-gray-500">Federal Tax Classification <span className="text-red-500">*</span></span>
+              <select value={form.federal_tax_class ?? ""} onChange={(e) => setForm({ ...form, federal_tax_class: e.target.value })} className="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm">
+                <option value="">Select…</option>
+                {FEDERAL_TAX_CLASSES.map((c) => <option key={c} value={c}>{c}</option>)}
+              </select>
+            </label>
+            <label className="block">
+              <span className="text-xs font-semibold uppercase tracking-wider text-gray-500">TIN Type <span className="text-red-500">*</span></span>
+              <select value={form.tin_type ?? ""} onChange={(e) => setForm({ ...form, tin_type: e.target.value })} className="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm">
+                <option value="">Select…</option>
+                {TIN_TYPES.map((t) => <option key={t.value} value={t.value}>{t.label}</option>)}
+              </select>
+            </label>
+            <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 space-y-3">
+              <div className="flex items-center gap-2 text-sm font-semibold text-amber-900"><ShieldCheck className="h-4 w-4" /> Taxpayer Identification Number</div>
+              {savedKeys.has("tin") ? (
+                <div className="text-xs text-amber-800">On file. Enter a new value only if you need to replace it.</div>
+              ) : null}
+              <SensitiveField label="TIN (9 digits)" value={tin} onChange={setTin} inputMode="numeric" />
+            </div>
+          </>
+        )}
+
+        {currentStep.key === "eligibility" && (
+          <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+            <div className="font-semibold mb-1">Form I-9 — Employment Eligibility</div>
+            <p>Your administrator will guide the I-9 process after you submit this packet. Please have valid identity + employment authorization documents ready to present in person or via the workflow they send you.</p>
+          </div>
+        )}
+
+        {currentStep.key === "emergency" && (
+          <>
+            <TwoCol>
+              <Field label="Emergency Contact Name" value={form.emergency_contact_name ?? ""} onChange={(v) => setForm({ ...form, emergency_contact_name: v })} />
+              <Field label="Relationship"           value={form.emergency_contact_relationship ?? ""} onChange={(v) => setForm({ ...form, emergency_contact_relationship: v })} />
+            </TwoCol>
+            <TwoCol>
+              <Field label="Phone" type="tel" inputMode="tel" value={form.emergency_contact_phone ?? ""} onChange={(v) => setForm({ ...form, emergency_contact_phone: v })} />
+              <Field label="Email" type="email"               value={form.emergency_contact_email ?? ""} onChange={(v) => setForm({ ...form, emergency_contact_email: v })} />
+            </TwoCol>
+          </>
+        )}
+
+        {currentStep.key === "review" && (
+          <div className="space-y-4">
+            <p className="text-sm text-gray-700">Please review the information below. Sensitive values are shown masked — the full values remain encrypted server-side.</p>
+            <ReviewRow k="Legal Name"    v={[form.legal_first_name, form.middle_name, form.legal_last_name].filter(Boolean).join(" ") || "—"} />
+            {state.admin.classification === "w2_employee" && <ReviewRow k="Date of Birth" v={form.date_of_birth ?? "—"} />}
+            <ReviewRow k="Address" v={form.address_street ? `${form.address_street}, ${form.address_city}, ${form.address_state} ${form.address_zip}` : "—"} />
+            {state.admin.classification === "w2_employee" ? (
+              <>
+                <ReviewRow k="SSN" v={form.ssn_last4 ? `***-**-${form.ssn_last4}` : "—"} />
+                <ReviewRow k="Filing Status" v={form.filing_status ?? "—"} />
+              </>
+            ) : (
+              <>
+                <ReviewRow k="Business Name" v={form.business_name ?? "—"} />
+                <ReviewRow k="Federal Tax Class" v={form.federal_tax_class ?? "—"} />
+                <ReviewRow k="TIN" v={form.tin_last4 ? `***-**-${form.tin_last4}` : "—"} />
+              </>
+            )}
+            <ReviewRow k="Bank" v={form.bank_name ? `${form.bank_name} (${form.account_type})` : "—"} />
+            <ReviewRow k="Routing" v={form.routing_last4 ? `••••${form.routing_last4}` : "—"} />
+            <ReviewRow k="Account" v={form.account_last4 ? `••••••${form.account_last4}` : "—"} />
+
+            <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-4 space-y-3">
+              <Field label="Type your legal name to sign" required value={signatureName} onChange={setSignatureName} />
+              <label className="flex items-start gap-2 text-sm text-emerald-900">
+                <input type="checkbox" checked={certified} onChange={(e) => setCertified(e.target.checked)} className="mt-1" />
+                <span>I certify that the information I have provided is complete and accurate to the best of my knowledge.</span>
+              </label>
+            </div>
+          </div>
+        )}
+
+        {error && (
+          <div className="flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"><AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />{error}</div>
+        )}
+
+        <div className="flex flex-wrap items-center justify-between gap-2 border-t border-gray-100 pt-4">
+          <button type="button" disabled={stepIndex === 0 || saving || submitting} onClick={prevStep} className="inline-flex items-center gap-1 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-700 disabled:opacity-40">
+            <ChevronLeft className="h-4 w-4" /> Back
+          </button>
+          {currentStep.key === "review" ? (
+            <button type="button" onClick={submit} disabled={submitting} className="inline-flex items-center gap-2 rounded-lg bg-green-primary px-5 py-2 text-sm font-semibold text-white hover:bg-green-hover disabled:opacity-50">
+              {submitting ? <><Loader2 className="h-4 w-4 animate-spin" /> Submitting…</> : <>Submit Packet <CheckCircle2 className="h-4 w-4" /></>}
+            </button>
+          ) : (
+            <button type="button" onClick={nextStep} disabled={saving} className="inline-flex items-center gap-1 rounded-lg bg-green-primary px-4 py-2 text-sm font-semibold text-white hover:bg-green-hover disabled:opacity-50">
+              {saving ? <><Loader2 className="h-4 w-4 animate-spin" /> Saving…</> : <>Save & Continue <ChevronRight className="h-4 w-4" /></>}
+            </button>
+          )}
+        </div>
+      </div>
+      <p className="mt-4 text-center text-xs text-gray-500">Vending Connector — payroll setup · your data is transmitted over HTTPS and encrypted at rest.</p>
+    </Shell>
+  );
+}
+
+function Shell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-light-warm to-white py-10">
+      <div className="mx-auto max-w-2xl px-4 sm:px-6">{children}</div>
+    </div>
+  );
+}
+
+function TwoCol({ children }: { children: React.ReactNode }) {
+  return <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">{children}</div>;
+}
+
+function Field({ label, value, onChange, required, type = "text", autoComplete, inputMode, placeholder }: {
+  label: string; value: string; onChange: (v: string) => void; required?: boolean;
+  type?: string; autoComplete?: string; inputMode?: React.HTMLAttributes<HTMLInputElement>["inputMode"]; placeholder?: string;
+}) {
+  return (
+    <label className="block">
+      <span className="text-xs font-semibold uppercase tracking-wider text-gray-500">{label}{required && <span className="text-red-500"> *</span>}</span>
+      <input type={type} value={value} onChange={(e) => onChange(e.target.value)} autoComplete={autoComplete} inputMode={inputMode} placeholder={placeholder}
+        className="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2.5 text-base text-gray-900" />
+    </label>
+  );
+}
+
+function ReadOnly({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-start justify-between gap-3 rounded-lg bg-gray-50 px-3 py-2 text-sm">
+      <span className="text-gray-500">{label}</span>
+      <span className="font-medium text-gray-900">{value}</span>
+    </div>
+  );
+}
+
+function SensitiveField({ label, value, onChange, show, onToggle, inputMode }: {
+  label: string; value: string; onChange: (v: string) => void;
+  show?: boolean; onToggle?: () => void; inputMode?: React.HTMLAttributes<HTMLInputElement>["inputMode"];
+}) {
+  return (
+    <label className="block">
+      <span className="text-xs font-medium text-gray-700">{label}</span>
+      <div className="relative">
+        <input type={show ? "text" : "password"} value={value} onChange={(e) => onChange(e.target.value)}
+          autoComplete="off" spellCheck={false} inputMode={inputMode}
+          className="mt-1 w-full rounded-lg border border-gray-200 bg-white px-3 py-2.5 pr-9 text-base font-mono text-gray-900" />
+        {onToggle && (
+          <button type="button" onClick={onToggle} className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-gray-400 hover:bg-gray-100" aria-label={show ? "Hide" : "Show"}>
+            {show ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+          </button>
+        )}
+      </div>
+    </label>
+  );
+}
+
+function ReviewRow({ k, v }: { k: string; v: string }) {
+  return (
+    <div className="flex items-start justify-between gap-3 border-b border-gray-100 py-2 text-sm">
+      <span className="text-gray-500">{k}</span>
+      <span className="font-medium text-gray-900 text-right">{v}</span>
+    </div>
+  );
+}

--- a/src/app/sales/team/AddToPayrollModal.tsx
+++ b/src/app/sales/team/AddToPayrollModal.tsx
@@ -1,0 +1,274 @@
+"use client";
+
+/**
+ * "Add to Payroll" modal opened from /sales/team.
+ *
+ * Admin picks classification (W-2 or 1099), enters employment /
+ * comp info, and fires POST /api/admin/payroll/profiles which
+ * creates the payroll_profiles row + issues a token + sends the
+ * secure invitation email in one shot.
+ *
+ * WORKER info (name / SSN / address / tax / bank) is deliberately
+ * NOT collected here — that flows through the /payroll/{token}
+ * portal so the worker submits their own sensitive data over the
+ * secure path.
+ */
+
+import { useState, useEffect } from "react";
+import { X, Loader2, Send, CheckCircle2, AlertCircle, Coins } from "lucide-react";
+import {
+  CLASSIFICATION_LABELS,
+  COMPANY_ENTITIES,
+  EMPLOYMENT_STATUSES,
+  PAY_FREQUENCIES,
+  PAY_TYPES,
+  type PayrollClassification,
+} from "@/lib/payroll/constants";
+
+interface Props {
+  memberId: string;
+  memberName: string;
+  memberEmail: string;
+  token: string;
+  onClose: () => void;
+  onSent?: () => void;
+}
+
+export default function AddToPayrollModal({ memberId, memberName, memberEmail, token, onClose, onSent }: Props) {
+  const [classification, setClassification] = useState<PayrollClassification>("w2_employee");
+  const [companyEntity, setCompanyEntity] = useState<string>(COMPANY_ENTITIES[0]);
+  const [jobTitle, setJobTitle] = useState("");
+  const [department, setDepartment] = useState("");
+  const [workLocation, setWorkLocation] = useState("");
+  const [employmentStatus, setEmploymentStatus] = useState("full_time");
+  const [hireDate, setHireDate] = useState("");
+  const [payType, setPayType] = useState("hourly");
+  const [payFrequency, setPayFrequency] = useState("biweekly");
+  const [hourlyRate, setHourlyRate] = useState("");
+  const [annualSalary, setAnnualSalary] = useState("");
+  const [commissionNotes, setCommissionNotes] = useState("");
+  const [expectedHours, setExpectedHours] = useState("");
+  const [overtimeEligible, setOvertimeEligible] = useState(false);
+  const [compensationNotes, setCompensationNotes] = useState("");
+  const [recipient, setRecipient] = useState(memberEmail);
+  const [workState, setWorkState] = useState("");
+  const [phase, setPhase] = useState<"edit" | "sending" | "done">("edit");
+  const [error, setError] = useState<string | null>(null);
+  const [okMessage, setOkMessage] = useState<string | null>(null);
+
+  useEffect(() => { setRecipient(memberEmail); }, [memberEmail]);
+
+  const showHourly = payType === "hourly" || payType === "hourly_commission";
+  const showSalary = payType === "salary" || payType === "salary_commission";
+  const showCommission = payType === "commission" || payType === "hourly_commission" || payType === "salary_commission" || payType === "commission_only";
+
+  async function send() {
+    setPhase("sending");
+    setError(null);
+    try {
+      const payload: Record<string, unknown> = {
+        team_member_id: memberId,
+        classification,
+        company_entity: companyEntity,
+        job_title: jobTitle || null,
+        department: department || null,
+        work_location: workLocation || null,
+        employment_status: employmentStatus,
+        hire_date: hireDate || null,
+        pay_type: payType,
+        pay_frequency: payFrequency,
+        overtime_eligible: overtimeEligible,
+        expected_hours_per_week: expectedHours ? Number(expectedHours) : null,
+        commission_notes: showCommission ? (commissionNotes || null) : null,
+        compensation_notes: compensationNotes || null,
+        recipient_email: recipient,
+        work_state: workState || null,
+      };
+      if (showHourly && hourlyRate) payload.hourly_rate_cents = Math.round(Number(hourlyRate) * 100);
+      if (showSalary && annualSalary) payload.annual_salary_cents = Math.round(Number(annualSalary) * 100);
+
+      const res = await fetch("/api/admin/payroll/profiles", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+        body: JSON.stringify(payload),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(json.error || `Failed (${res.status})`);
+      setOkMessage(`Payroll invitation sent to ${memberName} at ${recipient}.`);
+      setPhase("done");
+      onSent?.();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Send failed.");
+      setPhase("edit");
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-[9999] flex items-start justify-center bg-black/50 p-4 overflow-y-auto" role="dialog" aria-modal="true">
+      <div className="mt-10 w-full max-w-2xl rounded-2xl bg-white shadow-2xl mb-10">
+        <div className="flex items-start justify-between gap-4 border-b border-gray-100 px-6 py-5">
+          <div>
+            <div className="flex items-center gap-2">
+              <Coins className="h-5 w-5 text-green-primary" />
+              <h2 className="text-lg font-semibold text-gray-900">Add to Payroll</h2>
+            </div>
+            <p className="mt-1 text-sm text-gray-500">
+              Team Member: <span className="font-medium text-gray-800">{memberName}</span>
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={phase === "sending"}
+            className="rounded-lg p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-700"
+            aria-label="Close"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {phase === "edit" && (
+          <div className="p-6 space-y-5">
+            {/* Worker classification */}
+            <div className="rounded-xl border border-amber-200 bg-amber-50 p-4">
+              <label className="block text-xs font-semibold uppercase tracking-wider text-amber-800 mb-2">
+                Worker Classification (admin decides — worker cannot change)
+              </label>
+              <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                {(["w2_employee", "1099_contractor"] as PayrollClassification[]).map((v) => (
+                  <label key={v} className={`flex cursor-pointer items-center gap-2 rounded-lg border px-3 py-2 text-sm ${classification === v ? "border-amber-600 bg-white ring-2 ring-amber-500" : "border-amber-200 bg-white/70 hover:bg-white"}`}>
+                    <input type="radio" name="classification" value={v} checked={classification === v} onChange={() => setClassification(v)} />
+                    <span className="font-medium text-gray-800">{CLASSIFICATION_LABELS[v]}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+
+            {/* Company + recipient email */}
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <label className="block">
+                <span className="text-xs font-semibold uppercase tracking-wider text-gray-500">Company / Payroll Entity</span>
+                <select value={companyEntity} onChange={(e) => setCompanyEntity(e.target.value)} className="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm">
+                  {COMPANY_ENTITIES.map((c) => <option key={c} value={c}>{c}</option>)}
+                </select>
+              </label>
+              <label className="block">
+                <span className="text-xs font-semibold uppercase tracking-wider text-gray-500">Send To</span>
+                <input type="email" value={recipient} onChange={(e) => setRecipient(e.target.value)} className="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm" />
+              </label>
+            </div>
+
+            {/* Employment */}
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <TextField label="Job Title"      value={jobTitle}      onChange={setJobTitle} />
+              <TextField label="Department"     value={department}    onChange={setDepartment} />
+              <TextField label="Work Location"  value={workLocation}  onChange={setWorkLocation} />
+              <label className="block">
+                <span className="text-xs font-semibold uppercase tracking-wider text-gray-500">Employment Status</span>
+                <select value={employmentStatus} onChange={(e) => setEmploymentStatus(e.target.value)} className="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm">
+                  {EMPLOYMENT_STATUSES.map((s) => <option key={s.value} value={s.value}>{s.label}</option>)}
+                </select>
+              </label>
+              <label className="block">
+                <span className="text-xs font-semibold uppercase tracking-wider text-gray-500">Hire / Start Date</span>
+                <input type="date" value={hireDate} onChange={(e) => setHireDate(e.target.value)} className="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm" />
+              </label>
+              <TextField label="Work State (2-letter)" value={workState} onChange={setWorkState} placeholder="e.g. SC" />
+            </div>
+
+            {/* Compensation */}
+            <div className="rounded-xl border border-gray-200 bg-gray-50/60 p-4 space-y-3">
+              <div className="text-xs font-semibold uppercase tracking-wider text-gray-500">Compensation</div>
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                <label className="block">
+                  <span className="text-xs font-medium text-gray-600">Pay Type</span>
+                  <select value={payType} onChange={(e) => setPayType(e.target.value)} className="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm">
+                    {PAY_TYPES.map((p) => <option key={p.value} value={p.value}>{p.label}</option>)}
+                  </select>
+                </label>
+                <label className="block">
+                  <span className="text-xs font-medium text-gray-600">Pay Frequency</span>
+                  <select value={payFrequency} onChange={(e) => setPayFrequency(e.target.value)} className="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm">
+                    {PAY_FREQUENCIES.map((p) => <option key={p.value} value={p.value}>{p.label}</option>)}
+                  </select>
+                </label>
+                {showHourly && (
+                  <TextField label="Hourly Rate ($/hr)" value={hourlyRate} onChange={setHourlyRate} type="number" placeholder="e.g. 25.00" />
+                )}
+                {showSalary && (
+                  <TextField label="Annual Salary ($)" value={annualSalary} onChange={setAnnualSalary} type="number" placeholder="e.g. 65000" />
+                )}
+                <TextField label="Expected Hours / Week" value={expectedHours} onChange={setExpectedHours} type="number" placeholder="e.g. 40" />
+                <label className="flex items-center gap-2 mt-6">
+                  <input type="checkbox" checked={overtimeEligible} onChange={(e) => setOvertimeEligible(e.target.checked)} />
+                  <span className="text-sm text-gray-700">Overtime eligible</span>
+                </label>
+              </div>
+              {showCommission && (
+                <label className="block">
+                  <span className="text-xs font-medium text-gray-600">Commission structure / notes</span>
+                  <textarea rows={2} value={commissionNotes} onChange={(e) => setCommissionNotes(e.target.value)} className="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm" />
+                </label>
+              )}
+              <label className="block">
+                <span className="text-xs font-medium text-gray-600">Additional compensation notes</span>
+                <textarea rows={2} value={compensationNotes} onChange={(e) => setCompensationNotes(e.target.value)} className="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm" />
+              </label>
+            </div>
+
+            {error && (
+              <div className="flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+                <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+                <span>{error}</span>
+              </div>
+            )}
+            <div className="flex items-center justify-end gap-2 border-t border-gray-100 pt-4">
+              <button type="button" onClick={onClose} className="rounded-lg px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-100">Cancel</button>
+              <button type="button" onClick={send} className="inline-flex items-center gap-1.5 rounded-lg bg-green-primary px-4 py-2 text-sm font-semibold text-white hover:bg-green-hover">
+                <Send className="h-4 w-4" />
+                Send Payroll Setup
+              </button>
+            </div>
+          </div>
+        )}
+
+        {phase === "sending" && (
+          <div className="flex flex-col items-center justify-center gap-3 p-10 text-sm text-gray-600">
+            <Loader2 className="h-6 w-6 animate-spin text-green-primary" />
+            Creating payroll profile and sending invitation…
+          </div>
+        )}
+
+        {phase === "done" && (
+          <div className="p-6 space-y-4">
+            <div className="flex flex-col items-center gap-3 rounded-xl border border-emerald-200 bg-emerald-50 p-6 text-center">
+              <CheckCircle2 className="h-8 w-8 text-emerald-600" />
+              <p className="text-sm font-semibold text-emerald-800">{okMessage}</p>
+              <p className="text-xs text-emerald-700">
+                They&apos;ll receive a secure link to enter their tax, address, and banking details.
+              </p>
+            </div>
+            <div className="flex items-center justify-end">
+              <button type="button" onClick={onClose} className="rounded-lg bg-green-primary px-4 py-2 text-sm font-semibold text-white hover:bg-green-hover">Done</button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TextField({ label, value, onChange, type = "text", placeholder }: { label: string; value: string; onChange: (v: string) => void; type?: string; placeholder?: string }) {
+  return (
+    <label className="block">
+      <span className="text-xs font-semibold uppercase tracking-wider text-gray-500">{label}</span>
+      <input
+        type={type}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm text-gray-900"
+      />
+    </label>
+  );
+}

--- a/src/app/sales/team/page.tsx
+++ b/src/app/sales/team/page.tsx
@@ -4,8 +4,9 @@ import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { createBrowserClient } from "@/lib/supabase";
-import { Users, Loader2, Search, CheckCircle2, Clock, UserX, AlertTriangle, Plus, X, Eye, EyeOff, UserPlus, Trash2, Send, FileSignature, ClipboardCheck, Key } from "lucide-react";
+import { Users, Loader2, Search, CheckCircle2, Clock, UserX, AlertTriangle, Plus, X, Eye, EyeOff, UserPlus, Trash2, Send, FileSignature, ClipboardCheck, Key, Coins } from "lucide-react";
 import SendCredentialsModal from "./SendCredentialsModal";
+import AddToPayrollModal from "./AddToPayrollModal";
 
 interface TeamMember {
   id: string;
@@ -80,6 +81,9 @@ export default function TeamPage() {
   // Send Credentials modal — one open at a time, keyed by member.
   const [credentialsTarget, setCredentialsTarget] = useState<TeamMember | null>(null);
   const [credentialsToast, setCredentialsToast] = useState<string | null>(null);
+  // Add to Payroll modal — one open at a time, keyed by member.
+  const [payrollTarget, setPayrollTarget] = useState<TeamMember | null>(null);
+  const [payrollToast, setPayrollToast] = useState<string | null>(null);
 
   const loadTeamMembers = useCallback(async (t: string) => {
     const res = await fetch("/api/sales/users", { headers: { Authorization: `Bearer ${t}` } });
@@ -482,6 +486,15 @@ export default function TeamPage() {
                         >
                           <Key className="h-4 w-4" />
                         </button>
+                        <button
+                          type="button"
+                          onClick={() => setPayrollTarget(m)}
+                          className="inline-flex items-center gap-1 rounded-md p-1.5 text-gray-300 hover:bg-green-50 hover:text-green-600 transition-colors"
+                          title={`Add ${m.full_name || m.email} to payroll`}
+                          aria-label={`Add ${m.full_name || m.email} to payroll`}
+                        >
+                          <Coins className="h-4 w-4" />
+                        </button>
                         {m.id !== currentUserId && (
                           <button
                             type="button"
@@ -777,6 +790,28 @@ export default function TeamPage() {
           className="fixed bottom-6 right-6 z-[10000] max-w-sm rounded-lg border border-emerald-200 bg-white px-4 py-3 text-sm text-emerald-800 shadow-lg"
         >
           {credentialsToast}
+        </div>
+      )}
+
+      {payrollTarget && (
+        <AddToPayrollModal
+          memberId={payrollTarget.id}
+          memberName={payrollTarget.full_name || payrollTarget.email}
+          memberEmail={payrollTarget.email}
+          token={token}
+          onClose={() => setPayrollTarget(null)}
+          onSent={() => {
+            setPayrollToast(`Payroll invitation sent to ${payrollTarget?.full_name || payrollTarget?.email}.`);
+            window.setTimeout(() => setPayrollToast(null), 6_000);
+          }}
+        />
+      )}
+      {payrollToast && (
+        <div
+          role="status"
+          className="fixed bottom-6 right-6 z-[10000] max-w-sm rounded-lg border border-emerald-200 bg-white px-4 py-3 text-sm text-emerald-800 shadow-lg"
+        >
+          {payrollToast}
         </div>
       )}
     </div>

--- a/src/lib/payroll/constants.ts
+++ b/src/lib/payroll/constants.ts
@@ -1,0 +1,118 @@
+/**
+ * Shared constants for the Payroll Onboarding module. Consumed by
+ * both admin and worker surfaces so status/label semantics stay in
+ * one place.
+ */
+
+export type PayrollClassification = "w2_employee" | "1099_contractor";
+export type PayrollStatus =
+  | "not_added"
+  | "invite_ready"
+  | "invite_sent"
+  | "in_progress"
+  | "employee_action_required"
+  | "admin_review_required"
+  | "ready_for_quickbooks"
+  | "payroll_active"
+  | "update_requested"
+  | "inactive";
+
+export const STATUS_LABELS: Record<PayrollStatus, string> = {
+  not_added: "Not Added",
+  invite_ready: "Invite Ready",
+  invite_sent: "Invite Sent",
+  in_progress: "In Progress",
+  employee_action_required: "Employee Action Required",
+  admin_review_required: "Admin Review Required",
+  ready_for_quickbooks: "Ready for QuickBooks",
+  payroll_active: "Payroll Active",
+  update_requested: "Update Requested",
+  inactive: "Inactive",
+};
+
+export const STATUS_TONES: Record<PayrollStatus, string> = {
+  not_added: "bg-gray-100 text-gray-600 ring-gray-200",
+  invite_ready: "bg-sky-50 text-sky-700 ring-sky-200",
+  invite_sent: "bg-blue-50 text-blue-700 ring-blue-200",
+  in_progress: "bg-indigo-50 text-indigo-700 ring-indigo-200",
+  employee_action_required: "bg-amber-50 text-amber-700 ring-amber-200",
+  admin_review_required: "bg-purple-50 text-purple-700 ring-purple-200",
+  ready_for_quickbooks: "bg-emerald-50 text-emerald-700 ring-emerald-200",
+  payroll_active: "bg-green-100 text-green-800 ring-green-300",
+  update_requested: "bg-orange-50 text-orange-700 ring-orange-200",
+  inactive: "bg-gray-100 text-gray-500 line-through ring-gray-200",
+};
+
+export const CLASSIFICATION_LABELS: Record<PayrollClassification, string> = {
+  w2_employee: "W-2 Employee",
+  "1099_contractor": "1099 Independent Contractor",
+};
+
+export const PAY_TYPES = [
+  { value: "hourly",             label: "Hourly" },
+  { value: "salary",             label: "Salary" },
+  { value: "commission",         label: "Commission" },
+  { value: "hourly_commission",  label: "Hourly + Commission" },
+  { value: "salary_commission",  label: "Salary + Commission" },
+  { value: "commission_only",    label: "Commission Only" },
+] as const;
+
+export const PAY_FREQUENCIES = [
+  { value: "weekly",       label: "Weekly" },
+  { value: "biweekly",     label: "Bi-weekly" },
+  { value: "semimonthly",  label: "Semi-monthly" },
+  { value: "monthly",      label: "Monthly" },
+] as const;
+
+export const EMPLOYMENT_STATUSES = [
+  { value: "full_time",  label: "Full-time" },
+  { value: "part_time",  label: "Part-time" },
+  { value: "temporary",  label: "Temporary" },
+  { value: "other",      label: "Other" },
+] as const;
+
+export const FILING_STATUSES = [
+  { value: "single", label: "Single or Married Filing Separately" },
+  { value: "mfj",    label: "Married Filing Jointly or Qualifying Surviving Spouse" },
+  { value: "hoh",    label: "Head of Household" },
+] as const;
+
+export const ACCOUNT_TYPES = [
+  { value: "checking", label: "Checking" },
+  { value: "savings",  label: "Savings" },
+] as const;
+
+export const TIN_TYPES = [
+  { value: "ssn", label: "SSN" },
+  { value: "ein", label: "EIN" },
+] as const;
+
+export const FEDERAL_TAX_CLASSES = [
+  "Individual/sole proprietor",
+  "Single-member LLC",
+  "C corporation",
+  "S corporation",
+  "Partnership",
+  "Trust/estate",
+  "LLC (C corp taxation)",
+  "LLC (S corp taxation)",
+  "LLC (Partnership taxation)",
+  "Other",
+] as const;
+
+// The list of legal entities admin can pick from when configuring a
+// payroll profile. Kept short + editable — extend when new legal
+// entities are added to the business.
+export const COMPANY_ENTITIES = [
+  "Apex AI Vending LLP",
+  "Vending Connector",
+] as const;
+
+/** Sensitive field keys stored in payroll_encrypted. */
+export const ENCRYPTED_FIELD_KEYS = [
+  "ssn",
+  "tin",
+  "bank.routing",
+  "bank.account",
+  "w4.additional_withholding_cents",
+] as const;

--- a/src/lib/payroll/emails.ts
+++ b/src/lib/payroll/emails.ts
@@ -1,0 +1,128 @@
+import { Resend } from "resend";
+import { APEX_ADMIN_NOTIFY } from "@/lib/adminNotifyRecipients";
+
+/**
+ * Payroll onboarding transactional emails.
+ *
+ * Security constraints (per spec §"SECURITY ARCHITECTURE")
+ *   * Never include an SSN, TIN, bank number, or W-4 amount in an
+ *     email body — even in an admin-facing notification. Emails
+ *     carry names + status + a link to log in.
+ *   * The invitation URL contains the raw one-time token (that IS
+ *     the credential); no other payroll data appears in the URL.
+ */
+
+const FROM = process.env.FROM_EMAIL || "onboarding@bytebitevending.com";
+const REPLY_TO = process.env.PAYROLL_REPLY_TO || "james@apexaivending.com";
+
+let _resend: Resend | null = null;
+function getResend(): Resend {
+  if (!_resend) {
+    const key = process.env.RESEND_API_KEY;
+    if (!key) throw new Error("RESEND_API_KEY not configured");
+    _resend = new Resend(key);
+  }
+  return _resend;
+}
+
+function shell(body: string): string {
+  return `<div style="font-family:-apple-system,'Segoe UI',Inter,Arial,sans-serif;max-width:600px;margin:0 auto;padding:24px;color:#111">
+    <div style="margin-bottom:20px">
+      <div style="font-size:11px;font-weight:700;letter-spacing:0.15em;color:#16A34A;text-transform:uppercase">
+        Vending Connector · Apex AI Vending
+      </div>
+    </div>
+    ${body}
+    <p style="color:#888;font-size:11px;margin-top:32px;border-top:1px solid #eee;padding-top:12px;line-height:1.6">
+      Questions? Reply to this email or contact <a href="mailto:${REPLY_TO}" style="color:#16A34A">${REPLY_TO}</a>.
+    </p>
+  </div>`;
+}
+
+function esc(s: string | null | undefined): string {
+  if (s == null) return "";
+  return String(s).replace(/[&<>"']/g, (c) => ({
+    "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;",
+  }[c] as string));
+}
+
+/** Employee/contractor invitation to complete their payroll packet. */
+export async function sendPayrollInvitationEmail(args: {
+  toEmail: string;
+  recipientName: string | null;
+  classification: "w2_employee" | "1099_contractor";
+  packetUrl: string;
+  companyName?: string | null;
+}): Promise<void> {
+  const first = (args.recipientName || "there").trim().split(/\s+/)[0];
+  const classLabel = args.classification === "w2_employee" ? "W-2 employee" : "1099 contractor";
+  const html = shell(`
+    <h1 style="font-size:22px;font-weight:700;margin:0 0 12px">Complete Your Payroll Setup</h1>
+    <p style="line-height:1.6;color:#374151;margin:0 0 12px">Hi ${esc(first)},</p>
+    <p style="line-height:1.6;color:#374151;margin:0 0 12px">
+      Welcome to the team! We need a few pieces of information from you before we can complete your payroll setup as a <strong>${esc(classLabel)}</strong>${args.companyName ? ` at <strong>${esc(args.companyName)}</strong>` : ""}.
+    </p>
+    <p style="line-height:1.6;color:#374151;margin:0 0 16px">
+      Please use the secure link below to complete your payroll information.
+    </p>
+    <p style="margin:0 0 20px">
+      <a href="${esc(args.packetUrl)}" style="display:inline-block;background:#16A34A;color:#fff;padding:12px 20px;border-radius:8px;text-decoration:none;font-weight:600">Complete Payroll Setup</a>
+    </p>
+    <p style="line-height:1.5;color:#6b7280;font-size:12px;margin:16px 0 0">
+      <strong>For your security</strong>, please do not email Social Security numbers, banking information, tax forms, or other sensitive information to us — the secure link above is the only intended way to submit that data.
+    </p>
+    <p style="line-height:1.5;color:#6b7280;font-size:12px;margin:8px 0 0">
+      If you have any questions regarding your payroll setup, please contact your manager.
+    </p>
+    <p style="line-height:1.6;color:#374151;margin:16px 0 0">Thank you,<br>Vending Connector</p>
+  `);
+
+  const result = await getResend().emails.send({
+    from: FROM,
+    to: [args.toEmail],
+    replyTo: REPLY_TO,
+    subject: "Complete Your Payroll Setup – Vending Connector",
+    html,
+  });
+  if (result.error) {
+    throw new Error(`Resend rejected payroll invitation: ${result.error.message}`);
+  }
+}
+
+/** Admin notification when a worker submits their packet. Names + status only. */
+export async function sendPayrollAdminReviewEmail(args: {
+  recipientName: string | null;
+  recipientEmail: string;
+  classification: "w2_employee" | "1099_contractor";
+  reviewUrl: string;
+}): Promise<void> {
+  const classLabel = args.classification === "w2_employee" ? "W-2 employee" : "1099 contractor";
+  const html = shell(`
+    <h1 style="font-size:20px;font-weight:700;margin:0 0 12px">Payroll onboarding completed</h1>
+    <p style="line-height:1.6;color:#374151;margin:0 0 12px">
+      A payroll packet has been submitted and is ready for administrator review.
+    </p>
+    <div style="background:#f9fafb;border:1px solid #e5e7eb;border-radius:10px;padding:16px;margin:12px 0">
+      <div style="font-size:14px;color:#111827"><strong>Worker:</strong> ${esc(args.recipientName ?? args.recipientEmail)}</div>
+      <div style="font-size:14px;color:#111827"><strong>Email:</strong> ${esc(args.recipientEmail)}</div>
+      <div style="font-size:14px;color:#111827"><strong>Classification:</strong> ${esc(classLabel)}</div>
+    </div>
+    <p style="line-height:1.6;color:#374151;margin:0 0 12px">
+      Log in to Vending Connector to review the record. Sensitive fields (SSN, TIN, bank details) remain masked in the CRM and are never included in this notification.
+    </p>
+    <p style="margin:0 0 20px">
+      <a href="${esc(args.reviewUrl)}" style="display:inline-block;background:#16A34A;color:#fff;padding:10px 18px;border-radius:8px;text-decoration:none;font-weight:600">Open payroll record</a>
+    </p>
+  `);
+  const result = await getResend().emails.send({
+    from: FROM,
+    to: [...APEX_ADMIN_NOTIFY],
+    replyTo: REPLY_TO,
+    subject: `Payroll onboarding completed for ${args.recipientName ?? args.recipientEmail}`,
+    html,
+  });
+  if (result.error) {
+    console.error("[payroll] admin review email failed:", result.error.message);
+    // non-fatal — submission already succeeded
+  }
+}

--- a/src/lib/payroll/encryption.ts
+++ b/src/lib/payroll/encryption.ts
@@ -1,0 +1,110 @@
+import crypto from "node:crypto";
+
+/**
+ * Field-level AES-256-GCM encryption for payroll PII.
+ *
+ * Used for every sensitive value the worker submits — SSN, TIN, full
+ * bank routing/account numbers, W-4 additional-withholding amounts,
+ * anything else classified as sensitive.
+ *
+ * Key management
+ *   * The 32-byte master key is read from PAYROLL_ENCRYPTION_KEY
+ *     (base64-encoded 32 bytes). Missing / wrong-size key throws at
+ *     first encrypt call — deliberate: silent-plaintext fallback
+ *     would be a critical security bug.
+ *   * `key_version` is stamped on every ciphertext row so we can
+ *     rotate later by adding a KEY_V2 without re-encrypting live
+ *     rows in a single migration.
+ *   * NEVER expose the key over any API, log line, or error message.
+ *
+ * The ciphertext, iv, and auth tag are all stored as base64 strings
+ * on payroll_encrypted (see migration 157).
+ */
+
+const KEY_LEN = 32; // 256 bits
+const IV_LEN = 12;  // 96 bits — recommended for GCM
+const KEY_VERSION = 1;
+
+let _cachedKey: Buffer | null = null;
+function getMasterKey(): Buffer {
+  if (_cachedKey) return _cachedKey;
+  const raw = process.env.PAYROLL_ENCRYPTION_KEY;
+  if (!raw) {
+    throw new Error(
+      "PAYROLL_ENCRYPTION_KEY env var is not set — refusing to persist plaintext payroll data.",
+    );
+  }
+  let decoded: Buffer;
+  try {
+    decoded = Buffer.from(raw, "base64");
+  } catch {
+    throw new Error("PAYROLL_ENCRYPTION_KEY must be base64-encoded 32 bytes.");
+  }
+  if (decoded.length !== KEY_LEN) {
+    throw new Error(
+      `PAYROLL_ENCRYPTION_KEY must decode to exactly ${KEY_LEN} bytes (got ${decoded.length}).`,
+    );
+  }
+  _cachedKey = decoded;
+  return decoded;
+}
+
+export interface EncryptedField {
+  ciphertext: string;
+  iv: string;
+  auth_tag: string;
+  key_version: number;
+}
+
+export function encryptField(plaintext: string): EncryptedField {
+  if (plaintext == null) throw new Error("encryptField requires a plaintext string.");
+  const key = getMasterKey();
+  const iv = crypto.randomBytes(IV_LEN);
+  const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return {
+    ciphertext: encrypted.toString("base64"),
+    iv: iv.toString("base64"),
+    auth_tag: tag.toString("base64"),
+    key_version: KEY_VERSION,
+  };
+}
+
+export function decryptField(row: {
+  ciphertext: string;
+  iv: string;
+  auth_tag: string;
+  key_version?: number;
+}): string {
+  const key = getMasterKey();
+  const decipher = crypto.createDecipheriv(
+    "aes-256-gcm",
+    key,
+    Buffer.from(row.iv, "base64"),
+  );
+  decipher.setAuthTag(Buffer.from(row.auth_tag, "base64"));
+  const decrypted = Buffer.concat([
+    decipher.update(Buffer.from(row.ciphertext, "base64")),
+    decipher.final(),
+  ]);
+  return decrypted.toString("utf8");
+}
+
+/** Return the last 4 characters — used for UI display of SSN/bank/TIN. */
+export function last4(value: string): string {
+  if (!value) return "";
+  return value.slice(-4);
+}
+
+/** UI mask helpers — never send full values to the browser. */
+export function maskSsn(last: string): string {
+  return `***-**-${last}`;
+}
+export function maskBankAccount(last: string): string {
+  return `••••••${last}`;
+}
+export function maskTin(last: string, kind: "ssn" | "ein" | null): string {
+  if (kind === "ein") return `**-*****${last.slice(-1)}`;
+  return `***-**-${last}`;
+}

--- a/src/lib/payroll/token.ts
+++ b/src/lib/payroll/token.ts
@@ -1,0 +1,43 @@
+import crypto from "node:crypto";
+
+/**
+ * Payroll invitation token helpers. Same design as
+ * src/lib/contractorOnboarding/token.ts — kept independent so
+ * either flow can evolve without dragging the other.
+ *
+ * Raw token = 32 random bytes → base64url. Stored only as its
+ * SHA-256 hash. Verified with timingSafeEqual.
+ */
+
+const DEFAULT_TTL_DAYS = 21;
+
+export interface GeneratedToken {
+  raw: string;
+  hash: string;
+  expiresAt: string;
+}
+
+export function generatePayrollToken(ttlDays = DEFAULT_TTL_DAYS): GeneratedToken {
+  const raw = crypto.randomBytes(32).toString("base64url");
+  const hash = hashToken(raw);
+  const expiresAt = new Date(Date.now() + ttlDays * 24 * 60 * 60 * 1000).toISOString();
+  return { raw, hash, expiresAt };
+}
+
+export function hashToken(raw: string): string {
+  return crypto.createHash("sha256").update(raw, "utf8").digest("hex");
+}
+
+export function verifyToken(raw: string, storedHash: string): boolean {
+  if (!raw || !storedHash) return false;
+  const computed = hashToken(raw);
+  if (computed.length !== storedHash.length) return false;
+  try {
+    return crypto.timingSafeEqual(
+      Buffer.from(computed, "hex"),
+      Buffer.from(storedHash, "hex"),
+    );
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/payroll/tokenLookup.ts
+++ b/src/lib/payroll/tokenLookup.ts
@@ -1,0 +1,44 @@
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { hashToken } from "./token";
+
+/**
+ * Resolve a raw payroll invitation token to its profile + status
+ * flags. Used by every /api/payroll/[token]/* handler.
+ *
+ * Consumers should treat null as "invalid/expired/revoked" and
+ * return a 404 without leaking why (avoid enumeration).
+ */
+export interface ResolvedToken {
+  invitation_id: string;
+  profile_id: string;
+  expires_at: string;
+  used_at: string | null;
+  revoked_at: string | null;
+}
+
+export async function resolveRawPayrollToken(raw: string): Promise<ResolvedToken | null> {
+  if (!raw || raw.length < 20) return null;
+  const hash = hashToken(raw);
+  const { data } = await supabaseAdmin
+    .from("payroll_invitations")
+    .select("id, profile_id, expires_at, used_at, revoked_at")
+    .eq("token_hash", hash)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (!data) return null;
+  return {
+    invitation_id: data.id as string,
+    profile_id: data.profile_id as string,
+    expires_at: data.expires_at as string,
+    used_at: (data.used_at as string | null) ?? null,
+    revoked_at: (data.revoked_at as string | null) ?? null,
+  };
+}
+
+export function isTokenLive(tok: ResolvedToken): boolean {
+  if (tok.revoked_at) return false;
+  if (tok.used_at) return false;
+  if (new Date(tok.expires_at).getTime() < Date.now()) return false;
+  return true;
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -50,6 +50,7 @@ const PUBLIC_PREFIXES = [
   "/auth/",                  // Supabase OAuth / email-callback landing
   "/onboarding/",            // contractor onboarding — /onboarding/{token}
   "/sign/",                  // agreement signing — /sign/{token}
+  "/payroll/",               // payroll onboarding — /payroll/{token}
   "/placement/onboarding",   // placement provider self-serve intake
   "/coffee/claim",           // token-based coffee brewer claim
   "/coffee/guest-checkout",

--- a/supabase/migrations/157_payroll_onboarding.sql
+++ b/supabase/migrations/157_payroll_onboarding.sql
@@ -1,0 +1,260 @@
+-- Migration 157: Payroll onboarding — schema, private bucket, RLS
+--
+-- Backs the "Add to Payroll" workflow off the Team page. Data model
+-- separates concerns:
+--   * payroll_profiles       — one row per team member being onboarded;
+--                              holds admin-set job / comp fields, worker
+--                              classification, and lifecycle status.
+--   * payroll_invitations    — secure token records (hashed only, raw
+--                              never persisted). One profile can have
+--                              multiple invites (re-sends, revocations).
+--   * payroll_encrypted      — key-value store of AES-256-GCM-encrypted
+--                              sensitive fields (SSN, TIN, bank details,
+--                              W-4 elections). App-level encryption so
+--                              service-role queries never surface
+--                              plaintext without going through the
+--                              decrypt helper.
+--   * payroll_audit_events   — every access + change. Never carries a
+--                              sensitive field VALUE, only labels.
+--
+-- Private bucket 'payroll-documents' for any uploads (I-9 supporting
+-- docs, bank verification if opted in). Signed URLs only — no public
+-- read policy.
+
+-- ─────────────────────────────────────────────────────────────
+-- 1. Enums
+-- ─────────────────────────────────────────────────────────────
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'payroll_classification') THEN
+    CREATE TYPE payroll_classification AS ENUM ('w2_employee', '1099_contractor');
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'payroll_status') THEN
+    CREATE TYPE payroll_status AS ENUM (
+      'not_added',
+      'invite_ready',
+      'invite_sent',
+      'in_progress',
+      'employee_action_required',
+      'admin_review_required',
+      'ready_for_quickbooks',
+      'payroll_active',
+      'update_requested',
+      'inactive'
+    );
+  END IF;
+END $$;
+
+-- ─────────────────────────────────────────────────────────────
+-- 2. payroll_profiles
+-- ─────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.payroll_profiles (
+  id                        uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  team_member_id            uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  created_by_user_id        uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+
+  -- Admin-set (worker cannot change)
+  classification            payroll_classification NOT NULL,
+  job_title                 text,
+  department                text,
+  manager_user_id           uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+  work_location             text,
+  employment_status         text, -- full_time | part_time | temporary | other
+  hire_date                 date,
+  pay_type                  text, -- hourly | salary | commission | hourly_commission | salary_commission | commission_only
+  pay_frequency             text, -- weekly | biweekly | semimonthly | monthly
+  hourly_rate_cents         integer,
+  annual_salary_cents       integer,
+  commission_notes          text,
+  expected_hours_per_week   numeric,
+  overtime_eligible         boolean,
+  compensation_notes        text,
+  company_entity            text, -- free text; admin picks from configured list
+
+  -- Recipient email override (defaults to profiles.email at send time)
+  recipient_email           text,
+
+  -- Lifecycle
+  status                    payroll_status NOT NULL DEFAULT 'invite_ready',
+  submitted_at              timestamptz,
+  admin_reviewed_at         timestamptz,
+  admin_reviewed_by         uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+  ready_for_quickbooks_at   timestamptz,
+  payroll_active_at         timestamptz,
+  payroll_active_by         uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+
+  -- I-9 (W-2 only) — separate columns so admin verification is explicit
+  i9_status                 text, -- not_started | employee_section_complete | employer_verification_required | complete
+  i9_employee_completed_at  timestamptz,
+  i9_employer_verified_at   timestamptz,
+  i9_employer_verified_by   uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+
+  -- Contractor-only link (1099)
+  contractor_agreement_id   uuid, -- references contractor_onboarding.id if that flow was used
+
+  -- Signatures (typed name + timestamp + IP metadata; not the payroll data itself)
+  submission_signature_name text,
+  submission_signature_at   timestamptz,
+  submission_ip             text,
+  submission_user_agent     text,
+
+  -- Home vs work state flag for admin review
+  home_state                text,
+  work_state                text,
+
+  created_at                timestamptz NOT NULL DEFAULT now(),
+  updated_at                timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS payroll_profiles_team_member_key
+  ON public.payroll_profiles (team_member_id);
+
+CREATE INDEX IF NOT EXISTS payroll_profiles_status_idx
+  ON public.payroll_profiles (status, created_at DESC);
+
+ALTER TABLE public.payroll_profiles ENABLE ROW LEVEL SECURITY;
+-- No policies granted — admin API uses service role.
+
+-- ─────────────────────────────────────────────────────────────
+-- 3. payroll_invitations (hashed tokens only)
+-- ─────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.payroll_invitations (
+  id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  profile_id     uuid NOT NULL REFERENCES public.payroll_profiles(id) ON DELETE CASCADE,
+  token_hash     text NOT NULL,
+  expires_at     timestamptz NOT NULL,
+  sent_at        timestamptz,
+  opened_at      timestamptz,
+  used_at        timestamptz,
+  revoked_at     timestamptz,
+  revoked_by     uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+  created_by     uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+  created_at     timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS payroll_invitations_hash_idx
+  ON public.payroll_invitations (token_hash);
+CREATE INDEX IF NOT EXISTS payroll_invitations_profile_idx
+  ON public.payroll_invitations (profile_id, created_at DESC);
+
+ALTER TABLE public.payroll_invitations ENABLE ROW LEVEL SECURITY;
+
+-- ─────────────────────────────────────────────────────────────
+-- 4. payroll_encrypted — field-level AES-256-GCM
+-- ─────────────────────────────────────────────────────────────
+-- One row per encrypted field. field_key examples:
+--   'ssn', 'tin', 'bank.routing', 'bank.account', 'w4.additional_withholding',
+--   etc. Ciphertext + IV + auth tag are all base64.
+CREATE TABLE IF NOT EXISTS public.payroll_encrypted (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  profile_id   uuid NOT NULL REFERENCES public.payroll_profiles(id) ON DELETE CASCADE,
+  field_key    text NOT NULL,
+  ciphertext   text NOT NULL,
+  iv           text NOT NULL,
+  auth_tag     text NOT NULL,
+  key_version  int NOT NULL DEFAULT 1,
+  updated_at   timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS payroll_encrypted_field_key
+  ON public.payroll_encrypted (profile_id, field_key);
+
+ALTER TABLE public.payroll_encrypted ENABLE ROW LEVEL SECURITY;
+
+-- ─────────────────────────────────────────────────────────────
+-- 5. Non-encrypted worker fields
+--    (personal info the employee fills in but that isn't secret —
+--    name, DOB, address, phone. DOB stored as date since HR needs
+--    it plaintext for QB Payroll setup; treat as personal data,
+--    admin-visible only.)
+-- ─────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.payroll_worker_details (
+  profile_id            uuid PRIMARY KEY REFERENCES public.payroll_profiles(id) ON DELETE CASCADE,
+  legal_first_name      text,
+  middle_name           text,
+  legal_last_name       text,
+  preferred_name        text,
+  date_of_birth         date,
+  personal_email        text,
+  mobile_phone          text,
+
+  address_street        text,
+  address_unit          text,
+  address_city          text,
+  address_state         text,
+  address_zip           text,
+  address_country       text DEFAULT 'US',
+
+  -- W-4 non-sensitive
+  filing_status         text, -- single | mfj | hoh
+  multiple_jobs         boolean,
+  qualifying_children_amt integer,
+  other_dependents_amt  integer,
+  other_income_cents    integer,
+  deductions_cents      integer,
+  exempt                boolean,
+
+  -- Bank non-sensitive
+  account_holder_name   text,
+  bank_name             text,
+  account_type          text, -- checking | savings
+  routing_last4         text, -- for display; full routing is encrypted
+  account_last4         text, -- for display; full account is encrypted
+
+  -- Sensitive last-4s for display (full values encrypted in payroll_encrypted)
+  ssn_last4             text,
+
+  -- 1099 non-sensitive
+  business_name         text,
+  federal_tax_class     text,
+  tin_type              text, -- ssn | ein
+  tin_last4             text,
+
+  -- Emergency contact
+  emergency_contact_name         text,
+  emergency_contact_relationship text,
+  emergency_contact_phone        text,
+  emergency_contact_email        text,
+
+  -- Draft state — the wizard writes here after every step so save-and-resume works
+  last_step_completed   text,
+  step_data             jsonb NOT NULL DEFAULT '{}'::jsonb,
+
+  updated_at            timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.payroll_worker_details ENABLE ROW LEVEL SECURITY;
+
+-- ─────────────────────────────────────────────────────────────
+-- 6. Audit log — never carries sensitive VALUES, only field labels + actor
+-- ─────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.payroll_audit_events (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  profile_id    uuid NOT NULL REFERENCES public.payroll_profiles(id) ON DELETE CASCADE,
+  actor_user_id uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+  actor_kind    text NOT NULL, -- 'admin' | 'employee' | 'system' | 'webhook'
+  event_type    text NOT NULL, -- 'invite.sent', 'draft.saved', 'submitted', 'sensitive.revealed', etc.
+  description   text,
+  metadata      jsonb NOT NULL DEFAULT '{}'::jsonb, -- SAFE fields only; NEVER put SSN/bank/tin here
+  created_at    timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS payroll_audit_profile_idx
+  ON public.payroll_audit_events (profile_id, created_at DESC);
+
+ALTER TABLE public.payroll_audit_events ENABLE ROW LEVEL SECURITY;
+
+-- ─────────────────────────────────────────────────────────────
+-- 7. Private storage bucket (I-9 docs, bank verification uploads)
+-- ─────────────────────────────────────────────────────────────
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('payroll-documents', 'payroll-documents', false)
+ON CONFLICT (id) DO NOTHING;
+
+-- No client read policy — signed URLs only via admin API.
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
…izard)

Adds a native Vending Connector payroll onboarding module accessible from CRM -> Team via a new "Add to Payroll" (Coins) icon per team member. Admin selects W-2 or 1099 + employment + comp, and the system emails the worker a secure single-use token link to complete their own sensitive data (SSN / TIN / bank / W-4) over an encrypted channel.

Sensitive fields are AES-256-GCM encrypted at rest via a field- level pattern — nothing on the shared worker-details table holds full SSN or bank numbers; only last-4 for display. Full plaintext lives in payroll_encrypted and only decrypts on the admin /reveal endpoint (audit-logged per field, per reason).

Migration 157
- payroll_profiles           — one per team member (admin fields +
                                lifecycle status enum)
- payroll_invitations        — hashed tokens only, expiry, revocation
- payroll_worker_details     — non-sensitive worker data + last-4s
                                for display + JSONB step_data draft
- payroll_encrypted          — AES-256-GCM ciphertext/iv/auth_tag
                                per (profile, field_key)
- payroll_audit_events       — every access/change, values-free
- 'payroll-documents' private bucket

Library
- src/lib/payroll/encryption.ts  — AES-256-GCM helpers reading a base64 PAYROLL_ENCRYPTION_KEY env var. Throws loud if unset. Ships last-4 + mask helpers so UI never touches full values.
- src/lib/payroll/token.ts       — same hashed-token pattern as
   contractor onboarding; 21-day default TTL.
- src/lib/payroll/tokenLookup.ts — raw -> resolved token +
   isTokenLive helper.
- src/lib/payroll/emails.ts      — invitation email + admin
   "packet completed" notification. Neither carries any sensitive
   value in the body. Uses APEX_ADMIN_NOTIFY for the admin fan-out.
- src/lib/payroll/constants.ts   — status labels + tones +
   classification + pay/frequency lists + encrypted-field allowlist.

Admin API (all admin-only via getSalesUser + role === "admin")
- GET/POST /api/admin/payroll/profiles         — list + create/send
- GET/PATCH /api/admin/payroll/profiles/[id]   — masked detail + edit
- POST /api/admin/payroll/profiles/[id]/resend — new token, kill old
- POST /api/admin/payroll/profiles/[id]/revoke — kill all live invites
- POST /api/admin/payroll/profiles/[id]/mark-active — flip to
  payroll_active (audit-logged)
- POST /api/admin/payroll/profiles/[id]/reveal — decrypt one field
  behind a required reason string; audit-logged with actor + field

Employee portal API (public, token IS the credential)
- GET   /api/payroll/[token]              — read admin display + draft
- PATCH /api/payroll/[token]/save-draft   — save-and-resume per step;
   the encrypted allowlist auto-moves SSN/TIN/bank/W4-addl into the
   encrypted store and writes last-4 for display.
- POST  /api/payroll/[token]/submit       — validate required fields,
   flip status to admin_review_required, mark invite used, fire
   admin notification email.

Admin UI
- /admin/payroll                — dashboard w/ status tiles, search,
                                    filters, per-row status pill.
- /admin/payroll/[id]           — detail: overview + personal + direct
                                    deposit + tax + activity + reveal
                                    modal (required reason, single-
                                    view, re-masks on close).
- Team page: new Coins icon per row -> AddToPayrollModal
  (classification, company entity, employment info, comp fields —
  admin defines pay rate; worker cannot override).

Worker UI
- /payroll/[token]              — mobile-first multi-step wizard.
  W-2 (9 steps): Personal, Address, Employment (read-only from
  admin), Federal W-4, State Tax (deferred to admin per spec),
  Direct Deposit, I-9 note, Emergency Contact, Review & Submit.
  1099 (5 steps): Identity, W-9, Address, Direct Deposit, Review
  & Submit.
  Save-and-resume on every step; SSN/TIN/routing/account fields
  submit through the encrypted-field pipeline; "on file" hints show
  when a value was previously saved so re-entry is only required
  when replacing.

Security summary
- No SSN / TIN / bank number ever appears in an email, URL, audit description, or activity log. Only field-name labels do.
- App-level AES-256-GCM with a 32-byte master key from PAYROLL_ENCRYPTION_KEY (base64). key_version stamped on every row for future rotation.
- Sensitive last-4 stamped alongside encrypted values so the masked display never touches full data.
- Every reveal on the admin detail page requires a text reason and writes an audit row with the actor id + field key + reason.
- Token URL becomes invalid on: submit, revoke, or expiry.

Site middleware
- src/proxy.ts: /payroll/{token} added to the public prefixes so the token portal isn't gated by the site-wide signup wall (the URL itself IS the credential).

New env var
- PAYROLL_ENCRYPTION_KEY  — base64-encoded 32 bytes. Missing key throws at first encrypt call. Suggested generation: openssl rand -base64 32 Sets in Vercel + local .env before uploading any packet.

Requires migration 157 to be run in Supabase before use.

Typecheck clean.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2