### PR TITLE
Coffee catalog: fix empty product list — stop nesting the new junctio…

### DIFF
--- a/src/app/api/admin/coffee/products/route.ts
+++ b/src/app/api/admin/coffee/products/route.ts
@@ -9,15 +9,12 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    // Fetch products + primary category + full category list via the
-    // junction table. `categories` on each row is the array of every
-    // category the product belongs to; `coffee_categories` remains the
-    // primary category so existing UI columns don't need to change.
+    // Fetch primary product rows first. We hydrate junction rows in a
+    // second query so a schema-cache miss on the new join table can't
+    // break the admin catalog view.
     const { data, error } = await supabaseAdmin
       .from("coffee_products")
-      .select(
-        "*, coffee_categories(id, name, slug), coffee_product_categories(is_primary, coffee_categories(id, name, slug))"
-      )
+      .select("*, coffee_categories(id, name, slug)")
       .order("sort_order", { ascending: true })
       .order("name", { ascending: true });
 
@@ -25,14 +22,35 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ error: error.message }, { status: 500 });
     }
 
-    const products = (data || []).map((row: Record<string, unknown>) => {
-      const links = (row.coffee_product_categories as Array<{
-        is_primary: boolean;
-        coffee_categories: { id: string; name: string; slug: string } | null;
-      }> | null) ?? [];
-      const categories = links
-        .map((l) => l.coffee_categories)
-        .filter((c): c is { id: string; name: string; slug: string } => !!c);
+    const rows = data || [];
+    const categoriesByProduct = new Map<string, Array<{ id: string; name: string; slug: string }>>();
+    if (rows.length > 0) {
+      const { data: junctionRows } = await supabaseAdmin
+        .from("coffee_product_categories")
+        .select("product_id, coffee_categories(id, name, slug)")
+        .in("product_id", rows.map((r: { id: string }) => r.id));
+      for (const link of ((junctionRows || []) as unknown as Array<{
+        product_id: string;
+        coffee_categories: { id: string; name: string; slug: string } | { id: string; name: string; slug: string }[] | null;
+      }>)) {
+        const cat = Array.isArray(link.coffee_categories)
+          ? link.coffee_categories[0]
+          : link.coffee_categories;
+        if (!cat) continue;
+        const list = categoriesByProduct.get(link.product_id) ?? [];
+        list.push(cat);
+        categoriesByProduct.set(link.product_id, list);
+      }
+    }
+
+    const products = rows.map((row: Record<string, unknown>) => {
+      const linked = categoriesByProduct.get(row.id as string) ?? [];
+      const primary = row.coffee_categories as { id: string; name: string; slug: string } | null;
+      const categories = linked.length > 0
+        ? linked
+        : primary
+          ? [primary]
+          : [];
       const category_ids = categories.map((c) => c.id);
       return { ...row, categories, category_ids };
     });

--- a/src/app/api/coffee/products/route.ts
+++ b/src/app/api/coffee/products/route.ts
@@ -21,11 +21,16 @@ export async function GET(req: NextRequest) {
     const search = searchParams.get("search");
     const idsParam = searchParams.get("ids");
 
+    // NOTE: we intentionally do NOT nest coffee_product_categories in
+    // this select. PostgREST caches the schema and a brand-new join
+    // table (migration 160) may not be recognized in the cache
+    // immediately after the migration runs — nesting the relation
+    // would then error the whole request and the storefront would go
+    // empty. Instead we fetch the primary product row first and merge
+    // the extra category memberships in a second best-effort query.
     let query = supabaseAdmin
       .from("coffee_products")
-      .select(
-        "*, coffee_categories(id, name, slug), coffee_product_categories(is_primary, coffee_categories(id, name, slug))"
-      )
+      .select("*, coffee_categories(id, name, slug)")
       .eq("active", true)
       // sort_order first (0 = admin hasn't customized yet); name
       // second as a stable tiebreaker so ties don't render in a
@@ -55,22 +60,30 @@ export async function GET(req: NextRequest) {
         .single();
 
       if (cat) {
-        // Resolve every product that lives in this category through the
-        // junction table (many-to-many). Falls through to zero results
-        // when nothing matches instead of a bare .eq() on the legacy
-        // primary category_id column, so multi-category products
-        // surface correctly.
-        const { data: linkRows } = await supabaseAdmin
+        // Resolve every product in this category through the junction
+        // table (many-to-many). If the junction table isn't reachable
+        // (missing, schema cache stale, RLS wrong), fall back to the
+        // legacy single-category filter so the storefront doesn't
+        // suddenly return zero products.
+        const { data: linkRows, error: linkErr } = await supabaseAdmin
           .from("coffee_product_categories")
           .select("product_id")
           .eq("category_id", cat.id);
-        const productIds = (linkRows || [])
-          .map((r: { product_id: string }) => r.product_id)
-          .filter((id): id is string => typeof id === "string");
-        if (productIds.length === 0) {
-          return NextResponse.json({ products: [] });
+        if (linkErr) {
+          query = query.eq("category_id", cat.id);
+        } else {
+          const productIds = (linkRows || [])
+            .map((r: { product_id: string }) => r.product_id)
+            .filter((id): id is string => typeof id === "string");
+          if (productIds.length === 0) {
+            // Nothing in the junction table for this category — still
+            // fall back to legacy single-category so admin-created
+            // rows made before backfill also render.
+            query = query.eq("category_id", cat.id);
+          } else {
+            query = query.in("id", productIds);
+          }
         }
-        query = query.in("id", productIds);
       }
     }
 
@@ -91,14 +104,38 @@ export async function GET(req: NextRequest) {
       userId,
     });
 
+    // Best-effort category-array hydration. Two failure modes both
+    // resolve to "just use the primary coffee_categories row we
+    // already have" — a missing junction table (schema cache), or an
+    // empty junction (no backfill yet).
+    const categoriesByProduct = new Map<string, Array<{ id: string; name: string; slug: string }>>();
+    if (rows.length > 0) {
+      const { data: junctionRows } = await supabaseAdmin
+        .from("coffee_product_categories")
+        .select("product_id, coffee_categories(id, name, slug)")
+        .in("product_id", rows.map((r: { id: string }) => r.id));
+      for (const link of ((junctionRows || []) as unknown as Array<{
+        product_id: string;
+        coffee_categories: { id: string; name: string; slug: string } | { id: string; name: string; slug: string }[] | null;
+      }>)) {
+        const cat = Array.isArray(link.coffee_categories)
+          ? link.coffee_categories[0]
+          : link.coffee_categories;
+        if (!cat) continue;
+        const list = categoriesByProduct.get(link.product_id) ?? [];
+        list.push(cat);
+        categoriesByProduct.set(link.product_id, list);
+      }
+    }
+
     const products = rows.map((r: Record<string, unknown>) => {
-      const links = (r.coffee_product_categories as Array<{
-        is_primary: boolean;
-        coffee_categories: { id: string; name: string; slug: string } | null;
-      }> | null) ?? [];
-      const categories = links
-        .map((l) => l.coffee_categories)
-        .filter((c): c is { id: string; name: string; slug: string } => !!c);
+      const linkedCategories = categoriesByProduct.get(r.id as string) ?? [];
+      const primary = r.coffee_categories as { id: string; name: string; slug: string } | null;
+      const categories = linkedCategories.length > 0
+        ? linkedCategories
+        : primary
+          ? [primary]
+          : [];
       const base = { ...r, categories };
       const resolved = priced.get(r.id as string);
       if (!resolved) return base;


### PR DESCRIPTION
…n in the primary select

Migration 160 added coffee_product_categories, and the previous commit nested it as a related select on coffee_products. If PostgREST's schema cache hasn't reloaded to see the new join table yet, the whole request errors out and both the public shopper feed and the admin product list render empty.

Fix: fetch the primary product rows with just the legacy coffee_categories join (unchanged from before migration 160), then hydrate the extra memberships in a second best-effort query against coffee_product_categories. If that second query fails or returns nothing, we fall back to the primary category so the storefront always has SOMETHING to show. Same treatment on the admin route.

Category filter in the public API also degrades gracefully — if the junction table isn't reachable, we fall back to the legacy category_id = eq filter instead of returning an empty list.


Claude-Session: https://claude.ai/code/session_01DpmTFu9EYqShHFioncRiN2