### PR TITLE
Admin Users tab: force the scrollbar to always show + fetch up to 100…

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -239,7 +239,10 @@ function UsersManager({ token, onSuccess }: { token: string; onSuccess: (msg: st
       const params = new URLSearchParams();
       if (search) params.set("search", search);
       if (roleFilter) params.set("role", roleFilter);
-      params.set("limit", "100");
+      // Match the total user count so the "N users total" tally is not
+      // silently truncated by pagination. 1000 covers current + expected
+      // near-term growth; extend once we cross that.
+      params.set("limit", "1000");
       const res = await fetch(`/api/admin/users?${params}`, {
         headers: { Authorization: `Bearer ${token}` },
       });
@@ -468,10 +471,12 @@ function UsersManager({ token, onSuccess }: { token: string; onSuccess: (msg: st
       ) : (
         // Cap the users list at a scrollable height so long user lists
         // stay reachable without pushing the rest of the admin panel
-        // off-screen. Sticky thead keeps column labels visible while
-        // scrolling; overflow-auto handles both axes so wide + tall
-        // tables both work.
-        <div className="max-h-[calc(100vh-320px)] min-h-[240px] overflow-auto rounded-xl border border-gray-100">
+        // off-screen. overflow-y-scroll (not auto) forces the vertical
+        // scrollbar to always be visible — macOS's overlay scrollbars
+        // hide with `overflow-auto` and admins couldn't tell the region
+        // was scrollable. overflow-x-auto keeps a horizontal bar only
+        // when the table actually needs one.
+        <div className="max-h-[calc(100vh-320px)] min-h-[280px] overflow-y-scroll overflow-x-auto rounded-xl border border-gray-100 [scrollbar-gutter:stable]">
           <table className="w-full text-left text-sm">
             <thead className="sticky top-0 z-10 border-b border-gray-100 bg-gray-50 shadow-sm">
               <tr>

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -13,7 +13,7 @@ export async function GET(req: NextRequest) {
   const url = new URL(req.url);
   const search = url.searchParams.get("search") || "";
   const role = url.searchParams.get("role") || "";
-  const limit = Math.min(parseInt(url.searchParams.get("limit") || "50"), 200);
+  const limit = Math.min(parseInt(url.searchParams.get("limit") || "50"), 1000);
   const offset = parseInt(url.searchParams.get("offset") || "0");
 
   let query = supabaseAdmin


### PR DESCRIPTION
…0 users

Two bugs stacked together made the users list feel un-scrollable on production:

1. overflow-auto on the container hides the scrollbar on macOS (overlay scrollbars only appear during an active scroll gesture), so admins with a large user list had no visible affordance that the region scrolled at all. Switch to overflow-y-scroll and reserve a stable scrollbar gutter so the bar is always drawn.
2. The client asked for at most 100 users and the API capped every request at 200, so once an org grew past that the extra users were silently truncated and there was nothing to scroll to. Raise the client request to 1000 and the API cap to match.

Also bump the container's min-height to 280px so short lists still show enough room for the sticky header + a few rows without collapsing.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2