### PR TITLE
Complete Profile: force full-page nav after save + surface real save …

### DIFF
--- a/src/app/complete-profile/page.tsx
+++ b/src/app/complete-profile/page.tsx
@@ -38,6 +38,7 @@ export default function CompleteProfilePage() {
     async function init() {
       const { data: { session } } = await supabase.auth.getSession();
       if (!session?.access_token) {
+        setLoading(false);
         router.push("/login");
         return;
       }
@@ -49,9 +50,15 @@ export default function CompleteProfilePage() {
         });
         if (res.ok) {
           const profile = await res.json();
-          const hasRole = profile.role && !["operator"].includes(profile.role);
-          if (hasRole && profile.phone && profile.address && profile.city && profile.state && profile.zip) {
-            router.push("/dashboard");
+          // Any authenticated user with a real role + full contact info can
+          // proceed straight to the dashboard. The old "hasRole" check
+          // excluded operators (the OAuth-auto-created default role), which
+          // trapped operators with complete profiles on this page.
+          if (
+            profile.role &&
+            profile.phone && profile.address && profile.city && profile.state && profile.zip
+          ) {
+            window.location.href = "/dashboard";
             return;
           }
           if (profile.role && ["operator", "locator", "location_manager", "employee", "sales"].includes(profile.role)) {
@@ -111,14 +118,23 @@ export default function CompleteProfilePage() {
       });
 
       if (res.ok) {
-        router.push("/dashboard");
-      } else {
-        const data = await res.json().catch(() => ({ error: "Failed to save" }));
-        setError(data.error || "Failed to save");
-        window.scrollTo({ top: 0, behavior: "smooth" });
+        // Full-page navigation (not router.push) so the browser resends
+        // fresh cookies and the middleware re-reads the just-mirrored
+        // user_metadata / profile — otherwise a stale request cache can
+        // send /dashboard right back to /complete-profile and it looks
+        // to the user like Continue did nothing.
+        window.location.href = "/dashboard";
+        return;
       }
+      if (res.status === 401) {
+        window.location.href = "/login";
+        return;
+      }
+      const data = await res.json().catch(() => ({ error: "Failed to save" }));
+      setError(data.error || `Failed to save (status ${res.status})`);
+      window.scrollTo({ top: 0, behavior: "smooth" });
     } catch {
-      setError("Failed to save. Please try again.");
+      setError("Failed to save. Please check your connection and try again.");
       window.scrollTo({ top: 0, behavior: "smooth" });
     } finally {
       setSaving(false);


### PR DESCRIPTION
…errors

"Continue" appeared to do nothing for some users after a successful save:
- router.push("/dashboard") is a client-side navigation that can hand the middleware a stale request/cookie snapshot, and it silently bounces /dashboard back to /complete-profile without the user seeing anything change. window.location.href triggers a full document load so the middleware re-reads the freshly-mirrored user_metadata / profile.
- The mount-time redirect check only fired for non-operator roles, so an operator who returned to /complete-profile with a complete profile got stuck on the page. Broaden the check to any role + full contact info.
- If the PATCH returns 401 (stale token), route to /login instead of showing a bare "Failed to save".
- If the PATCH returns any other non-2xx and the body isn't JSON, show the status code so the user isn't staring at a generic "Failed to save" with no way forward.
- Also clear the loading spinner when init() bails to /login so the page doesn't hang on a permanent loader if the session probe misfires.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2