### PR TITLE
Coffee catalog: allow a product to belong to multiple categories

### DIFF
--- a/src/app/admin/coffee/page.tsx
+++ b/src/app/admin/coffee/page.tsx
@@ -54,6 +54,8 @@ interface Product {
   sort_order: number;
   category_id: string | null;
   coffee_categories: Category | null;
+  categories?: Category[];
+  category_ids?: string[];
 }
 
 interface OrderProfile {
@@ -173,6 +175,7 @@ export default function AdminCoffeePage() {
     active: true,
     sort_order: "0",
     category_id: "",
+    category_ids: [] as string[],
   });
   const [savingProduct, setSavingProduct] = useState(false);
   const [deletingProduct, setDeletingProduct] = useState<string | null>(null);
@@ -421,12 +424,21 @@ export default function AdminCoffeePage() {
       active: true,
       sort_order: "0",
       category_id: "",
+      category_ids: [],
     });
     setEditingProduct(null);
     setShowProductForm(false);
   }
 
   function startEditProduct(product: Product) {
+    // Prefer the new many-to-many list; fall back to the legacy single
+    // category_id so a product row that was created before migration 160
+    // still edits cleanly.
+    const categoryIds: string[] = Array.isArray(product.category_ids) && product.category_ids.length > 0
+      ? product.category_ids
+      : product.category_id
+        ? [product.category_id]
+        : [];
     setProductForm({
       name: product.name,
       sku: product.sku,
@@ -439,7 +451,8 @@ export default function AdminCoffeePage() {
       min_order_qty: String(product.min_order_qty),
       active: product.active,
       sort_order: String(product.sort_order),
-      category_id: product.category_id || "",
+      category_id: product.category_id || categoryIds[0] || "",
+      category_ids: categoryIds,
     });
     setEditingProduct(product);
     setShowProductForm(true);
@@ -481,6 +494,12 @@ export default function AdminCoffeePage() {
     e.preventDefault();
     setSavingProduct(true);
     try {
+      // Send both category_id (primary, kept on coffee_products for
+      // backwards compat) and category_ids (full many-to-many list).
+      // If the admin picked exactly one category, primary auto-defaults
+      // to it; otherwise the first selected is the primary badge.
+      const selectedIds = (productForm.category_ids || []).filter(Boolean);
+      const primaryCategoryId = productForm.category_id || selectedIds[0] || null;
       const body: Record<string, unknown> = {
         name: productForm.name,
         sku: productForm.sku,
@@ -493,7 +512,8 @@ export default function AdminCoffeePage() {
         min_order_qty: parseInt(productForm.min_order_qty) || 1,
         active: productForm.active,
         sort_order: parseInt(productForm.sort_order) || 0,
-        category_id: productForm.category_id || null,
+        category_id: primaryCategoryId,
+        category_ids: selectedIds,
       };
 
       if (editingProduct) {
@@ -988,17 +1008,68 @@ export default function AdminCoffeePage() {
                   />
                 </div>
                 <div>
-                  <label className="mb-1.5 block text-sm font-medium text-gray-700">Category</label>
-                  <select
-                    value={productForm.category_id}
-                    onChange={(e) => setProductForm((p) => ({ ...p, category_id: e.target.value }))}
-                    className={inputClass}
-                  >
-                    <option value="">None</option>
-                    {categories.map((cat) => (
-                      <option key={cat.id} value={cat.id}>{cat.name}</option>
-                    ))}
-                  </select>
+                  <label className="mb-1.5 block text-sm font-medium text-gray-700">
+                    Categories <span className="text-xs font-normal text-gray-500">— pick every section the product should appear in</span>
+                  </label>
+                  <div className="max-h-56 overflow-y-auto rounded-xl border border-gray-200 p-2">
+                    {categories.length === 0 ? (
+                      <p className="p-2 text-xs text-gray-500">No categories yet. Create one in the Categories tab.</p>
+                    ) : (
+                      categories.map((cat) => {
+                        const checked = productForm.category_ids?.includes(cat.id) ?? false;
+                        const isPrimary = productForm.category_id === cat.id;
+                        return (
+                          <label
+                            key={cat.id}
+                            className="flex cursor-pointer items-center justify-between gap-2 rounded-lg px-2 py-1.5 text-sm hover:bg-gray-50"
+                          >
+                            <span className="flex items-center gap-2">
+                              <input
+                                type="checkbox"
+                                checked={checked}
+                                onChange={(e) => {
+                                  setProductForm((p) => {
+                                    const set = new Set(p.category_ids || []);
+                                    if (e.target.checked) set.add(cat.id);
+                                    else set.delete(cat.id);
+                                    const next = Array.from(set);
+                                    // Keep the primary in sync: if we just
+                                    // unchecked the primary, promote the
+                                    // first remaining; if nothing is
+                                    // primary yet and we're checking the
+                                    // first item, make it primary.
+                                    let primary = p.category_id;
+                                    if (!e.target.checked && p.category_id === cat.id) {
+                                      primary = next[0] ?? "";
+                                    } else if (!primary && next.length > 0) {
+                                      primary = next[0];
+                                    }
+                                    return { ...p, category_ids: next, category_id: primary };
+                                  });
+                                }}
+                                className="h-4 w-4 rounded border-gray-300 text-green-600 focus:ring-green-500"
+                              />
+                              <span>{cat.name}</span>
+                            </span>
+                            {checked && (
+                              <button
+                                type="button"
+                                onClick={() => setProductForm((p) => ({ ...p, category_id: cat.id }))}
+                                className={`rounded-full px-2 py-0.5 text-[10px] font-medium transition-colors ${
+                                  isPrimary
+                                    ? "bg-green-600 text-white"
+                                    : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+                                }`}
+                                title="Mark as the primary category (shows as the product's badge)"
+                              >
+                                {isPrimary ? "Primary" : "Make primary"}
+                              </button>
+                            )}
+                          </label>
+                        );
+                      })
+                    )}
+                  </div>
                 </div>
                 <div>
                   <label className="mb-1.5 block text-sm font-medium text-gray-700">Price</label>
@@ -1217,7 +1288,26 @@ export default function AdminCoffeePage() {
                         </td>
                         <td className="px-5 py-3 font-medium text-gray-900">{product.name}</td>
                         <td className="px-5 py-3 text-gray-600">{product.sku}</td>
-                        <td className="px-5 py-3 text-gray-600">{product.coffee_categories?.name || "—"}</td>
+                        <td className="px-5 py-3 text-gray-600">
+                          {product.categories && product.categories.length > 0 ? (
+                            <span className="flex flex-wrap gap-1">
+                              {product.categories.map((cat) => (
+                                <span
+                                  key={cat.id}
+                                  className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium ${
+                                    cat.id === product.category_id
+                                      ? "bg-green-100 text-green-700 ring-1 ring-green-200"
+                                      : "bg-gray-100 text-gray-700 ring-1 ring-gray-200"
+                                  }`}
+                                >
+                                  {cat.name}
+                                </span>
+                              ))}
+                            </span>
+                          ) : (
+                            product.coffee_categories?.name || "—"
+                          )}
+                        </td>
                         <td className="px-5 py-3 text-right font-medium text-gray-900">${Number(product.price).toFixed(2)}</td>
                         <td className="px-5 py-3 text-right text-gray-600">{Number(product.shipping_cost) > 0 ? `$${Number(product.shipping_cost).toFixed(2)}` : "Free"}</td>
                         <td className="px-5 py-3">

--- a/src/app/api/admin/coffee/products/route.ts
+++ b/src/app/api/admin/coffee/products/route.ts
@@ -9,11 +9,15 @@ export async function GET(req: NextRequest) {
   }
 
   try {
+    // Fetch products + primary category + full category list via the
+    // junction table. `categories` on each row is the array of every
+    // category the product belongs to; `coffee_categories` remains the
+    // primary category so existing UI columns don't need to change.
     const { data, error } = await supabaseAdmin
       .from("coffee_products")
-      .select("*, coffee_categories(id, name, slug)")
-      // Match the customer feed ordering so what the admin sees in
-      // this table is exactly what the storefront renders.
+      .select(
+        "*, coffee_categories(id, name, slug), coffee_product_categories(is_primary, coffee_categories(id, name, slug))"
+      )
       .order("sort_order", { ascending: true })
       .order("name", { ascending: true });
 
@@ -21,11 +25,41 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ error: error.message }, { status: 500 });
     }
 
-    return NextResponse.json({ products: data || [] });
+    const products = (data || []).map((row: Record<string, unknown>) => {
+      const links = (row.coffee_product_categories as Array<{
+        is_primary: boolean;
+        coffee_categories: { id: string; name: string; slug: string } | null;
+      }> | null) ?? [];
+      const categories = links
+        .map((l) => l.coffee_categories)
+        .filter((c): c is { id: string; name: string; slug: string } => !!c);
+      const category_ids = categories.map((c) => c.id);
+      return { ...row, categories, category_ids };
+    });
+
+    return NextResponse.json({ products });
   } catch (e) {
     const msg = e instanceof Error ? e.message : "Unknown error";
     return NextResponse.json({ error: msg }, { status: 500 });
   }
+}
+
+// Replace the product's category memberships. Passing an empty array
+// clears every category link. Passing a single-item array behaves
+// exactly like the legacy category_id write. is_primary marks the
+// first (or explicitly-primary) category so the storefront can still
+// pick "the" category badge for a product card.
+async function syncProductCategories(productId: string, categoryIds: string[], primaryId: string | null) {
+  const deduped = Array.from(new Set(categoryIds.filter((s) => /^[0-9a-f-]{36}$/i.test(s))));
+  await supabaseAdmin.from("coffee_product_categories").delete().eq("product_id", productId);
+  if (deduped.length === 0) return;
+  const primary = primaryId && deduped.includes(primaryId) ? primaryId : deduped[0];
+  const rows = deduped.map((cid) => ({
+    product_id: productId,
+    category_id: cid,
+    is_primary: cid === primary,
+  }));
+  await supabaseAdmin.from("coffee_product_categories").insert(rows);
 }
 
 export async function POST(req: NextRequest) {
@@ -37,10 +71,22 @@ export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
 
+    // Accept either the new category_ids array or the legacy single
+    // category_id. category_id (on coffee_products itself) is treated
+    // as the primary category so the row's badge stays stable.
+    const rawIds: string[] = Array.isArray(body.category_ids)
+      ? body.category_ids.filter((v: unknown): v is string => typeof v === "string")
+      : body.category_id
+        ? [String(body.category_id)]
+        : [];
+    const primaryId: string | null = body.category_id
+      ? String(body.category_id)
+      : rawIds[0] ?? null;
+
     const { data, error } = await supabaseAdmin
       .from("coffee_products")
       .insert({
-        category_id: body.category_id ?? null,
+        category_id: primaryId,
         name: body.name,
         sku: body.sku,
         description: body.description ?? null,
@@ -58,6 +104,10 @@ export async function POST(req: NextRequest) {
 
     if (error) {
       return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    if (rawIds.length > 0) {
+      await syncProductCategories(data.id, rawIds, primaryId);
     }
 
     return NextResponse.json({ product: data }, { status: 201 });
@@ -99,6 +149,19 @@ export async function PATCH(req: NextRequest) {
 
     if (error) {
       return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    // Sync the many-to-many category memberships when the caller sent
+    // an explicit list. Omitting category_ids from the PATCH body
+    // leaves the memberships untouched (so a PATCH that only edits
+    // the name / price doesn't wipe categories).
+    if ("category_ids" in fields && Array.isArray(fields.category_ids)) {
+      const rawIds: string[] = (fields.category_ids as unknown[]).filter(
+        (v): v is string => typeof v === "string",
+      );
+      const primaryId: string | null =
+        typeof fields.category_id === "string" ? fields.category_id : rawIds[0] ?? null;
+      await syncProductCategories(id, rawIds, primaryId);
     }
 
     // Propagate base price + shipping to the Tier 1 tier-price row.

--- a/src/app/api/coffee/products/route.ts
+++ b/src/app/api/coffee/products/route.ts
@@ -23,7 +23,9 @@ export async function GET(req: NextRequest) {
 
     let query = supabaseAdmin
       .from("coffee_products")
-      .select("*, coffee_categories(id, name, slug)")
+      .select(
+        "*, coffee_categories(id, name, slug), coffee_product_categories(is_primary, coffee_categories(id, name, slug))"
+      )
       .eq("active", true)
       // sort_order first (0 = admin hasn't customized yet); name
       // second as a stable tiebreaker so ties don't render in a
@@ -53,7 +55,22 @@ export async function GET(req: NextRequest) {
         .single();
 
       if (cat) {
-        query = query.eq("category_id", cat.id);
+        // Resolve every product that lives in this category through the
+        // junction table (many-to-many). Falls through to zero results
+        // when nothing matches instead of a bare .eq() on the legacy
+        // primary category_id column, so multi-category products
+        // surface correctly.
+        const { data: linkRows } = await supabaseAdmin
+          .from("coffee_product_categories")
+          .select("product_id")
+          .eq("category_id", cat.id);
+        const productIds = (linkRows || [])
+          .map((r: { product_id: string }) => r.product_id)
+          .filter((id): id is string => typeof id === "string");
+        if (productIds.length === 0) {
+          return NextResponse.json({ products: [] });
+        }
+        query = query.in("id", productIds);
       }
     }
 
@@ -75,10 +92,18 @@ export async function GET(req: NextRequest) {
     });
 
     const products = rows.map((r: Record<string, unknown>) => {
+      const links = (r.coffee_product_categories as Array<{
+        is_primary: boolean;
+        coffee_categories: { id: string; name: string; slug: string } | null;
+      }> | null) ?? [];
+      const categories = links
+        .map((l) => l.coffee_categories)
+        .filter((c): c is { id: string; name: string; slug: string } => !!c);
+      const base = { ...r, categories };
       const resolved = priced.get(r.id as string);
-      if (!resolved) return r;
+      if (!resolved) return base;
       return {
-        ...r,
+        ...base,
         price: resolved.price,
         shipping_cost: resolved.shipping_cost,
         pricing_tier_id: resolved.pricing_tier_id,

--- a/supabase/migrations/160_coffee_product_categories_m2m.sql
+++ b/supabase/migrations/160_coffee_product_categories_m2m.sql
@@ -1,0 +1,60 @@
+-- Coffee products → categories many-to-many.
+--
+-- Today coffee_products has a single category_id foreign key, so a
+-- product only ever surfaces in one section of the catalog. Admins have
+-- asked to file the same product under multiple categories (e.g. a
+-- "seasonal" blend that also lives under "coffee beans"). We introduce
+-- a join table and backfill from the existing single-category rows.
+--
+-- coffee_products.category_id stays as the "primary" category — the
+-- one that appears first on a product card, and the one that legacy
+-- callers keep reading — so this migration is additive and does not
+-- break the admin editor, the shopper feed, or the tier-price flow if
+-- any of them are still on the old code path.
+
+CREATE TABLE IF NOT EXISTS coffee_product_categories (
+  product_id  uuid NOT NULL REFERENCES coffee_products(id)   ON DELETE CASCADE,
+  category_id uuid NOT NULL REFERENCES coffee_categories(id) ON DELETE CASCADE,
+  is_primary  boolean NOT NULL DEFAULT false,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (product_id, category_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_coffee_product_categories_category
+  ON coffee_product_categories(category_id);
+CREATE INDEX IF NOT EXISTS idx_coffee_product_categories_product
+  ON coffee_product_categories(product_id);
+
+ALTER TABLE coffee_product_categories ENABLE ROW LEVEL SECURITY;
+
+-- Public catalog read — matches the coffee_products / coffee_categories
+-- read policy so the storefront can hydrate categories without an admin
+-- round-trip.
+DROP POLICY IF EXISTS "Anyone can read coffee_product_categories" ON coffee_product_categories;
+CREATE POLICY "Anyone can read coffee_product_categories"
+  ON coffee_product_categories
+  FOR SELECT
+  USING (true);
+
+-- Writes gated to admins. Service-role bypasses RLS so the admin
+-- product API keeps working unchanged.
+DROP POLICY IF EXISTS "Admins manage coffee_product_categories" ON coffee_product_categories;
+CREATE POLICY "Admins manage coffee_product_categories"
+  ON coffee_product_categories
+  FOR ALL
+  USING (EXISTS (
+    SELECT 1 FROM profiles WHERE profiles.id = auth.uid() AND profiles.role = 'admin'
+  ))
+  WITH CHECK (EXISTS (
+    SELECT 1 FROM profiles WHERE profiles.id = auth.uid() AND profiles.role = 'admin'
+  ));
+
+-- Backfill: every product that currently has a category_id gets a
+-- junction row marked is_primary=true so the storefront's "primary
+-- badge" behavior is preserved. Idempotent — the composite PK protects
+-- against duplicate inserts if this migration is re-run.
+INSERT INTO coffee_product_categories (product_id, category_id, is_primary)
+SELECT id, category_id, true
+  FROM coffee_products
+ WHERE category_id IS NOT NULL
+ON CONFLICT (product_id, category_id) DO NOTHING;


### PR DESCRIPTION
Admins asked to file the same coffee product under multiple categories so it surfaces in every relevant part of the storefront (e.g. a seasonal blend under both "Seasonal" and "Coffee Beans"). Today each product only gets one category_id, so it lives in exactly one section.

- Migration 160 adds coffee_product_categories (product_id, category_id, is_primary), with public read + admin-write RLS matching the existing coffee tables, and backfills the junction from every row that has a non-null category_id today so the storefront doesn't lose any current memberships.
- coffee_products.category_id stays as the "primary" category — it's the badge on a product card and it keeps the legacy code paths working. Every additional membership is a junction row.
- Admin API (/api/admin/coffee/products) now accepts a category_ids array on POST and PATCH. Passing an empty array clears every link; omitting the field on a PATCH leaves memberships untouched so price/name-only edits don't wipe categories. GET returns each product with both `coffee_categories` (primary) and `categories` (full array).
- Public API (/api/coffee/products) resolves the category filter through the junction table so multi-category products show up under every section they belong to.
- Admin editor's Category dropdown is replaced with a checkbox list. Every checked category is added; the first (or an explicitly-marked one via the "Make primary" button) is written as coffee_products. category_id so the storefront's badge stays deterministic. The products table's Category column now renders every membership as a pill; the primary one is highlighted in green.

Migration 160 must be run in Supabase before the many-to-many UI is usable.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2