### PR TITLE
Coffee agreement v2 + customer sign-copy email + per-order shipping a…

### DIFF
--- a/src/app/api/coffee/agreement/sign/route.ts
+++ b/src/app/api/coffee/agreement/sign/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { Resend } from "resend";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { getUserIdFromRequest } from "@/lib/apiAuth";
-import { signAsProvider, getOrStartAgreement } from "@/lib/placementAgreements";
+import { signAsProvider, getOrStartAgreement, getActiveTemplate } from "@/lib/placementAgreements";
+import { generateCoffeeAgreementPdf } from "@/lib/pdf/coffeeAgreementPdf";
 
 /**
  * POST /api/coffee/agreement/sign
@@ -120,12 +121,87 @@ export async function POST(req: NextRequest) {
       console.error("[coffee.agreement.sign] profile grant failed:", e);
     }
 
-    // Notify admin so they know to countersign.
+    // Generate a customer-signed PDF (countersign fields left null — the
+    // fully-executed PDF with Apex countersignature is produced later by
+    // the countersign endpoint). We attach this to BOTH the admin
+    // notification and the customer's confirmation so the customer walks
+    // away with an immediate copy of what they just signed. Non-fatal —
+    // signing itself has already succeeded.
+    let signedPdfBytes: Uint8Array | null = null;
     try {
-      const resend = new Resend(process.env.RESEND_API_KEY);
+      const template = await getActiveTemplate("coffee_supply");
+      if (template) {
+        signedPdfBytes = await generateCoffeeAgreementPdf({
+          template_content_html: template.content_html,
+          template_title: template.title,
+          template_version: template.version,
+          template_effective_date: template.effective_date,
+          agreement_id: updated.id,
+          metadata: {
+            customer_name: customerName,
+            customer_address: customerAddress,
+            num_machines: numMachines,
+            authorized_representative_name: authRepName,
+            authorized_representative_title: authRepTitle,
+            ack_exclusive_supply: true,
+            ack_minimum_purchase: true,
+            ack_installation_maintenance: true,
+          },
+          signature: {
+            provider_typed_name: typedName,
+            provider_email: profile.email,
+            provider_signed_at_iso: updated.provider_signed_at ?? new Date().toISOString(),
+            provider_ip: ip,
+            provider_consent_esign: true,
+            countersigner_name: null,
+            countersigner_email: null,
+            countersigner_at_iso: null,
+          },
+        });
+      }
+    } catch (pdfErr) {
+      console.error("[coffee.agreement.sign] PDF gen failed:", pdfErr);
+    }
+
+    const resendClient = new Resend(process.env.RESEND_API_KEY);
+    const from = process.env.FROM_EMAIL || "receipts@bytebitevending.com";
+    const pdfAttachment = signedPdfBytes
+      ? [{
+          filename: `Coffee-Supply-Agreement-${customerName.replace(/[^A-Za-z0-9]+/g, "-")}.pdf`,
+          content: Buffer.from(signedPdfBytes).toString("base64"),
+        }]
+      : undefined;
+
+    // Customer confirmation — the on-file email receives a copy of the
+    // signed agreement immediately.
+    if (profile.email) {
+      try {
+        await resendClient.emails.send({
+          from,
+          to: profile.email,
+          subject: `Your signed Coffee Supply Agreement — copy attached`,
+          html: `
+            <p>Thanks for signing the Equipment Loan &amp; Beverage Supply Agreement.</p>
+            <p>Your signed copy is attached to this email for your records. You can start placing coffee orders right away — Apex AI Vending will countersign and send the fully-executed copy shortly.</p>
+            <p><strong>Customer:</strong> ${escapeHtml(customerName)}<br />
+               <strong>Address on file:</strong> ${escapeHtml(customerAddress)}<br />
+               <strong>Number of machines:</strong> ${numMachines}<br />
+               <strong>Authorized representative:</strong> ${escapeHtml(authRepName)} (${escapeHtml(authRepTitle)})<br />
+               <strong>Signed at:</strong> ${escapeHtml(updated.provider_signed_at || "")}</p>
+            <p><a href="${process.env.NEXT_PUBLIC_APP_URL || "https://vendingconnector.com"}/coffee" style="display:inline-block;background:#16a34a;color:#ffffff;padding:10px 24px;border-radius:6px;text-decoration:none;font-weight:600;">Start ordering</a></p>
+          `,
+          attachments: pdfAttachment,
+        });
+      } catch (e) {
+        console.error("[coffee.agreement.sign] customer notification failed:", e);
+      }
+    }
+
+    // Admin notification — same PDF attached so admin has the signed
+    // record in the inbox before countersigning.
+    try {
       const adminInbox = process.env.COFFEE_ADMIN_EMAIL || "james@apexaivending.com";
-      const from = process.env.FROM_EMAIL || "receipts@bytebitevending.com";
-      await resend.emails.send({
+      await resendClient.emails.send({
         from,
         to: adminInbox,
         subject: `Coffee Supply Agreement signed by ${customerName} — countersign needed`,
@@ -139,6 +215,7 @@ export async function POST(req: NextRequest) {
           <p><strong>Typed name:</strong> ${escapeHtml(typedName)}</p>
           <p><a href="${process.env.NEXT_PUBLIC_APP_URL || "https://vendingconnector.com"}/admin/coffee/agreements">Open the coffee agreements queue →</a></p>
         `,
+        attachments: pdfAttachment,
       });
     } catch (e) {
       console.error("[coffee.agreement.sign] admin notification failed:", e);

--- a/src/app/coffee/agreement/page.tsx
+++ b/src/app/coffee/agreement/page.tsx
@@ -289,7 +289,7 @@ export default function CoffeeAgreementPage() {
                 disabled={pendingCountersign}
                 className="mt-0.5"
               />
-              <span>I acknowledge <strong>installation, service, and day-to-day upkeep</strong> responsibilities as set out in section 8.</span>
+              <span>I acknowledge that <strong>Customer pays all shipping, installation, and service costs</strong>, and that on termination I must ship the Equipment back at my expense within <strong>15 days</strong> of the termination date.</span>
             </label>
           </div>
 

--- a/src/app/coffee/checkout/page.tsx
+++ b/src/app/coffee/checkout/page.tsx
@@ -63,6 +63,12 @@ function CheckoutContent() {
     notes: "",
   });
   const [billingSameAsShipping, setBillingSameAsShipping] = useState(false);
+  // Shipping address mode:
+  //   "default" — mirror whatever is on the profile (address on file).
+  //   "custom"  — enter a one-off address for this order only.
+  // The customer's profile is unaffected either way; this only controls
+  // what ships on THIS order.
+  const [shippingMode, setShippingMode] = useState<"default" | "custom">("default");
 
   useEffect(() => {
     const supabase = createBrowserClient();
@@ -306,35 +312,94 @@ function CheckoutContent() {
       <form onSubmit={handleSubmit} className="mt-8 grid gap-8 lg:grid-cols-5">
         <div className="lg:col-span-3 space-y-6">
           <div className="rounded-2xl border border-gray-100 bg-white p-6 shadow-sm">
-            <h2 className="text-lg font-bold text-gray-900 mb-4">Shipping Information</h2>
-            <div className="grid gap-4 sm:grid-cols-2">
+            <div className="mb-4 flex items-start justify-between gap-4">
+              <h2 className="text-lg font-bold text-gray-900">Shipping Information</h2>
+            </div>
+
+            {/* Default vs custom address selector. Default = whatever
+                is on file for the signed-in account (pulled from profile
+                on init). Custom = one-off address for THIS order only. */}
+            <div className="mb-4 grid gap-2 rounded-xl border border-gray-200 bg-gray-50 p-3 sm:grid-cols-2">
+              <label className={`flex cursor-pointer items-start gap-2 rounded-lg p-2 text-sm transition-colors ${
+                shippingMode === "default" ? "bg-white ring-2 ring-green-600" : "hover:bg-white"
+              }`}>
+                <input
+                  type="radio"
+                  name="shipping_mode"
+                  value="default"
+                  checked={shippingMode === "default"}
+                  onChange={() => {
+                    setShippingMode("default");
+                    if (profile) {
+                      setForm((prev) => ({
+                        ...prev,
+                        shipping_business_name: profile.company_name || "",
+                        shipping_name: profile.full_name || "",
+                        shipping_address: profile.address || "",
+                        shipping_city: profile.city || "",
+                        shipping_state: profile.state || "",
+                        shipping_zip: profile.zip || "",
+                        shipping_phone: profile.phone || "",
+                      }));
+                    }
+                  }}
+                  className="mt-0.5"
+                />
+                <span>
+                  <span className="font-semibold text-gray-900">Ship to default address</span>
+                  <span className="mt-0.5 block text-xs text-gray-500">
+                    {profile?.address
+                      ? `${profile.address}, ${profile.city || ""} ${profile.state || ""} ${profile.zip || ""}`.trim()
+                      : "Address on file for this account"}
+                  </span>
+                </span>
+              </label>
+              <label className={`flex cursor-pointer items-start gap-2 rounded-lg p-2 text-sm transition-colors ${
+                shippingMode === "custom" ? "bg-white ring-2 ring-green-600" : "hover:bg-white"
+              }`}>
+                <input
+                  type="radio"
+                  name="shipping_mode"
+                  value="custom"
+                  checked={shippingMode === "custom"}
+                  onChange={() => setShippingMode("custom")}
+                  className="mt-0.5"
+                />
+                <span>
+                  <span className="font-semibold text-gray-900">Custom address for this order</span>
+                  <span className="mt-0.5 block text-xs text-gray-500">Enter a one-off ship-to below.</span>
+                </span>
+              </label>
+            </div>
+
+            <div className={`grid gap-4 sm:grid-cols-2 ${shippingMode === "default" ? "opacity-60" : ""}`}>
               <div className="sm:col-span-2">
                 <label className="mb-1.5 block text-sm font-medium text-gray-700">Business Name <span className="text-red-500">*</span></label>
-                <input type="text" required value={form.shipping_business_name} onChange={(e) => updateForm("shipping_business_name", e.target.value)} className={inputClass} />
+                <input type="text" required value={form.shipping_business_name} onChange={(e) => updateForm("shipping_business_name", e.target.value)} disabled={shippingMode === "default"} className={inputClass} />
               </div>
               <div className="sm:col-span-2">
                 <label className="mb-1.5 block text-sm font-medium text-gray-700">Contact Name <span className="text-red-500">*</span></label>
-                <input type="text" required value={form.shipping_name} onChange={(e) => updateForm("shipping_name", e.target.value)} className={inputClass} />
+                <input type="text" required value={form.shipping_name} onChange={(e) => updateForm("shipping_name", e.target.value)} disabled={shippingMode === "default"} className={inputClass} />
               </div>
               <div className="sm:col-span-2">
                 <label className="mb-1.5 block text-sm font-medium text-gray-700">Street Address <span className="text-red-500">*</span></label>
-                <input type="text" required value={form.shipping_address} onChange={(e) => updateForm("shipping_address", e.target.value)} className={inputClass} />
+                <input type="text" required value={form.shipping_address} onChange={(e) => updateForm("shipping_address", e.target.value)} disabled={shippingMode === "default"} className={inputClass} />
               </div>
               <div>
                 <label className="mb-1.5 block text-sm font-medium text-gray-700">City <span className="text-red-500">*</span></label>
-                <input type="text" required value={form.shipping_city} onChange={(e) => updateForm("shipping_city", e.target.value)} className={inputClass} />
+                <input type="text" required value={form.shipping_city} onChange={(e) => updateForm("shipping_city", e.target.value)} disabled={shippingMode === "default"} className={inputClass} />
               </div>
               <div>
                 <label className="mb-1.5 block text-sm font-medium text-gray-700">State <span className="text-red-500">*</span></label>
-                <input type="text" required value={form.shipping_state} onChange={(e) => updateForm("shipping_state", e.target.value)} className={inputClass} />
+                <input type="text" required value={form.shipping_state} onChange={(e) => updateForm("shipping_state", e.target.value)} disabled={shippingMode === "default"} className={inputClass} />
               </div>
               <div>
                 <label className="mb-1.5 block text-sm font-medium text-gray-700">ZIP Code <span className="text-red-500">*</span></label>
-                <input type="text" required value={form.shipping_zip} onChange={(e) => updateForm("shipping_zip", e.target.value)} className={inputClass} />
+                <input type="text" required value={form.shipping_zip} onChange={(e) => updateForm("shipping_zip", e.target.value)} disabled={shippingMode === "default"} className={inputClass} />
               </div>
               <div>
                 <label className="mb-1.5 block text-sm font-medium text-gray-700">Phone <span className="text-red-500">*</span></label>
-                <input type="tel" required value={form.shipping_phone} onChange={(e) => updateForm("shipping_phone", e.target.value)} className={inputClass} />
+                <input type="tel" required value={form.shipping_phone} onChange={(e) => updateForm("shipping_phone", e.target.value)} disabled={shippingMode === "default"} className={inputClass} />
               </div>
             </div>
           </div>

--- a/supabase/migrations/159_coffee_supply_agreement_v2.sql
+++ b/supabase/migrations/159_coffee_supply_agreement_v2.sql
@@ -1,0 +1,93 @@
+-- Coffee Supply Agreement — version 2.
+--
+-- Replaces the v1 seed (migration 117) with the customer-requested
+-- terms: no fixed term, customer pays shipping/installation/service,
+-- 15-day return window at customer expense on termination, damaged
+-- product is customer's responsibility, no refunds, 30-day fulfillment
+-- window, and a drop-ship-to-consumer carve-out where the company
+-- retains fulfillment responsibility.
+--
+-- Existing signers of v1 keep their v1 user_agreements row (history is
+-- preserved). Anyone visiting /coffee/agreement after this migration
+-- will see + sign v2 because getActiveTemplate() picks whichever
+-- agreement_templates row for the type is currently is_active.
+
+-- Deactivate v1 so getActiveTemplate('coffee_supply') returns v2.
+UPDATE agreement_templates
+   SET is_active = false
+ WHERE agreement_type = 'coffee_supply'
+   AND version = 1;
+
+INSERT INTO agreement_templates (
+  agreement_type, version, title, effective_date, is_active, content_html, content_hash
+) VALUES (
+  'coffee_supply',
+  2,
+  'Apex AI Vending — Equipment Loan & Beverage Supply Agreement',
+  CURRENT_DATE,
+  true,
+  $$
+  <h1>Apex AI Vending — Equipment Loan &amp; Beverage Supply Agreement</h1>
+  <p><em>the apex of retail innovation</em></p>
+
+  <h2>1. Parties</h2>
+  <p>This Equipment Loan and Beverage Supply Agreement ("Agreement") is entered into by and between Apex AI Vending ("Company") and the Customer identified on the signature page below.</p>
+
+  <h2>2. Term</h2>
+  <p>This Agreement has no fixed term. It remains in effect from the Effective Date until terminated by either party in writing.</p>
+
+  <h2>3. Shipping, Installation &amp; Service Costs</h2>
+  <p>Customer is responsible for all costs of shipping, installation, and service related to the Equipment. Company will coordinate logistics on Customer's behalf; costs will be invoiced to and paid by Customer.</p>
+
+  <h2>4. Equipment Loan</h2>
+  <p>Company agrees to provide Customer with beverage vending equipment ("Equipment") at no purchase cost, subject to the terms and conditions of this Agreement. The number of machines is specified on the signature page below. Title to the Equipment remains with Company throughout the duration of this Agreement.</p>
+
+  <h2>5. Exclusive Product &amp; Supply Requirement</h2>
+  <p>Customer agrees to purchase all beverage products for use in the Equipment exclusively from Company. Customer shall not use any third-party products in the Equipment without prior written consent from Company.</p>
+
+  <h2>6. Minimum Purchase Requirement</h2>
+  <p>Customer agrees to purchase a minimum of Two Hundred Dollars ($200.00) per machine per month in beverage supplies from Company. Failure to meet this requirement may result in termination of this Agreement and removal of Equipment.</p>
+
+  <h2>7. Product Usage Compliance</h2>
+  <p>Customer shall use Company-supplied products in accordance with all applicable health, safety, and food service regulations. Customer shall maintain proper storage conditions for all beverage products.</p>
+
+  <h2>8. Order Fulfillment Window</h2>
+  <p>Company shall fulfill each order within thirty (30) days of receipt of the order, measured from order receipt to delivery.</p>
+
+  <h2>9. Damaged Product</h2>
+  <p>Any product damaged after delivery is the sole responsibility of Customer. No credit, replacement, or refund will be issued for product damaged in Customer's possession.</p>
+
+  <h2>10. No Refunds</h2>
+  <p>All sales of beverage products and supplies are final. No refunds will be issued.</p>
+
+  <h2>11. Drop-Shipment to Direct Consumers</h2>
+  <p>Where product is drop-shipped by Company directly to an end consumer at Customer's direction, that product is non-refundable to Customer, and Company retains responsibility for the fulfillment and delivery of that shipment to the end consumer.</p>
+
+  <h2>12. Pricing</h2>
+  <p>Company shall provide Customer with current pricing for all beverage products. Prices are subject to change with thirty (30) days written notice. Customer shall pay all invoices within thirty (30) days of receipt.</p>
+
+  <h2>13. Termination</h2>
+  <p>Either party may terminate this Agreement in writing at any time. Upon termination, Customer is responsible for shipping all Equipment back to Company at Customer's expense within fifteen (15) days of the termination date. Failure to return the Equipment within that window may result in Customer being invoiced for the Equipment's fair market replacement value.</p>
+
+  <h2>14. Limitation of Liability</h2>
+  <p>IN NO EVENT SHALL EITHER PARTY BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES. COMPANY'S TOTAL LIABILITY UNDER THIS AGREEMENT SHALL NOT EXCEED THE AMOUNTS PAID BY CUSTOMER IN THE TWELVE (12) MONTHS PRECEDING THE CLAIM.</p>
+
+  <h2>15. Governing Law</h2>
+  <p>This Agreement shall be governed by and construed in accordance with the laws of the State in which the Equipment is located, without regard to conflict of law principles.</p>
+
+  <h2>16. Entire Agreement</h2>
+  <p>This Agreement constitutes the entire agreement between the parties concerning the subject matter hereof and supersedes all prior agreements, understandings, negotiations, and discussions, whether oral or written.</p>
+
+  <h2>Acknowledgments</h2>
+  <p>The Customer acknowledges each of the following by checking the corresponding boxes on the signature page:</p>
+  <ul>
+    <li>Customer agrees to the exclusive supply requirement.</li>
+    <li>Customer acknowledges the minimum purchase requirement.</li>
+    <li>Customer acknowledges responsibility for shipping, installation, and service costs, and for returning the Equipment at Customer's expense within fifteen (15) days of termination.</li>
+  </ul>
+
+  <h2>Electronic Records &amp; Signatures</h2>
+  <p>The parties consent to conduct this transaction electronically. A typed name below constitutes a valid electronic signature under the E-SIGN Act and applicable state law.</p>
+  $$,
+  md5(random()::text || clock_timestamp()::text)
+) ON CONFLICT (agreement_type, version) DO NOTHING;


### PR DESCRIPTION
…ddress

Three related coffee changes:

1. Coffee supply agreement v2 (migration 159). Replaces the v1 five-year-term template with the customer-requested terms: no fixed term (either party may terminate in writing), Customer pays all shipping / installation / service costs, 15-day Equipment return window at Customer expense on termination, damaged product is Customer's responsibility, no refunds, 30-day fulfillment window from order receipt to delivery, and a drop-shipment-to-consumer carve-out where Company retains fulfillment responsibility. v1 is deactivated (is_active=false); existing signers keep their v1 row for history. New signers get v2 via getActiveTemplate.

   Sign page's third acknowledgment label rewritten to match the new term (shipping/installation/service + 15-day return).

2. Customer receives their signed copy by email. /api/coffee/agreement/sign now generates a customer-signed PDF (via the existing coffeeAgreementPdf module, with countersigner fields null) and emails it to profile.email as an attachment along with a confirmation body and a "Start ordering" CTA. Admin notification also carries the same PDF so the record is already in the countersign queue's inbox. Both emails are wrapped in try/catch — signing itself has already succeeded whether or not the emails go through.

3. Per-order shipping address selector. /coffee/checkout now has a radio: "Ship to default address" (mirrors the profile that's on file for the signed-in account) vs "Custom address for this order" (edits enabled for a one-off ship-to). Choice only affects THIS order; the profile itself is never mutated by checkout. Default is preselected so no clicks are added to the default flow.

Migration 159 needs to run in Supabase before v2 goes live.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2