### PR TITLE
Navbar: disable Link prefetch on the dropdown items so first click al…

### DIFF
--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -335,7 +335,7 @@ export default function Navbar() {
                       <Link
                         key={item.href}
                         href={item.href}
-                        onClick={() => setOpenGroup(null)}
+                        prefetch={false}
                         className="block rounded-lg px-3 py-2 transition-colors hover:bg-green-50"
                       >
                         <div className="text-sm font-semibold text-black-primary">{item.label}</div>


### PR DESCRIPTION
…ways navigates

Reproduces: dashboard → hover Services → click Coffee Program → nothing happens. Refresh, do the same, works. Same reported for the other dropdown items.

Cause: Next.js prefetches every visible Link's RSC payload on mount. For protected routes like /coffee, the prefetch response is served in the middleware context of that first-load session where the session cookie can still be settling in — occasionally the cached prefetch is poisoned (a redirect response, or a stale RSC), and the first click uses it and appears to no-op. A full-page refresh clears the router cache and the next prefetch is clean.

Fix:
- prefetch={false} on the dropdown Link items. They are one-hop nav buttons; the cost of skipping prefetch is one round-trip that only fires when the user actually clicks, and it avoids caching a bad response before the user has settled in.
- Also drop the setOpenGroup(null) onClick on the Link — it never needed to be there. The pathname useEffect already closes the dropdown once navigation lands, and adding another handler in the Link's click chain gave the browser one more thing to schedule around during the first-click race.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2