### PR TITLE
Lead Generator: add golf simulators + related venue types to the indu…

### DIFF
--- a/src/app/components/LeadGeneratorForm.tsx
+++ b/src/app/components/LeadGeneratorForm.tsx
@@ -12,6 +12,8 @@ const INDUSTRIES = [
   "electrical supply stores", "vocational schools", "universities",
   "cosmetology schools", "trucking schools", "nursing schools",
   "barbershops", "car washes", "laundromats",
+  "golf simulators", "golf simulator lounges", "indoor golf centers",
+  "golf entertainment venues", "topgolf",
 ];
 
 const US_STATES = [


### PR DESCRIPTION
…stry list

Adds five golf-simulator-related search terms to the LeadGeneratorForm INDUSTRIES list so the tool can build call lists for the emerging indoor-golf market:
- golf simulators
- golf simulator lounges
- indoor golf centers
- golf entertainment venues
- topgolf

The Places API text search (${industry} in ${city}, ${state}) already handles multi-word phrases so no other change is needed. Both the CRM shell (/sales/lead-generator) and the customer-facing shell (/tools/lead-generator) render the same list.

Typecheck clean.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2