### PR TITLE
Payroll: drop SSN collection + soft-fail when encryption key missing

### DIFF
--- a/src/app/api/payroll/[token]/save-draft/route.ts
+++ b/src/app/api/payroll/[token]/save-draft/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { isTokenLive, resolveRawPayrollToken } from "@/lib/payroll/tokenLookup";
-import { encryptField, last4 } from "@/lib/payroll/encryption";
+import { encryptField, isEncryptionConfigured, last4 } from "@/lib/payroll/encryption";
 
 /**
  * PATCH /api/payroll/[token]/save-draft
@@ -89,39 +89,62 @@ export async function PATCH(
   // 2) Encrypt + store each sensitive field. Also write the last-4
   //    onto payroll_worker_details for masked display (never the
   //    full value). Never log the plaintext.
+  //
+  //    Encryption is soft-fail: when PAYROLL_ENCRYPTION_KEY isn't
+  //    configured, non-sensitive fields still save normally. The
+  //    response carries a `warnings` array so the wizard can inform
+  //    the worker instead of hitting a scary error page. Sensitive
+  //    values are dropped from memory as soon as this handler
+  //    returns — they aren't persisted anywhere in the
+  //    unencrypted state.
   const last4Patch: Record<string, unknown> = {};
-  for (const [key, rawVal] of Object.entries(encrypted)) {
-    if (!ENCRYPTED_ALLOWLIST.has(key)) continue;
-    if (typeof rawVal !== "string") continue;
-    const clean = rawVal.replace(/[^0-9A-Za-z]/g, "").trim();
-    if (!clean) continue;
-    let enc;
-    try {
-      enc = encryptField(clean);
-    } catch (encErr) {
-      console.error("[payroll.save-draft] encrypt failed:", encErr);
-      return NextResponse.json(
-        { error: "Server misconfiguration prevented saving this field. The platform team has been notified." },
-        { status: 500 },
-      );
-    }
-    await supabaseAdmin.from("payroll_encrypted").upsert(
-      {
-        profile_id: profileId,
-        field_key: key,
-        ciphertext: enc.ciphertext,
-        iv: enc.iv,
-        auth_tag: enc.auth_tag,
-        key_version: enc.key_version,
-        updated_at: new Date().toISOString(),
-      },
-      { onConflict: "profile_id,field_key" },
-    );
+  const warnings: string[] = [];
+  const encryptionOk = isEncryptionConfigured();
 
-    if (key === "ssn") last4Patch.ssn_last4 = last4(clean);
-    else if (key === "tin") last4Patch.tin_last4 = last4(clean);
-    else if (key === "bank.routing") last4Patch.routing_last4 = last4(clean);
-    else if (key === "bank.account") last4Patch.account_last4 = last4(clean);
+  if (!encryptionOk && Object.keys(encrypted).some((k) => ENCRYPTED_ALLOWLIST.has(k))) {
+    warnings.push(
+      "Sensitive fields (SSN / TIN / bank details) were not stored — payroll encryption is not yet configured on the server. Non-sensitive fields on this step were saved. Ask your payroll admin to complete server configuration, then re-enter these fields.",
+    );
+    console.warn(
+      "[payroll.save-draft] Encryption key missing; dropped sensitive fields for profile:",
+      profileId,
+    );
+  }
+
+  if (encryptionOk) {
+    for (const [key, rawVal] of Object.entries(encrypted)) {
+      if (!ENCRYPTED_ALLOWLIST.has(key)) continue;
+      if (typeof rawVal !== "string") continue;
+      const clean = rawVal.replace(/[^0-9A-Za-z]/g, "").trim();
+      if (!clean) continue;
+      let enc;
+      try {
+        enc = encryptField(clean);
+      } catch (encErr) {
+        console.error("[payroll.save-draft] encrypt failed:", encErr);
+        warnings.push(
+          `Could not securely save ${key}. Non-sensitive fields on this step were saved. Please try that field again after the platform team investigates.`,
+        );
+        continue;
+      }
+      await supabaseAdmin.from("payroll_encrypted").upsert(
+        {
+          profile_id: profileId,
+          field_key: key,
+          ciphertext: enc.ciphertext,
+          iv: enc.iv,
+          auth_tag: enc.auth_tag,
+          key_version: enc.key_version,
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: "profile_id,field_key" },
+      );
+
+      if (key === "ssn") last4Patch.ssn_last4 = last4(clean);
+      else if (key === "tin") last4Patch.tin_last4 = last4(clean);
+      else if (key === "bank.routing") last4Patch.routing_last4 = last4(clean);
+      else if (key === "bank.account") last4Patch.account_last4 = last4(clean);
+    }
   }
   if (Object.keys(last4Patch).length > 0) {
     await supabaseAdmin
@@ -147,10 +170,13 @@ export async function PATCH(
     metadata: {
       step,
       // ONLY the keys of sensitive fields we saved — never values.
-      sensitive_keys_saved: Object.keys(encrypted).filter((k) => ENCRYPTED_ALLOWLIST.has(k)),
+      sensitive_keys_saved: encryptionOk
+        ? Object.keys(encrypted).filter((k) => ENCRYPTED_ALLOWLIST.has(k))
+        : [],
       non_sensitive_keys_saved: Object.keys(filteredNS),
+      encryption_configured: encryptionOk,
     },
   });
 
-  return NextResponse.json({ ok: true });
+  return NextResponse.json({ ok: true, warnings });
 }

--- a/src/app/api/payroll/[token]/submit/route.ts
+++ b/src/app/api/payroll/[token]/submit/route.ts
@@ -59,7 +59,9 @@ export async function POST(
 
   if (profile.classification === "w2_employee") {
     if (!worker?.date_of_birth) missing.push("Date of birth");
-    if (!encKeys.has("ssn")) missing.push("Social Security number");
+    // SSN is intentionally NOT required in this packet — the
+    // employer collects it out-of-band (QuickBooks Workforce
+    // invite or offline W-4).
     if (!worker?.filing_status) missing.push("Federal filing status");
   } else if (profile.classification === "1099_contractor") {
     if (!worker?.federal_tax_class) missing.push("Federal tax classification");

--- a/src/app/payroll/[token]/page.tsx
+++ b/src/app/payroll/[token]/page.tsx
@@ -114,7 +114,9 @@ export default function PayrollWizardPage() {
 
   // Draft form state (both admin steps display + worker inputs)
   const [form, setForm] = useState<WorkerDraft>({});
-  const [ssn, setSsn] = useState(""); const [ssn2, setSsn2] = useState(""); const [showSsn, setShowSsn] = useState(false);
+  // SSN input removed per product request — workers no longer enter
+  // their SSN through this packet. Employer collects it out-of-band
+  // (QuickBooks Workforce invite, offline form, etc.).
   const [tin, setTin] = useState("");
   const [routing, setRouting] = useState(""); const [routing2, setRouting2] = useState("");
   const [account, setAccount] = useState(""); const [account2, setAccount2] = useState(""); const [showAcct, setShowAcct] = useState(false);
@@ -138,8 +140,10 @@ export default function PayrollWizardPage() {
   const steps = state?.admin.classification === "1099_contractor" ? C1099_STEPS : W2_STEPS;
   const currentStep = steps[stepIndex];
 
+  const [warning, setWarning] = useState<string | null>(null);
   async function saveDraft(step: string, nonSensitive?: Record<string, unknown>, encrypted?: Record<string, string>): Promise<boolean> {
     setSaving(true);
+    setWarning(null);
     try {
       const res = await fetch(`/api/payroll/${token}/save-draft`, {
         method: "PATCH",
@@ -149,11 +153,13 @@ export default function PayrollWizardPage() {
       const json = await res.json().catch(() => ({}));
       if (!res.ok) { setError(json.error || `Save failed (${res.status})`); return false; }
       // Clear sensitive input state after successful save
-      if (encrypted?.ssn) setSsn(""), setSsn2("");
       if (encrypted?.tin) setTin("");
       if (encrypted?.["bank.routing"]) setRouting(""), setRouting2("");
       if (encrypted?.["bank.account"]) setAccount(""), setAccount2("");
       if (encrypted?.["w4.additional_withholding_cents"]) setAddlWithhold("");
+      if (Array.isArray(json.warnings) && json.warnings.length > 0) {
+        setWarning(json.warnings.join(" "));
+      }
       await load();
       return true;
     } finally { setSaving(false); }
@@ -176,15 +182,9 @@ export default function PayrollWizardPage() {
       if (!form.legal_first_name || !form.legal_last_name || !form.date_of_birth) {
         setError("Legal name and date of birth are required."); return false;
       }
-      if (state?.admin.classification === "w2_employee") {
-        if (ssn || ssn2) {
-          if (ssn !== ssn2) { setError("Social Security numbers don't match."); return false; }
-          if (!/^\d{9}$/.test(ssn.replace(/[^0-9]/g, ""))) { setError("SSN must be 9 digits."); return false; }
-          enc.ssn = ssn.replace(/[^0-9]/g, "");
-        } else if (!state?.saved_sensitive_keys.includes("ssn")) {
-          setError("Social Security number is required."); return false;
-        }
-      }
+      // SSN intentionally NOT collected in this packet — the
+      // employer captures it separately (e.g. QuickBooks Workforce
+      // invite). Wizard progresses without it.
       ns.legal_first_name = form.legal_first_name;
       ns.middle_name = form.middle_name;
       ns.legal_last_name = form.legal_last_name;
@@ -357,13 +357,11 @@ export default function PayrollWizardPage() {
             </TwoCol>
             <Field label="Mobile Phone" type="tel" autoComplete="tel" inputMode="tel" value={form.mobile_phone ?? ""} onChange={(v) => setForm({ ...form, mobile_phone: v })} />
             {state.admin.classification === "w2_employee" && (
-              <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 space-y-3">
-                <div className="flex items-center gap-2 text-sm font-semibold text-amber-900"><ShieldCheck className="h-4 w-4" /> Social Security Number</div>
-                {savedKeys.has("ssn") ? (
-                  <div className="text-xs text-amber-800">On file. Enter a new value only if you need to replace it — otherwise leave blank and continue.</div>
-                ) : null}
-                <SensitiveField label="SSN"          value={ssn}  show={showSsn} onToggle={() => setShowSsn(!showSsn)} onChange={setSsn}  inputMode="numeric" />
-                <SensitiveField label="Confirm SSN"  value={ssn2} show={showSsn} onToggle={() => setShowSsn(!showSsn)} onChange={setSsn2} inputMode="numeric" />
+              <div className="rounded-xl border border-sky-200 bg-sky-50 p-4 text-sm text-sky-900">
+                <div className="font-semibold mb-1">About your Social Security Number</div>
+                <p className="text-xs">
+                  We do not collect your SSN through this packet. Your employer will collect it separately (typically via a QuickBooks Workforce invite or an offline W-4). No action needed from you here.
+                </p>
               </div>
             )}
           </>
@@ -529,7 +527,6 @@ export default function PayrollWizardPage() {
             <ReviewRow k="Address" v={form.address_street ? `${form.address_street}, ${form.address_city}, ${form.address_state} ${form.address_zip}` : "—"} />
             {state.admin.classification === "w2_employee" ? (
               <>
-                <ReviewRow k="SSN" v={form.ssn_last4 ? `***-**-${form.ssn_last4}` : "—"} />
                 <ReviewRow k="Filing Status" v={form.filing_status ?? "—"} />
               </>
             ) : (
@@ -555,6 +552,9 @@ export default function PayrollWizardPage() {
 
         {error && (
           <div className="flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"><AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />{error}</div>
+        )}
+        {warning && (
+          <div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800"><AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />{warning}</div>
         )}
 
         <div className="flex flex-wrap items-center justify-between gap-2 border-t border-gray-100 pt-4">

--- a/src/lib/payroll/encryption.ts
+++ b/src/lib/payroll/encryption.ts
@@ -26,13 +26,20 @@ const IV_LEN = 12;  // 96 bits — recommended for GCM
 const KEY_VERSION = 1;
 
 let _cachedKey: Buffer | null = null;
+/** True when PAYROLL_ENCRYPTION_KEY is configured and valid. */
+export function isEncryptionConfigured(): boolean {
+  try {
+    return !!getMasterKey();
+  } catch {
+    return false;
+  }
+}
+
 function getMasterKey(): Buffer {
   if (_cachedKey) return _cachedKey;
   const raw = process.env.PAYROLL_ENCRYPTION_KEY;
   if (!raw) {
-    throw new Error(
-      "PAYROLL_ENCRYPTION_KEY env var is not set — refusing to persist plaintext payroll data.",
-    );
+    throw new Error("PAYROLL_ENCRYPTION_KEY env var is not set.");
   }
   let decoded: Buffer;
   try {


### PR DESCRIPTION
Two coupled fixes.

1. Remove SSN from the packet Employer captures SSN out-of-band (QuickBooks Workforce invite or offline W-4). Wizard no longer asks for it; server no longer requires it on submit.
   - src/app/payroll/[token]/page.tsx: dropped ssn/ssn2/showSsn state, dropped the amber "Social Security Number" input block from the Personal step, replaced with an informational blue note. Removed the SSN review row.
   - src/app/api/payroll/[token]/submit/route.ts: dropped "Social Security number" from the W-2 required list.

2. Encryption fails soft when PAYROLL_ENCRYPTION_KEY isn't set Previously any sensitive-field submission hit a scary "Server misconfiguration prevented saving this field. The platform team has been notified." error and stalled the wizard.
   - src/lib/payroll/encryption.ts: new isEncryptionConfigured() helper that probes the key at runtime.
   - src/app/api/payroll/[token]/save-draft/route.ts: when the key isn't configured, non-sensitive fields still save normally, sensitive values are dropped from server memory, and the response carries a `warnings: string[]` array explaining that sensitive fields weren't stored and that the payroll admin needs to complete server configuration. Wizard renders warnings in an amber banner and continues to the next step instead of dead-ending.
   - Audit metadata records `encryption_configured: false` on save events fired while the key is missing, so the paper trail shows exactly which drafts happened without encryption in place.

Non-sensitive data is unaffected. TIN + bank details still flow through the encrypted pipeline when the key IS set — no security regression. Typecheck clean.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2