### PR TITLE
Payroll: hide entry points from the UI (backend intact)

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -4733,14 +4733,9 @@ export default function AdminPage() {
                 <span className="hidden sm:inline">Workflow Backfill</span>
                 <span className="sm:hidden">Backfill</span>
               </Link>
-              <Link
-                href="/admin/payroll"
-                className="inline-flex items-center gap-2 rounded-xl border border-green-primary px-4 py-2.5 text-sm font-medium text-green-primary shadow-sm transition-colors hover:bg-green-50"
-              >
-                <DollarSign className="h-4 w-4" />
-                <span className="hidden sm:inline">Payroll</span>
-                <span className="sm:hidden">Pay</span>
-              </Link>
+              {/* Payroll header link temporarily hidden. Backend +
+                  pages remain intact — restore this block to bring
+                  the entry point back. */}
               <Link
                 href="/sales"
                 className="inline-flex items-center gap-2 rounded-xl bg-green-primary px-4 py-2.5 text-sm font-medium text-white shadow-sm transition-colors hover:bg-green-primary/90"

--- a/src/app/sales/team/page.tsx
+++ b/src/app/sales/team/page.tsx
@@ -4,9 +4,11 @@ import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { createBrowserClient } from "@/lib/supabase";
-import { Users, Loader2, Search, CheckCircle2, Clock, UserX, AlertTriangle, Plus, X, Eye, EyeOff, UserPlus, Trash2, Send, FileSignature, ClipboardCheck, Key, Coins } from "lucide-react";
+import { Users, Loader2, Search, CheckCircle2, Clock, UserX, AlertTriangle, Plus, X, Eye, EyeOff, UserPlus, Trash2, Send, FileSignature, ClipboardCheck, Key } from "lucide-react";
 import SendCredentialsModal from "./SendCredentialsModal";
-import AddToPayrollModal from "./AddToPayrollModal";
+// Payroll UI temporarily hidden — keep the backend module (schema,
+// APIs, /payroll/[token] portal) intact so it can be re-enabled by
+// restoring these imports + the row button + the modal wire below.
 
 interface TeamMember {
   id: string;
@@ -81,9 +83,6 @@ export default function TeamPage() {
   // Send Credentials modal — one open at a time, keyed by member.
   const [credentialsTarget, setCredentialsTarget] = useState<TeamMember | null>(null);
   const [credentialsToast, setCredentialsToast] = useState<string | null>(null);
-  // Add to Payroll modal — one open at a time, keyed by member.
-  const [payrollTarget, setPayrollTarget] = useState<TeamMember | null>(null);
-  const [payrollToast, setPayrollToast] = useState<string | null>(null);
 
   const loadTeamMembers = useCallback(async (t: string) => {
     const res = await fetch("/api/sales/users", { headers: { Authorization: `Bearer ${t}` } });
@@ -486,15 +485,6 @@ export default function TeamPage() {
                         >
                           <Key className="h-4 w-4" />
                         </button>
-                        <button
-                          type="button"
-                          onClick={() => setPayrollTarget(m)}
-                          className="inline-flex items-center gap-1 rounded-md p-1.5 text-gray-300 hover:bg-green-50 hover:text-green-600 transition-colors"
-                          title={`Add ${m.full_name || m.email} to payroll`}
-                          aria-label={`Add ${m.full_name || m.email} to payroll`}
-                        >
-                          <Coins className="h-4 w-4" />
-                        </button>
                         {m.id !== currentUserId && (
                           <button
                             type="button"
@@ -793,27 +783,6 @@ export default function TeamPage() {
         </div>
       )}
 
-      {payrollTarget && (
-        <AddToPayrollModal
-          memberId={payrollTarget.id}
-          memberName={payrollTarget.full_name || payrollTarget.email}
-          memberEmail={payrollTarget.email}
-          token={token}
-          onClose={() => setPayrollTarget(null)}
-          onSent={() => {
-            setPayrollToast(`Payroll invitation sent to ${payrollTarget?.full_name || payrollTarget?.email}.`);
-            window.setTimeout(() => setPayrollToast(null), 6_000);
-          }}
-        />
-      )}
-      {payrollToast && (
-        <div
-          role="status"
-          className="fixed bottom-6 right-6 z-[10000] max-w-sm rounded-lg border border-emerald-200 bg-white px-4 py-3 text-sm text-emerald-800 shadow-lg"
-        >
-          {payrollToast}
-        </div>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
Per product request. Removes user-facing access to the payroll onboarding module without deleting any code.

- src/app/sales/team/page.tsx: dropped the Coins icon action per team-member row, the payrollTarget state, the AddToPayrollModal import, and the modal + toast render block. Kept the SendCredentialsModal wiring unchanged.
- src/app/admin/page.tsx: hidden the Payroll pill in the header action row (replaced with a comment marker for easy restore).

Left in place (unreachable via UI, still functional via direct URL):
- Migration 157 tables + private bucket
- All /api/admin/payroll + /api/payroll endpoints
- /admin/payroll dashboard, /admin/payroll/[id] detail, /payroll/[token] worker wizard
- src/app/sales/team/AddToPayrollModal.tsx
- src/lib/payroll/* helpers

To re-enable: restore the two comment blocks in the two files above and the entry points come back with no other changes needed.

Typecheck clean.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2